### PR TITLE
CDAP-3902: Remove remote call for registering dataset usage in DatasetInstanceService

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
+
+/**
+ * Provides metadata about datasets for {@link DatasetProvider}.
+ */
+public interface DatasetMetaProvider {
+
+  DatasetTypeMeta getType(Id.DatasetInstance instance) throws Exception;
+  DatasetSpecification getSpec(Id.DatasetInstance instance) throws Exception;
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetProvider.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
+import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
+import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
+import co.cask.cdap.data2.dataset2.module.lib.DatasetModules;
+import co.cask.cdap.proto.DatasetModuleMeta;
+import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Objects;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides {@link Dataset} instances directly using {@link DatasetSpecification}.
+ */
+@SuppressWarnings("unchecked")
+public class DatasetProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DatasetProvider.class);
+  private final DatasetDefinitionRegistryFactory registryFactory;
+
+  @Inject
+  public DatasetProvider(DatasetDefinitionRegistryFactory registryFactory) {
+    this.registryFactory = registryFactory;
+  }
+
+  public <T extends Dataset> T get(
+    DatasetMetaProvider metaProvider,
+    Id.DatasetInstance instance,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception {
+
+    return get(instance.getNamespace(), metaProvider.getType(instance), metaProvider.getSpec(instance),
+               null, classLoader, arguments);
+  }
+
+  public <T extends Dataset> T get(
+    Id.Namespace namespace,
+    DatasetTypeMeta typeMeta,
+    DatasetSpecification spec,
+    @Nullable DatasetClassLoaderProvider classLoaderProvider,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws IOException {
+
+    classLoaderProvider = classLoaderProvider == null ?
+      new ConstantClassLoaderProvider(classLoader) : classLoaderProvider;
+    DatasetType type = getType(typeMeta, classLoader, classLoaderProvider);
+    return (T) type.getDataset(DatasetContext.from(namespace.getId()), spec, arguments);
+  }
+
+  public <T extends Dataset> T get(Id.Namespace namespace,
+                                   DatasetTypeMeta typeMeta,
+                                   DatasetSpecification spec) throws IOException {
+    return get(namespace, typeMeta, spec, null, null, null);
+  }
+
+  // can be used directly if DatasetTypeMeta is known, like in create dataset by dataset ops executor service
+
+  /**
+   * Return an instance of the {@link DatasetType} corresponding to given dataset modules. Uses the given
+   * classloader as a parent for all dataset modules, and the given classloader provider to get classloaders for
+   * each dataset module in given the dataset type meta. Order of dataset modules in the given
+   * {@link DatasetTypeMeta} is important. The classloader for the first dataset module is used as the parent of
+   * the second dataset module and so on until the last dataset module. The classloader for the last dataset module
+   * is then used as the classloader for the returned {@link DatasetType}.
+   *
+   * @param implementationInfo the dataset type metadata to instantiate the type from
+   * @param classLoader the parent classloader to use for dataset modules
+   * @param classLoaderProvider the classloader provider to get classloaders for each dataset module
+   * @param <T> the type of DatasetType
+   * @return an instance of the DatasetType
+   */
+  public <T extends DatasetType> T getType(
+    DatasetTypeMeta implementationInfo,
+    ClassLoader classLoader,
+    DatasetClassLoaderProvider classLoaderProvider) {
+
+    if (classLoader == null) {
+      classLoader = Objects.firstNonNull(Thread.currentThread().getContextClassLoader(), getClass().getClassLoader());
+    }
+
+    DatasetDefinitionRegistry registry = registryFactory.create();
+    List<DatasetModuleMeta> modulesToLoad = implementationInfo.getModules();
+    for (DatasetModuleMeta moduleMeta : modulesToLoad) {
+      // adding dataset module jar to classloader
+      try {
+        classLoader = classLoaderProvider.get(moduleMeta, classLoader);
+      } catch (IOException e) {
+        LOG.error("Was not able to init classloader for module {} while trying to load type {}",
+                  moduleMeta, implementationInfo, e);
+        throw Throwables.propagate(e);
+      }
+
+      Class<?> moduleClass;
+
+      // try program class loader then cdap class loader
+      try {
+        moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), classLoader, this);
+      } catch (ClassNotFoundException e) {
+        try {
+          moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), null, this);
+        } catch (ClassNotFoundException e2) {
+          LOG.error("Was not able to load dataset module class {} while trying to load type {}",
+                    moduleMeta.getClassName(), implementationInfo, e);
+          throw Throwables.propagate(e);
+        }
+      }
+
+      try {
+        DatasetModule module = DatasetModules.getDatasetModule(moduleClass);
+        module.register(registry);
+      } catch (Exception e) {
+        LOG.error("Was not able to load dataset module class {} while trying to load type {}",
+                  moduleMeta.getClassName(), implementationInfo, e);
+        throw Throwables.propagate(e);
+      }
+    }
+
+    // contract of DatasetTypeMeta is that the last module returned by getModules() is the one
+    // that announces the dataset's type. The classloader for the returned DatasetType must be the classloader
+    // for that last module.
+    return (T) new DatasetType(registry.get(implementationInfo.getName()), classLoader);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -21,26 +21,19 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
-import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
-import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
-import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.SingleTypeModule;
-import co.cask.cdap.data2.dataset2.module.lib.DatasetModules;
 import co.cask.cdap.proto.DatasetMeta;
