### PR TITLE
Make sure that stop is called for HBaseTestBase, ZkClientService and …

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableTest.java
@@ -40,23 +40,21 @@ import org.junit.rules.TemporaryFolder;
 @Category(SlowTests.class)
 public class HBaseKVTableTest extends NoTxKeyValueTableTest {
   @ClassRule
-  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  @ClassRule
+  public static final HBaseTestBase TEST_HBASE = new HBaseTestFactory().get();
 
-  private static HBaseTestBase testHBase;
   private static HBaseTableUtil hBaseTableUtil = new HBaseTableUtilFactory(CConfiguration.create()).get();
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    testHBase = new HBaseTestFactory().get();
-    testHBase.startHBase();
-    hBaseTableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), NAMESPACE_ID);
+    hBaseTableUtil.createNamespaceIfNotExists(TEST_HBASE.getHBaseAdmin(), NAMESPACE_ID);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
-    hBaseTableUtil.deleteAllInNamespace(testHBase.getHBaseAdmin(), NAMESPACE_ID);
-    hBaseTableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), NAMESPACE_ID);
-    testHBase.stopHBase();
+    hBaseTableUtil.deleteAllInNamespace(TEST_HBASE.getHBaseAdmin(), NAMESPACE_ID);
+    hBaseTableUtil.deleteNamespaceIfExists(TEST_HBASE.getHBaseAdmin(), NAMESPACE_ID);
   }
 
   @Override
@@ -65,7 +63,7 @@ public class HBaseKVTableTest extends NoTxKeyValueTableTest {
       @Override
       protected void configure() {
         bind(CConfiguration.class).toInstance(CConfiguration.create());
-        bind(Configuration.class).toInstance(testHBase.getConfiguration());
+        bind(Configuration.class).toInstance(TEST_HBASE.getConfiguration());
         bind(HBaseTableUtil.class).toInstance(hBaseTableUtil);
       }
     });

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
@@ -44,6 +44,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -59,18 +60,18 @@ import static org.junit.Assert.assertEquals;
 @Category(SlowTests.class)
 public class HBaseMetricsTableTest extends MetricsTableTest {
 
-  private static HBaseTestBase testHBase;
+  @ClassRule
+  public static final HBaseTestBase TEST_HBASE = new HBaseTestFactory().get();
+
   private static HBaseTableUtil tableUtil;
   private static DatasetFramework dsFramework;
 
   @BeforeClass
   public static void setup() throws Exception {
-    testHBase = new HBaseTestFactory().get();
-    testHBase.startHBase();
     CConfiguration conf = CConfiguration.create();
     conf.set(Constants.CFG_HDFS_USER, System.getProperty("user.name"));
     Injector injector = Guice.createInjector(new DataFabricDistributedModule(),
-                                             new ConfigModule(conf, testHBase.getConfiguration()),
+                                             new ConfigModule(conf, TEST_HBASE.getConfiguration()),
                                              new ZKClientModule(),
                                              new DiscoveryRuntimeModule().getDistributedModules(),
                                              new TransactionMetricsModule(),
@@ -80,14 +81,13 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
 
     dsFramework = injector.getInstance(DatasetFramework.class);
     tableUtil = injector.getInstance(HBaseTableUtil.class);
-    tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Id.Namespace.SYSTEM);
+    tableUtil.createNamespaceIfNotExists(TEST_HBASE.getHBaseAdmin(), Id.Namespace.SYSTEM);
   }
 
   @AfterClass
   public static void tearDown() throws Exception {
-    tableUtil.deleteAllInNamespace(testHBase.getHBaseAdmin(), Id.Namespace.SYSTEM);
-    tableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), Id.Namespace.SYSTEM);
-    testHBase.stopHBase();
+    tableUtil.deleteAllInNamespace(TEST_HBASE.getHBaseAdmin(), Id.Namespace.SYSTEM);
+    tableUtil.deleteNamespaceIfExists(TEST_HBASE.getHBaseAdmin(), Id.Namespace.SYSTEM);
   }
 
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
@@ -82,30 +82,28 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
   private static final Logger LOG = LoggerFactory.getLogger(HBaseTableTest.class);
 
   @ClassRule
