### PR TITLE
Upgrade kafka version to 0.8.2.2 to include the fix for KAFKA-1228

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/realtime/source/KafkaSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/realtime/source/KafkaSourceTest.java
@@ -273,7 +273,7 @@ public class KafkaSourceTest {
     prop.setProperty("log.retention.hours", "24");
     prop.setProperty("log.flush.interval.messages", "10");
     prop.setProperty("log.flush.interval.ms", "1000");
-    prop.setProperty("log.segment.bytes", "100");
+    prop.setProperty("log.segment.bytes", "200");
     prop.setProperty("zookeeper.connect", zkConnectStr);
     prop.setProperty("zookeeper.connection.timeout.ms", "1000000");
     prop.setProperty("default.replication.factor", "1");

--- a/cdap-notifications/src/test/java/co/cask/cdap/notifications/kafka/KafkaNotificationTest.java
+++ b/cdap-notifications/src/test/java/co/cask/cdap/notifications/kafka/KafkaNotificationTest.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.KafkaConstants;
 import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.notifications.NotificationTest;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import com.google.common.base.Preconditions;
@@ -37,6 +38,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -84,8 +87,32 @@ public class KafkaNotificationTest extends NotificationTest {
     // TODO remove once Twill addLatest bug is fixed
     feedManager.createFeed(FEED1);
     feedManager.createFeed(FEED2);
-    getNotificationService().publish(FEED1, "test").get();
-    getNotificationService().publish(FEED2, "test").get();
+
+    // Try to publish to the feeds. Needs to retry multiple times due to race between Kafka server registers itself
+    // to ZK and the publisher be able to see the changes in the ZK to get the broker list
+    Tasks.waitFor(true, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        try {
+          getNotificationService().publish(FEED1, "test").get();
+          return true;
+        } catch (Throwable t) {
+          return false;
+        }
+      }
+    }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+    Tasks.waitFor(true, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        try {
+          getNotificationService().publish(FEED2, "test").get();
+          return true;
+        } catch (Throwable t) {
+          return false;
+        }
+      }
+    }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+
     feedManager.deleteFeed(FEED1);
     feedManager.deleteFeed(FEED2);
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/StringPartitioner.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/StringPartitioner.java
@@ -28,7 +28,7 @@ import kafka.utils.VerifiableProperties;
  * A simple partitioner based on String keys.
  */
 @SuppressWarnings("UnusedDeclaration")
-public final class StringPartitioner implements Partitioner<String> {
+public final class StringPartitioner implements Partitioner {
   private final int numPartitions;
 
   public StringPartitioner(VerifiableProperties props) {
@@ -45,7 +45,7 @@ public final class StringPartitioner implements Partitioner<String> {
   }
 
   @Override
-  public int partition(String key, int numPartitions) {
-    return Math.abs(Hashing.md5().hashString(key).asInt()) % this.numPartitions;
+  public int partition(Object key, int numPartitions) {
+    return Math.abs(Hashing.md5().hashString(key.toString()).asInt()) % this.numPartitions;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <jetty8.version>8.1.15.v20140411</jetty8.version>
     <jline.version>2.12</jline.version>
     <junit.version>4.11</junit.version>
-    <kafka.version>0.8.0</kafka.version>
+    <kafka.version>0.8.2.2</kafka.version>
     <leveldb.version>0.6</leveldb.version>
     <logback.version>1.0.9</logback.version>
     <mockito.version>1.9.5</mockito.version>


### PR DESCRIPTION
Upgrade kafka version to 0.8.2.2 to include the fix for https://issues.apache.org/jira/browse/KAFKA-1228.

Tested on SDK, this resolves the issue we were facing in CDAP-3963.
Will test on cluster shortly.

https://issues.cask.co/browse/CDAP-3963
http://builds.cask.co/browse/CDAP-RBT507-4