### PR TITLE
CDAP-3902: Remove unnecessary remote calls when getting a dataset instance

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
@@ -18,6 +18,8 @@ package co.cask.cdap.data.runtime;
 
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.common.runtime.RuntimeModule;
+import co.cask.cdap.data2.datafabric.dataset.DatasetProvider;
+import co.cask.cdap.data2.datafabric.dataset.DefaultDatasetProvider;
 import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -66,6 +68,10 @@ public class DataSetsModules extends RuntimeModule {
           .to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
         expose(DatasetFramework.class).annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK));
 
+        bind(DatasetProvider.class)
+          .to(DefaultDatasetProvider.class);
+        expose(DatasetProvider.class);
+
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);
         bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
@@ -97,6 +103,10 @@ public class DataSetsModules extends RuntimeModule {
           .to(RemoteDatasetFramework.class);
         expose(DatasetFramework.class).annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK));
 
+        bind(DatasetProvider.class)
+          .to(DefaultDatasetProvider.class);
+        expose(DatasetProvider.class);
+
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);
         bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
@@ -127,6 +137,10 @@ public class DataSetsModules extends RuntimeModule {
           .annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK))
           .to(RemoteDatasetFramework.class);
         expose(DatasetFramework.class).annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK));
+
+        bind(DatasetProvider.class)
+          .to(DefaultDatasetProvider.class);
+        expose(DatasetProvider.class);
 
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.proto.DatasetMeta;
+import co.cask.cdap.proto.Id;
+
+/**
+ * Provides metadata about datasets for {@link LocalDatasetProvider}.
+ */
+public interface DatasetMetaProvider {
+  DatasetMeta getMeta(Id.DatasetInstance instance) throws Exception;
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.proto.Id;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides {@link Dataset} instances.
+ */
+public interface DatasetProvider {
+
+  <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception;
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DefaultDatasetProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DefaultDatasetProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.proto.Id;
+import com.google.inject.Inject;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides {@link Dataset} instances using {@link DatasetFramework}. Default implementation.
+ */
+public class DefaultDatasetProvider implements DatasetProvider {
+
+  private final DatasetFramework framework;
+
+  @Inject
+  public DefaultDatasetProvider(DatasetFramework framework) {
+    this.framework = framework;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception {
+
+    return framework.getDataset(instance, arguments, classLoader);
+  }
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/LocalDatasetProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/LocalDatasetProvider.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.data2.datafabric.dataset.service.DatasetInstanceService;
+import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
+import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
+import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
+import co.cask.cdap.data2.dataset2.module.lib.DatasetModules;
+import co.cask.cdap.proto.DatasetMeta;
+import co.cask.cdap.proto.DatasetModuleMeta;
+import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Objects;
+import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides {@link Dataset} instances using {@link DatasetMetaProvider}.
+ * Used by {@link RemoteDatasetFramework} and {@link DatasetInstanceService}.
+ * Use this when you want to control how dataset instances are created. For example, when
+ * you want to obtain a {@link Dataset} instance without having to make remote calls.
+ */
+public class LocalDatasetProvider implements DatasetProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LocalDatasetProvider.class);
+  private final DatasetDefinitionRegistryFactory registryFactory;
+  private final DatasetMetaProvider metaProvider;
+
+  private LocalDatasetProvider(DatasetDefinitionRegistryFactory registryFactory, DatasetMetaProvider metaProvider) {
+    this.registryFactory = registryFactory;
+    this.metaProvider = metaProvider;
+  }
+
+  public LocalDatasetProvider(DatasetDefinitionRegistryFactory registryFactory, RemoteDatasetFramework metaProvider) {
+    this(registryFactory, (DatasetMetaProvider) metaProvider);
+  }
+
+  public LocalDatasetProvider(DatasetDefinitionRegistryFactory registryFactory, DatasetInstanceService metaProvider) {
+    this(registryFactory, (DatasetMetaProvider) metaProvider);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception {
+
+    ConstantClassLoaderProvider classLoaderProvider = new ConstantClassLoaderProvider(classLoader);
+    DatasetMeta meta = metaProvider.getMeta(instance);
+    DatasetType type = getType(meta.getType(), classLoader, classLoaderProvider);
+    return (T) type.getDataset(
+      DatasetContext.from(instance.getNamespaceId()), meta.getSpec(), arguments);
+  }
+
+  public <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    DatasetTypeMeta typeMeta, DatasetSpecification spec,
+    DatasetClassLoaderProvider classLoaderProvider,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws IOException {
+
+    classLoaderProvider = classLoaderProvider == null ?
+      new ConstantClassLoaderProvider(classLoader) : classLoaderProvider;
+    DatasetType type = getType(typeMeta, classLoader, classLoaderProvider);
+    return (T) type.getDataset(DatasetContext.from(instance.getNamespaceId()), spec, arguments);
+  }
+
+  // can be used directly if DatasetTypeMeta is known, like in create dataset by dataset ops executor service
+
+  /**
+   * Return an instance of the {@link DatasetType} corresponding to given dataset modules. Uses the given
+   * classloader as a parent for all dataset modules, and the given classloader provider to get classloaders for
+   * each dataset module in given the dataset type meta. Order of dataset modules in the given
+   * {@link DatasetTypeMeta} is important. The classloader for the first dataset module is used as the parent of
+   * the second dataset module and so on until the last dataset module. The classloader for the last dataset module
+   * is then used as the classloader for the returned {@link DatasetType}.
+   *
+   * @param implementationInfo the dataset type metadata to instantiate the type from
+   * @param classLoader the parent classloader to use for dataset modules
+   * @param classLoaderProvider the classloader provider to get classloaders for each dataset module
+   * @param <T> the type of DatasetType
+   * @return an instance of the DatasetType
+   */
+  public <T extends DatasetType> T getType(
+    DatasetTypeMeta implementationInfo,
+    ClassLoader classLoader,
+    DatasetClassLoaderProvider classLoaderProvider) {
+
+    if (classLoader == null) {
+      classLoader = Objects.firstNonNull(Thread.currentThread().getContextClassLoader(), getClass().getClassLoader());
+    }
+
+    DatasetDefinitionRegistry registry = registryFactory.create();
+    List<DatasetModuleMeta> modulesToLoad = implementationInfo.getModules();
+    for (DatasetModuleMeta moduleMeta : modulesToLoad) {
+      // adding dataset module jar to classloader
+      try {
+        classLoader = classLoaderProvider.get(moduleMeta, classLoader);
+      } catch (IOException e) {
+        LOG.error("Was not able to init classloader for module {} while trying to load type {}",
+                  moduleMeta, implementationInfo, e);
+        throw Throwables.propagate(e);
+      }
+
+      Class<?> moduleClass;
+
+      // try program class loader then cdap class loader
+      try {
+        moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), classLoader, this);
+      } catch (ClassNotFoundException e) {
+        try {
+          moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), null, this);
+        } catch (ClassNotFoundException e2) {
+          LOG.error("Was not able to load dataset module class {} while trying to load type {}",
+                    moduleMeta.getClassName(), implementationInfo, e);
+          throw Throwables.propagate(e);
+        }
+      }
+
+      try {
+        DatasetModule module = DatasetModules.getDatasetModule(moduleClass);
+        module.register(registry);
+      } catch (Exception e) {
+        LOG.error("Was not able to load dataset module class {} while trying to load type {}",
+                  moduleMeta.getClassName(), implementationInfo, e);
+        throw Throwables.propagate(e);
+      }
+    }
+
+    // contract of DatasetTypeMeta is that the last module returned by getModules() is the one
+    // that announces the dataset's type. The classloader for the returned DatasetType must be the classloader
+    // for that last module.
+    return (T) new DatasetType(registry.get(implementationInfo.getName()), classLoader);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -21,26 +21,20 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
-import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
-import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.SingleTypeModule;
-import co.cask.cdap.data2.dataset2.module.lib.DatasetModules;
 import co.cask.cdap.proto.DatasetMeta;
-import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
-import com.google.common.base.Objects;
-import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -59,7 +53,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -71,12 +64,12 @@ import javax.annotation.Nullable;
  * {@link co.cask.cdap.data2.dataset2.DatasetFramework} implementation that talks to DatasetFramework Service
  */
 @SuppressWarnings("unchecked")
-public class RemoteDatasetFramework implements DatasetFramework {
+public class RemoteDatasetFramework implements DatasetFramework, DatasetMetaProvider {
   private static final Logger LOG = LoggerFactory.getLogger(RemoteDatasetFramework.class);
 
   private final CConfiguration cConf;
   private final LoadingCache<Id.Namespace, DatasetServiceClient> clientCache;
-  private final DatasetDefinitionRegistryFactory registryFactory;
+  private final LocalDatasetProvider instances;
 
   @Inject
   public RemoteDatasetFramework(CConfiguration cConf, final DiscoveryServiceClient discoveryClient,
@@ -88,7 +81,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
         return new DatasetServiceClient(discoveryClient, namespace);
       }
     });
-    this.registryFactory = registryFactory;
+    this.instances = new LocalDatasetProvider(registryFactory, this);
   }
 
   @Override
