### PR TITLE
CDAP-3902: Remove unnecessary remote calls when getting a dataset instance

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
@@ -18,6 +18,8 @@ package co.cask.cdap.data.runtime;
 
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.common.runtime.RuntimeModule;
+import co.cask.cdap.data2.datafabric.dataset.DatasetProvider;
+import co.cask.cdap.data2.datafabric.dataset.DefaultDatasetProvider;
 import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -66,6 +68,10 @@ public class DataSetsModules extends RuntimeModule {
           .to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
         expose(DatasetFramework.class).annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK));
 
+        bind(DatasetProvider.class)
+          .to(DefaultDatasetProvider.class);
+        expose(DatasetProvider.class);
+
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);
         bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
@@ -97,6 +103,10 @@ public class DataSetsModules extends RuntimeModule {
           .to(RemoteDatasetFramework.class);
         expose(DatasetFramework.class).annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK));
 
+        bind(DatasetProvider.class)
+          .to(DefaultDatasetProvider.class);
+        expose(DatasetProvider.class);
+
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);
         bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
@@ -127,6 +137,10 @@ public class DataSetsModules extends RuntimeModule {
           .annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK))
           .to(RemoteDatasetFramework.class);
         expose(DatasetFramework.class).annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK));
+
+        bind(DatasetProvider.class)
+          .to(DefaultDatasetProvider.class);
+        expose(DatasetProvider.class);
 
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/AbstractDatasetProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/AbstractDatasetProvider.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.data2.datafabric.dataset.service.DatasetInstanceService;
+import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
+import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
+import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
+import co.cask.cdap.data2.dataset2.module.lib.DatasetModules;
+import co.cask.cdap.proto.DatasetMeta;
+import co.cask.cdap.proto.DatasetModuleMeta;
+import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Objects;
+import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides {@link Dataset} instances using methods implemented by subclasses.
+ * Used by {@link RemoteDatasetFramework} and {@link DatasetInstanceService}.
+ * Use this when you want to control how dataset instances are created. For example, when
+ * you want to obtain a {@link Dataset} instance without having to make remote calls.
+ */
+public abstract class AbstractDatasetProvider implements DatasetProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractDatasetProvider.class);
+  private final DatasetDefinitionRegistryFactory registryFactory;
+
+  protected AbstractDatasetProvider(DatasetDefinitionRegistryFactory registryFactory) {
+    this.registryFactory = registryFactory;
+  }
+
+  /**
+   * Gets the {@link DatasetMeta} for a dataset.
+   *
+   * @param instance the dataset
+   * @return the {@link DatasetMeta}
+   */
+  public abstract DatasetMeta getMeta(Id.DatasetInstance instance) throws Exception;
+
+  /**
+   * Creates the dataset if it doesn't already exist.
+   *
+   * @param instance the dataset
+   * @param type the type of dataset to create
+   * @param creationProps creation properties
+   */
+  public abstract void createIfNotExists(Id.DatasetInstance instance, String type,
+                                         DatasetProperties creationProps) throws Exception;
+
+  @Override
+  public <T extends Dataset> T getOrCreate(
+    Id.DatasetInstance instance, String type,
+    DatasetProperties creationProps,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception {
+
+    T result = get(instance, classLoader, arguments);
+    if (result != null) {
+      return result;
+    }
+
+    createIfNotExists(instance, type, creationProps);
+    return get(instance, classLoader, arguments);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception {
+
+    ConstantClassLoaderProvider classLoaderProvider = new ConstantClassLoaderProvider(classLoader);
+    DatasetMeta meta = getMeta(instance);
+    DatasetType type = getType(meta.getType(), classLoader, classLoaderProvider);
+    return (T) type.getDataset(
+      DatasetContext.from(instance.getNamespaceId()), meta.getSpec(), arguments);
+  }
+
+  public <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    DatasetTypeMeta typeMeta, DatasetSpecification spec,
+    DatasetClassLoaderProvider classLoaderProvider,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws IOException {
+
+    classLoaderProvider = classLoaderProvider == null ?
+      new ConstantClassLoaderProvider(classLoader) : classLoaderProvider;
+    DatasetType type = getType(typeMeta, classLoader, classLoaderProvider);
+    return (T) type.getDataset(DatasetContext.from(instance.getNamespaceId()), spec, arguments);
+  }
+
+  // can be used directly if DatasetTypeMeta is known, like in create dataset by dataset ops executor service
+
+  /**
+   * Return an instance of the {@link DatasetType} corresponding to given dataset modules. Uses the given
+   * classloader as a parent for all dataset modules, and the given classloader provider to get classloaders for
+   * each dataset module in given the dataset type meta. Order of dataset modules in the given
+   * {@link DatasetTypeMeta} is important. The classloader for the first dataset module is used as the parent of
+   * the second dataset module and so on until the last dataset module. The classloader for the last dataset module
+   * is then used as the classloader for the returned {@link DatasetType}.
+   *
+   * @param implementationInfo the dataset type metadata to instantiate the type from
+   * @param classLoader the parent classloader to use for dataset modules
+   * @param classLoaderProvider the classloader provider to get classloaders for each dataset module
+   * @param <T> the type of DatasetType
+   * @return an instance of the DatasetType
+   */
+  public <T extends DatasetType> T getType(
+    DatasetTypeMeta implementationInfo,
+    ClassLoader classLoader,
+    DatasetClassLoaderProvider classLoaderProvider) {
+
+    if (classLoader == null) {
+      classLoader = Objects.firstNonNull(Thread.currentThread().getContextClassLoader(), getClass().getClassLoader());
+    }
+
+    DatasetDefinitionRegistry registry = registryFactory.create();
+    List<DatasetModuleMeta> modulesToLoad = implementationInfo.getModules();
+    for (DatasetModuleMeta moduleMeta : modulesToLoad) {
+      // adding dataset module jar to classloader
+      try {
+        classLoader = classLoaderProvider.get(moduleMeta, classLoader);
+      } catch (IOException e) {
+        LOG.error("Was not able to init classloader for module {} while trying to load type {}",
+                  moduleMeta, implementationInfo, e);
+        throw Throwables.propagate(e);
+      }
+
+      Class<?> moduleClass;
+
+      // try program class loader then cdap class loader
+      try {
+        moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), classLoader, this);
+      } catch (ClassNotFoundException e) {
+        try {
+          moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), null, this);
+        } catch (ClassNotFoundException e2) {
+          e.addSuppressed(e2);
+          LOG.error("Was not able to load dataset module class {} while trying to load type {}",
+                    moduleMeta.getClassName(), implementationInfo, e);
+          throw Throwables.propagate(e);
+        }
+      }
+
+      try {
+        DatasetModule module = DatasetModules.getDatasetModule(moduleClass);
+        module.register(registry);
+      } catch (Exception e) {
+        LOG.error("Was not able to load dataset module class {} while trying to load type {}",
+                  moduleMeta.getClassName(), implementationInfo, e);
+        throw Throwables.propagate(e);
+      }
+    }
+
+    // contract of DatasetTypeMeta is that the last module returned by getModules() is the one
+    // that announces the dataset's type. The classloader for the returned DatasetType must be the classloader
+    // for that last module.
+    return (T) new DatasetType(registry.get(implementationInfo.getName()), classLoader);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.proto.Id;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides {@link Dataset} instances.
+ */
+public interface DatasetProvider {
+
+  /**
+   * Gets a dataset.
+   *
+   * @param instance the dataset ID
+   * @param classLoader the classloader to use
+   * @param arguments the runtime arguments for the dataset
+   * @param <T> the type of dataset
+   * @return the dataset
+   */
+  <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception;
+
+  /**
+   * Gets a dataset, and creates it first if it doesn't yet exist.
+   *
+   * @param instance the dataset ID
+   * @param type the type of dataset
+   * @param creationProps the creation properties
+   * @param classLoader the classloader to use
+   * @param arguments the runtime arguments for the dataset
+   * @param <T> the type of dataset
+   * @return the dataset
+   */
+  <T extends Dataset> T getOrCreate(
+    Id.DatasetInstance instance,
+    String type,
+    DatasetProperties creationProps,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception;
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DefaultDatasetProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DefaultDatasetProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.proto.Id;
+import com.google.inject.Inject;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides {@link Dataset} instances using {@link DatasetFramework}. Default implementation.
+ */
+public class DefaultDatasetProvider implements DatasetProvider {
+
+  private final DatasetFramework framework;
+
+  @Inject
+  public DefaultDatasetProvider(DatasetFramework framework) {
+    this.framework = framework;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception {
+
+    return framework.getDataset(instance, arguments, classLoader);
+  }
+
+  @Override
+  public <T extends Dataset> T getOrCreate(
+    Id.DatasetInstance instance, String type, DatasetProperties creationProps,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception {
+
+    return DatasetsUtil.getOrCreateDataset(framework, instance, type, creationProps, arguments, classLoader);
+  }
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -21,26 +21,21 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
-import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
-import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
+import co.cask.cdap.data2.dataset2.InstanceConflictException;
 import co.cask.cdap.data2.dataset2.SingleTypeModule;
-import co.cask.cdap.data2.dataset2.module.lib.DatasetModules;
 import co.cask.cdap.proto.DatasetMeta;
-import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
-import com.google.common.base.Objects;
-import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -59,7 +54,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -76,7 +70,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
 
   private final CConfiguration cConf;
   private final LoadingCache<Id.Namespace, DatasetServiceClient> clientCache;
-  private final DatasetDefinitionRegistryFactory registryFactory;
+  private final AbstractDatasetProvider instances;
 
   @Inject
   public RemoteDatasetFramework(CConfiguration cConf, final DiscoveryServiceClient discoveryClient,
@@ -88,7 +82,23 @@ public class RemoteDatasetFramework implements DatasetFramework {
         return new DatasetServiceClient(discoveryClient, namespace);
       }
     });
-    this.registryFactory = registryFactory;
+    this.instances = new AbstractDatasetProvider(registryFactory) {
+      @Override
+      public DatasetMeta getMeta(Id.DatasetInstance instance) throws Exception {
+        return RemoteDatasetFramework.this.clientCache.getUnchecked(instance.getNamespace())
+          .getInstance(instance.getId());
+      }
+
+      @Override
+      public void createIfNotExists(Id.DatasetInstance instance, String type,
+                                    DatasetProperties creationProps) throws Exception {
+        try {
+          RemoteDatasetFramework.this.addInstance(type, instance, creationProps);
+        } catch (InstanceConflictException e) {
+          // ignore, since this indicates the dataset already exists
+        }
+      }
+    };
   }
 
   @Override
@@ -207,8 +217,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
       return null;
     }
 
-    DatasetType type =
-      getDatasetType(instanceInfo.getType(), parentClassLoader, classLoaderProvider);
+    DatasetType type = instances.getType(instanceInfo.getType(), parentClassLoader, classLoaderProvider);
     return (T) type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespaceId()), instanceInfo.getSpec());
   }
 