-import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
-import com.google.common.base.Objects;
-import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -59,7 +52,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -76,11 +68,11 @@ public class RemoteDatasetFramework implements DatasetFramework {
 
   private final CConfiguration cConf;
   private final LoadingCache<Id.Namespace, DatasetServiceClient> clientCache;
-  private final DatasetDefinitionRegistryFactory registryFactory;
+  private final DatasetProvider instances;
 
   @Inject
   public RemoteDatasetFramework(CConfiguration cConf, final DiscoveryServiceClient discoveryClient,
-                                DatasetDefinitionRegistryFactory registryFactory) {
+                                DatasetProvider instances) {
     this.cConf = cConf;
     this.clientCache = CacheBuilder.newBuilder().build(new CacheLoader<Id.Namespace, DatasetServiceClient>() {
       @Override
@@ -88,7 +80,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
         return new DatasetServiceClient(discoveryClient, namespace);
       }
     });
-    this.registryFactory = registryFactory;
+    this.instances = instances;
   }
 
   @Override
@@ -207,8 +199,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
       return null;
     }
 
-    DatasetType type =
-      getDatasetType(instanceInfo.getType(), parentClassLoader, classLoaderProvider);
+    DatasetType type = instances.getType(instanceInfo.getType(), parentClassLoader, classLoaderProvider);
     return (T) type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespaceId()), instanceInfo.getSpec());
   }
 
@@ -233,7 +224,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
   @Override
   public <T extends Dataset> T getDataset(
     Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
-    ClassLoader classLoader,
+    @Nullable ClassLoader classLoader,
     DatasetClassLoaderProvider classLoaderProvider,
     @Nullable Iterable<? extends Id> owners) throws DatasetManagementException, IOException {
 
@@ -243,9 +234,23 @@ public class RemoteDatasetFramework implements DatasetFramework {
       return null;
     }
 
-    DatasetType type = getDatasetType(instanceInfo.getType(), classLoader, classLoaderProvider);
-    return (T) type.getDataset(DatasetContext.from(datasetInstanceId.getNamespaceId()),
-      instanceInfo.getSpec(), arguments);
+    return (T) instances.get(
+      datasetInstanceId.getNamespace(), instanceInfo.getType(), instanceInfo.getSpec(),
+      classLoaderProvider, classLoader, arguments);
+  }
+
+  @Override
+  public DatasetTypeMeta getType(Id.DatasetInstance instance) throws Exception {
+    DatasetMeta meta = clientCache.getUnchecked(instance.getNamespace())
+      .getInstance(instance.getId(), ImmutableList.<Id>of());
+    return meta == null ? null : meta.getType();
+  }
+
+  @Override
+  public DatasetSpecification getSpec(Id.DatasetInstance instance) throws Exception {
+    DatasetMeta meta = clientCache.getUnchecked(instance.getNamespace())
+      .getInstance(instance.getId(), ImmutableList.<Id>of());
+    return meta == null ? null : meta.getSpec();
   }
 
   @Override
