### PR TITLE
Fix the parameter name in docs

### DIFF
--- a/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
+++ b/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
@@ -32,7 +32,7 @@ Configurations for submitting to non-default YARN queues can be specified in two
     </property>
 
     <property>
-      <name>app.scheduler.queue</name>
+      <name>apps.scheduler.queue</name>
       <value>app</value>
       <description>Scheduler queue for CDAP programs and Explore Queries</description>
     </property>


### PR DESCRIPTION
app.scheduler.name -> apps.scheduler.name 