### PR TITLE
CDAP-3990 allow adding the same dataset instance or module

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/internal/dataset/DatasetCreationSpec.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/dataset/DatasetCreationSpec.java
@@ -18,6 +18,8 @@ package co.cask.cdap.internal.dataset;
 
 import co.cask.cdap.api.dataset.DatasetProperties;
 
+import java.util.Objects;
+
 /**
  * Information for creating dataset instance.
  */
@@ -42,5 +44,26 @@ public final class DatasetCreationSpec {
 
   public DatasetProperties getProperties() {
     return props;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DatasetCreationSpec that = (DatasetCreationSpec) o;
+
+    return Objects.equals(instanceName, that.instanceName) &&
+      Objects.equals(typeName, that.typeName) &&
+      Objects.equals(props.getProperties(), that.props.getProperties());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(instanceName, typeName, props.getProperties());
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/DefaultDatasetConfigurerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/DefaultDatasetConfigurerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app;
+
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.internal.api.DefaultDatasetConfigurer;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class DefaultDatasetConfigurerTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDuplicateDatasetModules() {
+    DefaultDatasetConfigurer configurer = new DefaultDatasetConfigurer();
+
+    configurer.addDatasetModule("TestModule", TestModule1.class);
+    // adding the same one multiple times is ok
+    configurer.addDatasetModule("TestModule", TestModule1.class);
+
+    // using a different class should fail
+    configurer.addDatasetModule("TestModule", TestModule2.class);
+  }
+
+  @Test
+  public void testDuplicateDatasetInstance() {
+    DefaultDatasetConfigurer configurer = new DefaultDatasetConfigurer();
+
+    configurer.createDataset("ds", Table.class.getName());
+    // adding the same one multiple times is ok
+    configurer.createDataset("ds", Table.class);
+    configurer.createDataset("ds", Table.class.getName(), DatasetProperties.EMPTY);
+    configurer.createDataset("ds", Table.class, DatasetProperties.EMPTY);
+
+    // adding a different one with the same name should fail
+    try {
+      configurer.createDataset("ds", "Taybull");
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    try {
+      configurer.createDataset("ds", IndexedTable.class);
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    try {
+      configurer.createDataset("ds", "Table", DatasetProperties.builder().add("k", "v").build());
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    try {
+      configurer.createDataset("ds", Table.class, DatasetProperties.builder().add("k", "v").build());
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  private static class TestModule1 implements DatasetModule {
+    @Override
+    public void register(DatasetDefinitionRegistry registry) {
+      //no-op
+    }
+  }
+
+  private static class TestModule2 implements DatasetModule {
+    @Override
+    public void register(DatasetDefinitionRegistry registry) {
+      //no-op
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithDuplicateData.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithDuplicateData.java
@@ -20,29 +20,27 @@ import co.cask.cdap.api.Config;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.dataset.lib.IndexedTable;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.worker.AbstractWorker;
 
 /**
  * App with streams, datasets, plugins added multiple times that should result in an error.
  */
-public class AppWithDuplicateStreams extends AbstractApplication<AppWithDuplicateStreams.ConfigClass> {
+public class AppWithDuplicateData extends AbstractApplication<AppWithDuplicateData.ConfigClass> {
 
   public static class ConfigClass extends Config {
-    private boolean multiStreams;
     private boolean multiDatasets;
     private boolean multiPlugins;
     private boolean multiModules;
 
     public ConfigClass() {
       multiDatasets = false;
-      multiStreams = false;
       multiPlugins = false;
       multiModules = false;
     }
 
-    public ConfigClass(boolean streams, boolean datasets, boolean plugins, boolean multiModules) {
-      this.multiStreams = streams;
+    public ConfigClass(boolean datasets, boolean plugins, boolean multiModules) {
       this.multiDatasets = datasets;
       this.multiPlugins = plugins;
       this.multiModules = multiModules;
@@ -52,12 +50,9 @@ public class AppWithDuplicateStreams extends AbstractApplication<AppWithDuplicat
   @Override
   public void configure() {
     ConfigClass config = getConfig();
-    if (config.multiStreams) {
-      addStream("input1");
-    }
 
     if (config.multiDatasets) {
-      createDataset("data1", KeyValueTable.class);
+      createDataset("data1", Table.class);
     }
 
     if (config.multiPlugins) {
@@ -65,7 +60,7 @@ public class AppWithDuplicateStreams extends AbstractApplication<AppWithDuplicat
     }
 
     if (config.multiModules) {
-      addDatasetModule(KeyValueTable.class.getName(), IndexedTable.class);
+      addDatasetModule("module", IndexedTable.class);
     }
     addWorker(new DumbWorker());
   }
@@ -80,8 +75,8 @@ public class AppWithDuplicateStreams extends AbstractApplication<AppWithDuplicat
     @Override
     protected void configure() {
       super.configure();
-      addStream("input1");
       createDataset("data1", KeyValueTable.class);
+      addDatasetModule("module", Table.class);
       usePlugin("t1", "n1", "plug", PluginProperties.builder().build());
     }
   }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -119,20 +119,20 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
   }
 
   @Test
-  public void testInvalidAppWithDuplicateStreams() throws Exception {
+  public void testInvalidAppWithDuplicateDatasets() throws Exception {
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "invalid-app", "1.0.0-SNAPSHOT");
-    addAppArtifact(artifactId, AppWithDuplicateStreams.class);
+    addAppArtifact(artifactId, AppWithDuplicateData.class);
 
     Id.Artifact pluginArtifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "test-plugin", "1.0.0-SNAPSHOT");
     addPluginArtifact(pluginArtifactId, artifactId, ToStringPlugin.class);
 
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "InvalidApp");
 
-    for (int choice = 8; choice > 0; choice /= 2) {
+    for (int choice = 4; choice > 0; choice /= 2) {
       try {
-        AppRequest<AppWithDuplicateStreams.ConfigClass> createRequest = new AppRequest<>(
+        AppRequest<AppWithDuplicateData.ConfigClass> createRequest = new AppRequest<>(
           new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()),
-          new AppWithDuplicateStreams.ConfigClass((choice == 8), (choice == 4), (choice == 2), (choice == 1)));
+          new AppWithDuplicateData.ConfigClass((choice == 4), (choice == 2), (choice == 1)));
         deployApplication(appId, createRequest);
         // fail if we succeed with application deployment
         Assert.fail();
@@ -141,9 +141,9 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
       }
     }
 
-    AppRequest<AppWithDuplicateStreams.ConfigClass> createRequest = new AppRequest<>(
+    AppRequest<AppWithDuplicateData.ConfigClass> createRequest = new AppRequest<>(
       new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()),
-      new AppWithDuplicateStreams.ConfigClass(false, false, false, false));
+      new AppWithDuplicateData.ConfigClass(false, false, false));
     deployApplication(appId, createRequest);
   }
 


### PR DESCRIPTION
Fixed a bug where the dataset configurer would error out if the
same dataset instance or module was added multiple times.
Enhancing the logic to check for equality, so that an exception
is only thrown if the same instance or module is added with a
different value.