### PR TITLE
Template for CI-based Docker builds

### DIFF
--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -1,7 +1,7 @@
 {
   "cdap": {
-    "version": "VERSION",
+    "version": "{{VERSION}}",
     "sdk": {
-      "url": "URI"
+      "url": "{{URI}}"
   }
 }

--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -1,0 +1,7 @@
+{
+  "cdap": {
+    "version": "VERSION",
+    "sdk": {
+      "url": "URI"
+  }
+}


### PR DESCRIPTION
This will be used by the upcoming build pipeline to take build artifacts from previous builds and using them, versus only using released artifacts. This is done by replacing the URI with a location on the local disk, skipping the need for a cdap cookbook update to test new SDK versions in Docker/VM.