### PR TITLE
CDAP-4038 adding tpfs and snapshot parquet sources.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/BaseETLBatchTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/BaseETLBatchTest.java
@@ -35,9 +35,11 @@ import co.cask.cdap.etl.batch.sink.TimePartitionedFileSetDatasetParquetSink;
 import co.cask.cdap.etl.batch.source.DBSource;
 import co.cask.cdap.etl.batch.source.KVTableSource;
 import co.cask.cdap.etl.batch.source.SnapshotFileBatchAvroSource;
+import co.cask.cdap.etl.batch.source.SnapshotFileBatchParquetSource;
 import co.cask.cdap.etl.batch.source.StreamBatchSource;
 import co.cask.cdap.etl.batch.source.TableSource;
 import co.cask.cdap.etl.batch.source.TimePartitionedFileSetDatasetAvroSource;
+import co.cask.cdap.etl.batch.source.TimePartitionedFileSetDatasetParquetSource;
 import co.cask.cdap.etl.common.DBRecord;
 import co.cask.cdap.etl.test.sink.MetaKVTableSink;
 import co.cask.cdap.etl.test.source.MetaKVTableSource;
@@ -64,6 +66,7 @@ import org.apache.twill.filesystem.Location;
 import org.hsqldb.jdbc.JDBCDriver;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import parquet.avro.AvroParquetInputFormat;
 import parquet.avro.AvroParquetOutputFormat;
 import parquet.avro.AvroParquetReader;
 
