### PR TITLE
Fixes empty output schema to have appropriate message instead of showing both the table and the message

### DIFF
--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
@@ -37,12 +37,23 @@
   </h4>
 
   <fieldset class="clearfix" ng-disabled="isDisabled">
-    <my-schema-editor
-      ng-model="plugin.outputSchema"
-      data-disabled="plugin.implicitSchema || isDisabled"
-      plugin-properties="plugin.properties"
-      config="PluginEditController.schemaProperties">
-    </my-schema-editor>
+    <div ng-if="isDisabled">
+      <my-schema-editor
+        ng-model="plugin.outputSchema"
+        ng-if="plugin.outputSchema"
+        data-disabled="plugin.implicitSchema || isDisabled"
+        plugin-properties="plugin.properties"
+        config="PluginEditController.schemaProperties">
+      </my-schema-editor>
+    </div>
+    <div ng-if="!isDisabled">
+      <my-schema-editor
+        ng-model="plugin.outputSchema"
+        data-disabled="plugin.implicitSchema || isDisabled"
+        plugin-properties="plugin.properties"
+        config="PluginEditController.schemaProperties">
+      </my-schema-editor>
+    </div>
   </fieldset>
 
   <div ng-if="!plugin.outputSchema && isDisabled && plugin.properties.format !== 'clf' && plugin.properties.format !== 'syslog'">


### PR DESCRIPTION
![outputschema](https://cloud.githubusercontent.com/assets/1452845/10681430/0dce14ea-78de-11e5-858c-3917b877f8c1.gif)
