### PR TITLE
Feature/hdinsight constrain

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
+++ b/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
@@ -4,7 +4,8 @@
       "zookeeper.quorum": "ZK_QUORUM",
       "kafka.log.dir": "/var/cdap/kafka-logs"
     },
-    "skip_prerequisites": "true"
+    "skip_prerequisites": "true",
+    "version": "3.2.0-1"
   },
   "hadoop": {
     "distribution": "hdp",

--- a/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
+++ b/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
@@ -2,7 +2,8 @@
   "cdap": {
     "cdap_site": {
       "zookeeper.quorum": "ZK_QUORUM",
-      "kafka.log.dir": "/var/cdap/kafka-logs"
+      "kafka.log.dir": "/var/cdap/kafka-logs",
+      "explore.enabled": "true"
     },
     "skip_prerequisites": "true",
     "version": "3.2.0-1"

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -36,7 +36,7 @@ __create_tmpdir() { mkdir -p ${__tmpdir}; };
 apt-get install --yes git || die "Failed to install git"
 
 # Install chef
-curl -L https://www.chef.io/chef/install.sh | sudo bash ./install.sh -v ${CHEF_VERSION} || die "Failed to install chef"
+curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v ${CHEF_VERSION} || die "Failed to install chef"
 
 # Clone CDAP repo
 __create_tmpdir

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -20,6 +20,9 @@
 
 die() { echo "ERROR: ${*}"; exit 1; };
 
+CDAP_BRANCH='release/3.2'
+CHEF_VERSION='11.18.12'
+
 __tmpdir="/tmp/cdap_install.$$.$(date +%s)"
 __gitdir="${__tmpdir}/cdap"
 
@@ -33,11 +36,11 @@ __create_tmpdir() { mkdir -p ${__tmpdir}; };
 apt-get install --yes git || die "Failed to install git"
 
 # Install chef
-curl -L https://www.chef.io/chef/install.sh | sudo bash || die "Failed to install chef"
+curl -L https://www.chef.io/chef/install.sh | sudo bash ./install.sh -v ${CHEF_VERSION} || die "Failed to install chef"
 
 # Clone CDAP repo
 __create_tmpdir
-git clone --depth 1 https://github.com/caskdata/cdap.git ${__gitdir}
+git clone --depth 1 --branch ${CDAP_BRANCH} https://github.com/caskdata/cdap.git ${__gitdir}
 
 # Setup cookbook repo
 test -d /var/chef/cookbooks && rm -rf /var/chef/cookbooks


### PR DESCRIPTION
updates to HDInsight install:
   - [x] constrain chef version to a known good version
   - [x] specify the cdap repo branch to clone
   - [x] specify a CDAP release version for chef to install (this is within the template read from the cloned branch)
   - [x] enable explore