### PR TITLE
Fix/ui outputschema null

### DIFF
--- a/cdap-ui/app/features/hydrator/controllers/create/plugin-edit-form-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/plugin-edit-form-ctrl.js
@@ -235,6 +235,11 @@ angular.module(PKG.name + '.feature.hydrator')
               if ($scope.plugin.properties[outputSchemaProperty[0]] !== $scope.plugin.outputSchema) {
                 $scope.plugin.properties[outputSchemaProperty[0]] = $scope.plugin.outputSchema;
               }
+              $scope.$watch('plugin.outputSchema', function() {
+                if(validateSchema()) {
+                  $scope.plugin.properties[outputSchemaProperty[0]] = $scope.plugin.outputSchema;
+                }
+              });
             }
 
             // Mark the configfetched to show that configurations have been received.
@@ -267,7 +272,6 @@ angular.module(PKG.name + '.feature.hydrator')
       this.configfetched = true;
     }
 
-    $scope.$watch('plugin.outputSchema', validateSchema);
     $scope.$watchCollection('plugin.properties', function() {
       MyNodeConfigService.notifyPluginSaveListeners($scope.plugin.id);
     });

--- a/cdap-ui/app/features/hydrator/controllers/create/plugin-edit-form-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/plugin-edit-form-ctrl.js
@@ -175,12 +175,15 @@ angular.module(PKG.name + '.feature.hydrator')
             if (res.outputschema) {
               outputSchemaProperty = Object.keys(res.outputschema);
               if (!res.outputschema.implicit) {
-                this.schemaProperties = res.outputschema[outputSchemaProperty[0]];
                 this.isOuputSchemaExists = (propertiesFromBackend.indexOf(outputSchemaProperty[0]) !== -1);
-                this.isOutputSchemaRequired = $scope.plugin._backendProperties[outputSchemaProperty[0]].required;
-                index = propertiesFromBackend.indexOf(outputSchemaProperty[0]);
-                if (index !== -1) {
-                  propertiesFromBackend.splice(index, 1);
+                if (this.isOuputSchemaExists) {
+                  this.schemaProperties = res.outputschema[outputSchemaProperty[0]];
+                  this.isOutputSchemaRequired = $scope.plugin._backendProperties[outputSchemaProperty[0]].required;
+                  index = propertiesFromBackend.indexOf(outputSchemaProperty[0]);
+
+                  if (index !== -1) {
+                    propertiesFromBackend.splice(index, 1);
+                  }
                 }
               }
             } else {

--- a/cdap-ui/templates/cdap-etl-batch/SnapshotAvro.json
+++ b/cdap-ui/templates/cdap-etl-batch/SnapshotAvro.json
@@ -9,7 +9,7 @@
         "name" : {
           "widget": "dataset-selector",
           "label": "Dataset Name"
-        }
+        },
 
         "basePath" : {
           "widget": "textbox",


### PR DESCRIPTION
- Fixes output schema to be properly propagated. Recent change broke the assignment of 'schema' property of any plugin. This PR fixes that.
- Fixes output schema to be optional. The same plugin (for instance MongoDB) could have an output schema for source but not one for sink. This should not fail or error out in UI.

TODO:
 Right now we assume there is going to be only one output schema. When we refactor the plugin edit controller we will account to more than one output schema per plugin.