### PR TITLE
Docs/3.2.1 release notes

### DIFF
--- a/cdap-docs/included-applications/build.sh
+++ b/cdap-docs/included-applications/build.sh
@@ -37,7 +37,7 @@ function download_includes() {
   test_an_include 0c22ee5c57de83614d8235096e8efa8d "${cdap_etl}/batch/sink/SnapshotFileBatchParquetSink.java"
   test_an_include 288b88b520b32f16fb0d0dafab5c52be "${cdap_etl}/batch/sink/SnapshotFileBatchSink.java"
   test_an_include 8e51b83878c90f000e59ada65630457d "${cdap_etl}/batch/sink/TableSink.java"
-  test_an_include 2417871dcd685d2ed75c10df712c9f8c "${cdap_etl}/batch/sink/TimePartitionedFileSetDatasetAvroSink.java"
+  test_an_include ea3eb9208a4bfeaead70ea689fba5cae "${cdap_etl}/batch/sink/TimePartitionedFileSetDatasetAvroSink.java"
   test_an_include 95ae9c116aa257efd5e3bb6cacaa4033 "${cdap_etl}/batch/sink/TimePartitionedFileSetDatasetParquetSink.java"
   test_an_include 3069701c1070f0546d6a73800f558e72 "${cdap_etl}/batch/sink/TimePartitionedFileSetSink.java"
 
@@ -69,8 +69,8 @@ function download_includes() {
   # Transforms
   test_an_include 06ddd340ba65bbc068ab3e3cf2f346c1 "${cdap_etl}/transform/LogParserTransform.java"
   test_an_include 7b5386499cc1a646e5be38ab5269d076 "${cdap_etl}/transform/ProjectionTransform.java"
-  test_an_include 54cc16b74a04a15bd29e8100ae209b2e "${cdap_etl}/transform/ScriptFilterTransform.java"
-  test_an_include d095c2d250bf7cc7c5d4aaa794c2885b "${cdap_etl}/transform/ScriptTransform.java"
+  test_an_include 50f4c36bf7a0fcb5acf0fc72df049afb "${cdap_etl}/transform/ScriptFilterTransform.java"
+  test_an_include 91b2b4ae0e5a4e58a411b387e88d1c4e "${cdap_etl}/transform/ScriptTransform.java"
   test_an_include c3eb291d7b7d4ca0934d151bed882dd3 "${cdap_etl}/transform/StructuredRecordToGenericRecordTransform.java"
   test_an_include c2d115c4993b10f1a787c789665626d4 "${cdap_etl}/transform/ValidatorTransform.java"
 

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -23,6 +23,61 @@ Cask Data Application Platform Release Notes
    :backlinks: none
    :depth: 2
 
+`Release 3.2.1 <http://docs.cask.co/cdap/3.2.1/index.html>`__
+=============================================================
+
+New Features
+------------
+
+- `CDAP-3951 <https://issues.cask.co/browse/CDAP-3951>`__ -
+  Added the ability for S3 batch sources and sinks to set additional file system properties.
+  
+Improvements
+------------
+
+- `CDAP-3870 <https://issues.cask.co/browse/CDAP-3870>`__ -
+  Added logging and metrics support for *Script*, *ScriptFilter*, and *Validator* transforms.
+  
+- `CDAP-3884 <https://issues.cask.co/browse/CDAP-3884>`__ -
+  Added "cdap-hbase-compat-1.1", required for HDP 2.3 installations, to the installation instruction documentation.
+  
+- `CDAP-3939 <https://issues.cask.co/browse/CDAP-3939>`__ -
+  Improved artifact and application deployment failure handling.
+
+Bug Fixes
+---------
+
+- `CDAP-3342 <https://issues.cask.co/browse/CDAP-3342>`__ -
+  Fixed a problem with the CDAP SDK unable to start on certain Windows machines by updating
+  the Hadoop native library in CDAP with a version that does not have a dependency on a
+  debug version of the Microsoft ``msvcr100.dll``.
+  
+- `CDAP-3815 <https://issues.cask.co/browse/CDAP-3815>`__ -
+  Fixed an issue where the regex filter for S3 batch sources wasn't being applied correctly.
+  
+- `CDAP-3829 <https://issues.cask.co/browse/CDAP-3829>`__ -
+  Fixed snapshot sinks so that the data is explorable as a ``PartitionedFileSet``.
+  
+- `CDAP-3833 <https://issues.cask.co/browse/CDAP-3833>`__ -
+  Fixed snapshot sinks so that they can be read safely.
+  
+- `CDAP-3859 <https://issues.cask.co/browse/CDAP-3859>`__ -
+  Fixed a compilation error in the Maven application archetype.
+  
+- `CDAP-3860 <https://issues.cask.co/browse/CDAP-3860>`__ -
+  Fixed a bug where plugins, packaged in the same artifact as an application class, could not be used by that application class.
+  
+- `CDAP-3891 <https://issues.cask.co/browse/CDAP-3891>`__ -
+  Updated the documentation to remove references to application templates and adaptors that were removed as of CDAP 3.2.0.
+  
+- `CDAP-3949 <https://issues.cask.co/browse/CDAP-3949>`__ -
+  Fixed a problem with running certain examples on Linux systems by increasing the maximum
+  Java heap size of the Standalone SDK on Linux systems to 2048m.
+
+- `CDAP-3961 <https://issues.cask.co/browse/CDAP-3961>`__ -
+  Fixed a missing dependency on ``cdap-hbase-compat-1.1`` package in the CDAP Master package. 
+
+
 `Release 3.2.0 <http://docs.cask.co/cdap/3.2.0/index.html>`__
 =============================================================
 

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -38,9 +38,6 @@ Improvements
 - `CDAP-3870 <https://issues.cask.co/browse/CDAP-3870>`__ -
   Added logging and metrics support for *Script*, *ScriptFilter*, and *Validator* transforms.
   
-- `CDAP-3884 <https://issues.cask.co/browse/CDAP-3884>`__ -
-  Added "cdap-hbase-compat-1.1", required for HDP 2.3 installations, to the installation instruction documentation.
-  
 - `CDAP-3939 <https://issues.cask.co/browse/CDAP-3939>`__ -
   Improved artifact and application deployment failure handling.
 


### PR DESCRIPTION
Corrects MD5 hashes for included applications.

[Quick Build passed](https://builds.cask.co/browse/CDAP-DOB20)

[3.2.1 Release Notes](http://builds.cask.co/artifact/CDAP-DOB20/shared/build-1/Docs-HTML/3.2.0/en/reference-manual/release-notes.html#release-3-2-1)