@@ -334,51 +339,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
                                                   ClassLoader classLoader,
                                                   DatasetClassLoaderProvider classLoaderProvider) {
 
-    if (classLoader == null) {
-      classLoader = Objects.firstNonNull(Thread.currentThread().getContextClassLoader(), getClass().getClassLoader());
-    }
-
-    DatasetDefinitionRegistry registry = registryFactory.create();
-    List<DatasetModuleMeta> modulesToLoad = implementationInfo.getModules();
-    for (DatasetModuleMeta moduleMeta : modulesToLoad) {
-      // adding dataset module jar to classloader
-      try {
-        classLoader = classLoaderProvider.get(moduleMeta, classLoader);
-      } catch (IOException e) {
-        LOG.error("Was not able to init classloader for module {} while trying to load type {}",
-                  moduleMeta, implementationInfo, e);
-        throw Throwables.propagate(e);
-      }
-
-      Class<?> moduleClass;
-
-      // try program class loader then cdap class loader
-      try {
-        moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), classLoader, this);
-      } catch (ClassNotFoundException e) {
-        try {
-          moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), null, this);
-        } catch (ClassNotFoundException e2) {
-          LOG.error("Was not able to load dataset module class {} while trying to load type {}",
-                    moduleMeta.getClassName(), implementationInfo, e);
-          throw Throwables.propagate(e);
-        }
-      }
-
-      try {
-        DatasetModule module = DatasetModules.getDatasetModule(moduleClass);
-        module.register(registry);
-      } catch (Exception e) {
-        LOG.error("Was not able to load dataset module class {} while trying to load type {}",
-                  moduleMeta.getClassName(), implementationInfo, e);
-        throw Throwables.propagate(e);
-      }
-    }
-
-    // contract of DatasetTypeMeta is that the last module returned by getModules() is the one
-    // that announces the dataset's type. The classloader for the returned DatasetType must be the classloader
-    // for that last module.
-    return (T) new DatasetType(registry.get(implementationInfo.getName()), classLoader);
+    return instances.getType(implementationInfo, classLoader, classLoaderProvider);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -27,16 +27,21 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.AbstractNamespaceClient;
+import co.cask.cdap.data2.datafabric.dataset.DatasetMetaProvider;
+import co.cask.cdap.data2.datafabric.dataset.DatasetProvider;
 import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpResponse;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
+import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
+import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
@@ -51,7 +56,7 @@ import javax.annotation.Nullable;
 /**
  * Handles dataset instance management calls.
  */