@@ -161,6 +154,12 @@ public class RemoteDatasetFramework implements DatasetFramework {
   }
 
   @Override
+  public DatasetMeta getMeta(Id.DatasetInstance instance) throws Exception {
+    return clientCache.getUnchecked(instance.getNamespace())
+      .getInstance(instance.getId());
+  }
+
+  @Override
   public boolean hasInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
     return clientCache.getUnchecked(datasetInstanceId.getNamespace()).getInstance(datasetInstanceId.getId()) != null;
   }
@@ -207,8 +206,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
       return null;
     }
 
-    DatasetType type =
-      getDatasetType(instanceInfo.getType(), parentClassLoader, classLoaderProvider);
+    DatasetType type = instances.getType(instanceInfo.getType(), parentClassLoader, classLoaderProvider);
     return (T) type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespaceId()), instanceInfo.getSpec());
   }
 
@@ -233,7 +231,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
   @Override
   public <T extends Dataset> T getDataset(
     Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
-    ClassLoader classLoader,
+    @Nullable ClassLoader classLoader,
     DatasetClassLoaderProvider classLoaderProvider,
     @Nullable Iterable<? extends Id> owners) throws DatasetManagementException, IOException {
 
@@ -243,9 +241,9 @@ public class RemoteDatasetFramework implements DatasetFramework {
       return null;
     }
 
-    DatasetType type = getDatasetType(instanceInfo.getType(), classLoader, classLoaderProvider);
-    return (T) type.getDataset(DatasetContext.from(datasetInstanceId.getNamespaceId()),
-      instanceInfo.getSpec(), arguments);
+    return (T) instances.get(
+      datasetInstanceId, instanceInfo.getType(), instanceInfo.getSpec(),
+      classLoaderProvider, classLoader, arguments);
   }
 
   @Override
