### PR TITLE
Fix/ui hydrator usability

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -300,7 +300,6 @@ angular.module(PKG.name + '.commons')
     }
 
     $scope.$on('$destroy', function() {
-      MyNodeConfigService.unRegisterPluginResetCallback($scope.$id);
       MyNodeConfigService.unRegisterPluginSaveCallback($scope.$id);
       closeAllPopovers();
       angular.forEach(popoverScopes, function (s) {

--- a/cdap-ui/app/directives/widget-container/widget-container.less
+++ b/cdap-ui/app/directives/widget-container/widget-container.less
@@ -35,7 +35,13 @@
 body.state-hydrator {
   [plugin-property-edit-view] {
     .widget-group-container {
+      border: 1px solid #eee;
+      border-bottom: 0;
+      padding: 10px;
 
+      &:last-child {
+        border-bottom: 1px solid #eee;
+      }
       &.well {
         h3 { margin: 0 0 10px 0; }
 

--- a/cdap-ui/app/features/hydrator/bottompanel.less
+++ b/cdap-ui/app/features/hydrator/bottompanel.less
@@ -29,6 +29,7 @@ body.theme-cdap.state-hydrator {
       }
     }
   }
+
   div.console {
     background-color: white;
     position: relative;
@@ -97,6 +98,11 @@ body.theme-cdap.state-hydrator {
       }
       .panel-body {
         min-height: 50px;
+      }
+    }
+    .sink-output-schema {
+      .output-schema {
+        margin-top: 20px;
       }
     }
     .input-schema {

--- a/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -16,7 +16,7 @@
 
 
 angular.module(PKG.name + '.feature.hydrator')
-  .controller('NodeConfigController', function($scope, IMPLICIT_SCHEMA, MyAppDAGService, $filter, $q, $rootScope, myPipelineApi, $state, $timeout, GLOBALS, MyNodeConfigService, $bootstrapModal) {
+  .controller('NodeConfigController', function($scope, IMPLICIT_SCHEMA, MyAppDAGService, $filter, $q, $rootScope, myPipelineApi, $state, $timeout, GLOBALS, MyNodeConfigService) {
 
     $scope.type = MyAppDAGService.metadata.template.type;
 
@@ -28,60 +28,15 @@ angular.module(PKG.name + '.feature.hydrator')
     function onPluginRemoved(nodeId) {
       if ($scope.plugin && $scope.plugin.id === nodeId){
         $scope.isValidPlugin = false;
-        MyNodeConfigService.setIsPluginBeingEdited(false);
       }
     }
 
     function onPluginChange(plugin) {
-      var defer = $q.defer();
       $scope.type = MyAppDAGService.metadata.template.type;
       if (plugin && $scope.plugin && plugin.id === $scope.plugin.id) {
         return;
       }
-      if (!MyNodeConfigService.getIsPluginBeingEdited()) {
-        switchPlugin(plugin);
-        defer.resolve(true);
-      } else {
-        confirmPluginSwitch()
-          .then(
-            function yes() {
-              switchPlugin(plugin);
-            },
-            function no() {
-              MyNodeConfigService.resetPlugin($scope.plugin);
-              console.log('User chose to stay in the same plugin');
-            }
-          );
-        defer.resolve(false);
-      }
-      return defer.promise;
-    }
-
-    function confirmPluginSwitch() {
-      var defer = $q.defer();
-
-      $bootstrapModal.open({
-        keyboard: false,
-        templateUrl: '/assets/features/hydrator/templates/partial/confirm.html',
-        size: 'sm',
-        windowClass: 'center',
-        controller: ['$scope', function ($scope) {
-          $scope.continue = function () {
-            $scope.$close('close');
-          };
-
-          $scope.cancel = function () {
-            $scope.$close('keep open');
-          };
-        }]
-      }).result.then(function (closing) {
-        if (closing === 'close') {
-          defer.resolve(true);
-        } else {
-          defer.reject(false);
-        }
-      });
-      return defer.promise;
+      switchPlugin(plugin);
     }
 
     function switchPlugin(plugin) {

--- a/cdap-ui/app/features/hydrator/controllers/create/plugin-edit-form-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/plugin-edit-form-ctrl.js
@@ -16,7 +16,6 @@
 
 angular.module(PKG.name + '.feature.hydrator')
   .controller('PluginEditController', function($scope, PluginConfigFactory, myHelpers, EventPipe, $timeout, MyAppDAGService, GLOBALS, MyNodeConfigService) {
-    $scope.pluginCopy = {};
 
     var propertiesFromBackend = Object.keys($scope.plugin._backendProperties);
     // Make a local copy that is a mix of properties from backend + config from nodejs
@@ -34,7 +33,6 @@ angular.module(PKG.name + '.feature.hydrator')
     this.configfetched = false;
     this.properties = [];
     this.noconfig = null;
-    this.MyNodeConfigService = MyNodeConfigService;
     /////////////////////////////////////
     /*
      This is snippet is here because the widget-schema-editor edits the outputschema that we pass in
@@ -44,9 +42,6 @@ angular.module(PKG.name + '.feature.hydrator')
      So we are temporarily doing the coversion here before passing it to the widget-schema-editor so that it doesn't trigger that initial change.
      This should eventually be removed and moved to a service (or a factory). For lack of time my sin stays here. - Ajai
     */
-    if (!$scope.isDisabled) {
-      MyNodeConfigService.setIsPluginBeingEdited(false);
-    }
 
     var typeMap = 'map<string, string>';
     var mapObj = {
@@ -238,30 +233,16 @@ angular.module(PKG.name + '.feature.hydrator')
                 $scope.plugin.properties[outputSchemaProperty[0]] = $scope.plugin.outputSchema;
               }
             }
-            $scope.pluginCopy = angular.copy($scope.plugin);
 
             // Mark the configfetched to show that configurations have been received.
             this.configfetched = true;
             this.config = res;
             this.noconfig = false;
 
-            if (!$scope.isDisabled) {
-              setWatchersForPropertiesAndSchema();
-            }
           }.bind(this),
           function error() {
             // TODO: Hacky. Need to fix this for am-fade-top animation for modals.
             $timeout(function() {
-              $scope.pluginCopy = angular.copy($scope.plugin);
-              if (!$scope.isDisabled) {
-                $scope.$watch('pluginCopy.properties', function() {
-                    var strProp1 = JSON.stringify($scope.pluginCopy.properties);
-                    var strProp2 = JSON.stringify($scope.plugin.properties);
-                    if (strProp1 !== strProp2) {
-                      MyNodeConfigService.setIsPluginBeingEdited(true);
-                    }
-                }, true);
-              }
               // Didn't receive a configuration from the backend. Fallback to all textboxes.
               this.noconfig = true;
               this.configfetched = true;
@@ -271,6 +252,11 @@ angular.module(PKG.name + '.feature.hydrator')
     } else {
       this.configfetched = true;
     }
+
+    $scope.$watch('plugin.outputSchema', validateSchema);
+    $scope.$watchCollection('plugin.properties', function() {
+      MyNodeConfigService.notifyPluginSaveListeners($scope.plugin.id);
+    });
 
     function setGroups(propertiesFromBackend, res, group) {
       // For each group in groups iterate over its fields in position (order of all fields)
@@ -323,96 +309,15 @@ angular.module(PKG.name + '.feature.hydrator')
       };
     }
 
-    function setWatchersForPropertiesAndSchema() {
-      if ($scope.plugin._backendProperties.schema) {
-        $scope.$watch('pluginCopy.outputSchema', function () {
-          if (!$scope.pluginCopy.outputSchema) {
-            if ($scope.pluginCopy.properties && $scope.plugin.properties.schema) {
-              $scope.pluginCopy.properties.schema = null;
-            }
-            return;
-          }
-
-          if (!$scope.pluginCopy.properties) {
-            $scope.pluginCopy.properties = {};
-          }
-          if ($scope.pluginCopy.properties.schema !== $scope.pluginCopy.outputSchema) {
-            $scope.pluginCopy.properties.schema = $scope.pluginCopy.outputSchema;
-          }
-        });
-      } else {
-        $scope.$watch('pluginCopy.outputSchema', function () {
-          var originalOutputSchema = $scope.plugin.outputSchema;
-          var copyOutputSchema = $scope.pluginCopy.outputSchema;
-          if (originalOutputSchema !== copyOutputSchema) {
-            MyNodeConfigService.setIsPluginBeingEdited(true);
-          }
-        });
-      }
-
-      $scope.$watch('pluginCopy.label', function() {
-        var copyLabel = $scope.pluginCopy.label;
-        var originalLabel = $scope.plugin.label;
-        if (copyLabel !== originalLabel) {
-          MyNodeConfigService.setIsPluginBeingEdited(true);
-        }
-      });
-
-      $scope.$watch('pluginCopy.errorDatasetName', function() {
-        var copyErrorDataset = $scope.pluginCopy.errorDatasetName;
-        var originalErrorDataset = $scope.plugin.errorDatasetName;
-        if (copyErrorDataset !== originalErrorDataset) {
-          MyNodeConfigService.setIsPluginBeingEdited(true);
-        }
-      });
-
-      $scope.$watch('pluginCopy.validationFields', function() {
-        var copyValidationFields = JSON.stringify($scope.pluginCopy.validationFields);
-        var originalValidationFields = JSON.stringify($scope.plugin.validationFields);
-        if (copyValidationFields !== originalValidationFields) {
-          MyNodeConfigService.setIsPluginBeingEdited(true);
-        }
-      });
-
-      $scope.$watch('pluginCopy.properties', function() {
-          var strProp1 = JSON.stringify($scope.pluginCopy.properties);
-          var strProp2 = JSON.stringify($scope.plugin.properties);
-          if (strProp1 !== strProp2) {
-            MyNodeConfigService.setIsPluginBeingEdited(true);
-          }
-      }, true);
-    }
-
-    this.reset = function () {
-      $scope.pluginCopy.properties = angular.copy($scope.plugin.properties);
-      $scope.pluginCopy.outputSchema = angular.copy($scope.plugin.outputSchema);
-      $scope.pluginCopy.errorDatasetName = angular.copy($scope.plugin.errorDatasetName);
-      EventPipe.emit('resetValidatorValidationFields', $scope.plugin.validationFields);
-      MyNodeConfigService.setIsPluginBeingEdited(false);
-      EventPipe.emit('plugin.reset');
-    };
-
     this.schemaClear = function () {
       EventPipe.emit('schema.clear');
-    };
-
-    this.save = function () {
-      if (validateSchema() || $scope.plugin.name === 'Validator') {
-        $scope.plugin.properties = angular.copy($scope.pluginCopy.properties);
-        $scope.plugin.outputSchema = angular.copy($scope.pluginCopy.outputSchema);
-        $scope.plugin.errorDatasetName = $scope.pluginCopy.errorDatasetName;
-        $scope.plugin.validationFields = angular.copy($scope.pluginCopy.validationFields);
-        $scope.plugin.label = $scope.pluginCopy.label;
-        MyNodeConfigService.setIsPluginBeingEdited(false);
-        MyNodeConfigService.notifyPluginSaveListeners($scope.plugin.id);
-      }
     };
 
     function validateSchema() {
       $scope.errors = [];
       var schema;
       try {
-        schema = JSON.parse($scope.pluginCopy.outputSchema);
+        schema = JSON.parse($scope.plugin.outputSchema);
         schema = schema.fields;
       } catch (e) {
         schema = null;

--- a/cdap-ui/app/features/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/toppanel-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.hydrator')
-  .controller('TopPanelController', function(EventPipe, CanvasFactory, MyAppDAGService, $scope, $timeout, $bootstrapModal, $alert, $state, $stateParams, GLOBALS, HydratorErrorFactory, MyConsoleTabService, MyNodeConfigService) {
+  .controller('TopPanelController', function(EventPipe, CanvasFactory, MyAppDAGService, $scope, $timeout, $bootstrapModal, $alert, $state, $stateParams, GLOBALS, HydratorErrorFactory, MyConsoleTabService) {
 
     this.metadata = MyAppDAGService['metadata'];
     function resetMetadata() {
@@ -181,18 +181,6 @@ angular.module(PKG.name + '.feature.hydrator')
 
     this.validatePipeline = function() {
       var errors = HydratorErrorFactory.isModelValid(MyAppDAGService.nodes, MyAppDAGService.connections, MyAppDAGService.metadata, MyAppDAGService.getConfig());
-
-      if (MyNodeConfigService.getIsPluginBeingEdited()) {
-        if (errors === true) {
-          errors = {};
-        }
-        errors.canvas = errors.canvas || [];
-        errors.canvas.push(
-          GLOBALS.en.hydrator.studio.unsavedPluginMessage1 +
-          MyNodeConfigService.plugin.label +
-          GLOBALS.en.hydrator.studio.unsavedPluginMessage2
-        );
-      }
 
       if (angular.isObject(errors)) {
         MyAppDAGService.notifyError(errors);

--- a/cdap-ui/app/features/hydrator/services/node-config-service.js
+++ b/cdap-ui/app/features/hydrator/services/node-config-service.js
@@ -17,38 +17,8 @@
 angular.module(PKG.name + '.feature.hydrator')
   .service('MyNodeConfigService', function() {
     this.pluginChangeListeners = {};
-    this.pluginResetListeners = {};
     this.pluginRemoveListeners = {};
     this.pluginSaveListeners = {};
-
-    this.isModelTouched = false;
-
-    this.setIsPluginBeingEdited = function(isPluginSaved) {
-      this.isModelTouched = isPluginSaved;
-    };
-
-    this.getIsPluginBeingEdited = function() {
-      return this.isModelTouched;
-    };
-
-    this.resetPlugin = function(plugin) {
-      this.plugin = plugin;
-      this.notifyPluginResetListeners();
-    };
-
-    this.notifyPluginResetListeners = function() {
-      angular.forEach(this.pluginResetListeners, function(callback) {
-        callback(this.plugin);
-      }.bind(this));
-    };
-
-    this.registerPluginResetCallback = function(id, callback) {
-      this.pluginResetListeners[id] = callback;
-    };
-
-    this.unRegisterPluginResetCallback = function(id) {
-      delete this.pluginResetListeners[id];
-    };
 
     this.setPlugin = function(plugin) {
       this.plugin = plugin;

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-config-form.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-config-form.html
@@ -55,39 +55,8 @@
         <div ng-include="'/assets/features/hydrator/templates/create/popovers/plugin-edit-properties-template.html'"></div>
       </div>
 
-      <div class="col-xs-12">
-        <div class="schema-error">
-          <ul>
-            <li class="text-danger" ng-repeat="error in errors">{{ error }}</li>
-          </ul>
-        </div>
-        <h4 class="sink-schema" ng-if="pluginCopy.properties.schema !== undefined || pluginCopy.implicitSchema">
-          <span>Schema</span>
-          <span class="fa fa-asterisk ng-scope" ng-if="pluginCopy._backendProperties['schema'].required"></span>
-          <button
-            class="btn btn-sm btn-default pull-right"
-            ng-click="PluginEditController.schemaClear()"
-            ng-if="(!pluginCopy.implicitSchema && !isDisabled)"
-            ng-disabled="pluginCopy.implicitSchema || pluginCopy.properties.format === 'clf' || pluginCopy.properties.format === 'syslog'">
-            Clear
-          </button>
-        </h4>
-
-        <fieldset ng-disabled="isDisabled">
-          <my-schema-editor
-            ng-if="pluginCopy.properties.schema !== undefined || pluginCopy.implicitSchema"
-            ng-model="pluginCopy.outputSchema"
-            data-disabled="pluginCopy.implicitSchema || isDisabled"
-            plugin-properties="pluginCopy.properties"
-            config="PluginEditController.schemaProperties">
-          </my-schema-editor>
-        </fieldset>
-
-        <div ng-if="pluginCopy.properties.schema !== undefined && !pluginCopy.outputSchema && isDisabled">
-          <div class="well well-lg">
-            <h4>There is no output schema</h4>
-          </div>
-        </div>
+      <div class="col-xs-12 sink-output-schema" ng-if="PluginEditController.isOuputSchemaExists || pluginCopy.implicitSchema">
+        <div ng-include="'/assets/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html'"></div>
       </div>
     </div>
   </div>

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-config-form.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-config-form.html
@@ -55,7 +55,7 @@
         <div ng-include="'/assets/features/hydrator/templates/create/popovers/plugin-edit-properties-template.html'"></div>
       </div>
 
-      <div class="col-xs-12 sink-output-schema" ng-if="PluginEditController.isOuputSchemaExists || pluginCopy.implicitSchema">
+      <div class="col-xs-12 sink-output-schema" ng-if="PluginEditController.isOuputSchemaExists || plugin.implicitSchema">
         <div ng-include="'/assets/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html'"></div>
       </div>
     </div>

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-form.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-form.html
@@ -36,18 +36,6 @@
       <h3>{{plugin.name}} Properties</h3>
       <p>{{plugin.description}}</p>
     </div>
-    <div class="btn-group pull-right">
-      <div ng-if="!isDisabled" class="non-info">
-        <a class="btn btn-default"
-            ng-disabled="PluginEditController.MyNodeConfigService.isModelTouched == false"
-            ng-click="PluginEditController.reset()">Reset</a>
-      </div>
-      <div ng-if="!isDisabled"  class="non-info">
-        <a class="btn btn-success"
-            ng-disabled="PluginEditController.MyNodeConfigService.isModelTouched == false"
-            ng-click="PluginEditController.save()">Save</a>
-      </div>
-    </div>
   </div>
 
   <div class="bottompanel-body" ng-class="{'modal-sink': plugin.type === 'sink'}">

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-noconfig-form.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-noconfig-form.html
@@ -14,14 +14,14 @@
   the License.
 -->
 
-<div class="row" ng-if="pluginCopy.name !== 'Validator'">
+<div class="row" ng-if="plugin.name !== 'Validator'">
   <div class="col-xs-12">
     <fieldset ng-disabled="isDisabled">
       <div ng-if="PluginEditController.noconfig">
         <div class="well well-lg widget-group-container">
-          <div ng-repeat="(name, value) in pluginCopy.properties track by $index">
+          <div ng-repeat="(name, value) in plugin.properties track by $index">
             <div class="form-group">
-              <label ng-init="title='info';description=pluginCopy._backendProperties[name].description"
+              <label ng-init="title='info';description=plugin._backendProperties[name].description"
                       class="control-label">
                 <span>{{name}}</span>
                 <span class="fa fa-info-circle"
@@ -29,12 +29,12 @@
                       tooltip-placement="right"
                       tooltip-append-to-body="true">
                 </span>
-                <span class="fa fa-asterisk" ng-if="pluginCopy._backendProperties[name].required"></span>
+                <span class="fa fa-asterisk" ng-if="plugin._backendProperties[name].required"></span>
               </label>
               <input type="text"
                       class="form-control"
-                      ng-model="pluginCopy.properties[name]"
-                      ng-disabled="pluginCopy.pluginTemplate && pluginCopy.lock[name]" />
+                      ng-model="plugin.properties[name]"
+                      ng-disabled="plugin.pluginTemplate && plugin.lock[name]" />
             </div>
           </div>
         </div>
@@ -43,7 +43,7 @@
   </div>
 </div>
 
-<div ng-if="isTransform && pluginCopy.name === 'Validator'">
+<div ng-if="isTransform && plugin.name === 'Validator'">
   <div class="col-lg-12">
     <div ng-include="'/assets/features/hydrator/templates/create/popovers/plugin-edit-validator-transform.html'"></div>
   </div>

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
@@ -30,22 +30,22 @@
     <button
       class="btn btn-sm btn-default pull-right"
       ng-click="PluginEditController.schemaClear()"
-      ng-if="(!pluginCopy.implicitSchema && !isDisabled)"
-      ng-disabled="pluginCopy.implicitSchema || pluginCopy.properties.format === 'clf' || pluginCopy.properties.format === 'syslog'">
+      ng-if="(!plugin.implicitSchema && !isDisabled)"
+      ng-disabled="plugin.implicitSchema || plugin.properties.format === 'clf' || plugin.properties.format === 'syslog'">
       Clear
     </button>
   </h4>
 
   <fieldset class="clearfix" ng-disabled="isDisabled">
     <my-schema-editor
-      ng-model="pluginCopy.outputSchema"
-      data-disabled="pluginCopy.implicitSchema || isDisabled"
-      plugin-properties="pluginCopy.properties"
+      ng-model="plugin.outputSchema"
+      data-disabled="plugin.implicitSchema || isDisabled"
+      plugin-properties="plugin.properties"
       config="PluginEditController.schemaProperties">
     </my-schema-editor>
   </fieldset>
 
-  <div ng-if="!pluginCopy.outputSchema && isDisabled && pluginCopy.properties.format !== 'clf' && pluginCopy.properties.format !== 'syslog'">
+  <div ng-if="!plugin.outputSchema && isDisabled && plugin.properties.format !== 'clf' && plugin.properties.format !== 'syslog'">
     <div class="well well-lg">
       <h4>There is no output schema</h4>
     </div>

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
@@ -22,7 +22,20 @@
     </ul>
   </div>
 
-  <h4>Output Schema</h4>
+  <h4>
+    <span ng-if="!isSink">Ouput Schema</span>
+    <span ng-if="isSink">Schema</span>
+
+    <span class="fa fa-asterisk ng-scope" ng-if="PluginEditController.isOutputSchemaRequired"></span>
+    <button
+      class="btn btn-sm btn-default pull-right"
+      ng-click="PluginEditController.schemaClear()"
+      ng-if="(!pluginCopy.implicitSchema && !isDisabled)"
+      ng-disabled="pluginCopy.implicitSchema || pluginCopy.properties.format === 'clf' || pluginCopy.properties.format === 'syslog'">
+      Clear
+    </button>
+  </h4>
+
   <fieldset class="clearfix" ng-disabled="isDisabled">
     <my-schema-editor
       ng-model="pluginCopy.outputSchema"

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-properties-template.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-properties-template.html
@@ -23,6 +23,7 @@
       </div>
       <div ng-repeat="group in PluginEditController.config.groups.position">
         <div class="widget-group-container">
+          <h4>{{PluginEditController.config.groups[group].display}}</h4>
           <div ng-repeat="field in PluginEditController.groups[group].position">
             <div ng-if="field !== 'schema'">
               <div class="form-group">

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-properties-template.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-properties-template.html
@@ -15,11 +15,12 @@
 -->
 
 <form plugin-property-edit-view>
+  p:{{plugin.properties}}
   <fieldset ng-disabled="isDisabled">
       <h4>Configuration</h4>
       <div class="form-group">
         <label class="control-label">Label</label>
-        <input type="text" class="form-control" ng-model="pluginCopy.label"/>
+        <input type="text" class="form-control" ng-model="plugin.label"/>
       </div>
       <div ng-repeat="group in PluginEditController.config.groups.position">
         <div class="widget-group-container">
@@ -42,10 +43,10 @@
                        class="my-widget-container"
                        data-info="{{plugin.myconfig.widget}}"
                        ng-class="{'select-wrapper': PluginEditController.groups[group].fields[field].widget === 'select'}"
-                       data-model="pluginCopy.properties[field]"
+                       data-model="plugin.properties[field]"
                        data-myconfig="PluginEditController.groups[group].fields[field]"
-                       data-properties="pluginCopy.properties"
-                       widget-disabled="pluginCopy.pluginTemplate && pluginCopy.lock[field]"
+                       data-properties="plugin.properties"
+                       widget-disabled="plugin.pluginTemplate && plugin.lock[field]"
                        widget-container>
                   </div>
                 </div>

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-validator-transform.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-validator-transform.html
@@ -17,4 +17,4 @@
 <my-validators
   input-schema="inputSchema"
   is-disabled="isDisabled"
-  ng-model="pluginCopy"></my-validators>
+  ng-model="plugin"></my-validators>

--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -633,22 +633,6 @@ angular.module(PKG.name + '.services')
     this.save = function() {
       var defer = $q.defer();
 
-      if (MyNodeConfigService.getIsPluginBeingEdited()) {
-        // This should have been a popup that we show for un-saved changes while switching the node.
-        // Couldn't do it here because we cannot set it to another plugin. Hence the console message.
-        // If we are able to fuse 4 hydrogen atoms and things turn out good, we will have auto-correct
-        // in the next realease and we should be able to remove a majority of
-        // communication happening with save and reset in node configuration.
-        this.notifyError({
-          canvas: [
-            GLOBALS.en.hydrator.studio.unsavedPluginMessage1 +
-            MyNodeConfigService.plugin.label +
-            GLOBALS.en.hydrator.studio.unsavedPluginMessage2
-          ]
-        });
-        defer.reject();
-        return defer.promise;
-      }
       this.isConfigTouched = false;
       var config = this.getConfig();
       var errors = HydratorErrorFactory.isModelValid(this.nodes, this.connections, this.metadata, config);

--- a/cdap-ui/templates/cdap-etl-batch/File.json
+++ b/cdap-ui/templates/cdap-etl-batch/File.json
@@ -43,8 +43,8 @@
       }
     }
   },
-  "implicit": {
-    "schema": {
+  "outputschema":{
+    "implicit": {
       "ts": "long",
       "body": "string"
     }

--- a/cdap-ui/templates/cdap-etl-batch/S3Avro.json
+++ b/cdap-ui/templates/cdap-etl-batch/S3Avro.json
@@ -28,10 +28,11 @@
       }
     }
   },
-  "schema" : {
-     "widget": "schema",
-     "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
-     "schema-default-type" : "string"
+  "outputschema": {
+    "schema" : {
+       "widget": "schema",
+       "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
+       "schema-default-type" : "string"
+    }
   }
-
 }

--- a/cdap-ui/templates/cdap-etl-batch/S3Parquet.json
+++ b/cdap-ui/templates/cdap-etl-batch/S3Parquet.json
@@ -28,10 +28,11 @@
       }
     }
   },
-  "schema" : {
-     "widget": "schema",
-     "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
-     "schema-default-type" : "string"
+  "outputschema": {
+    "schema" : {
+       "widget": "schema",
+       "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
+       "schema-default-type" : "string"
+    }
   }
-
 }

--- a/cdap-ui/templates/cdap-etl-batch/SnapshotAvro.json
+++ b/cdap-ui/templates/cdap-etl-batch/SnapshotAvro.json
@@ -18,9 +18,11 @@
       }
     }
   },
-  "schema" : {
-    "widget": "schema",
-    "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
-    "schema-default-type" : "string"
+  "outputschema": {
+    "schema" : {
+      "widget": "schema",
+      "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
+      "schema-default-type" : "string"
+    }
   }
 }

--- a/cdap-ui/templates/cdap-etl-batch/SnapshotParquet.json
+++ b/cdap-ui/templates/cdap-etl-batch/SnapshotParquet.json
@@ -18,9 +18,11 @@
       }
     }
   },
-  "schema" : {
-    "widget": "schema",
-    "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
-    "schema-default-type" : "string"
+  "outputschema": {
+    "schema" : {
+      "widget": "schema",
+      "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
+      "schema-default-type" : "string"
+    }
   }
 }

--- a/cdap-ui/templates/cdap-etl-batch/Stream.json
+++ b/cdap-ui/templates/cdap-etl-batch/Stream.json
@@ -38,10 +38,12 @@
        }
     }
   },
-  "schema" : {
-    "widget": "schema",
-    "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
-    "schema-default-type" : "string",
-    "property-watch": "format"
+  "outputschema": {
+    "schema" : {
+      "widget": "schema",
+      "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
+      "schema-default-type" : "string",
+      "property-watch": "format"
+    }
   }
 }

--- a/cdap-ui/templates/cdap-etl-batch/TPFSAvro.json
+++ b/cdap-ui/templates/cdap-etl-batch/TPFSAvro.json
@@ -38,9 +38,11 @@
        }
     }
   },
-  "schema" : {
-     "widget": "schema",
-     "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
-     "schema-default-type" : "string"
+  "outputschema": {
+    "schema" : {
+       "widget": "schema",
+       "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
+       "schema-default-type" : "string"
+    }
   }
 }

--- a/cdap-ui/templates/cdap-etl-batch/TPFSParquet.json
+++ b/cdap-ui/templates/cdap-etl-batch/TPFSParquet.json
@@ -28,9 +28,11 @@
        }
     }
   },
-  "schema" : {
-     "widget": "schema",
-     "schema-types" : [ "boolean", "int", "long", "float", "double", "string", "map<string, string>" ],
-     "schema-default-type" : "string"
+  "outputschema": {
+    "schema" : {
+      "widget": "schema",
+      "schema-types" : [ "boolean", "int", "long", "float", "double", "string", "map<string, string>" ],
+      "schema-default-type" : "string"
+    }
   }
 }

--- a/cdap-ui/templates/cdap-etl-realtime/Jms.json
+++ b/cdap-ui/templates/cdap-etl-realtime/Jms.json
@@ -67,8 +67,8 @@
     }
 
   },
-  "implicit": {
-    "schema": {
+  "outputschema": {
+    "implicit": {
       "message": "string"
     }
   }

--- a/cdap-ui/templates/cdap-etl-realtime/Kafka.json
+++ b/cdap-ui/templates/cdap-etl-realtime/Kafka.json
@@ -73,10 +73,12 @@
        }
     }
   },
-  "schema" : {
-     "widget": "schema",
-     "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
-     "schema-default-type" : "string",
-     "property-watch": "format"
+  "outputschema": {
+    "schema" : {
+      "widget": "schema",
+      "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
+      "schema-default-type" : "string",
+      "property-watch": "format"
+    }
   }
 }

--- a/cdap-ui/templates/cdap-etl-realtime/Twitter.json
+++ b/cdap-ui/templates/cdap-etl-realtime/Twitter.json
@@ -47,8 +47,8 @@
       }
     }
   },