-  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  @ClassRule
+  public static final HBaseTestBase TEST_HBASE = new HBaseTestFactory().get();
 
-  private static HBaseTestBase testHBase;
   private static HBaseTableUtil hBaseTableUtil;
   private static CConfiguration cConf;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    testHBase = new HBaseTestFactory().get();
-    testHBase.startHBase();
     cConf = CConfiguration.create();
     hBaseTableUtil = new HBaseTableUtilFactory(cConf).get();
     // TODO: CDAP-1634 - Explore a way to not have every HBase test class do this.
-    hBaseTableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), NAMESPACE1);
-    hBaseTableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), NAMESPACE2);
+    hBaseTableUtil.createNamespaceIfNotExists(TEST_HBASE.getHBaseAdmin(), NAMESPACE1);
+    hBaseTableUtil.createNamespaceIfNotExists(TEST_HBASE.getHBaseAdmin(), NAMESPACE2);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
-    hBaseTableUtil.deleteAllInNamespace(testHBase.getHBaseAdmin(), NAMESPACE1);
-    hBaseTableUtil.deleteAllInNamespace(testHBase.getHBaseAdmin(), NAMESPACE2);
-    hBaseTableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), NAMESPACE1);
-    hBaseTableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), NAMESPACE2);
-    testHBase.stopHBase();
+    hBaseTableUtil.deleteAllInNamespace(TEST_HBASE.getHBaseAdmin(), NAMESPACE1);
+    hBaseTableUtil.deleteAllInNamespace(TEST_HBASE.getHBaseAdmin(), NAMESPACE2);
+    hBaseTableUtil.deleteNamespaceIfExists(TEST_HBASE.getHBaseAdmin(), NAMESPACE1);
+    hBaseTableUtil.deleteNamespaceIfExists(TEST_HBASE.getHBaseAdmin(), NAMESPACE2);
   }
 
   @Override
@@ -116,15 +114,15 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
       .property(Table.PROPERTY_READLESS_INCREMENT, "true")
       .property(Table.PROPERTY_CONFLICT_LEVEL, conflictLevel.name())
       .build();
-    return new HBaseTable(datasetContext, spec, cConf, testHBase.getConfiguration(), hBaseTableUtil);
+    return new HBaseTable(datasetContext, spec, cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
   }
 
   @Override
   protected HBaseTableAdmin getTableAdmin(DatasetContext datasetContext, String name,
                                           DatasetProperties props) throws IOException {
     DatasetSpecification spec = new HBaseTableDefinition("foo").configure(name, props);
-    return new HBaseTableAdmin(datasetContext, spec, testHBase.getConfiguration(), hBaseTableUtil,
-                               cConf, new LocalLocationFactory(tmpFolder.newFolder()));
+    return new HBaseTableAdmin(datasetContext, spec, TEST_HBASE.getConfiguration(), hBaseTableUtil,
+                               cConf, new LocalLocationFactory(TMP_FOLDER.newFolder()));
   }
 
   @Override
@@ -144,7 +142,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     DatasetSpecification ttlTableSpec = DatasetSpecification.builder(ttlTable, HBaseTable.class.getName())
       .properties(props.getProperties())
       .build();