@@ -233,7 +242,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
   @Override
   public <T extends Dataset> T getDataset(
     Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
-    ClassLoader classLoader,
+    @Nullable ClassLoader classLoader,
     DatasetClassLoaderProvider classLoaderProvider,
     @Nullable Iterable<? extends Id> owners) throws DatasetManagementException, IOException {
 
@@ -243,9 +252,9 @@ public class RemoteDatasetFramework implements DatasetFramework {
       return null;
     }
 
-    DatasetType type = getDatasetType(instanceInfo.getType(), classLoader, classLoaderProvider);
-    return (T) type.getDataset(DatasetContext.from(datasetInstanceId.getNamespaceId()),
-      instanceInfo.getSpec(), arguments);
+    return (T) instances.get(
+      datasetInstanceId, instanceInfo.getType(), instanceInfo.getSpec(),
+      classLoaderProvider, classLoader, arguments);
   }
 
   @Override
@@ -334,51 +343,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
                                                   ClassLoader classLoader,
                                                   DatasetClassLoaderProvider classLoaderProvider) {
 
-    if (classLoader == null) {
-      classLoader = Objects.firstNonNull(Thread.currentThread().getContextClassLoader(), getClass().getClassLoader());
-    }
-
-    DatasetDefinitionRegistry registry = registryFactory.create();
-    List<DatasetModuleMeta> modulesToLoad = implementationInfo.getModules();
-    for (DatasetModuleMeta moduleMeta : modulesToLoad) {
-      // adding dataset module jar to classloader
-      try {
-        classLoader = classLoaderProvider.get(moduleMeta, classLoader);
-      } catch (IOException e) {
-        LOG.error("Was not able to init classloader for module {} while trying to load type {}",
-                  moduleMeta, implementationInfo, e);
-        throw Throwables.propagate(e);
-      }
-
-      Class<?> moduleClass;
-
-      // try program class loader then cdap class loader
-      try {
-        moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), classLoader, this);
-      } catch (ClassNotFoundException e) {
-        try {
-          moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), null, this);
-        } catch (ClassNotFoundException e2) {
-          LOG.error("Was not able to load dataset module class {} while trying to load type {}",
-                    moduleMeta.getClassName(), implementationInfo, e);
-          throw Throwables.propagate(e);
-        }
-      }
-
-      try {
-        DatasetModule module = DatasetModules.getDatasetModule(moduleClass);
-        module.register(registry);
-      } catch (Exception e) {
-        LOG.error("Was not able to load dataset module class {} while trying to load type {}",
-                  moduleMeta.getClassName(), implementationInfo, e);
-        throw Throwables.propagate(e);
-      }
-    }
-
-    // contract of DatasetTypeMeta is that the last module returned by getModules() is the one
-    // that announces the dataset's type. The classloader for the returned DatasetType must be the classloader
-    // for that last module.
-    return (T) new DatasetType(registry.get(implementationInfo.getName()), classLoader);
+    return instances.getType(implementationInfo, classLoader, classLoaderProvider);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -18,13 +18,14 @@ package co.cask.cdap.data2.registry;
 
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.datafabric.dataset.DatasetProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterators;
@@ -52,14 +53,17 @@ public class UsageRegistry {
   private final Transactional<UsageDatasetIterable, UsageDataset> txnl;
 
   @Inject
-  public UsageRegistry(TransactionExecutorFactory txExecutorFactory, final DatasetFramework datasetFramework) {
+  public UsageRegistry(TransactionExecutorFactory txExecutorFactory,
+                       final DatasetProvider provider) {
     txnl = Transactional.of(txExecutorFactory, new Supplier<UsageDatasetIterable>() {
       @Override
       public UsageDatasetIterable get() {
         try {
-          Object usageDataset = DatasetsUtil.getOrCreateDataset(datasetFramework, USAGE_INSTANCE_ID,
-                                                                UsageDataset.class.getSimpleName(),
-                                                                DatasetProperties.EMPTY, null, null);
+          Object usageDataset = Preconditions.checkNotNull(
+            provider.getOrCreate(USAGE_INSTANCE_ID, UsageDataset.class.getSimpleName(),
+                                 DatasetProperties.EMPTY, null, null),
+            "Couldn't get/create usage registry dataset");
+
           // Backward compatible check for version <= 3.0.0
           if (usageDataset instanceof UsageDataset) {
             return new UsageDatasetIterable((UsageDataset) usageDataset);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -43,7 +43,6 @@ import co.cask.cdap.data2.dataset2.SingleTypeModule;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.proto.Id;
@@ -131,7 +130,9 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
       new InMemoryDatasetOpExecutor(framework),
       exploreFacade,
       cConf,
-      new UsageRegistry(txExecutorFactory, framework), NAMESPACE_CLIENT);
+      txExecutorFactory,
+      registryFactory,
+      NAMESPACE_CLIENT);
 
     service = new DatasetService(cConf,
                                  namespacedLocationFactory,

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerTest.java
@@ -288,8 +288,9 @@ public class DatasetInstanceHandlerTest extends DatasetServiceTestBase {
     HttpResponse response = makeInstancesRequest(nonExistent.getId());
     assertNamespaceNotFound(response, nonExistent);
 
-    response = getInstance(datasetInstance);
-    assertNamespaceNotFound(response, nonExistent);
+    // TODO: commented out for now until we add back namespace checks on get dataset CDAP-3901
+//    response = getInstance(datasetInstance);
+//    assertNamespaceNotFound(response, nonExistent);
 
     response = createInstance(datasetInstance, Table.class.getName(), null);
     assertNamespaceNotFound(response, nonExistent);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -44,7 +44,6 @@ import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.internal.test.AppJarHelper;
@@ -187,7 +186,9 @@ public abstract class DatasetServiceTestBase {
       new InMemoryDatasetOpExecutor(dsFramework),
       exploreFacade,
       cConf,
-      new UsageRegistry(txExecutorFactory, dsFramework), namespaceClient);
+      txExecutorFactory,
+      registryFactory,
+      namespaceClient);
 
     service = new DatasetService(cConf,
                                  namespacedLocationFactory,

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -32,6 +32,7 @@ import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.config.DefaultConfigStore;
 import co.cask.cdap.data.runtime.DataFabricDistributedModule;
+import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data.view.ViewAdminModules;
@@ -72,6 +73,7 @@ import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
+import com.google.inject.util.Modules;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.twill.zookeeper.ZKClientService;
@@ -149,6 +151,21 @@ public class UpgradeTool {
       new LocationRuntimeModule().getDistributedModules(),
       new ZKClientModule(),
       new DiscoveryRuntimeModule().getDistributedModules(),
+      Modules.override(new DataSetsModules().getDistributedModules()).with(
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(DatasetFramework.class).to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
+            install(new FactoryModuleBuilder()
+                      .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
+                      .build(DatasetDefinitionRegistryFactory.class));
+            // Upgrade tool does not need to record lineage for now.
+            bind(LineageWriter.class).to(NoOpLineageWriter.class);
+            // No need to do anything with Metadata store for now.
+            bind(BusinessMetadataStore.class).to(NoOpBusinessMetadataStore.class);
+          }
+        }
+      ),
       new ViewAdminModules().getDistributedModules(),
       new StreamAdminModules().getDistributedModules(),
       new NotificationFeedClientModule(),
@@ -168,17 +185,8 @@ public class UpgradeTool {
           // the DataFabricDistributedModule needs MetricsCollectionService binding and since Upgrade tool does not do
           // anything with Metrics we just bind it to NoOpMetricsCollectionService
           bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
-          install(new FactoryModuleBuilder()
-                    .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
-                    .build(DatasetDefinitionRegistryFactory.class));
-
           bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
           bind(MetricStore.class).to(DefaultMetricStore.class);
-          bind(DatasetFramework.class).to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
-          // Upgrade tool does not need to record lineage for now.
-          bind(LineageWriter.class).to(NoOpLineageWriter.class);
-          // No need to do anything with Metadata store for now.
-          bind(BusinessMetadataStore.class).to(NoOpBusinessMetadataStore.class);
         }
 
         @Provides


### PR DESCRIPTION
- Added DatasetProvider and DatasetMetaProvider
- Made UsageRegistry obtain the usage registry dataset instance by using
  DatasetProvider instead of DatasetFramework
- Removed namespace existence check in DatasetInstanceService.get()

https://issues.cask.co/browse/CDAP-3902
http://builds.cask.co/browse/CDAP-DUT2984

Reopened from https://github.com/caskdata/cdap/pull/4320

### After changes (total time taken)
N=300: 5787, 6596, 6201, 7068, 6513
N=500: 7702, 7985, 7871, 7920, 9149
N=1000: 12762, 13178, 13163, 12120
N=2000: 19436 (w/ a few ServiceUnavailableExceptions), 15377 (w/ a few ServiceUnavailableExceptions)

### Before changes (total time taken)
N=300: 15535, 11385, 9931, 9153, 8549
N=500: 18091 (w/ timeouts), 17249 (w/ timeouts)