### PR TITLE
Feature/hdinsight hive

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
+++ b/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
@@ -3,7 +3,7 @@
     "cdap_site": {
       "zookeeper.quorum": "ZK_QUORUM",
       "kafka.log.dir": "/var/cdap/kafka-logs",
-      "explore.enabled": "true"
+      "explore.enabled": "false"
     },
     "fs_superuser": "root",
     "skip_prerequisites": "true",

--- a/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
+++ b/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
@@ -3,7 +3,7 @@
     "cdap_site": {
       "zookeeper.quorum": "{{ZK_QUORUM}}",
       "kafka.log.dir": "/var/cdap/kafka-logs",
-      "explore.enabled": "false"
+      "explore.enabled": "{{EXPLORE_ENABLED}}"
     },
     "fs_superuser": "root",
     "skip_prerequisites": "true",

--- a/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
+++ b/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
@@ -1,16 +1,16 @@
 {
   "cdap": {
     "cdap_site": {
-      "zookeeper.quorum": "ZK_QUORUM",
+      "zookeeper.quorum": "{{ZK_QUORUM}}",
       "kafka.log.dir": "/var/cdap/kafka-logs",
       "explore.enabled": "false"
     },
     "fs_superuser": "root",
     "skip_prerequisites": "true",
-    "version": "CDAP_VERSION"
+    "version": "{{CDAP_VERSION}}"
   },
   "hadoop": {
     "distribution": "hdp",
-    "distribution_version": "HDP_VERSION"
+    "distribution_version": "{{HDP_VERSION}}"
   }
 }

--- a/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
+++ b/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
@@ -7,7 +7,7 @@
     },
     "fs_superuser": "root",
     "skip_prerequisites": "true",
-    "version": "3.2.0-1"
+    "version": "3.2.1-1"
   },
   "hadoop": {
     "distribution": "hdp",

--- a/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
+++ b/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
@@ -5,6 +5,7 @@
       "kafka.log.dir": "/var/cdap/kafka-logs",
       "explore.enabled": "true"
     },
+    "fs_superuser": "root",
     "skip_prerequisites": "true",
     "version": "3.2.0-1"
   },

--- a/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
+++ b/cdap-distributions/src/hdinsight/cdap-site.xml.template.json
@@ -7,7 +7,7 @@
     },
     "fs_superuser": "root",
     "skip_prerequisites": "true",
-    "version": "3.2.1-1"
+    "version": "CDAP_VERSION"
   },
   "hadoop": {
     "distribution": "hdp",

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -66,7 +66,7 @@ sed \
   ${__cdap_site_template} > ${__tmpdir}/generated-conf.json
 
 # Install/Configure ntp, CDAP
-chef-solo -o 'recipe[ntp::default],recipe[cdap::fullstack]' -j ${__tmpdir}/generated-conf.json
+chef-solo -o 'recipe[ntp::default],recipe[cdap::fullstack],recipe[cdap::init]' -j ${__tmpdir}/generated-conf.json
 
 # Start CDAP Services
 for i in /etc/init.d/cdap-*

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -21,6 +21,7 @@
 die() { echo "ERROR: ${*}"; exit 1; };
 
 CDAP_BRANCH='release/3.2'
+CDAP_VERSION='3.2.1-1'
 CHEF_VERSION='11.18.12'
 
 __tmpdir="/tmp/cdap_install.$$.$(date +%s)"
@@ -63,6 +64,7 @@ __hdp_version=$(ls /usr/hdp | grep "^[0-9]*\.") || die "Cannot determine HDP ver
 sed \
   -e "s/ZK_QUORUM/${__zk_quorum}/" \
   -e "s/HDP_VERSION/${__hdp_version}/" \
+  -e "s/CDAP_VERSION/${CDAP_VERSION}/" \
   ${__cdap_site_template} > ${__tmpdir}/generated-conf.json
 
 # Install/Configure ntp, CDAP

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -23,6 +23,7 @@ die() { echo "ERROR: ${*}"; exit 1; };
 CDAP_BRANCH='release/3.2'
 CDAP_VERSION='3.2.1-1'
 CHEF_VERSION='11.18.12'
+EXPLORE_ENABLED='false'
 
 __tmpdir="/tmp/cdap_install.$$.$(date +%s)"
 __gitdir="${__tmpdir}/cdap"
@@ -65,6 +66,7 @@ sed \
   -e "s/{{ZK_QUORUM}}/${__zk_quorum}/" \
   -e "s/{{HDP_VERSION}}/${__hdp_version}/" \
   -e "s/{{CDAP_VERSION}}/${CDAP_VERSION}/" \
+  -e "s/{{EXPLORE_ENABLED}}/${EXPLORE_ENABLED}/" \
   ${__cdap_site_template} > ${__tmpdir}/generated-conf.json
 
 # Install/Configure ntp, CDAP

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -62,9 +62,9 @@ __hdp_version=$(ls /usr/hdp | grep "^[0-9]*\.") || die "Cannot determine HDP ver
 
 # Create chef json configuration
 sed \
-  -e "s/ZK_QUORUM/${__zk_quorum}/" \
-  -e "s/HDP_VERSION/${__hdp_version}/" \
-  -e "s/CDAP_VERSION/${CDAP_VERSION}/" \
+  -e "s/{{ZK_QUORUM}}/${__zk_quorum}/" \
+  -e "s/{{HDP_VERSION}}/${__hdp_version}/" \
+  -e "s/{{CDAP_VERSION}}/${CDAP_VERSION}/" \
   ${__cdap_site_template} > ${__tmpdir}/generated-conf.json
 
 # Install/Configure ntp, CDAP


### PR DESCRIPTION
enhancements to the hdinsight installer:

   - [x] specify the cdap version and explore.enabled in the script, and then do token substitution in the template.  This is so that all variables are in the released artifact.  Otherwise as soon as we update the git release branch they would take effect.
   - [x] run the cdap[init] recipe, which creates HDFS directories, and is required for hive
   - [x] disable hive for now as it is not working
   - [x] use ``{{TOKEN}}`` for token substitution, consistent with other scripts we have.