### PR TITLE
Improve SDK packaging

### DIFF
--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -332,6 +332,8 @@
                         <exclude>pom.xml</exclude>
                         <exclude>build.gradle</exclude>
                         <exclude>**/target/original*.jar</exclude>
+                        <exclude>**/target/apidocs/**</exclude>
+                        <exclude>**/target/stage-packaging*/**</exclude>
                       </excludes>
                     </resource>
                   </resources>


### PR DESCRIPTION
We have been including in the SDK's ``examples`` directories files that are not required. For example, in 3.2.0 SDK's *Purchase* example *target* directory:
```
Purchase-3.2.0-javadoc.jar
Purchase-3.2.0-sources.jar
Purchase-3.2.0.jar
apidocs
stage-packaging
stage-packaging-deb
```
Only the first three JARs are required; ``apidocs`` just has GIFs, and the ``stage-packaging`` directories has copies of the ``bin`` scripts included higher up.

This PR fixes that by excluding these directories, and reduces the file size of the ZIP...
