### PR TITLE
Fixes maven UI build to ignore dist and other un-necessary folders + fixes UI issues

### DIFF
--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -427,7 +427,7 @@ gulp.task('style', ['css']);
 gulp.task('watch:build', ['watch:js', 'css', 'img', 'tpl', 'html.dev']);
 gulp.task('build', ['js', 'css', 'img', 'tpl', 'html']);
 
-gulp.task('distribute', ['build', 'rev:replace']);
+gulp.task('distribute', ['clean', 'build', 'rev:replace']);
 
 gulp.task('default', ['lint', 'build']);
 

--- a/cdap-ui/app/features/apps/controllers/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/apps/controllers/tabs/status-ctrl.js
@@ -60,5 +60,7 @@ class AppDetailStatusController {
   }
 }
 
+AppDetailStatusController.$inject = ['$state', 'myPipelineApi', 'MyAppDAGService', 'CanvasFactory', 'GLOBALS', '$scope'];
+
 angular.module(PKG.name + '.feature.apps')
   .controller('AppDetailStatusController', AppDetailStatusController);

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -118,6 +118,9 @@
                   <exclude>**/*.svg</exclude>
                   <exclude>**/bower_components/**</exclude>
                   <exclude>**/node_modules/**</exclude>
+                  <exclude>**/dist/**</exclude>
+                  <exclude>**/logs/**</exclude>
+                  <exclude>**/npm-debug.log</exclude>
                   <exclude>**/node/**</exclude>
                   <exclude>**/*.json</exclude>
                 </excludes>


### PR DESCRIPTION
- Fixes maven UI build process, where the maven build would take forever to RAT check UI because the 'dist' folder generated as part of the build process still stays and we are not ignoring it.
- Fixes a UI es6ify issue (ng-sanitize for app status controller)


