### PR TITLE
disabled resizing in modal textareas

### DIFF
--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -486,6 +486,7 @@ body.theme-cdap {
     }
     textarea.form-control {
       min-height: 100px;
+      resize: none;
     }
     button.form-control:focus {
       outline: none;


### PR DESCRIPTION
*  Disables resizing in modal textreas. Modal textareas will scroll vertically when there is more text than rows initially displayed

![textarea](https://cloud.githubusercontent.com/assets/5335210/10678066/ceb5b704-78c4-11e5-9a90-4a0d94a178fb.gif)