@@ -334,51 +332,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
                                                   ClassLoader classLoader,
                                                   DatasetClassLoaderProvider classLoaderProvider) {
 
-    if (classLoader == null) {
-      classLoader = Objects.firstNonNull(Thread.currentThread().getContextClassLoader(), getClass().getClassLoader());
-    }
-
-    DatasetDefinitionRegistry registry = registryFactory.create();
-    List<DatasetModuleMeta> modulesToLoad = implementationInfo.getModules();
-    for (DatasetModuleMeta moduleMeta : modulesToLoad) {
-      // adding dataset module jar to classloader
-      try {
-        classLoader = classLoaderProvider.get(moduleMeta, classLoader);
-      } catch (IOException e) {
-        LOG.error("Was not able to init classloader for module {} while trying to load type {}",
-                  moduleMeta, implementationInfo, e);
-        throw Throwables.propagate(e);
-      }
-
-      Class<?> moduleClass;
-
-      // try program class loader then cdap class loader
-      try {
-        moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), classLoader, this);
-      } catch (ClassNotFoundException e) {
-        try {
-          moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), null, this);
-        } catch (ClassNotFoundException e2) {
-          LOG.error("Was not able to load dataset module class {} while trying to load type {}",
-                    moduleMeta.getClassName(), implementationInfo, e);
-          throw Throwables.propagate(e);
-        }
-      }
-
-      try {
-        DatasetModule module = DatasetModules.getDatasetModule(moduleClass);
-        module.register(registry);
-      } catch (Exception e) {
-        LOG.error("Was not able to load dataset module class {} while trying to load type {}",
-                  moduleMeta.getClassName(), implementationInfo, e);
-        throw Throwables.propagate(e);
-      }
-    }
-
-    // contract of DatasetTypeMeta is that the last module returned by getModules() is the one
-    // that announces the dataset's type. The classloader for the returned DatasetType must be the classloader
-    // for that last module.
-    return (T) new DatasetType(registry.get(implementationInfo.getName()), classLoader);
+    return instances.getType(implementationInfo, classLoader, classLoaderProvider);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -27,16 +27,22 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.AbstractNamespaceClient;
+import co.cask.cdap.data2.datafabric.dataset.DatasetMetaProvider;
+import co.cask.cdap.data2.datafabric.dataset.LocalDatasetProvider;
 import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpResponse;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
