### PR TITLE
CDAP-3861 bugfix: use Futures.getUnChecked to make sure the services …

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractMasterTwillRunnable.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractMasterTwillRunnable.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.hadoop.conf.Configuration;
@@ -111,7 +112,9 @@ public abstract class AbstractMasterTwillRunnable extends AbstractTwillRunnable 
           Threads.SAME_THREAD_EXECUTOR);
     }
 
-    Services.chainStart(services.get(0), services.subList(1, services.size()).toArray(new Service[0]));
+    Futures.getUnchecked(
+      Services.chainStart(services.get(0), services.subList(1, services.size()).toArray(new Service[0])));
+
     LOG.info("Runnable started {}", name);
 
 
@@ -126,7 +129,8 @@ public abstract class AbstractMasterTwillRunnable extends AbstractTwillRunnable 
     }
 
     List<Service> reverse = Lists.reverse(services);
-    Services.chainStop(reverse.get(0), reverse.subList(1, reverse.size()).toArray(new Service[0]));
+    Futures.getUnchecked(
+      Services.chainStop(reverse.get(0), reverse.subList(1, reverse.size()).toArray(new Service[0])));
 
     LOG.info("Runnable stopped {}", name);
   }


### PR DESCRIPTION
…are started/stopped in AbstractMasterTwillRunnable