-    HBaseTable table = new HBaseTable(CONTEXT1, ttlTableSpec, cConf, testHBase.getConfiguration(), hBaseTableUtil);
+    HBaseTable table = new HBaseTable(CONTEXT1, ttlTableSpec, cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
 
     DetachedTxSystemClient txSystemClient = new DetachedTxSystemClient();
     Transaction tx = txSystemClient.startShort();
@@ -176,7 +174,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     DatasetSpecification noTtlTableSpec = DatasetSpecification.builder(noTtlTable, HBaseTable.class.getName())
       .properties(props2.getProperties())
       .build();
-    HBaseTable table2 = new HBaseTable(CONTEXT1, noTtlTableSpec, cConf, testHBase.getConfiguration(), hBaseTableUtil);
+    HBaseTable table2 = new HBaseTable(CONTEXT1, noTtlTableSpec, cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
 
     tx = txSystemClient.startShort();
     table2.startTx(tx);
@@ -204,7 +202,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     String presplittedTable = "presplitted";
     getTableAdmin(CONTEXT1, presplittedTable, props).create();
 
-    try (HBaseAdmin hBaseAdmin = testHBase.getHBaseAdmin()) {
+    try (HBaseAdmin hBaseAdmin = TEST_HBASE.getHBaseAdmin()) {
       List<HRegionInfo> regions = hBaseTableUtil.getTableRegions(hBaseAdmin, TableId.from(NAMESPACE1.getId(),
                                                                                           presplittedTable));
       // note: first region starts at very first row key, so we have one extra to the splits count
@@ -224,7 +222,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     TableId enabledTableId = TableId.from(NAMESPACE1.getId(), enabledTableName);
     HBaseTableAdmin disabledAdmin = getTableAdmin(CONTEXT1, disableTableName, DatasetProperties.EMPTY);
     disabledAdmin.create();
-    HBaseAdmin admin = testHBase.getHBaseAdmin();
+    HBaseAdmin admin = TEST_HBASE.getHBaseAdmin();
 
     DatasetProperties props =
       DatasetProperties.builder().add(Table.PROPERTY_READLESS_INCREMENT, "true").build();
@@ -257,7 +255,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
       final byte[] expectedValue = Bytes.add(IncrementHandlerState.DELTA_MAGIC_PREFIX, Bytes.toBytes(10L));
       final AtomicBoolean foundValue = new AtomicBoolean();
       byte [] enabledTableNameBytes = hBaseTableUtil.getHTableDescriptor(admin, enabledTableId).getName();
-      testHBase.forEachRegion(enabledTableNameBytes, new Function<HRegion, Object>() {
+      TEST_HBASE.forEachRegion(enabledTableNameBytes, new Function<HRegion, Object>() {
         @Override
         public Object apply(HRegion hRegion) {
           Scan scan = hBaseTableUtil.buildScan().build();
@@ -294,10 +292,10 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     String tableName = "testcf";
     DatasetSpecification spec = tableDefinition.configure(tableName, props);
 
-    DatasetAdmin admin = new HBaseTableAdmin(CONTEXT1, spec, testHBase.getConfiguration(), hBaseTableUtil,
-                                             CConfiguration.create(), new LocalLocationFactory(tmpFolder.newFolder()));
+    DatasetAdmin admin = new HBaseTableAdmin(CONTEXT1, spec, TEST_HBASE.getConfiguration(), hBaseTableUtil,
+                                             CConfiguration.create(), new LocalLocationFactory(TMP_FOLDER.newFolder()));
     admin.create();
-    final HBaseTable table = new HBaseTable(CONTEXT1, spec, cConf, testHBase.getConfiguration(), hBaseTableUtil);
+    final HBaseTable table = new HBaseTable(CONTEXT1, spec, cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
 
     TransactionSystemClient txClient = new DetachedTxSystemClient();
     TransactionExecutor executor = new DefaultTransactionExecutor(txClient, table);
@@ -308,7 +306,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
       }
     });
 
-    final HBaseTable table2 = new HBaseTable(CONTEXT1, spec, cConf, testHBase.getConfiguration(), hBaseTableUtil);
+    final HBaseTable table2 = new HBaseTable(CONTEXT1, spec, cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
     executor = new DefaultTransactionExecutor(txClient, table2);
     executor.execute(new TransactionExecutor.Subroutine() {
       @Override
@@ -318,7 +316,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     });
 
     // Verify the column family name
-    HTableDescriptor htd = hBaseTableUtil.getHTableDescriptor(testHBase.getHBaseAdmin(),
+    HTableDescriptor htd = hBaseTableUtil.getHTableDescriptor(TEST_HBASE.getHBaseAdmin(),
                                                               TableId.from(CONTEXT1.getNamespaceId(), tableName));
     HColumnDescriptor hcd = htd.getFamily(Bytes.toBytes("t"));
     Assert.assertNotNull(hcd);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseFileStreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseFileStreamAdminTest.java
@@ -67,8 +67,9 @@ public class HBaseFileStreamAdminTest extends StreamAdminTest {
 
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
+  @ClassRule
+  public static HBaseTestBase testHBase = new HBaseTestFactory().get();
 
-  private static HBaseTestBase testHBase;
   private static StreamAdmin streamAdmin;
   private static TransactionManager txManager;
   private static StreamFileWriterFactory fileWriterFactory;
@@ -78,9 +79,6 @@ public class HBaseFileStreamAdminTest extends StreamAdminTest {
   public static void init() throws Exception {
     InMemoryZKServer zkServer = InMemoryZKServer.builder().setDataDir(tmpFolder.newFolder()).build();
     zkServer.startAndWait();
-
-    testHBase = new HBaseTestFactory().get();
-    testHBase.startHBase();
 
     Configuration hConf = testHBase.getConfiguration();
 
@@ -126,7 +124,6 @@ public class HBaseFileStreamAdminTest extends StreamAdminTest {
   public static void finish() throws Exception {
     streamCoordinatorClient.stopAndWait();
     txManager.stopAndWait();
-    testHBase.stopHBase();
   }
 
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/util/hbase/ConfigurationTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/util/hbase/ConfigurationTableTest.java
@@ -24,6 +24,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.SlowTests;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -37,27 +38,28 @@ import static org.junit.Assert.assertNotNull;
  */
 @Category(SlowTests.class)
 public class ConfigurationTableTest {
+
+  @ClassRule
+  public static final HBaseTestBase TEST_HBASE = new HBaseTestFactory().get();
+
   private static HBaseTableUtil tableUtil;
-  private static HBaseTestBase testHBase = new HBaseTestFactory().get();
   private static CConfiguration cConf = CConfiguration.create();
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
-    testHBase.startHBase();
     tableUtil = new HBaseTableUtilFactory(cConf).get();
-    tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Id.Namespace.SYSTEM);
+    tableUtil.createNamespaceIfNotExists(TEST_HBASE.getHBaseAdmin(), Id.Namespace.SYSTEM);
   }
 
   @AfterClass
   public static void teardownAfterClass() throws Exception {
-    tableUtil.deleteAllInNamespace(testHBase.getHBaseAdmin(), Id.Namespace.SYSTEM);
-    tableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), Id.Namespace.SYSTEM);
-    testHBase.stopHBase();
+    tableUtil.deleteAllInNamespace(TEST_HBASE.getHBaseAdmin(), Id.Namespace.SYSTEM);
+    tableUtil.deleteNamespaceIfExists(TEST_HBASE.getHBaseAdmin(), Id.Namespace.SYSTEM);
   }
 
   @Test
   public void testConfigurationSerialization() throws Exception {
-    ConfigurationTable configTable = new ConfigurationTable(testHBase.getConfiguration());
+    ConfigurationTable configTable = new ConfigurationTable(TEST_HBASE.getConfiguration());
     configTable.write(ConfigurationTable.Type.DEFAULT, cConf);
 
     String configTableQualifier = "configuration";

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
@@ -38,8 +38,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
@@ -51,27 +49,24 @@ import java.util.concurrent.TimeUnit;
  *
  */
 public abstract class AbstractHBaseTableUtilTest {
-  private static final Logger LOG = LoggerFactory.getLogger(AbstractHBaseTableUtilTest.class);
 
   @ClassRule
-  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  @ClassRule
+  public static final HBaseTestBase TEST_HBASE = new HBaseTestFactory().get();
 
   protected static CConfiguration cConf;
-  private static HBaseTestBase testHBase;
   private static HBaseAdmin hAdmin;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    testHBase = new HBaseTestFactory().get();
-    testHBase.startHBase();
-    hAdmin = new HBaseAdmin(testHBase.getConfiguration());
+    hAdmin = new HBaseAdmin(TEST_HBASE.getConfiguration());
     cConf = CConfiguration.create();
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     hAdmin.close();
-    testHBase.stopHBase();
   }
 
   protected abstract HBaseTableUtil getTableUtil();
@@ -147,7 +142,7 @@ public abstract class AbstractHBaseTableUtilTest {
     drop("namespace", "table1");
     Assert.assertFalse(exists("namespace", "table1"));
     //TODO: TestHBase methods should eventually accept namespace as a param, but will add them incrementally
-    testHBase.forceRegionFlush(Bytes.toBytes(getTableNameAsString(TableId.from("namespace", "table2"))));
+    TEST_HBASE.forceRegionFlush(Bytes.toBytes(getTableNameAsString(TableId.from("namespace", "table2"))));
     truncate("namespace", "table3");
 
     Tasks.waitFor(true, new Callable<Boolean>() {
@@ -208,7 +203,7 @@ public abstract class AbstractHBaseTableUtilTest {
     Assert.assertEquals("cdap.user.my.dataset",
                         getNameConverter().getHBaseTableName(tablePrefix, tableId));
     Assert.assertEquals(getTableNameAsString(tableId),
-                        Bytes.toString(tableUtil.createHTable(testHBase.getConfiguration(), tableId).getTableName()));
+                        Bytes.toString(tableUtil.createHTable(TEST_HBASE.getConfiguration(), tableId).getTableName()));
     drop(tableId);
     tableId = TableId.from("default", "system.queue.config");
     create(tableId);
@@ -216,7 +211,7 @@ public abstract class AbstractHBaseTableUtilTest {
     Assert.assertEquals("cdap.system.queue.config",
                         getNameConverter().getHBaseTableName(tablePrefix, tableId));
     Assert.assertEquals(getTableNameAsString(tableId),
-                        Bytes.toString(tableUtil.createHTable(testHBase.getConfiguration(), tableId).getTableName()));
+                        Bytes.toString(tableUtil.createHTable(TEST_HBASE.getConfiguration(), tableId).getTableName()));
     drop(tableId);
     tableId = TableId.from("myspace", "could.be.any.table.name");
     createNamespace("myspace");
@@ -225,7 +220,7 @@ public abstract class AbstractHBaseTableUtilTest {
     Assert.assertEquals("could.be.any.table.name",
                         getNameConverter().getHBaseTableName(tablePrefix, tableId));
     Assert.assertEquals(getTableNameAsString(tableId),
-                        Bytes.toString(tableUtil.createHTable(testHBase.getConfiguration(), tableId).getTableName()));
+                        Bytes.toString(tableUtil.createHTable(TEST_HBASE.getConfiguration(), tableId).getTableName()));
     drop(tableId);
     deleteNamespace("myspace");
   }
@@ -322,7 +317,8 @@ public abstract class AbstractHBaseTableUtilTest {
   }
 
   private void writeSome(String namespace, String tableName) throws IOException {
-    try (HTable table = getTableUtil().createHTable(testHBase.getConfiguration(), TableId.from(namespace, tableName))) {
+    try (HTable table = getTableUtil().createHTable(TEST_HBASE.getConfiguration(),
+                                                    TableId.from(namespace, tableName))) {
       // writing at least couple megs to reflect in "megabyte"-based metrics
       for (int i = 0; i < 8; i++) {
         Put put = new Put(Bytes.toBytes("row" + i));

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -39,8 +39,6 @@ import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.experimental.categories.Category;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -57,7 +55,6 @@ import static org.junit.Assert.assertNotNull;
  */
 @Category(SlowTests.class)
 public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
-  private static final Logger LOG = LoggerFactory.getLogger(IncrementHandlerTest.class);
 
   @Override
   public void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception {
@@ -120,8 +117,8 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
     tableDesc.addFamily(columnDesc);
     tableDesc.addCoprocessor(IncrementHandler.class.getName());
     HTableDescriptor htd = tableDesc.build();
-    testUtil.getHBaseAdmin().createTable(htd);
-    testUtil.waitUntilTableAvailable(htd.getName(), 5000);
+    TEST_HBASE.getHBaseAdmin().createTable(htd);
+    TEST_HBASE.waitUntilTableAvailable(htd.getName(), 5000);
     return tableUtil.createHTable(conf, tableId);
   }
 
@@ -133,7 +130,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
       columnDesc.setValue(prop.getKey(), prop.getValue());
     }
     return new HBase96RegionWrapper(
-        IncrementSummingScannerTest.createRegion(testUtil.getConfiguration(), cConf, tableId, columnDesc));
+        IncrementSummingScannerTest.createRegion(TEST_HBASE.getConfiguration(), cConf, tableId, columnDesc));
   }
 
   public static ColumnCell convertCell(Cell cell) {

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -47,8 +47,8 @@ import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.wal.HLog;
 import org.apache.hadoop.hbase.regionserver.wal.HLogFactory;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.List;
@@ -62,22 +62,17 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link IncrementSummingScanner} implementation.
  */
 public class IncrementSummingScannerTest {
+  @ClassRule
+  public static final HBase96Test TEST_HBASE = new HBase96Test();
+
   private static final byte[] TRUE = Bytes.toBytes(true);
-  private static HBase96Test testUtil;
   private static Configuration conf;
   private static CConfiguration cConf;
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
-    testUtil = new HBase96Test();
-    testUtil.startHBase();
-    conf = testUtil.getConfiguration();
+    conf = TEST_HBASE.getConfiguration();
     cConf = CConfiguration.create();
-  }
-
-  @AfterClass
-  public static void shutdownAfterClass() throws Exception {
-    testUtil.stopHBase();
   }
 
   @Test

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
@@ -116,8 +116,8 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
     tableDesc.addFamily(columnDesc);
     tableDesc.addCoprocessor(IncrementHandler.class.getName());
     HTableDescriptor htd = tableDesc.build();
-    testUtil.getHBaseAdmin().createTable(htd);
-    testUtil.waitUntilTableAvailable(htd.getName(), 5000);
+    TEST_HBASE.getHBaseAdmin().createTable(htd);
+    TEST_HBASE.waitUntilTableAvailable(htd.getName(), 5000);
     return tableUtil.createHTable(conf, tableId);
   }
 
@@ -129,7 +129,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
       columnDesc.setValue(prop.getKey(), prop.getValue());
     }
     return new HBase98RegionWrapper(
-        IncrementSummingScannerTest.createRegion(testUtil.getConfiguration(), cConf, tableId, columnDesc));
+        IncrementSummingScannerTest.createRegion(TEST_HBASE.getConfiguration(), cConf, tableId, columnDesc));
   }
 
   public static ColumnCell convertCell(Cell cell) {

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -47,8 +47,8 @@ import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.wal.HLog;
 import org.apache.hadoop.hbase.regionserver.wal.HLogFactory;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.List;
@@ -62,22 +62,18 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link IncrementSummingScanner} implementation.
  */
 public class IncrementSummingScannerTest {
+
+  @ClassRule
+  public static final HBase98Test TEST_HBASE = new HBase98Test();
+
   private static final byte[] TRUE = Bytes.toBytes(true);
-  private static HBase98Test testUtil;
   private static Configuration conf;
   private static CConfiguration cConf;
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
-    testUtil = new HBase98Test();
-    testUtil.startHBase();
-    conf = testUtil.getConfiguration();
+    conf = TEST_HBASE.getConfiguration();
     cConf = CConfiguration.create();
-  }
-
-  @AfterClass
-  public static void shutdownAfterClass() throws Exception {
-    testUtil.stopHBase();
   }
 
   @Test

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -48,8 +48,8 @@ import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.wal.WAL;
 import org.apache.hadoop.hbase.wal.WALFactory;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -64,22 +64,18 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link IncrementSummingScanner} implementation.
  */
 public class IncrementSummingScannerTest {
+
+  @ClassRule
+  public static final HBase10CDHTest TEST_HBASE = new HBase10CDHTest();
+
   private static final byte[] TRUE = Bytes.toBytes(true);
-  private static HBase10CDHTest testUtil;
   private static Configuration conf;
   private static CConfiguration cConf;
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
-    testUtil = new HBase10CDHTest();
-    testUtil.startHBase();
-    conf = testUtil.getConfiguration();
+    conf = TEST_HBASE.getConfiguration();
     cConf = CConfiguration.create();
-  }
-
-  @AfterClass
-  public static void shutdownAfterClass() throws Exception {
-    testUtil.stopHBase();
   }
 
   @Test

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementHandlerTest.java
@@ -116,8 +116,8 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
     tableDesc.addFamily(columnDesc);
     tableDesc.addCoprocessor(IncrementHandler.class.getName());
     HTableDescriptor htd = tableDesc.build();
-    testUtil.getHBaseAdmin().createTable(htd);
-    testUtil.waitUntilTableAvailable(htd.getName(), 5000);
+    TEST_HBASE.getHBaseAdmin().createTable(htd);
+    TEST_HBASE.waitUntilTableAvailable(htd.getName(), 5000);
     return tableUtil.createHTable(conf, tableId);
   }
 
@@ -129,7 +129,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
       columnDesc.setValue(prop.getKey(), prop.getValue());
     }
     return new HBase98RegionWrapper(
-        IncrementSummingScannerTest.createRegion(testUtil.getConfiguration(), cConf, tableId, columnDesc));
+        IncrementSummingScannerTest.createRegion(TEST_HBASE.getConfiguration(), cConf, tableId, columnDesc));
   }
 
   public static ColumnCell convertCell(Cell cell) {

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -48,8 +48,8 @@ import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.wal.WAL;
 import org.apache.hadoop.hbase.wal.WALFactory;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -64,22 +64,18 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link IncrementSummingScanner} implementation.
  */
 public class IncrementSummingScannerTest {
+
+  @ClassRule
+  public static final HBase10Test TEST_HBASE = new HBase10Test();
+
   private static final byte[] TRUE = Bytes.toBytes(true);
-  private static HBase10Test testUtil;
   private static Configuration conf;
   private static CConfiguration cConf;
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
-    testUtil = new HBase10Test();
-    testUtil.startHBase();
-    conf = testUtil.getConfiguration();
+    conf = TEST_HBASE.getConfiguration();
     cConf = CConfiguration.create();
-  }
-
-  @AfterClass
-  public static void shutdownAfterClass() throws Exception {
-    testUtil.stopHBase();
   }
 
   @Test

--- a/cdap-hbase-compat-1.1/src/test/java/co/cask/cdap/data2/increment/hbase11/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-1.1/src/test/java/co/cask/cdap/data2/increment/hbase11/IncrementHandlerTest.java
@@ -116,8 +116,8 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
     tableDesc.addFamily(columnDesc);
     tableDesc.addCoprocessor(IncrementHandler.class.getName());
     HTableDescriptor htd = tableDesc.build();
-    testUtil.getHBaseAdmin().createTable(htd);
-    testUtil.waitUntilTableAvailable(htd.getName(), 5000);
+    TEST_HBASE.getHBaseAdmin().createTable(htd);
+    TEST_HBASE.waitUntilTableAvailable(htd.getName(), 5000);
     return tableUtil.createHTable(conf, tableId);
   }
 
@@ -129,7 +129,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
       columnDesc.setValue(prop.getKey(), prop.getValue());
     }
     return new HBase98RegionWrapper(
-        IncrementSummingScannerTest.createRegion(testUtil.getConfiguration(), cConf, tableId, columnDesc));
+        IncrementSummingScannerTest.createRegion(TEST_HBASE.getConfiguration(), cConf, tableId, columnDesc));
   }
 
   public static ColumnCell convertCell(Cell cell) {

--- a/cdap-hbase-compat-1.1/src/test/java/co/cask/cdap/data2/increment/hbase11/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.1/src/test/java/co/cask/cdap/data2/increment/hbase11/IncrementSummingScannerTest.java
@@ -49,8 +49,8 @@ import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.wal.WAL;
 import org.apache.hadoop.hbase.wal.WALFactory;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -65,22 +65,18 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link IncrementSummingScanner} implementation.
  */
 public class IncrementSummingScannerTest {
+
+  @ClassRule
+  public static final HBase11Test TEST_HBASE = new HBase11Test();
+
   private static final byte[] TRUE = Bytes.toBytes(true);
-  private static HBase11Test testUtil;
   private static Configuration conf;
   private static CConfiguration cConf;
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
-    testUtil = new HBase11Test();
-    testUtil.startHBase();
-    conf = testUtil.getConfiguration();
+    conf = TEST_HBASE.getConfiguration();
     cConf = CConfiguration.create();
-  }
-
-  @AfterClass
-  public static void shutdownAfterClass() throws Exception {
-    testUtil.stopHBase();
   }
 
   @Test


### PR DESCRIPTION
…ZkServer even if there are previous exceptions. Stop was not getting called previously if either tableUtil or testHBase was null in the deleteNamespace method. This fix does not silently mask the NPE, but only makes sure that stop is called irrespective of it. Will need to debug the NPE separately.

Most recent failure for this test: https://builds.cask.co/download/CDAP-DUT3003-JOB1/build_logs/CDAP-DUT3003-JOB1-2.log

Build: http://builds.cask.co/browse/CDAP-DUT3007-1