+import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
+import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
@@ -51,7 +57,7 @@ import javax.annotation.Nullable;
 /**
  * Handles dataset instance management calls.
  */
-public class DatasetInstanceService {
+public class DatasetInstanceService implements DatasetMetaProvider {
   private static final Logger LOG = LoggerFactory.getLogger(DatasetInstanceService.class);
 
   private final DatasetTypeManager implManager;
@@ -65,12 +71,15 @@ public class DatasetInstanceService {
   @Inject
   public DatasetInstanceService(DatasetTypeManager implManager, DatasetInstanceManager instanceManager,
                                 DatasetOpExecutor opExecutorClient, ExploreFacade exploreFacade, CConfiguration conf,
-                                UsageRegistry usageRegistry, AbstractNamespaceClient namespaceClient) {
+                                TransactionExecutorFactory txFactory,
+                                DatasetDefinitionRegistryFactory registryFactory,
+                                AbstractNamespaceClient namespaceClient,
+                                DatasetFramework framework) {
     this.opExecutorClient = opExecutorClient;
     this.implManager = implManager;
     this.instanceManager = instanceManager;
     this.exploreFacade = exploreFacade;
-    this.usageRegistry = usageRegistry;
+    this.usageRegistry = new UsageRegistry(txFactory, new LocalDatasetProvider(registryFactory, this), framework);
     this.namespaceClient = namespaceClient;
     this.allowDatasetUncheckedUpgrade = conf.getBoolean(Constants.Dataset.DATASET_UNCHECKED_UPGRADE);
   }
@@ -99,8 +108,6 @@ public class DatasetInstanceService {
    * @throws IOException if there is a problem in making an HTTP request to check if the namespace exists.
    */
   public DatasetMeta get(Id.DatasetInstance instance, List<? extends Id> owners) throws Exception {
-    // Throws NamespaceNotFoundException if the namespace does not exist
-    ensureNamespaceExists(instance.getNamespace());
     DatasetSpecification spec = instanceManager.get(instance);
     if (spec == null) {
       throw new NotFoundException(instance);
@@ -115,6 +122,11 @@ public class DatasetInstanceService {
 
     registerUsage(instance, owners);
     return new DatasetMeta(spec, typeMeta, null);
+  }
+
+  @Override
+  public DatasetMeta getMeta(Id.DatasetInstance instance) throws Exception {
+    return get(instance, ImmutableList.<Id>of());
   }
 
   private void registerUsage(Id.DatasetInstance instance, List<? extends Id> owners) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -43,7 +43,6 @@ import co.cask.cdap.data2.dataset2.SingleTypeModule;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.proto.Id;
@@ -131,7 +130,10 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
       new InMemoryDatasetOpExecutor(framework),
       exploreFacade,
       cConf,
-      new UsageRegistry(txExecutorFactory, framework), NAMESPACE_CLIENT);
+      txExecutorFactory,
+      registryFactory,
+      NAMESPACE_CLIENT,
+      framework);
 
     service = new DatasetService(cConf,
                                  namespacedLocationFactory,

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerTest.java
@@ -288,8 +288,9 @@ public class DatasetInstanceHandlerTest extends DatasetServiceTestBase {
     HttpResponse response = makeInstancesRequest(nonExistent.getId());
     assertNamespaceNotFound(response, nonExistent);
 
-    response = getInstance(datasetInstance);
-    assertNamespaceNotFound(response, nonExistent);
+    // TODO: commented out for now until we add back namespace checks on get dataset CDAP-3901
+//    response = getInstance(datasetInstance);
+//    assertNamespaceNotFound(response, nonExistent);
 
     response = createInstance(datasetInstance, Table.class.getName(), null);
     assertNamespaceNotFound(response, nonExistent);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -44,7 +44,6 @@ import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.internal.test.AppJarHelper;
@@ -187,7 +186,10 @@ public abstract class DatasetServiceTestBase {
       new InMemoryDatasetOpExecutor(dsFramework),
       exploreFacade,
       cConf,
-      new UsageRegistry(txExecutorFactory, dsFramework), namespaceClient);
+      txExecutorFactory,
+      registryFactory,
+      namespaceClient,
+      dsFramework);
 
     service = new DatasetService(cConf,
                                  namespacedLocationFactory,

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -32,6 +32,7 @@ import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.config.DefaultConfigStore;
 import co.cask.cdap.data.runtime.DataFabricDistributedModule;
+import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data.view.ViewAdminModules;
@@ -72,6 +73,7 @@ import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
+import com.google.inject.util.Modules;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.twill.zookeeper.ZKClientService;
@@ -149,6 +151,21 @@ public class UpgradeTool {
       new LocationRuntimeModule().getDistributedModules(),
       new ZKClientModule(),
       new DiscoveryRuntimeModule().getDistributedModules(),
+      Modules.override(new DataSetsModules().getDistributedModules()).with(
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(DatasetFramework.class).to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
+            install(new FactoryModuleBuilder()
+                      .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
+                      .build(DatasetDefinitionRegistryFactory.class));
+            // Upgrade tool does not need to record lineage for now.
+            bind(LineageWriter.class).to(NoOpLineageWriter.class);
+            // No need to do anything with Metadata store for now.
+            bind(BusinessMetadataStore.class).to(NoOpBusinessMetadataStore.class);
+          }
+        }
+      ),
       new ViewAdminModules().getDistributedModules(),
       new StreamAdminModules().getDistributedModules(),
       new NotificationFeedClientModule(),
@@ -168,17 +185,8 @@ public class UpgradeTool {
           // the DataFabricDistributedModule needs MetricsCollectionService binding and since Upgrade tool does not do
           // anything with Metrics we just bind it to NoOpMetricsCollectionService
           bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
-          install(new FactoryModuleBuilder()
-                    .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
-                    .build(DatasetDefinitionRegistryFactory.class));
-
           bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
           bind(MetricStore.class).to(DefaultMetricStore.class);
-          bind(DatasetFramework.class).to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
-          // Upgrade tool does not need to record lineage for now.
-          bind(LineageWriter.class).to(NoOpLineageWriter.class);
-          // No need to do anything with Metadata store for now.
-          bind(BusinessMetadataStore.class).to(NoOpBusinessMetadataStore.class);
         }
 
         @Provides


### PR DESCRIPTION
- Added DatasetProvider and DatasetMetaProvider
- Made UsageRegistry obtain the usage registry dataset instance by using
  DatasetProvider instead of DatasetFramework
- Removed namespace existence check in DatasetInstanceService.get()

https://issues.cask.co/browse/CDAP-3902
http://builds.cask.co/browse/CDAP-DUT2980

# Performance test
* Distributed CDAP cluster with 3 slaves
* N threads concurrently doing a single get dataset operation with 1 owner
  * Before changes, the get dataset RPC should cause the dataset service to make 2 extra RPCs: one for getting the usage registry dataset and another for checking namespace existence
  * After changes, the get dataset RPC should cause the dataset service to make 0 extra RPCs

cdap-site.xml:
```
<property>
  <name>dataset.service.exec.threads</name>
  <value>300</value>
</property>
<property>
  <name>dataset.service.worker.threads</name>
  <value>30</value>
</property>
<property>
  <name>app.exec.threads</name>
  <value>20</value>
</property>
```

## Results
Format: `N=<# of threads>: <total time for run 1>, <total time for run 2>, ..`

### After changes (total time taken)
N=300: 3632, 3510, 3312, 3343, 3912
N=500: 4666, 4486, 4942, 4786, 4976
N=1000: 6995, 6712, 6523, 6379, 6492
N=2000: 11092, 10241 (w/ failures)

### Before changes (total time taken)
N=300: 6902, 5285, 4778, 4576, 4826
N=500: 17425 (was able to send ~20 requests with ~2000ms response time, but most requests failed), 17049 (same as first try)