### PR TITLE
CDAP-2151: Fix flaky RemoteDatasetFrameworkTest cleanup for namespace…

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -310,7 +310,7 @@ class DatasetServiceClient {
   }
 
   private String resolve(String resource) throws DatasetManagementException {
-    Discoverable discoverable = endpointStrategySupplier.get().pick(1, TimeUnit.SECONDS);
+    Discoverable discoverable = endpointStrategySupplier.get().pick(3, TimeUnit.SECONDS);
     if (discoverable == null) {
       throw new ServiceUnavailableException("DatasetService");
     }


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-2151

The timeout of 1 second to get the dataset service might not  be enough on slow machines. Please see comments on the issue for details.

Build: http://builds.cask.co/browse/CDAP-DUT3008-1