### PR TITLE
CDAP-3822 Don't propagate the failure to create the Spark framework c…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -202,9 +202,6 @@ public class ArtifactInspector {
       ClassLoader pluginClassLoader = pluginInstantiator.getArtifactClassLoader(artifactId);
       for (Class<?> cls : getPluginClasses(exportPackages, pluginClassLoader)) {
         Plugin pluginAnnotation = cls.getAnnotation(Plugin.class);
-        if (pluginAnnotation == null) {
-          continue;
-        }
         Map<String, PluginPropertyField> pluginProperties = Maps.newHashMap();
         try {
           String configField = getProperties(TypeToken.of(cls), pluginProperties);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -306,7 +306,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
       @Override
       public void error(Throwable cause) {
-        LOG.error("Program runner error out.", cause);
+        LOG.error("Program runner errored out.", cause);
         state.setException(cause);
       }
     }, MoreExecutors.sameThreadExecutor());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
@@ -158,12 +158,6 @@ final class HttpHandlerGenerator {
         private boolean visitedPath = !inspectDelegate;
 
         @Override
-        public void visit(int version, int access, String name, String signature,
-                          String superName, String[] interfaces) {
-          super.visit(version, access, name, signature, superName, interfaces);
-        }
-
-        @Override
         public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
           // Copy the class annotation if it is @Path. Only do it for one time
           Type type = Type.getType(desc);


### PR DESCRIPTION
Opening PR for review of the approach, which I am unsure of.

Don't propagate the failure to create the Spark framework classloader. Instead, try to do without it.

https://issues.cask.co/browse/CDAP-3822