### PR TITLE
(CDAP-4089) Temporary workaround by removing offending jar

### DIFF
--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -84,7 +84,7 @@ sed \
 chef-solo -o 'recipe[ntp::default],recipe[cdap::fullstack],recipe[cdap::init]' -j ${__tmpdir}/generated-conf.json
 
 # Temporary Hack to workaround CDAP-4089
-rm /opt/cdap/kafka/lib/log4j.log4j-1.2.14.jar
+rm -f /opt/cdap/kafka/lib/log4j.log4j-1.2.14.jar
 
 # Start CDAP Services
 for i in /etc/init.d/cdap-*

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -72,6 +72,9 @@ sed \
 # Install/Configure ntp, CDAP
 chef-solo -o 'recipe[ntp::default],recipe[cdap::fullstack],recipe[cdap::init]' -j ${__tmpdir}/generated-conf.json
 
+# Temporary Hack to workaround CDAP-4089
+rm /opt/cdap/kafka/lib/log4j.log4j-1.2.14.jar
+
 # Start CDAP Services
 for i in /etc/init.d/cdap-*
 do


### PR DESCRIPTION
- [x] ugly hack to workaround https://issues.cask.co/browse/CDAP-4089, otherwise there is no way to start cdap_kafka.  This should be fixed in the next patch release.