### PR TITLE
CDAP-3870 Adding logging and metrics support for transforms 

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/TransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/TransformContext.java
@@ -55,6 +55,12 @@ public interface TransformContext {
   Metrics getMetrics();
 
   /**
+   * Get the stage number of the transform, this is useful for setting the context for logging in transform.
+   * @return {@link Integer} stage number
+   */
+  Integer getStageId();
+
+  /**
    * Creates a new instance of a plugin.
    * The instance returned will have the {@link PluginConfig} setup with
    * {@link PluginProperties} provided at the time when the

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/BatchTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/BatchTransformContext.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.TransformContext;
+import co.cask.cdap.etl.common.PluginID;
 import co.cask.cdap.etl.common.ScopedPluginContext;
 
 /**
@@ -38,6 +39,11 @@ public class BatchTransformContext extends ScopedPluginContext implements Transf
   @Override
   public Metrics getMetrics() {
     return metrics;
+  }
+
+  @Override
+  public Integer getStageId() {
+    return PluginID.from(stageId).getStage();
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/MapReduceRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/MapReduceRuntimeContext.java
@@ -22,7 +22,9 @@ import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.common.PluginID;
 import co.cask.cdap.etl.common.ScopedPluginContext;
+import co.cask.cdap.etl.common.StageMetrics;
 
 import java.util.Map;
 
@@ -44,7 +46,12 @@ public class MapReduceRuntimeContext extends ScopedPluginContext implements Batc
 
   @Override
   public Metrics getMetrics() {
-    return metrics;
+    return new StageMetrics(metrics, PluginID.from(stageId));
+  }
+
+  @Override
+  public Integer getStageId() {
+    return PluginID.from(stageId).getStage();
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/RealtimeTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/RealtimeTransformContext.java
@@ -20,12 +20,17 @@ import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.worker.WorkerContext;
 import co.cask.cdap.etl.api.TransformContext;
+import co.cask.cdap.etl.common.PluginID;
 import co.cask.cdap.etl.common.ScopedPluginContext;
+import co.cask.cdap.etl.common.StageMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Context for the Transform Stage.
  */
 public class RealtimeTransformContext extends ScopedPluginContext implements TransformContext {
+  private static final Logger LOG = LoggerFactory.getLogger(RealtimeTransformContext.class);
   private final WorkerContext context;
   private final Metrics metrics;
 
@@ -37,7 +42,12 @@ public class RealtimeTransformContext extends ScopedPluginContext implements Tra
 
   @Override
   public Metrics getMetrics() {
-    return metrics;
+    return new StageMetrics(metrics, PluginID.from(stageId));
+  }
+
+  @Override
+  public Integer getStageId() {
+    return PluginID.from(stageId).getStage();
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptFilterTransform.java
@@ -31,6 +31,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
@@ -60,6 +62,7 @@ public class ScriptFilterTransform extends Transform<StructuredRecord, Structure
   private ScriptEngine engine;
   private Invocable invocable;
   private Metrics metrics;
+  private Logger logger;
 
   public ScriptFilterTransform(ScriptFilterConfig scriptFilterConfig) {
     this.scriptFilterConfig = scriptFilterConfig;
@@ -75,8 +78,9 @@ public class ScriptFilterTransform extends Transform<StructuredRecord, Structure
 
   @Override
   public void initialize(TransformContext context) {
-    init();
     metrics = context.getMetrics();
+    logger = LoggerFactory.getLogger(ScriptFilterTransform.class.getName() + ".stage-" + context.getStageId());
+    init();
   }
 
   @Override
@@ -97,6 +101,10 @@ public class ScriptFilterTransform extends Transform<StructuredRecord, Structure
   private void init() {
     ScriptEngineManager manager = new ScriptEngineManager();
     engine = manager.getEngineByName("JavaScript");
+
+    // initialize metrics and logging
+    engine.put("metrics", metrics);
+    engine.put("LOG", logger);
 
     // this is pretty ugly, but doing this so that we can pass the 'input' json into the shouldFilter function.
     // that is, we want people to implement

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ValidatorTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ValidatorTransform.java
@@ -87,6 +87,7 @@ public class ValidatorTransform extends Transform<StructuredRecord, StructuredRe
   private Metrics metrics;
   private Invocable invocable;
   private ScriptEngine engine;
+  private Logger logger;
 
   // for unit tests, otherwise config is injected by plugin framework.
   public ValidatorTransform(ValidatorConfig config) {
@@ -123,8 +124,9 @@ public class ValidatorTransform extends Transform<StructuredRecord, StructuredRe
 
   @VisibleForTesting
   void setUpInitialScript(TransformContext context, List<Validator> validators) throws ScriptException {
-    init(validators);
     metrics = context.getMetrics();
+    logger = LoggerFactory.getLogger(ValidatorTransform.class.getName() + ".stage-" + context.getStageId());
+    init(validators);
   }
 
   @Override
@@ -171,6 +173,8 @@ public class ValidatorTransform extends Transform<StructuredRecord, StructuredRe
     for (Validator validator : validators) {
       engine.put(validator.getValidatorName(), validator.getValidator());
     }
+    engine.put("metrics", metrics);
+    engine.put("LOG", logger);
 
     // this is pretty ugly, but doing this so that we can pass the 'input' json into the isValid function.
     // that is, we want people to implement

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/common/MockRealtimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/common/MockRealtimeContext.java
@@ -48,6 +48,11 @@ public class MockRealtimeContext implements RealtimeContext {
   }
 
   @Override
+  public Integer getStageId() {
+    return 1;
+  }
+
+  @Override
   public int getInstanceId() {
     return 0;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/MockTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/MockTransformContext.java
@@ -54,6 +54,11 @@ public class MockTransformContext implements TransformContext {
   }
 
   @Override
+  public Integer getStageId() {
+    return 1;
+  }
+
+  @Override
   public <T> T newPluginInstance(String pluginId) throws InstantiationException {
     return null;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/ScriptTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/ScriptTransformTest.java
@@ -77,7 +77,7 @@ public class ScriptTransformTest {
     ScriptTransform.Config config = new ScriptTransform.Config(
       "function transform(x) { x.intField = x.intField * 1024; return x; }", null);
     Transform<StructuredRecord, StructuredRecord> transform = new ScriptTransform(config);
-    transform.initialize(null);
+    transform.initialize(new MockTransformContext());
 
     MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(RECORD1, emitter);
@@ -129,7 +129,7 @@ public class ScriptTransformTest {
       "function transform(input) { return { 'x':input.intField, 'y':input.longField }; }",
       outputSchema.toString());
     Transform<StructuredRecord, StructuredRecord> transform = new ScriptTransform(config);
-    transform.initialize(null);
+    transform.initialize(new MockTransformContext());
 
     MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(RECORD1, emitter);
@@ -197,6 +197,8 @@ public class ScriptTransformTest {
       "  var e = input.inner1.list[0].e;\n" +
       "  var val = power(pi.val, 3) + power(e.val, 2);\n" +
       "  print(pi); print(e);\n" +
+      "  metrics.count(\"script.transform.count\", 1);\n" +
+      "  LOG.info(\"Log test from Script Transform\");\n" +
       "  return { 'x':val };\n" +
       "}" +
       "function power(x, y) { \n" +
@@ -208,7 +210,7 @@ public class ScriptTransformTest {
       "}",
       outputSchema.toString());
     Transform<StructuredRecord, StructuredRecord> transform = new ScriptTransform(config);
-    transform.initialize(null);
+    transform.initialize(new MockTransformContext());
 
     MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(input, emitter);

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/ValidatorTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/ValidatorTransformTest.java
@@ -50,6 +50,8 @@ public class ValidatorTransformTest {
         "      } else if (!coreValidator.isInRange(input.content_length, 0, 1024 * 1024)) {" +
         "         isValid = false; errMsg = \"content length >1MB\"; errCode = 10;" +
         "      }" +
+        " metrics.count(\"valid.processed\", 1);" +
+        " LOG.info(\"Test Log from Validator Transform\");" +
         "      return {'isValid': isValid, 'errorCode': errCode, 'errorMsg': errMsg}; " +
         "   };";
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/resources/logback-test.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/resources/logback-test.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright © 2015 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<!--                                                                         -->
+<!-- AppFabric Logging Configuration                                         -->
+<!--                                                                         -->
+<!-- We use the LogBack project for logging in AppFabric. The manual for     -->
+<!-- Logback can be found here: http://logback.qos.ch/manual                 -->
+<!--                                                                         -->
+
+<configuration>
+  <!--Supressing some chatty loggers -->
+  <logger name="org.apache.hadoop" level="INFO"/>
+  <logger name="org.mortbay.log" level="INFO"/>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{ISO8601} - %-5p [%t:%c{40}@%L] - %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="CLOG" class="co.cask.cdap.common.logging.logback.CAppender">              
+    <layout>                      
+      <!-- Note: we don't insert new line in the pattern as this is done on higher level (in old back-end) -->
+      <pattern>%d{ISO8601} - %-5p [%t:%c{40}@%L] - %m</pattern>       
+    </layout>
+  </appender>
+
+  <logger name="co.cask.cdap" level="INFO" />
+
+  <root level="WARN">
+    <appender-ref ref="CLOG"/>
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/LoggingConfiguration.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/LoggingConfiguration.java
@@ -51,7 +51,7 @@ public final class LoggingConfiguration {
   // Table used to store log metadata
   public static final String LOG_META_DATA_TABLE = "log.meta";
   // Defaults
-  public static final String DEFAULT_LOG_PATTERN = "%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n";
+  public static final String DEFAULT_LOG_PATTERN = "%d{ISO8601} - %-5p [%t:%c{40}@%L] - %m%n";
   public static final String DEFAULT_KAFKA_PRODUCER_TYPE = "async";
   public static final long DEFAULT_KAFKA_PROCUDER_BUFFER_MS = 1000;
   public static final String DEFAULT_NUM_PARTITIONS = "10";


### PR DESCRIPTION
Metrics context is similar to how we record filtered metrics currently. 
For Logging context,  Along with the class name we also add the stage number 
Example : co.cask.cdap.etl.transform.ValidatorTransform.stage-2

In order to show the ValidatorTransform along with the stage, i have modified the LogHandler default pattern to be the set context (``c``) instead of class name (``C``).

JIRA : https://issues.cask.co/browse/CDAP-3870