-  "implicit": {
-    "schema": {
+  "outputschema": {
+    "implicit": {
       "id": "long",
       "message": "string",
       "lang": ["string", "null"],

--- a/cdap-ui/templates/common/KVTable.json
+++ b/cdap-ui/templates/common/KVTable.json
@@ -24,8 +24,8 @@
        }
     }
   },
-  "implicit" : {
-    "schema": {
+  "outputschema": {
+    "implicit": {
       "key": "bytes",
       "value": "bytes"
     }

--- a/cdap-ui/templates/common/Script.json
+++ b/cdap-ui/templates/common/Script.json
@@ -15,9 +15,11 @@
        }
     }
   },
-  "schema" : {
-     "widget": "schema",
-     "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
-     "schema-default-type" : "string"
+  "outputschema": {
+    "schema" : {
+      "widget": "schema",
+      "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
+      "schema-default-type" : "string"
+    }
   }
 }

--- a/cdap-ui/templates/common/Table.json
+++ b/cdap-ui/templates/common/Table.json
@@ -20,10 +20,12 @@
        }
     }
   },
-  "schema" : {
-     "widget": "schema",
-     "description" : "Specify the schema for the table",
-     "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
-     "schema-default-type" : "string"
+  "outputschema": {
+    "schema" : {
+      "widget": "schema",
+      "description" : "Specify the schema for the table",
+      "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
+      "schema-default-type" : "string"
+    }
   }
 }


### PR DESCRIPTION
- Fixes displaying group names provided in plugin's node proxy configuration 
- Adds a border for groups in node configuration
- Removes 'Save' & 'Reset' buttons from node configuration tabs.
- Removes hardcoding 'schema' property in UI. 
   - Replaces schema with 'outputschema' as explicit label in node proxy to mark a field as output schema.
   - The reasoning behind this is to have any name for a property and assign it as output schema. The end goal is to have multiple output schema. Right now we assume only 1 output schema.