### PR TITLE
(CDAP-4026) Made MapReduceTaskContext available to plugins.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchRuntimeContext.java
@@ -47,6 +47,13 @@ public interface BatchRuntimeContext<T> extends DatasetContext, TransformContext
    */
   Map<String, String> getRuntimeArguments();
 
-  T getOriginalContext();
+  /**
+   * Returns the processing framework's context, to enable advanced use-cases in plugins.
+   * E.g. this method could give access to the {@link MapReduceTaskContext} for pipelines that use
+   * MapReduce as the processing framework.
+   *
+   * @return the processing framework context
+   */
 
+  T getOriginalContext();
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchRuntimeContext.java
@@ -18,15 +18,18 @@ package co.cask.cdap.etl.api.batch;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.etl.api.TransformContext;
 
 import java.util.Map;
 
 /**
  * Context passed to Batch Source and Sink.
+ *
+ * @param <T>  the context used to construct the BatchRuntimeContext, eg. {@link MapReduceTaskContext}
  */
 @Beta
-public interface BatchRuntimeContext extends DatasetContext, TransformContext {
+public interface BatchRuntimeContext<T> extends DatasetContext, TransformContext {
 
   /**
    * Returns the logical start time of the Batch Job.  Logical start time is the time when this Batch
@@ -43,5 +46,7 @@ public interface BatchRuntimeContext extends DatasetContext, TransformContext {
    * @return runtime arguments of the Batch Job.
    */
   Map<String, String> getRuntimeArguments();
+
+  T getOriginalContext();
 
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/test/sink/MetaKVTableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/test/sink/MetaKVTableSink.java
@@ -20,10 +20,13 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.etl.batch.sink.KVTableSink;
+import com.google.common.base.Preconditions;
 
 /**
  * Test Batch Sink that writes to a table in {@link BatchSink#prepareRun} and {@link BatchSink#onRunFinish}.
@@ -50,6 +53,14 @@ public class MetaKVTableSink extends KVTableSink {
     super.prepareRun(context);
     KeyValueTable table = context.getDataset(META_TABLE);
     table.write(PREPARE_RUN_KEY, PREPARE_RUN_KEY);
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+    Preconditions.checkArgument(context.getOriginalContext() instanceof MapReduceTaskContext,
+                                "Expected the original context to be an instance of MapReduceTaskContext");
+
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/test/source/MetaKVTableSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/test/source/MetaKVTableSource.java
@@ -20,10 +20,13 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import co.cask.cdap.etl.batch.source.KVTableSource;
+import com.google.common.base.Preconditions;
 
 /**
  * Test Batch Source that writes to a table in {@link BatchSource#prepareRun} and {@link BatchSource#onRunFinish}.
@@ -43,6 +46,13 @@ public class MetaKVTableSource extends KVTableSource {
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
     pipelineConfigurer.createDataset(META_TABLE, KeyValueTable.class, DatasetProperties.EMPTY);
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+    Preconditions.checkArgument(context.getOriginalContext() instanceof MapReduceTaskContext,
+                                "Expected the original context to be an instance of MapReduceTaskContext");
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/MapReduceRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/MapReduceRuntimeContext.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * transforms, and sinks don't need to worry that plugins they use conflict with plugins other sources, transforms,
  * or sinks use.
  */
-public class MapReduceRuntimeContext extends ScopedPluginContext implements BatchRuntimeContext {
+public class MapReduceRuntimeContext extends ScopedPluginContext implements BatchRuntimeContext<MapReduceTaskContext> {
   private final MapReduceTaskContext context;
   private final Metrics metrics;
 
@@ -82,6 +82,11 @@ public class MapReduceRuntimeContext extends ScopedPluginContext implements Batc
   @Override
   public Map<String, String> getRuntimeArguments() {
     return context.getRuntimeArguments();
+  }
+
+  @Override
+  public MapReduceTaskContext getOriginalContext() {
+    return context;
   }
 
   @Override


### PR DESCRIPTION
Jira: [CDAP-4026](https://issues.cask.co/browse/CDAP-4026)
Build: http://builds.cask.co/browse/CDAP-RBT511-1

Usage example: 
```
class MySource extends BatchSource {
@Override
  public void initialize(BatchRuntimeContext context) throws Exception {
    super.initialize(context);
    // You can also cache this if its required in the transform method
    MapReduceTaskContext mrTaskContext = (MapReduceTaskContext) context.getOriginalContext();
    Path[] cacheFiles = mapperContext.getLocalCacheFiles();
    // work on files from dist cache....
    Path filePath = ((CombineFileSplit) mapperContext.getInputSplit()).getPath(0);
    // make decisions based on InputSplit
    // update MR counters 
    mapperContext.getCounter("group", "counter").increment(1);
}
```
