### PR TITLE
CDAP-3982 add method to RuntimeContext to get namespace

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/RuntimeContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/RuntimeContext.java
@@ -34,4 +34,9 @@ public interface RuntimeContext {
    * @return A map of argument key and value.
    */
   Map<String, String> getRuntimeArguments();
+
+  /**
+   * @return The application namespace
+   */
+  String getNamespace();
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -131,6 +131,11 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     return program.getApplicationSpecification();
   }
 
+  @Override
+  public String getNamespace() {
+    return program.getNamespaceId();
+  }
+
   /**
    * Returns the {@link PluginInstantiator} used by this context or {@code null} if there is no plugin support.
    */

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -121,6 +121,11 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   }
 
   @Override
+  public String getNamespace() {
+    return delegate.getNamespace();
+  }
+
+  @Override
   public URL getServiceURL(String applicationId, String serviceId) {
     return delegate.getServiceURL(applicationId, serviceId);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
@@ -101,6 +101,11 @@ public abstract class AbstractSparkContext implements SparkContext, Closeable {
   }
 
   @Override
+  public String getNamespace() {
+    return programId.getNamespaceId();
+  }
+
+  @Override
   public SparkSpecification getSpecification() {
     return specification;
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppUsingNamespace.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppUsingNamespace.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.service.AbstractService;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpServiceContext;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * App used to test namespace availability.
+ */
+public class AppUsingNamespace extends AbstractApplication {
+  public static final String SERVICE_NAME = "nsService";
+
+  @Override
+  public void configure() {
+    addService(new NamespaceService());
+  }
+
+  public static class NamespaceService extends AbstractService {
+    @Override
+    protected void configure() {
+      setName(SERVICE_NAME);
+      addHandler(new NamespaceHandler());
+    }
+  }
+
+  public static class NamespaceHandler extends AbstractHttpServiceHandler {
+    private String namespace;
+
+    @Override
+    public void initialize(HttpServiceContext context) throws Exception {
+      super.initialize(context);
+      namespace = context.getNamespace();
+    }
+
+    @Path("/ns")
+    @GET
+    public void getNamespace(HttpServiceRequest request, HttpServiceResponder responder) {
+      responder.sendString(namespace);
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -406,6 +406,11 @@ public class HttpHandlerGeneratorTest {
     }
 
     @Override
+    public String getNamespace() {
+      return null;
+    }
+
+    @Override
     public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
       return getDataset(name, null);
     }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.test.app;
 
+import co.cask.cdap.AppUsingNamespace;
 import co.cask.cdap.ConfigTestApp;
 import co.cask.cdap.api.app.Application;
 import co.cask.cdap.api.common.Bytes;
@@ -211,6 +212,20 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     history = countService.getHistory(ProgramRunStatus.ALL);
     Assert.assertEquals(1, history.size());
     Assert.assertEquals(ProgramRunStatus.RUNNING, history.get(0).getStatus());
+  }
+
+  @Test
+  public void testNamespaceAvailableAtRuntime() throws Exception {
+    ApplicationManager applicationManager = deployApplication(testSpace, AppUsingNamespace.class);
+    ServiceManager serviceManager = applicationManager.getServiceManager(AppUsingNamespace.SERVICE_NAME);
+    serviceManager.start();
+    serviceManager.waitForStatus(true, 1, 10);
+
+    URL serviceURL = serviceManager.getServiceURL(10, TimeUnit.SECONDS);
+    Assert.assertEquals(testSpace.getId(), callServiceGet(serviceURL, "ns"));
+
+    serviceManager.stop();
+    serviceManager.waitForStatus(false, 1, 10);
   }
 
   @Test


### PR DESCRIPTION
this makes it possible for a program to get its namespace at
runtime. This is useful for a variety of use cases. For example,
you could have a worker that makes program lifecycle calls,
which need namespace in the url. Or you could call some program
that makes an external call to some http endpoint, and needs the
namespace to uniquely identify itself.