### PR TITLE
fixes header issues affecting ubuntu OS

### DIFF
--- a/cdap-ui/app/directives/navbar-hydrator/navbar.less
+++ b/cdap-ui/app/directives/navbar-hydrator/navbar.less
@@ -20,15 +20,11 @@
 
 body {
   [my-navbar-hydrator] {
-    padding-right: 0;
-    margin: 0;
-    width: 100%;
     @media (max-width: @screen-xs-max) {
       padding-left: 0;
     }
     div.navbar-header {
       float: left;
-      position: relative;
     }
     a.navbar-brand {
       margin-top:12px;
@@ -36,6 +32,9 @@ body {
       max-width: 188px;
       max-height: 34px;
       padding: 0 15px;
+      @media (max-width: @screen-xs-max) {
+        padding: 0;
+      }
       &:focus {
         outline: none;
       }
@@ -65,15 +64,19 @@ body {
     }
 
     nav {
-      display: block;
-      padding-right: 15px;
       text-align: center;
       ul.navbar-nav {
         float: none;
         margin: 0 auto;
-        width: 285px;
+        max-width: 300px;
         li {
-          float: left;
+          @media (max-width: @screen-xs-max) {
+            display: inline-block;
+            float: none;
+          }
+          @media (min-width: @screen-sm-min) {
+            float: left;
+          }
           a {
             height: 58px;
             line-height: 60px;

--- a/cdap-ui/app/features/admin/templates/namespace/streamscreate.html
+++ b/cdap-ui/app/features/admin/templates/namespace/streamscreate.html
@@ -23,30 +23,28 @@
 </div>
 <div class="modal-body">
   <form class="form-horizontal">
-    <div class="form-group">
-      <label class="col-sm-2 control-label">
-        <span>Stream ID</span>
-        <span class="fa fa-asterisk"></span>
-      </label>
-      <div class="col-sm-10">
-        <input type="text"
-          class="form-control"
-          ng-model="streamId"
-          ng-keypress="enter($event)"
-          placeholder="Stream ID"
-          name="streamId"
-          cask-focus="streamId">
-        <div class="alert alert-danger alert-dismissible"
-             ng-show="error"
-             role="alert">
-          <button type="button"
-                  class="close"
-                  ng-click="error=null"
-                  aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-          <p><i class="fa fa-exclamation-circle"></i>  {{error}}</p>
-        </div>
+    <label class="col-sm-2 control-label">
+      <span>Stream ID</span>
+      <span class="fa fa-asterisk"></span>
+    </label>
+    <div class="col-sm-10">
+      <input type="text"
+        class="form-control"
+        ng-model="streamId"
+        ng-keypress="enter($event)"
+        placeholder="Stream ID"
+        name="streamId"
+        cask-focus="streamId">
+      <div class="alert alert-danger alert-dismissible"
+           ng-show="error"
+           role="alert">
+        <button type="button"
+                class="close"
+                ng-click="error=null"
+                aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <p><i class="fa fa-exclamation-circle"></i>  {{error}}</p>
       </div>
     </div>
   </form>

--- a/cdap-ui/app/features/explore/explore.less
+++ b/cdap-ui/app/features/explore/explore.less
@@ -77,7 +77,7 @@ body.state-explore {
         float: left;
 
         &:not(:last-child) {
-          margin-right: 3px;
+          margin-right: 2px;
         }
 
         .tab-heading {

--- a/cdap-ui/app/features/hydrator/leftpanel.less
+++ b/cdap-ui/app/features/hydrator/leftpanel.less
@@ -47,6 +47,7 @@ body.theme-cdap.state-hydrator-create {
         width: 130px;
         .name {
           display: inline-block;
+          max-width: 88px;
         }
       }
       + .right-wrapper {
@@ -213,7 +214,6 @@ body.theme-cdap.state-hydrator-create {
         }
         > .fa {
           font-size: 12px;
-          height: 18px;
           width: 18px;
           line-height: 40px;
           vertical-align: top;

--- a/cdap-ui/app/features/streams/templates/streamscreate.html
+++ b/cdap-ui/app/features/streams/templates/streamscreate.html
@@ -22,20 +22,17 @@
     <div class="text-center bg-danger" ng-show="CreateController.error">
       <p><i class="fa fa-exclamation-circle"></i>  {{CreateController.error}}</p>
     </div>
-
-    <div class="form-group">
-      <label class="col-sm-2 control-label">
-        <span>Stream ID</span>
-        <span class="fa fa-asterisk"></span>
-      </label>
-      <div class="col-sm-10">
-        <input type="text"
-               class="form-control"
-               ng-model="CreateController.streamId"
-               placeholder="Stream ID"
-               name="streamId"
-               cask-focus="streamId">
-      </div>
+    <label class="col-sm-2 control-label">
+      <span>Stream ID</span>
+      <span class="fa fa-asterisk"></span>
+    </label>
+    <div class="col-sm-10">
+      <input type="text"
+             class="form-control"
+             ng-model="CreateController.streamId"
+             placeholder="Stream ID"
+             name="streamId"
+             cask-focus="streamId">
     </div>
   </form>
 </div>

--- a/cdap-ui/app/index.html
+++ b/cdap-ui/app/index.html
@@ -36,7 +36,7 @@
 
     <header class="navbar navbar-fixed-top navbar-hydrator"
             ng-if="$state.includes('hydrator.**')">
-      <div role="navigation" class="container" my-navbar-hydrator></div>
+      <div role="navigation" my-navbar-hydrator></div>
     </header>
 
     <main class="container">


### PR DESCRIPTION
*  Changes overall styling of Hydrator header and navbar to fix styling issues affecting Ubuntu OS. Screenshots below showing the UI running with the fix in each browser
*  Fixes some minor styling bugs including: 1) Hydrator leftpanel - new width properties to prevent longer plugin names from breaking the plugin container, 2) Streams create modal - removing unnecessary form-group class around label and input, which was causing a horizontal scrollbar to display, 3) Explore screen: decreasing right margin of tab headers by 1 px to prevent overflowing on larger devices.

Chrome:
![chrome](https://cloud.githubusercontent.com/assets/5335210/10680546/909a3ae2-78d5-11e5-90b0-2d628030ce85.gif)

Chromium:
![chromium](https://cloud.githubusercontent.com/assets/5335210/10680549/9c749be6-78d5-11e5-8368-3c2fb2b69026.gif)

Firefox:
![firefox](https://cloud.githubusercontent.com/assets/5335210/10680551/a2738f5c-78d5-11e5-8ffc-a0175671946b.gif)