@@ -88,17 +91,18 @@ public class BaseETLBatchTest extends TestBase {
     addAppArtifact(APP_ARTIFACT_ID, ETLBatchApplication.class,
       BatchSource.class.getPackage().getName(),
       PipelineConfigurable.class.getPackage().getName(),
-      "org.apache.avro.mapred", "org.apache.avro", "org.apache.avro.generic");
+      "org.apache.avro.mapred", "org.apache.avro", "org.apache.avro.generic", "org.apache.avro.io");
 
     // add artifact for batch sources and sinks
     addPluginArtifact(Id.Artifact.from(Id.Namespace.DEFAULT, "batch-plugins", "1.0.0"), APP_ARTIFACT_ID,
                       DBSource.class, KVTableSource.class, StreamBatchSource.class, TableSource.class, DBRecord.class,
                       TimePartitionedFileSetDatasetAvroSource.class,
+                      TimePartitionedFileSetDatasetParquetSource.class, AvroParquetInputFormat.class,
                       BatchCubeSink.class, DBSink.class, KVTableSink.class, TableSink.class,
                       TimePartitionedFileSetDatasetAvroSink.class, AvroKeyOutputFormat.class, AvroKey.class,
                       TimePartitionedFileSetDatasetParquetSink.class, AvroParquetOutputFormat.class,
                       SnapshotFileBatchAvroSink.class, SnapshotFileBatchParquetSink.class,
-                      SnapshotFileBatchAvroSource.class,
+                      SnapshotFileBatchAvroSource.class, SnapshotFileBatchParquetSource.class,
                       S3AvroBatchSink.class, S3ParquetBatchSink.class);
     // add artifact for transforms
     addPluginArtifact(Id.Artifact.from(Id.Namespace.DEFAULT, "transforms", "1.0.0"), APP_ARTIFACT_ID,

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -201,7 +201,7 @@
                 <!-- build bundle jar for batch. excluding realtime-->
                 <Export-Package>co.cask.cdap.etl.batch.*;co.cask.cdap.etl.transform.*;
                   co.cask.cdap.etl.validator.*;
-                  co.cask.cdap.etl.common;org.apache.avro.mapreduce;parquet.avro</Export-Package>
+                  co.cask.cdap.etl.common;org.apache.avro.mapreduce;parquet.avro.*;parquet.hadoop.*</Export-Package>
                 <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
                 <Embed-Transitive>true</Embed-Transitive>
                 <Embed-Directory>lib</Embed-Directory>

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/SnapshotFileBatchParquetSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/SnapshotFileBatchParquetSource.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.source;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.UnsupportedTypeException;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.common.AvroToStructuredTransformer;
+import co.cask.cdap.etl.common.SchemaConverter;
+import co.cask.cdap.etl.common.SnapshotFileSetConfig;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.io.NullWritable;
+import parquet.avro.AvroParquetInputFormat;
+import parquet.avro.AvroParquetOutputFormat;
+
+import javax.annotation.Nullable;
+
+/**
+ * Reads data written by a {@link SnapshotFileBatchParquetSource}. Reads only the most recent partition.
+ */
+@Plugin(type = "batchsource")
+@Name("SnapshotParquet")
+@Description("Reads the most recent snapshot that was written to a SnapshotParquet sink.")
+public class SnapshotFileBatchParquetSource extends SnapshotFileBatchSource<NullWritable, GenericRecord> {
+  private final AvroToStructuredTransformer recordTransformer = new AvroToStructuredTransformer();
+  private final SnapshotParquetConfig config;
+
+  public SnapshotFileBatchParquetSource(SnapshotParquetConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  @Override
+  public void transform(KeyValue<NullWritable, GenericRecord> input,
+                        Emitter<StructuredRecord> emitter) throws Exception {
+    emitter.emit(recordTransformer.transform(input.getValue()));
+  }
+
+  @Override
+  protected void addFileProperties(FileSetProperties.Builder propertiesBuilder) {
+    propertiesBuilder.setInputFormat(AvroParquetInputFormat.class)
+      .setOutputFormat(AvroParquetOutputFormat.class)
+      .setEnableExploreOnCreate(true)
+      .setExploreFormat("parquet");
+    try {
+      String hiveSchema = SchemaConverter.toHiveSchema(
+        co.cask.cdap.api.data.schema.Schema.parseJson(config.schema.toLowerCase()));
+      propertiesBuilder.setExploreSchema(hiveSchema.substring(1, hiveSchema.length() - 1));
+    } catch (UnsupportedTypeException e) {
+      throw new IllegalArgumentException("schema " + config.schema + " is not supported.", e);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("schema " + config.schema + " is invalid.", e);
+    }
+  }
+
+  /**
+   * Config for SnapshotFileBatchAvroSource
+   */
+  public static class SnapshotParquetConfig extends SnapshotFileSetConfig {
+    @Description("The Parquet schema of the records to read.")
+    private String schema;
+
+    public SnapshotParquetConfig(String name, @Nullable String basePath, String schema) {
+      super(name, basePath, null);
+      this.schema = schema;
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/SnapshotFileBatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/SnapshotFileBatchSource.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.etl.batch.source;
 
 import co.cask.cdap.api.data.format.StructuredRecord;
-import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
@@ -52,6 +51,7 @@ public abstract class SnapshotFileBatchSource<KEY, VALUE> extends BatchSource<KE
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     PartitionedFileSetProperties.Builder fileProperties = SnapshotFileSet.getBaseProperties(config);
+    addFileProperties(fileProperties);
 
     pipelineConfigurer.createDataset(config.getName(), PartitionedFileSet.class, fileProperties.build());
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/TimePartitionedFileSetSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/TimePartitionedFileSetSource.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.source;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.etl.common.ETLUtils;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Base class to read from a {@link TimePartitionedFileSet}.
+ *
+ * @param <KEY> type of input key
+ * @param <VALUE> type of input value
+ */
+public abstract class TimePartitionedFileSetSource<KEY, VALUE> extends BatchSource<KEY, VALUE, StructuredRecord> {
+
+  private final TPFSConfig config;
+
+  /**
+   * Config for TimePartitionedFileSetDatasetAvroSource
+   */
+  public static class TPFSConfig extends PluginConfig {
+    @Description("Name of the TimePartitionedFileSet to read.")
+    private String name;
+
+    @Description("Base path for the TimePartitionedFileSet. Defaults to the name of the dataset.")
+    @Nullable
+    private String basePath;
+
+    @Description("Size of the time window to read with each run of the pipeline. " +
+      "The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' " +
+      "for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, a value of '5m' means each run of " +
+      "the pipeline will read 5 minutes of events from the TPFS source.")
+    private String duration;
+
+    @Description("Optional delay for reading from TPFS source. The value must be " +
+      "of the same format as the duration value. For example, a duration of '5m' and a delay of '10m' means each run " +
+      "of the pipeline will read 5 minutes of data from 15 minutes before its logical start time to 10 minutes " +
+      "before its logical start time. The default value is 0.")
+    @Nullable
+    private String delay;
+
+    protected void validate() {
+      // check duration and delay
+      long durationInMs = ETLUtils.parseDuration(duration);
+      Preconditions.checkArgument(durationInMs > 0, "Duration must be greater than 0");
+      if (!Strings.isNullOrEmpty(delay)) {
+        ETLUtils.parseDuration(delay);
+      }
+    }
+  }
+
+  public TimePartitionedFileSetSource(TPFSConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    config.validate();
+    String tpfsName = config.name;
+    FileSetProperties.Builder properties = FileSetProperties.builder();
+    if (!Strings.isNullOrEmpty(config.basePath)) {
+      properties.setBasePath(config.basePath);
+    }
+    addFileSetProperties(properties);
+
+    pipelineConfigurer.createDataset(tpfsName, TimePartitionedFileSet.class.getName(), properties.build());
+  }
+
+  /**
+   * Set file set specific properties, such as input/output format and explore properties.
+   */
+  protected abstract void addFileSetProperties(FileSetProperties.Builder properties);
+
+  protected void setInput(BatchSourceContext context) {
+    Map<String, String> runtimeArgs = context.getRuntimeArguments();
+    long runtime = context.getLogicalStartTime();
+    if (runtimeArgs.containsKey("runtime")) {
+      runtime = Long.parseLong(runtimeArgs.get("runtime"));
+    }
+
+    long duration = ETLUtils.parseDuration(config.duration);
+    long delay = Strings.isNullOrEmpty(config.delay) ? 0 : ETLUtils.parseDuration(config.delay);
+    long endTime = runtime - delay;
+    long startTime = endTime - duration;
+    Map<String, String> sourceArgs = Maps.newHashMap();
+    TimePartitionedFileSetArguments.setInputStartTime(sourceArgs, startTime);
+    TimePartitionedFileSetArguments.setInputEndTime(sourceArgs, endTime);
+    TimePartitionedFileSet source = context.getDataset(config.name, sourceArgs);
+    context.setInput(config.name, source);
+  }
+}

--- a/cdap-docs/included-applications/source/etl/plugins/batchsources/index.rst
+++ b/cdap-docs/included-applications/source/etl/plugins/batchsources/index.rst
@@ -16,6 +16,8 @@ Batch Sources
     KVTable <kvtable>
     S3 <s3>
     SnapshotAvro <snapshotavro>
+    SnapshotParquet <snapshotparquet>
     Stream <stream>
     Table <table>
     TPFSAvro <tpfsavro>
+    TPFSParquet <tpfsparquet>

--- a/cdap-docs/included-applications/source/etl/plugins/batchsources/snapshotparquet.rst
+++ b/cdap-docs/included-applications/source/etl/plugins/batchsources/snapshotparquet.rst
@@ -19,7 +19,7 @@ This source is used whenever you want to read data written to the corresponding
 SnapshotParquet sink. It will read only the last snapshot written to that sink.
 For example, you might want to create daily snapshots of a database by reading the entire contents of
 a table and writing it to a SnapshotParquet sink. You might then want to use this source to read the most
-recent snapshot and run some data analysis on it.
+recent snapshot and run a data analysis on it.
 
 .. rubric:: Properties
 

--- a/cdap-docs/included-applications/source/etl/plugins/batchsources/snapshotparquet.rst
+++ b/cdap-docs/included-applications/source/etl/plugins/batchsources/snapshotparquet.rst
@@ -1,0 +1,59 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+
+.. _included-apps-etl-plugins-batch-sinks-snapshotparquet:
+
+==============================
+Batch Sources: SnapshotParquet
+==============================
+
+.. rubric:: Description
+
+A batch source that reads from a corresponding SnapshotParquet sink.
+The source will only read the most recent snapshot written to the sink.
+
+.. rubric:: Use Case
+
+This source is used whenever you want to read data written to the corresponding
+SnapshotParquet sink. It will read only the last snapshot written to that sink.
+For example, you might want to create daily snapshots of a database by reading the entire contents of
+a table and writing it to a SnapshotParquet sink. You might then want to use this source to read the most
+recent snapshot and run some data analysis on it.
+
+.. rubric:: Properties
+
+**name:** Name of the PartitionedFileSet to which records are written.
+If it doesn't exist, it will be created.
+
+**schema:** The Parquet schema of the record being written to the sink as a JSON object.
+
+**basePath:** Base path for the PartitionedFileSet. Defaults to the name of the dataset.
+
+**fileProperties:** Advanced feature to specify any additional properties that should be used with the sink,
+specified as a JSON object of string to string. These properties are set on the dataset if one is created.
+The properties are also passed to the dataset at runtime as arguments.
+
+.. rubric:: Example
+
+::
+
+  {
+    "name": "SnapshotParquet",
+    "properties": {
+      "name": "users",
+      "schema": "{
+        \"type\":\"record\",
+        \"name\":\"user\",
+        \"fields\":[
+          {\"name\":\"id\",\"type\":\"long\"},
+          {\"name\":\"name\",\"type\":\"string\"},
+          {\"name\":\"birthyear\",\"type\":\"int\"}
+        ]
+      }"
+    }
+  }
+
+This example will read from a SnapshotFileSet named 'users'. It will read data in Parquet format
+using the given schema. Every time the pipeline runs, only the most recently added snapshot will
+be read.

--- a/cdap-docs/included-applications/source/etl/plugins/batchsources/tpfsparquet.rst
+++ b/cdap-docs/included-applications/source/etl/plugins/batchsources/tpfsparquet.rst
@@ -29,13 +29,13 @@ reads the newly-arrived files, performs data validation and cleansing, and then 
 dataset.
 
 **duration:** Size of the time window to read with each run of the pipeline. The format is
-expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with
+expected to be a number followed by an 's', 'm', 'h', or 'd' (specifying the time unit), with
 's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, a value of
 '5m' means each run of the pipeline will read 5 minutes of events from the TPFS source.
 
 **delay:** Optional delay for reading from TPFS source. The value must be of the same
 format as the duration value. For example, a duration of '5m' and a delay of '10m' means
-each run of the pipeline will read events 5 minutes of data from 15 minutes before its logical
+each run of the pipeline will read events for 5 minutes of data from 15 minutes before its logical
 start time to 10 minutes before its logical start time. The default value is 0.
 
 .. rubric:: Example

--- a/cdap-docs/included-applications/source/etl/plugins/batchsources/tpfsparquet.rst
+++ b/cdap-docs/included-applications/source/etl/plugins/batchsources/tpfsparquet.rst
@@ -1,0 +1,82 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+
+.. _included-apps-etl-plugins-batch-sources-tpfsparquet:
+
+==========================
+Batch Sources: TPFSParquet 
+==========================
+
+.. rubric:: Description
+
+Reads from a TimePartitionedFileSet whose data is in Parquet format.
+
+.. rubric:: Use Case
+
+The source is used when you need to read partitions of a TimePartitionedFileSet.
+For example, suppose there is an application that ingests data by writing to a TimePartitionedFileSet,
+where arrival time of the data is used as the partition key. You may want to create a pipeline that
+reads the newly-arrived files, performs data validation and cleansing, and then writes to a Table.
+
+.. rubric:: Properties 
+
+**name:** Name of the TimePartitionedFileSet from which the records are to be read from.
+
+**schema:** The Parquet schema of the record being read from the source as a JSON Object.
+
+**basePath:** Base path for the TimePartitionedFileSet. Defaults to the name of the
+dataset.
+
+**duration:** Size of the time window to read with each run of the pipeline. The format is
+expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with
+'s' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, a value of
+'5m' means each run of the pipeline will read 5 minutes of events from the TPFS source.
+
+**delay:** Optional delay for reading from TPFS source. The value must be of the same
+format as the duration value. For example, a duration of '5m' and a delay of '10m' means
+each run of the pipeline will read events 5 minutes of data from 15 minutes before its logical
+start time to 10 minutes before its logical start time. The default value is 0.
+
+.. rubric:: Example
+
+::
+
+  {
+    "name": "TPFSParquet",
+    "properties": {
+      "name": "webactivity",
+      "duration": "5m",
+      "delay": "1m",
+      "schema": "{
+        \"type\":\"record\",
+        \"name\":\"webactivity\",
+        \"fields\":[
+          {\"name\":\"date\",\"type\":\"string\"},
+          {\"name\":\"userid\",\"type\":\"long\"},
+          {\"name\":\"action\",\"type\":\"string\"},
+          {\"name\":\"item\",\"type\":\"string\"}
+        ]
+      }"
+    }
+  }
+
+This example reads from a TimePartitionedFileSet named 'webactivity', assuming the underlying
+files are in Parquet format. TimePartitionedFileSets are partitioned by year, month, day, hour,
+and minute. Suppose the current run was scheduled to start at 10:00am on January 1, 2015.
+Since the 'delay' property is set to one minute, only data before 9:59am January 1, 2015 will
+be read. This excludes the partition for year 2015, month 1, day 1, hour 9, and minute 59.
+Since the 'duration' property is set to five minutes, a total of five partitions will be read.
+This means partitions for year 2015, month 1, day 1, hour 9, and minutes 54, 55, 56, 57, and 58
+will be read. The source will read the actual data using the given schema. This means it will output
+records with this schema::
+
+  +=======================+
+  | field name  | type    |
+  +=======================+
+  | date        | string  |
+  | userid      | long    |
+  | action      | string  |
+  | item        | string  |
+  +=======================+
+


### PR DESCRIPTION
Adding matching parquet sources for the parquet sinks. As part of
this, doing some refactoring so that avro and parquet tpfs sources
can share most of their code.