### PR TITLE
fixes instance control styling in Safari

### DIFF
--- a/cdap-ui/app/directives/instance-control/instance-control.html
+++ b/cdap-ui/app/directives/instance-control/instance-control.html
@@ -1,18 +1,18 @@
 <!--
   Copyright © 2015 Cask Data, Inc.
- 
+
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
   the License at
- 
+
   http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
   License for the specific language governing permissions and limitations under
   the License.
---> 
+-->
 
 <table class="table table-curved borderless">
   <tr>

--- a/cdap-ui/app/directives/instance-control/instance-control.less
+++ b/cdap-ui/app/directives/instance-control/instance-control.less
@@ -52,16 +52,21 @@ my-instance-control {
   }
 
   input[type="number"] {
+    padding: 0 12px 0 0;
+    text-indent: 12px;
     position: relative;
+
     // Only apply number input styling to Chrome
     @supports (-webkit-appearance:none) {
       &.mod::-webkit-outer-spin-button,
       &.mod::-webkit-inner-spin-button {
         display: block;
-        width: 45px;
+        width: 32px;
         height: 32px;
         border-left: 1px solid @table-border-color;
         color: @cdap-header;
+        overflow: hidden;
+        padding-right: 12px;
         position: absolute;
         top: 0;
         right: 0;
@@ -72,8 +77,8 @@ my-instance-control {
         &:before, &:after {
           display: block;
           font-family: 'FontAwesome';
-          width: 8px;
-          margin: 0 auto;
+          width: 32px;
+          text-align: center;
         }
         &:before {
           content: '\f0d8';
@@ -85,10 +90,11 @@ my-instance-control {
         }
       }
       + span {
+        background-image: url('@{img-path}/divider.png');
+        display: block;
         position: absolute;
-        width: 46px;
-        background-color: @table-border-color;
         height: 1px;
+        width: 46px;
         right: 10px;
         bottom: 25px;
       }


### PR DESCRIPTION
*  Fixes instance control (number input) in Service detail view
*  As styling of the number input is only possible with webkit, non-webkit browsers will default to their native styling for this element (see graphics below)

Safari:
![safari](https://cloud.githubusercontent.com/assets/5335210/10467121/db0d6782-71ac-11e5-80cb-05a7aaf4e5fc.gif)


Chrome:
![chrome](https://cloud.githubusercontent.com/assets/5335210/10467113/d66c224a-71ac-11e5-98b4-d61645687b6f.gif)


Firefox:
![ff](https://cloud.githubusercontent.com/assets/5335210/10467109/cfda5d98-71ac-11e5-9af7-5d1d3c7d30df.gif)
