### PR TITLE
(CDAP-3951) Have S3BatchConfig extend FileBatchConfig, so users can r…

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/S3AvroBatchSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/S3AvroBatchSink.java
@@ -84,13 +84,15 @@ public class S3AvroBatchSink extends S3BatchSink<AvroKey<GenericRecord>, NullWri
     @Description(SCHEMA_DESC)
     private String schema;
 
+    @SuppressWarnings("unused")
     public S3AvroSinkConfig() {
       super();
     }
 
-    public S3AvroSinkConfig(String basePath, String pathFormat, String schema,
-                            String accessID, String accessKey) {
-      super(basePath, pathFormat, accessID, accessKey);
+    @SuppressWarnings("unused")
+    public S3AvroSinkConfig(String basePath, String schema, String accessID, String accessKey, String pathFormat,
+                            String filesystemProperties) {
+      super(basePath, accessID, accessKey, pathFormat, filesystemProperties);
       this.schema = schema;
     }
   }
@@ -103,6 +105,7 @@ public class S3AvroBatchSink extends S3BatchSink<AvroKey<GenericRecord>, NullWri
     private final Map<String, String> conf;
 
     public S3AvroOutputFormatProvider(S3AvroSinkConfig config, BatchSinkContext context) {
+      @SuppressWarnings("ConstantConditions")
       SimpleDateFormat format = new SimpleDateFormat(config.pathFormat);
 
       conf = Maps.newHashMap();

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/S3ParquetBatchSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/S3ParquetBatchSink.java
@@ -81,13 +81,15 @@ public class S3ParquetBatchSink extends S3BatchSink<Void, GenericRecord> {
     @Description(SCHEMA_DESC)
     private String schema;
 
+    @SuppressWarnings("unused")
     public S3ParquetSinkConfig() {
       super();
     }
 
-    public S3ParquetSinkConfig(String basePath, String pathFormat, String schema,
-                               String accessID, String accessKey) {
-      super(basePath, pathFormat, accessID, accessKey);
+    @SuppressWarnings("unused")
+    public S3ParquetSinkConfig(String basePath, String schema, String accessID, String accessKey, String pathFormat,
+                               String fileSystemProperties) {
+      super(basePath, accessID, accessKey, pathFormat, fileSystemProperties);
       this.schema = schema;
     }
   }
@@ -100,6 +102,7 @@ public class S3ParquetBatchSink extends S3BatchSink<Void, GenericRecord> {
     private final Map<String, String> conf;
 
     public S3ParquetOutputFormatProvider(S3ParquetSinkConfig config, BatchSinkContext context) {
+      @SuppressWarnings("ConstantConditions")
       SimpleDateFormat format = new SimpleDateFormat(config.pathFormat);
 
       conf = Maps.newHashMap();

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/S3BatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/S3BatchSource.java
@@ -19,11 +19,13 @@ package co.cask.cdap.etl.batch.source;
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
-import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.etl.api.batch.BatchSource;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -35,68 +37,56 @@ import javax.annotation.Nullable;
 public class S3BatchSource extends FileBatchSource {
   private static final String ACCESS_ID_DESCRIPTION = "Access ID of the Amazon S3 instance to connect to.";
   private static final String ACCESS_KEY_DESCRIPTION = "Access Key of the Amazon S3 instance to connect to.";
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
+  @SuppressWarnings("unused")
   private final S3BatchConfig config;
 
   public S3BatchSource(S3BatchConfig config) {
-    super(new FileBatchConfig("S3", config.path, config.fileRegex, config.timeTable, config.inputFormatClass,
-                              createFileSystemProperties(config.accessID, config.accessKey), config.maxSplitSize));
+    // update fileSystemProperties with S3 properties, so FileBatchSource.prepareRun can use them
+    super(new FileBatchConfig(config.path, config.fileRegex, config.timeTable, config.inputFormatClass,
+                              updateFileSystemProperties(
+                                config.fileSystemProperties, config.accessID, config.accessKey
+                              ),
+                              config.maxSplitSize));
     this.config = config;
   }
 
-  private static String createFileSystemProperties(String accessID, String accessKey) {
-    return new Gson().toJson(ImmutableMap.of(
-      "fs.s3n.awsAccessKeyId", accessID,
-      "fs.s3n.awsSecretAccessKey", accessKey
-    ));
+  private static String updateFileSystemProperties(@Nullable String fileSystemProperties, String accessID,
+                                                   String accessKey) {
+    Map<String, String> providedProperties;
+    if (fileSystemProperties == null) {
+      providedProperties = new HashMap<>();
+    } else {
+      providedProperties = GSON.fromJson(fileSystemProperties, MAP_STRING_STRING_TYPE);
+    }
+    providedProperties.put("fs.s3n.awsAccessKeyId", accessID);
+    providedProperties.put("fs.s3n.awsSecretAccessKey", accessKey);
+    return GSON.toJson(providedProperties);
   }
 
   /**
    * Config class that contains properties needed for the S3 source.
    */
-  public static class S3BatchConfig extends PluginConfig {
-    @Name("accessID")
+  public static class S3BatchConfig extends FileBatchConfig {
     @Description(ACCESS_ID_DESCRIPTION)
     private String accessID;
 
-    @Name("accessKey")
     @Description(ACCESS_KEY_DESCRIPTION)
     private String accessKey;
 
-    @Name("path")
-    @Description(PATH_DESCRIPTION)
-    private String path;
-
-    @Name("fileRegex")
-    @Nullable
-    @Description(REGEX_DESCRIPTION)
-    private String fileRegex;
-
-    @Name("timeTable")
-    @Nullable
-    @Description(TABLE_DESCRIPTION)
-    private String timeTable;
-
-    @Name("inputFormatClass")
-    @Nullable
-    @Description(INPUT_FORMAT_CLASS_DESCRIPTION)
-    private String inputFormatClass;
-
-    @Name("maxSplitSize")
-    @Nullable
-    @Description(MAX_SPLIT_SIZE_DESCRIPTION)
-    private String maxSplitSize;
+    public S3BatchConfig(String accessID, String accessKey, String path) {
+      this(accessID, accessKey, path, null, null, null, null, null);
+    }
 
     public S3BatchConfig(String accessID, String accessKey, String path, @Nullable String regex,
                          @Nullable String timeTable, @Nullable String inputFormatClass,
-                         @Nullable String maxSplitSize) {
+                         @Nullable String fileSystemProperties, @Nullable String maxSplitSize) {
+      super(path, regex, timeTable, inputFormatClass,
+            updateFileSystemProperties(fileSystemProperties, accessID, accessKey), maxSplitSize);
       this.accessID = accessID;
       this.accessKey = accessKey;
-      this.path = path;
-      this.fileRegex = regex;
-      this.timeTable = timeTable;
-      this.inputFormatClass = inputFormatClass;
-      this.maxSplitSize = maxSplitSize;
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/common/BatchFileFilter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/common/BatchFileFilter.java
@@ -80,7 +80,8 @@ public class BatchFileFilter extends Configured implements PathFilter {
 
     //filter by file name using regex from configuration
     if (!useTimeFilter) {
-      Matcher matcher = regex.matcher(filePathName);
+      String fileName = path.getName();
+      Matcher matcher = regex.matcher(fileName);
       return matcher.matches();
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/batch/sink/S3BatchSinkTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/batch/sink/S3BatchSinkTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.sink;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Tests for {@link S3BatchSink} configuration.
+ */
+public class S3BatchSinkTest {
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+
+  @Test
+  public void testFileSystemProperties() {
+    String accessID = "accessID";
+    String accessKey = "accessKey";
+    String path = "/path";
+    String schema = "schema";
+    // Test default properties
+    S3AvroBatchSink.S3AvroSinkConfig s3AvroSinkConfig =
+      new S3AvroBatchSink.S3AvroSinkConfig(path, schema, accessID, accessKey, null, null);
+    S3AvroBatchSink s3AvroBatchSink = new S3AvroBatchSink(s3AvroSinkConfig);
+    S3BatchSink.S3BatchSinkConfig s3BatchSinkConfig = s3AvroBatchSink.getConfig();
+    Map<String, String> fsProperties = GSON.fromJson(s3BatchSinkConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);
+    Assert.assertNotNull(fsProperties);
+    Assert.assertEquals(2, fsProperties.size());
+    Assert.assertEquals(accessID, fsProperties.get("fs.s3n.awsAccessKeyId"));
+    Assert.assertEquals(accessKey, fsProperties.get("fs.s3n.awsSecretAccessKey"));
+
+    // Test extra properties
+    S3ParquetBatchSink.S3ParquetSinkConfig s3ParquetSinkConfig =
+      new S3ParquetBatchSink.S3ParquetSinkConfig(path, schema, accessID, accessKey, null,
+                                                 GSON.toJson(ImmutableMap.of("s3.compression", "gzip")));
+    S3ParquetBatchSink s3ParquetBatchSink = new S3ParquetBatchSink(s3ParquetSinkConfig);
+    s3BatchSinkConfig = s3ParquetBatchSink.getConfig();
+    fsProperties = GSON.fromJson(s3BatchSinkConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);
+    Assert.assertNotNull(fsProperties);
+    Assert.assertEquals(3, fsProperties.size());
+    Assert.assertEquals(accessID, fsProperties.get("fs.s3n.awsAccessKeyId"));
+    Assert.assertEquals(accessKey, fsProperties.get("fs.s3n.awsSecretAccessKey"));
+    Assert.assertEquals("gzip", fsProperties.get("s3.compression"));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/batch/source/S3BatchSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/batch/source/S3BatchSourceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.source;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Tests for {@link S3BatchSource} configuration.
+ */
+public class S3BatchSourceTest {
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+
+  @Test
+  public void testFileSystemProperties() {
+    String accessID = "accessID";
+    String accessKey = "accessKey";
+    String path = "/path";
+    // Test default properties
+    S3BatchSource.S3BatchConfig s3BatchConfig = new S3BatchSource.S3BatchConfig(accessID, accessKey, path);
+    S3BatchSource s3BatchSource = new S3BatchSource(s3BatchConfig);
+    FileBatchSource.FileBatchConfig fileBatchConfig = s3BatchSource.getConfig();
+    Map<String, String> fsProperties = GSON.fromJson(fileBatchConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);
+    Assert.assertNotNull(fsProperties);
+    Assert.assertEquals(2, fsProperties.size());
+    Assert.assertEquals(accessID, fsProperties.get("fs.s3n.awsAccessKeyId"));
+    Assert.assertEquals(accessKey, fsProperties.get("fs.s3n.awsSecretAccessKey"));
+
+    // Test extra properties
+    s3BatchConfig = new S3BatchSource.S3BatchConfig(accessID, accessKey, path, null, null, null,
+                                                    GSON.toJson(ImmutableMap.of("s3.compression", "gzip")), null);
+    s3BatchSource = new S3BatchSource(s3BatchConfig);
+    fileBatchConfig = s3BatchSource.getConfig();
+    fsProperties = GSON.fromJson(fileBatchConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);
+    Assert.assertNotNull(fsProperties);
+    Assert.assertEquals(3, fsProperties.size());
+    Assert.assertEquals(accessID, fsProperties.get("fs.s3n.awsAccessKeyId"));
+    Assert.assertEquals(accessKey, fsProperties.get("fs.s3n.awsSecretAccessKey"));
+    Assert.assertEquals("gzip", fsProperties.get("s3.compression"));
+  }
+}

--- a/cdap-ui/templates/cdap-etl-batch/File.json
+++ b/cdap-ui/templates/cdap-etl-batch/File.json
@@ -6,11 +6,6 @@
       "display" : "File Batch Source Properties",
       "position" : [ "fileSystem", "fileSystemProperties", "path", "fileRegex", "timeTable", "inputFormatClass", "maxSplitSize" ],
       "fields" : {
-        "fileSystem" : {
-          "widget": "textbox",
-          "label": "File System"
-        },
-
         "fileSystemProperties" : {
           "widget": "json-editor",
           "label": "File System Properties"

--- a/cdap-ui/templates/cdap-etl-batch/S3.json
+++ b/cdap-ui/templates/cdap-etl-batch/S3.json
@@ -6,6 +6,11 @@
       "display" : "S3 Batch Source",
       "position" : [ "accessID", "accessKey", "path", "fileRegex", "timeTable", "inputFormatClass", "maxSplitSize" ],
       "fields" : {
+        "fileSystemProperties" : {
+          "widget": "json-editor",
+          "label": "File System Properties"
+        },
+
         "accessID" : {
           "widget": "textbox",
           "label": "Access ID"

--- a/cdap-ui/templates/cdap-etl-batch/S3Avro.json
+++ b/cdap-ui/templates/cdap-etl-batch/S3Avro.json
@@ -6,6 +6,11 @@
       "display" : "S3 Sink - Avro",
       "position" : [ "accessID", "accessKey", "basePath", "pathFormat"],
       "fields" : {
+        "fileSystemProperties" : {
+          "widget": "json-editor",
+          "label": "File System Properties"
+        },
+
         "accessID" : {
           "widget": "textbox",
           "label": "Access ID"

--- a/cdap-ui/templates/cdap-etl-batch/S3Parquet.json
+++ b/cdap-ui/templates/cdap-etl-batch/S3Parquet.json
@@ -6,6 +6,11 @@
       "display" : "S3 Sink - Parquet",
       "position" : [ "accessID", "accessKey", "basePath", "pathFormat"],
       "fields" : {
+        "fileSystemProperties" : {
+          "widget": "json-editor",
+          "label": "File System Properties"
+        },
+
         "accessID" : {
           "widget": "textbox",
           "label": "Access ID"


### PR DESCRIPTION
…e-use fileSystemProperties to send file system configurations to Hadoop, like in FileBatchSource.

- Remove the unused fileSystem property from FileBatchSource. Other minor cleanup.
- Introduce fileSystemProperties for S3 Batch Sinks.

(CDAP-3815) Fix FileBatchFilter to apply the provided regex filter on file names instead of on the complete path. Also update S3 MapReduce test to test this behavior.

Jiras: 
[CDAP-3951](https://issues.cask.co/browse/CDAP-3951)
[CDAP-3815](https://issues.cask.co/browse/CDAP-3815)

Build: http://builds.cask.co/browse/CDAP-RBT506-1