### PR TITLE
Update CDAP SDK docs for Windows

### DIFF
--- a/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
@@ -23,16 +23,22 @@ CDAP Software Development Kit (SDK)
 
 .. rubric:: System Requirements and Dependencies
 
-The CDAP SDK runs on Linux, MacOS and Windows, and has three requirements:
+The CDAP SDK runs on Linux, MacOS and Windows, and has these requirements:
 
 - `JDK 7 or 8 <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__ 
   (required to run CDAP; note that $JAVA_HOME should be set)
 - `Node.js <http://nodejs.org/dist/>`__ (|node-js-version|; required to run the CDAP UI; we recommend |recommended-node-js-version|)
 - `Apache Maven 3.0+ <http://maven.apache.org>`__ (required to build CDAP applications)
 
+If you are **running under Microsoft Windows**, you will need to have installed the 
+`Microsoft Visual C++ 2010 Redistributable Package
+<http://www.microsoft.com/en-us/download/details.aspx?id=14632>`__ in order to have the
+required DLLs to run Hadoop and CDAP; currently, CDAP is supported only on 64-bit Windows
+platforms.
+
 .. _recommend-using-an-ide:
 
-We recommend using an IDE when building CDAP applications, such as either `IntelliJ
+**We recommend using an IDE** when building CDAP applications, such as either `IntelliJ
 <https://www.jetbrains.com/idea/>`__ or `Eclipse, <https://www.eclipse.org/>`__ as
 described in the section on :ref:`development environment setup. <dev-env>`
 


### PR DESCRIPTION
Quick Build passed: http://builds.cask.co/browse/CDAP-DOB13-1

[Updated CDAP SDK docs](http://builds.cask.co/artifact/CDAP-DOB13/shared/build-1/Docs-HTML/3.2.0/en/developers-manual/getting-started/standalone/index.html#standalone-index)

Fix for https://issues.cask.co/browse/CDAP-3952