### PR TITLE
CDAP-3999 improve error logging in Script transforms.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptFilterTransform.java
@@ -102,7 +102,7 @@ public class ScriptFilterTransform extends Transform<StructuredRecord, Structure
         metrics.count("filtered", 1);
       }
     } catch (Exception e) {
-      throw new IllegalArgumentException("Invalid filter condition.", e);
+      throw new IllegalArgumentException("Could not transform input: " + input, e);
     }
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptTransform.java
@@ -120,7 +120,7 @@ public class ScriptTransform extends Transform<StructuredRecord, StructuredRecor
       StructuredRecord output = decodeRecord(scriptOutput, schema == null ? input.getSchema() : schema);
       emitter.emit(output);
     } catch (Exception e) {
-      throw new IllegalArgumentException("Could not transform input: " + e.getMessage(), e);
+      throw new IllegalArgumentException("Could not transform input: " + input, e);
     }
   }
 
@@ -153,7 +153,7 @@ public class ScriptTransform extends Transform<StructuredRecord, StructuredRecor
         return decodeUnion(object, schema.getUnionSchemas());
     }
 
-    throw new RuntimeException("Unable decode object with schema " + schema);
+    throw new RuntimeException("Unable to decode object with schema: " + schema);
   }
 
   private StructuredRecord decodeRecord(Map nativeObject, Schema schema) {
@@ -196,7 +196,7 @@ public class ScriptTransform extends Transform<StructuredRecord, StructuredRecor
       case STRING:
         return (String) object;
     }
-    throw new RuntimeException("Unable decode object with schema " + schema);
+    throw new RuntimeException("Unable decode object with schema: " + schema);
   }
 
   private Map<Object, Object> decodeMap(Map<Object, Object> object, Schema keySchema, Schema valSchema) {


### PR DESCRIPTION
When script fails to run the script on an input, it is helpful to specify what the input record was that it failed on.

Also, it may not necessarily be an invalid filter condition that caused the exception (ScriptFilterTransform.java).

https://issues.cask.co/browse/CDAP-3999
http://builds.cask.co/browse/CDAP-RBT512-1