-public class DatasetInstanceService {
+public class DatasetInstanceService implements DatasetMetaProvider {
   private static final Logger LOG = LoggerFactory.getLogger(DatasetInstanceService.class);
 
   private final DatasetTypeManager implManager;
@@ -65,12 +70,14 @@ public class DatasetInstanceService {
   @Inject
   public DatasetInstanceService(DatasetTypeManager implManager, DatasetInstanceManager instanceManager,
                                 DatasetOpExecutor opExecutorClient, ExploreFacade exploreFacade, CConfiguration conf,
-                                UsageRegistry usageRegistry, AbstractNamespaceClient namespaceClient) {
+                                TransactionExecutorFactory txFactory,
+                                DatasetDefinitionRegistryFactory registryFactory,
+                                AbstractNamespaceClient namespaceClient) {
     this.opExecutorClient = opExecutorClient;
     this.implManager = implManager;
     this.instanceManager = instanceManager;
     this.exploreFacade = exploreFacade;
-    this.usageRegistry = usageRegistry;
+    this.usageRegistry = new UsageRegistry(txFactory, new DatasetProvider(registryFactory), this);
     this.namespaceClient = namespaceClient;
     this.allowDatasetUncheckedUpgrade = conf.getBoolean(Constants.Dataset.DATASET_UNCHECKED_UPGRADE);
   }
@@ -99,8 +106,6 @@ public class DatasetInstanceService {
    * @throws IOException if there is a problem in making an HTTP request to check if the namespace exists.
    */
   public DatasetMeta get(Id.DatasetInstance instance, List<? extends Id> owners) throws Exception {
-    // Throws NamespaceNotFoundException if the namespace does not exist
-    ensureNamespaceExists(instance.getNamespace());
     DatasetSpecification spec = instanceManager.get(instance);
     if (spec == null) {
       throw new NotFoundException(instance);
@@ -115,6 +120,16 @@ public class DatasetInstanceService {
 
     registerUsage(instance, owners);
     return new DatasetMeta(spec, typeMeta, null);
+  }
+
+  @Override
+  public DatasetTypeMeta getType(Id.DatasetInstance instance) throws Exception {
+    return get(instance, ImmutableList.<Id>of()).getType();
+  }
+
+  @Override
+  public DatasetSpecification getSpec(Id.DatasetInstance instance) throws Exception {
+    return get(instance, ImmutableList.<Id>of()).getSpec();
   }
 
   private void registerUsage(Id.DatasetInstance instance, List<? extends Id> owners) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.ServiceUnavailableException;
+import co.cask.cdap.data2.datafabric.dataset.DatasetMetaProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
@@ -52,7 +53,7 @@ import javax.annotation.Nullable;
  * </tt>
  */
 // todo: use dataset instead of dataset instance in namings
-public interface DatasetFramework {
+public interface DatasetFramework extends DatasetMetaProvider {
 
   /**
    * Adds dataset types by adding dataset module to the system. Calling this method to add {@link DatasetModule} may

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -31,6 +31,7 @@ import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.module.lib.DatasetModules;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
+import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -417,6 +418,16 @@ public class InMemoryDatasetFramework implements DatasetFramework {
     } finally {
       readLock.unlock();
     }
+  }
+
+  @Override
+  public DatasetTypeMeta getType(Id.DatasetInstance instance) throws Exception {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DatasetSpecification getSpec(Id.DatasetInstance instance) throws Exception {
+    return instances.get(instance.getNamespace(), instance);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
@@ -28,6 +28,7 @@ import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
+import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
@@ -209,5 +210,15 @@ public class LineageWriterDatasetFramework implements DatasetFramework, ProgramC
       lineageWriter.addAccess(programContext.getRun(), datasetInstanceId, AccessType.UNKNOWN,
                               programContext.getComponentId());
     }
+  }
+
+  @Override
+  public DatasetTypeMeta getType(Id.DatasetInstance instance) throws Exception {
+    return delegate.getType(instance);
+  }
+
+  @Override
+  public DatasetSpecification getSpec(Id.DatasetInstance instance) throws Exception {
+    return delegate.getSpec(instance);
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -43,7 +43,6 @@ import co.cask.cdap.data2.dataset2.SingleTypeModule;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.proto.Id;
@@ -105,7 +104,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
 
     LocalLocationFactory locationFactory = new LocalLocationFactory(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
     NamespacedLocationFactory namespacedLocationFactory = new DefaultNamespacedLocationFactory(cConf, locationFactory);
-    framework = new RemoteDatasetFramework(cConf, discoveryService, registryFactory);
+    framework = new RemoteDatasetFramework(cConf, discoveryService, new DatasetProvider(registryFactory));
     SystemDatasetInstantiatorFactory datasetInstantiatorFactory =
       new SystemDatasetInstantiatorFactory(locationFactory, framework, cConf);
 
@@ -131,7 +130,9 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
       new InMemoryDatasetOpExecutor(framework),
       exploreFacade,
       cConf,
-      new UsageRegistry(txExecutorFactory, framework), NAMESPACE_CLIENT);
+      txExecutorFactory,
+      registryFactory,
+      NAMESPACE_CLIENT);
 
     service = new DatasetService(cConf,
                                  namespacedLocationFactory,

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -33,6 +33,7 @@ import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
+import co.cask.cdap.data2.datafabric.dataset.DatasetProvider;
 import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpHTTPHandler;
@@ -44,7 +45,6 @@ import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.internal.test.AppJarHelper;
@@ -155,7 +155,7 @@ public abstract class DatasetServiceTestBase {
 
     locationFactory = injector.getInstance(LocationFactory.class);
     NamespacedLocationFactory namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
-    dsFramework = new RemoteDatasetFramework(cConf, discoveryService, registryFactory);
+    dsFramework = new RemoteDatasetFramework(cConf, discoveryService, new DatasetProvider(registryFactory));
     SystemDatasetInstantiatorFactory datasetInstantiatorFactory =
       new SystemDatasetInstantiatorFactory(locationFactory, dsFramework, cConf);
 
@@ -187,7 +187,9 @@ public abstract class DatasetServiceTestBase {
       new InMemoryDatasetOpExecutor(dsFramework),
       exploreFacade,
       cConf,
-      new UsageRegistry(txExecutorFactory, dsFramework), namespaceClient);
+      txExecutorFactory,
+      registryFactory,
+      namespaceClient);
 
     service = new DatasetService(cConf,
                                  namespacedLocationFactory,

--- a/cdap-master/src/main/java/SimpleTest.java
+++ b/cdap-master/src/main/java/SimpleTest.java
@@ -1,0 +1,107 @@
+/*
+* Copyright © 2015 Cask Data, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
+import co.cask.cdap.data.runtime.DataFabricModules;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.tephra.runtime.DiscoveryModules;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ */
+public class SimpleTest {
+  private static final Logger LOG = LoggerFactory.getLogger(SimpleTest.class);
+
+  public static void main(String[] args) throws Exception {
+    Injector injector = Guice.createInjector(
+      new ConfigModule(),
+      new ZKClientModule(),
+      new LocationRuntimeModule().getDistributedModules(),
+      new DiscoveryModules().getDistributedModules(),
+      new DataFabricModules().getDistributedModules(),
+      new DataSetsModules().getDistributedModules(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
+        }
+      }
+    );
+
+    ZKClientService zkClient = injector.getInstance(ZKClientService.class);
+    zkClient.startAndWait();
+
+    final DatasetFramework dsFramework = injector.getInstance(DatasetFramework.class);
+    final Id.DatasetInstance id = Id.DatasetInstance.from("custom", "history");
+    int count = Integer.parseInt(args[0]);
+    LOG.error("Starting {} threads", count);
+    final CyclicBarrier barrier = new CyclicBarrier(count + 1);
+    ExecutorService executor = Executors.newFixedThreadPool(count);
+    for (int i = 0; i < count; i++) {
+      executor.submit(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            barrier.await();
+            long start = System.nanoTime();
+
+            Dataset dataset = dsFramework.getDataset(
+              id, null, null, new ConstantClassLoaderProvider(null),
+              ImmutableList.of(Id.Program.from("foo", "noapp", ProgramType.SERVICE, "noprogram")));
+            if (dataset == null) {
+              LOG.error("Not exists");
+            }
+
+            long elapse = System.nanoTime() - start;
+            LOG.error("Call time: " + TimeUnit.NANOSECONDS.toMillis(elapse));
+          } catch (Exception e) {
+            LOG.error("Got exception: ", e);
+          }
+        }
+      });
+    }
+
+    long start = System.nanoTime();
+    barrier.await();
+    executor.shutdown();
+    executor.awaitTermination(1, TimeUnit.DAYS);
+    long elapse = System.nanoTime() - start;
+    LOG.error("Time: " + TimeUnit.NANOSECONDS.toMillis(elapse));
+
+    zkClient.stopAndWait();
+  }
+}


### PR DESCRIPTION
- Added DatasetProvider and DatasetMetaProvider
- Made UsageRegistry obtain the usage registry dataset instance by using
  DatasetProvider instead of DatasetFramework