### PR TITLE
CDAP-4032: Support dataset lookup from TransformContext

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/TransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/TransformContext.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.api;
 
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginConfigurer;
@@ -26,7 +27,7 @@ import co.cask.cdap.api.plugin.PluginProperties;
  * Context passed to ETL stages.
  */
 @Beta
-public interface TransformContext {
+public interface TransformContext extends DatasetContext {
 
   /**
    * Gets the {@link PluginProperties} associated with the stage.

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/BatchTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/BatchTransformContext.java
@@ -16,11 +16,15 @@
 
 package co.cask.cdap.etl.batch;
 
+import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.TransformContext;
 import co.cask.cdap.etl.common.ScopedPluginContext;
+
+import java.util.Map;
 
 /**
  * Context for the Transform Stage.
@@ -58,5 +62,16 @@ public class BatchTransformContext extends ScopedPluginContext implements Transf
   @Override
   public PluginProperties getScopedPluginProperties(String scopedPluginId) {
     return context.getPluginProperties(scopedPluginId);
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
+    return context.getDataset(name);
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
+    throws DatasetInstantiationException {
+    return context.getDataset(name, arguments);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/RealtimeTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/RealtimeTransformContext.java
@@ -16,11 +16,16 @@
 
 package co.cask.cdap.etl.realtime;
 
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.worker.WorkerContext;
 import co.cask.cdap.etl.api.TransformContext;
 import co.cask.cdap.etl.common.ScopedPluginContext;
+
+import java.util.Map;
 
 /**
  * Context for the Transform Stage.
@@ -28,11 +33,13 @@ import co.cask.cdap.etl.common.ScopedPluginContext;
 public class RealtimeTransformContext extends ScopedPluginContext implements TransformContext {
   private final WorkerContext context;
   private final Metrics metrics;
+  private final DatasetContext datasetContext;
 
-  public RealtimeTransformContext(WorkerContext context, Metrics metrics, String stageId) {
+  public RealtimeTransformContext(WorkerContext context, Metrics metrics, String stageId, DatasetContext dataset) {
     super(stageId);
     this.context = context;
     this.metrics = metrics;
+    this.datasetContext = dataset;
   }
 
   @Override
@@ -58,5 +65,22 @@ public class RealtimeTransformContext extends ScopedPluginContext implements Tra
   @Override
   public PluginProperties getScopedPluginProperties(String scopedPluginId) {
     return context.getPluginProperties(scopedPluginId);
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
+    if (datasetContext == null) {
+      throw new IllegalStateException("Dataset context is not available");
+    }
+    return datasetContext.getDataset(name);
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
+    throws DatasetInstantiationException {
+    if (datasetContext == null) {
+      throw new IllegalStateException("Dataset context is not available");
+    }
+    return datasetContext.getDataset(name, arguments);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/WorkerRealtimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/WorkerRealtimeContext.java
@@ -28,7 +28,7 @@ public class WorkerRealtimeContext extends RealtimeTransformContext implements R
   private final WorkerContext context;
 
   public WorkerRealtimeContext(WorkerContext context, Metrics metrics, String pluginPrefix) {
-    super(context, metrics, pluginPrefix);
+    super(context, metrics, pluginPrefix, null);
     this.context = context;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/common/MockRealtimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/common/MockRealtimeContext.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.etl.common;
 
+import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.realtime.RealtimeContext;
@@ -69,6 +71,17 @@ public class MockRealtimeContext implements RealtimeContext {
 
   @Override
   public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return null;
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
+    return null;
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name,
+                                          Map<String, String> arguments) throws DatasetInstantiationException {
     return null;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/MockTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/MockTransformContext.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.etl.transform;
 
+import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.TransformContext;
@@ -60,6 +62,17 @@ public class MockTransformContext implements TransformContext {
 
   @Override
   public <T> Class<T> loadPluginClass(String pluginId) {
+    return null;
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
+    return null;
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name,
+                                          Map<String, String> arguments) throws DatasetInstantiationException {
     return null;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/ETLWorker.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/ETLWorker.java
@@ -192,7 +192,7 @@ public class ETLWorker extends AbstractWorker {
   @SuppressWarnings("unchecked")
   private void initializeSinks(WorkerContext context) throws Exception {
     List<SinkInfo> sinkInfos = GSON.fromJson(context.getSpecification().getProperty(Constants.Sink.PLUGINIDS),
-                                                 SINK_INFO_TYPE);
+                                             SINK_INFO_TYPE);
     sinks = Lists.newArrayListWithCapacity(sinkInfos.size());
 
     for (SinkInfo sinkInfo : sinkInfos) {
@@ -205,7 +205,7 @@ public class ETLWorker extends AbstractWorker {
     }
   }
 
-  private List<TransformDetail> initializeTransforms(WorkerContext context) throws Exception {
+  private List<TransformDetail> initializeTransforms(final WorkerContext context) throws Exception {
     List<TransformInfo> transformInfos =
       GSON.fromJson(context.getSpecification().getProperty(Constants.Transform.PLUGINIDS), TRANSFORMDETAILS_LIST_TYPE);
     Preconditions.checkArgument(transformInfos != null);
@@ -213,12 +213,18 @@ public class ETLWorker extends AbstractWorker {
     tranformIdToDatasetName = new HashMap<>(transformInfos.size());
 
     for (int i = 0; i < transformInfos.size(); i++) {
-      String transformId = transformInfos.get(i).getTransformId();
+      final String transformId = transformInfos.get(i).getTransformId();
       try {
-        Transform transform = context.newPluginInstance(transformId);
-        RealtimeTransformContext transformContext = new RealtimeTransformContext(context, metrics, transformId);
+        final Transform transform = context.newPluginInstance(transformId);
         LOG.debug("Transform Class : {}", transform.getClass().getName());
-        transform.initialize(transformContext);
+        getContext().execute(new TxRunnable() {
+          @Override
+          public void run(DatasetContext datasetContext) throws Exception {
+            final RealtimeTransformContext transformContext = new RealtimeTransformContext(
+              context, metrics, transformId, datasetContext);
+            transform.initialize(transformContext);
+          }
+        });
         StageMetrics stageMetrics = new StageMetrics(metrics, PluginID.from(transformId));
         transformDetailList.add(new TransformDetail(transformId, transform, stageMetrics));
         if (transformInfos.get(i).getErrorDatasetName() != null) {
@@ -238,7 +244,7 @@ public class ETLWorker extends AbstractWorker {
     final SourceState nextState = new SourceState();
     final List<Object> dataToSink = Lists.newArrayList();
     final Map<String, List<InvalidEntry>> transformIdToErrorRecords = intializeTransformIdToErrorsList();
-    Set<String> transformErrorsWithoutDataset = Sets.newHashSet();
+    final Set<String> transformErrorsWithoutDataset = Sets.newHashSet();
     // Fetch SourceState from State Table.
     // Only required at the beginning since we persist the state if there is a change.
     getContext().execute(new TxRunnable() {
@@ -267,33 +273,38 @@ public class ETLWorker extends AbstractWorker {
         continue;
       }
 
-      // For each object emitted by the source, invoke the transformExecutor and collect all the data
-      // to be persisted in the sink.
-      for (Object sourceData : sourceEmitter) {
-        try {
-          TransformResponse transformResponse = transformExecutor.runOneIteration(sourceData);
-          while (transformResponse.getEmittedRecords().hasNext()) {
-            dataToSink.add(transformResponse.getEmittedRecords().next());
-          }
-
-          Map<String, Collection<InvalidEntry>> entryMap = transformResponse.getMapTransformIdToErrorEmitter();
-
-          for (Map.Entry<String, Collection<InvalidEntry>> entry : entryMap.entrySet()) {
-            String transformId = entry.getKey();
-            if (!tranformIdToDatasetName.containsKey(transformId)) {
-              if (!transformErrorsWithoutDataset.contains(transformId)) {
-                LOG.warn("Error records were emitted in transform {}, " +
-                           "but error dataset is not configured for this transform", transformId);
+      getContext().execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          // For each object emitted by the source, invoke the transformExecutor and collect all the data
+          // to be persisted in the sink.
+          for (Object sourceData : sourceEmitter) {
+            try {
+              TransformResponse transformResponse = transformExecutor.runOneIteration(sourceData);
+              while (transformResponse.getEmittedRecords().hasNext()) {
+                dataToSink.add(transformResponse.getEmittedRecords().next());
               }
-              continue;
+
+              Map<String, Collection<InvalidEntry>> entryMap = transformResponse.getMapTransformIdToErrorEmitter();
+
+              for (Map.Entry<String, Collection<InvalidEntry>> entry : entryMap.entrySet()) {
+                String transformId = entry.getKey();
+                if (!tranformIdToDatasetName.containsKey(transformId)) {
+                  if (!transformErrorsWithoutDataset.contains(transformId)) {
+                    LOG.warn("Error records were emitted in transform {}, " +
+                               "but error dataset is not configured for this transform", transformId);
+                  }
+                  continue;
+                }
+                transformIdToErrorRecords.get(transformId).addAll(entry.getValue());
+              }
+            } catch (Exception e) {
+              LOG.warn("Exception thrown while processing data {}", sourceData, e);
             }
-            transformIdToErrorRecords.get(transformId).addAll(entry.getValue());
           }
-        } catch (Exception e) {
-          LOG.warn("Exception thrown while processing data {}", sourceData, e);
+          sourceEmitter.reset();
         }
-      }
-      sourceEmitter.reset();
+      });
 
       // Start a Transaction if there is data to persist or if the Source state has changed.
       try {


### PR DESCRIPTION
Changes
* Make TransformContext extend DatasetContext
  * Modify BatchTransformContext, RealtimeTransformContext, other internal implementations
* Wrap Transform initialization and record transformation in transactions. This will add extra overhead to transforms, so maybe we want some way for the Transform implementation to specify if it needs to be wrapped in a transaction.