### PR TITLE
alertOnValium: Fix/ui thwart mad alerts clicking

### DIFF
--- a/cdap-ui/app/directives/flow-graph/flow.js
+++ b/cdap-ui/app/directives/flow-graph/flow.js
@@ -29,7 +29,7 @@ var baseDirective = {
   controller: 'myFlowController'
 };
 
-module.directive('myFlowGraph', function ($filter, $state, $alert, myStreamService, $location, FlowFactories) {
+module.directive('myFlowGraph', function ($filter, $state, myStreamService, $location, FlowFactories) {
   return angular.extend({
     link: function (scope, elem, attr) {
       scope.render = FlowFactories.genericRender.bind(null, scope, $filter, $location, tip);

--- a/cdap-ui/app/features/admin/controllers/namespace/stream-metadata-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/stream-metadata-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin')
-  .controller('NamespaceStreamMetadataController', function($scope, $stateParams, myHelpers, $alert, myStreamApi, $state, EventPipe) {
+  .controller('NamespaceStreamMetadataController', function($scope, $stateParams, myHelpers, $alert, myStreamApi, $state, EventPipe, myAlertOnValium) {
 
     $scope.avro = {};
 
@@ -128,7 +128,7 @@ angular.module(PKG.name + '.feature.admin')
         .then(function() {
           $scope.reload();
 
-          $alert({
+          myAlertOnValium.show({
             type: 'success',
             title: 'Success',
             content: 'Stream properties have been successfully saved'

--- a/cdap-ui/app/features/admin/controllers/namespace/streams-create-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/streams-create-ctrl.js
@@ -23,7 +23,11 @@ angular.module(PKG.name + '.feature.admin')
     $scope.streamId = '';
 
     $scope.createStream = function() {
+      if ($scope.isSaving) {
+        return;
+      }
       $scope.isSaving = true;
+
       var params = {
         namespace: $stateParams.nsadmin,
         streamId: $scope.streamId,

--- a/cdap-ui/app/features/admin/controllers/namespace/templates-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/templates-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin')
-  .controller('NamespaceTemplatesController', function ($scope, myPipelineApi, PluginConfigFactory, myHelpers, mySettings, $stateParams, $alert, $state, GLOBALS, $rootScope) {
+  .controller('NamespaceTemplatesController', function ($scope, myPipelineApi, PluginConfigFactory, myHelpers, mySettings, $stateParams, $alert, $state, GLOBALS, $rootScope, myAlertOnValium) {
 
     var vm = this;
     var oldTemplateName;
@@ -152,8 +152,8 @@ angular.module(PKG.name + '.feature.admin')
 
     vm.save = function () {
 
-      if (!vm.pluginConfig.pluginTemplate) {
-        $alert({
+      if (!vm.pluginConfig || !vm.pluginConfig.pluginTemplate) {
+        myAlertOnValium.show({
           type: 'danger',
           title: 'Error!',
           content: GLOBALS.en.admin.templateNameMissingError
@@ -164,7 +164,7 @@ angular.module(PKG.name + '.feature.admin')
 
       var list = vm.pluginList.map(function (p) { return p.name; });
       if (list.indexOf(vm.pluginConfig.pluginTemplate) !== -1) {
-        $alert({
+        myAlertOnValium.show({
           type: 'danger',
           title: 'Error!',
           content: GLOBALS.en.admin.pluginSameNameError

--- a/cdap-ui/app/features/admin/controllers/preferences-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/preferences-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin')
-  .controller('PreferencesController', function ($scope, $filter, $alert, $state, rSource, myPreferenceApi) {
+  .controller('PreferencesController', function ($scope, $filter, $state, rSource, myPreferenceApi, myAlertOnValium) {
     var filterFilter = $filter('filter');
 
     $scope.parentPreferences = [];
@@ -122,7 +122,7 @@ angular.module(PKG.name + '.feature.admin')
 
       setPreference(params, obj,
         function () {
-          $alert({
+          myAlertOnValium.show({
             content: 'Your preferences have been successfully saved',
             type: 'success'
           });

--- a/cdap-ui/app/features/admin/templates/namespace/streamscreate.html
+++ b/cdap-ui/app/features/admin/templates/namespace/streamscreate.html
@@ -57,9 +57,9 @@
             ng-disabled="isSaving == true || !streamId.length"
             ng-click="createStream()"
             ng-class="{'btn-success': streamId.length > 0}">
-      <div ng-if="isSaving == true" >
+      <span ng-if="isSaving == true" >
         <span class="fa fa-spin fa-refresh"></span>
-      </div>
+      </span>
       <span>Create</span>
     </button>
 </div>

--- a/cdap-ui/app/features/dashboard/controllers/userdashboard-ctrl.js
+++ b/cdap-ui/app/features/dashboard/controllers/userdashboard-ctrl.js
@@ -19,7 +19,7 @@
  */
 
 angular.module(PKG.name+'.feature.dashboard').controller('UserDashboardCtrl',
-function ($scope, $state, $dropdown, rDashboardsModel, MY_CONFIG, $alert, DashboardHelper) {
+function ($scope, $state, $dropdown, rDashboardsModel, MY_CONFIG, myAlertOnValium, DashboardHelper) {
 
   $scope.unknownBoard = false;
   $scope.liveDashboard = false;
@@ -87,7 +87,7 @@ function ($scope, $state, $dropdown, rDashboardsModel, MY_CONFIG, $alert, Dashbo
     var timeRange = $scope.timeOptions.endMs - $scope.timeOptions.startMs;
     if (timeRange >  limitInDays * millisecondsPerDay) {
       // Note: alternative is to interpolate the many many points we get from the backend (mostly will be 0s?).
-      $alert({
+      myAlertOnValium.show({
         content: 'Please choose a shorter time range. Current time range limit is ' + limitInDays + ' days.',
         type: 'warning'
       });

--- a/cdap-ui/app/features/hydrator/controllers/list-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/list-ctrl.js
@@ -14,9 +14,8 @@
  * the License.
  */
 
-var alertpromise;
 angular.module(PKG.name + '.feature.hydrator')
-  .controller('HydratorListController', function($scope, myPipelineApi, $stateParams, GLOBALS, mySettings, $state, $alert, $timeout, myHelpers, myWorkFlowApi, myWorkersApi, MyDataSource, myAppsApi) {
+  .controller('HydratorListController', function($scope, myPipelineApi, $stateParams, GLOBALS, mySettings, $state, $timeout, myHelpers, myWorkFlowApi, myWorkersApi, MyDataSource, myAppsApi, $alert) {
 
     var dataSrc = new MyDataSource($scope);
 
@@ -208,31 +207,17 @@ angular.module(PKG.name + '.feature.hydrator')
         })
         .then(
           function success() {
-            var alertObj = {
+            $alert({
               type: 'success',
               content: 'Pipeline draft ' + draftName + ' deleted successfully'
-            }, e;
-            if (!alertpromise) {
-              alertpromise = $alert(alertObj);
-              e = $scope.$on('alert.hide', function() {
-                alertpromise = null;
-                e(); // un-register from listening to the hide event of a closed alert.
-              });
-            }
+            });
             $state.reload();
           },
           function error() {
-            var alertObj = {
+            $alert({
               type: 'danger',
               content: 'Pipeline draft ' + draftName + ' delete failed'
-            }, e;
-            if (!alertpromise) {
-              alertpromise = $alert(alertObj);
-              e = $scope.$on('alert.hide', function() {
-                alertpromise = null;
-                e();
-              });
-            }
+            });
             $state.reload();
           });
     };
@@ -247,30 +232,16 @@ angular.module(PKG.name + '.feature.hydrator')
       myAppsApi.delete(deleteParams)
         .$promise
         .then(function success () {
-          var alertObj = {
+          $alert({
             type: 'success',
             content: 'Pipeline ' + appId + ' deleted successfully'
-          }, e;
-          if (!alertpromise) {
-            alertpromise = $alert(alertObj);
-            e = $scope.$on('alert.hide', function() {
-              alertpromise = null;
-              e(); // un-register from listening to the hide event of a closed alert.
-            });
-          }
+          });
           $state.reload();
         }, function error () {
-          var alertObj = {
+          $alert({
             type: 'danger',
             content: 'Pipeline ' + appId + ' delete failed'
-          }, e;
-          if (!alertpromise) {
-            alertpromise = $alert(alertObj);
-            e = $scope.$on('alert.hide', function() {
-              alertpromise = null;
-              e();
-            });
-          }
+          });
           $state.reload();
         });
     };

--- a/cdap-ui/app/features/login/routes.js
+++ b/cdap-ui/app/features/login/routes.js
@@ -47,7 +47,7 @@ angular.module(PKG.name+'.feature.login')
         }
       });
   })
-  .run(function ($rootScope, $state, $alert, $location, MYAUTH_EVENT, myNamespace, $q, myHelpers) {
+  .run(function ($rootScope, $state, $location, MYAUTH_EVENT, myNamespace, $q, myHelpers) {
 
     $rootScope.$on(MYAUTH_EVENT.loginSuccess, function onLoginSuccess() {
       // General case: User logs in and we emit login success event.
@@ -91,14 +91,14 @@ angular.module(PKG.name+'.feature.login')
     });
 
   })
-  .run(function ($rootScope, $state, $alert, MYAUTH_EVENT, MY_CONFIG, myAlert, myAuth) {
+  .run(function ($rootScope, $state, myAlertOnValium, MYAUTH_EVENT, MY_CONFIG, myAlert, myAuth) {
 
     $rootScope.$on(MYAUTH_EVENT.logoutSuccess, function () {
       $state.go('login');
     });
 
     $rootScope.$on(MYAUTH_EVENT.sessionTimeout, function() {
-      $alert({
+      myAlertOnValium.show({
         type: 'danger',
         title: 'Session Timeout',
         message: 'Your current session has timed out. Please login again.'
@@ -123,7 +123,7 @@ angular.module(PKG.name+'.feature.login')
         ],
         function (v) {
           $rootScope.$on(v.event, function () {
-            $alert({
+            myAlertOnValium.show({
               title: v.title,
               content: v.message,
               type: v.eventType

--- a/cdap-ui/app/features/workflows/controllers/tabs/runs/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/workflows/controllers/tabs/runs/tabs/status-ctrl.js
@@ -19,12 +19,11 @@ var runparams = {},
     params;
 
 class WorkflowsRunsStatusController {
-  constructor($state, $scope, myWorkFlowApi, $filter, $alert, GraphHelpers, MyDataSource, myMapreduceApi, mySparkApi) {
+  constructor($state, $scope, myWorkFlowApi, $filter, GraphHelpers, MyDataSource, myMapreduceApi, mySparkApi) {
     this.dataSrc = new MyDataSource($scope);
     this.$state = $state;
     this.$scope = $scope;
     this.myWorkFlowApi = myWorkFlowApi;
-    this.$alert = $alert;
     this.GraphHelpers = GraphHelpers;
     this.myMapreduceApi = myMapreduceApi;
     this.mySparkApi = mySparkApi;
@@ -234,6 +233,6 @@ class WorkflowsRunsStatusController {
 
 }
 
-WorkflowsRunsStatusController.$inject = ['$state', '$scope', 'myWorkFlowApi', '$filter', '$alert', 'GraphHelpers', 'MyDataSource', 'myMapreduceApi', 'mySparkApi'];
+WorkflowsRunsStatusController.$inject = ['$state', '$scope', 'myWorkFlowApi', '$filter', 'GraphHelpers', 'MyDataSource', 'myMapreduceApi', 'mySparkApi'];
 angular.module(`${PKG.name}.feature.workflows`)
   .controller('WorkflowsRunsStatusController', WorkflowsRunsStatusController);

--- a/cdap-ui/app/services/alert-on-valium/alert-on-valium.js
+++ b/cdap-ui/app/services/alert-on-valium/alert-on-valium.js
@@ -1,0 +1,19 @@
+angular.module(PKG.name + '.services')
+  .factory('myAlertOnValium', function($alert) {
+    var isAnAlertOpened = false,
+        alertObj;
+     function show(obj) {
+       if (!isAnAlertOpened) {
+         isAnAlertOpened = true;
+         alertObj = $alert(obj);
+         alertObj.$scope
+          .$on('alert.hide', function() {
+            isAnAlertOpened = false;
+          });
+       }
+     }
+
+     return {
+       show: show
+     };
+  });

--- a/cdap-ui/app/services/file-uploader.js
+++ b/cdap-ui/app/services/file-uploader.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.services')
-  .factory('myFileUploader', function($q, $window, $alert, cfpLoadingBar, myAuth, myAlert) {
+  .factory('myFileUploader', function($q, $window, cfpLoadingBar, myAuth, myAlert) {
     function upload(fileObj, contentType){
       var deferred = $q.defer();
       if (!myAuth.currentUser) {

--- a/cdap-ui/app/services/service-status-factory.js
+++ b/cdap-ui/app/services/service-status-factory.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.services')
-  .service('ServiceStatusFactory', function(MyDataSource, $alert, $timeout, EventPipe, $state, myAuth) {
+  .service('ServiceStatusFactory', function(MyDataSource, $timeout, EventPipe, $state, myAuth) {
     this.systemStatus = 'green';
 
     // Apart from invalid token there should be no scenario

--- a/cdap-ui/app/services/status-factory.js
+++ b/cdap-ui/app/services/status-factory.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.services')
-  .service('StatusFactory', function($http, EventPipe, myAuth, $rootScope, MYAUTH_EVENT, MY_CONFIG, $alert, $timeout) {
+  .service('StatusFactory', function($http, EventPipe, myAuth, $rootScope, MYAUTH_EVENT, MY_CONFIG, $timeout) {
 
     this.startPolling = function () {
       beginPolling.bind(this)();


### PR DESCRIPTION
- Adds a service that can be replaced in place of ```$alert``` to show subsequent alerts only when the previous one is closed.
- Modifies relevant references of ```$alert``` to ```myAlertOnValium``` .

![alert](https://cloud.githubusercontent.com/assets/1452845/10655652/76c81030-782b-11e5-86c3-bded82a72997.gif)
