### PR TITLE
(CDAP-3997) Added plugin support to Spark

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginConfig.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginConfig.java
@@ -19,11 +19,15 @@ package co.cask.cdap.api.plugin;
 import co.cask.cdap.api.Config;
 import co.cask.cdap.api.annotation.Beta;
 
+import java.io.Serializable;
+
 /**
  * Base class for writing configuration class for template plugin.
  */
 @Beta
-public abstract class PluginConfig extends Config {
+public abstract class PluginConfig extends Config implements Serializable {
+
+  private static final long serialVersionUID = 125560021489909246L;
 
   private PluginProperties properties;
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginContext.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.annotation.Beta;
 
 /**
  * Provides access to plugin context when a program is executing.
- * TODO: Rename the methods in the class to the ones in AdapterContext once templates/adapters are removed.
  */
 @Beta
 public interface PluginContext {

--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginProperties.java
@@ -18,6 +18,7 @@ package co.cask.cdap.api.plugin;
 
 import co.cask.cdap.api.annotation.Beta;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,7 +27,9 @@ import java.util.Map;
  * Plugin instance properties.
  */
 @Beta
-public class PluginProperties {
+public class PluginProperties implements Serializable {
+
+  private static final long serialVersionUID = -7396484717511717753L;
 
   // Currently only support String->String map.
   private final Map<String, String> properties;

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/AbstractSpark.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/AbstractSpark.java
@@ -18,7 +18,7 @@ package co.cask.cdap.api.spark;
 
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.annotation.Beta;
-import co.cask.cdap.internal.api.AbstractProgramDatasetConfigurable;
+import co.cask.cdap.internal.api.AbstractPluginConfigurable;
 
 import java.util.Map;
 
@@ -26,7 +26,7 @@ import java.util.Map;
  * This abstract class provides a default implementation of {@link Spark} methods for easy extension.
  */
 @Beta
-public abstract class AbstractSpark extends AbstractProgramDatasetConfigurable<SparkConfigurer> implements Spark {
+public abstract class AbstractSpark extends AbstractPluginConfigurable<SparkConfigurer> implements Spark {
 
   private SparkConfigurer configurer;
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkConfigurer.java
@@ -20,12 +20,13 @@ import co.cask.cdap.api.DatasetConfigurer;
 import co.cask.cdap.api.ProgramConfigurer;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.plugin.PluginConfigurer;
 
 /**
  * Configurer for configuring {@link Spark}.
  */
 @Beta
-public interface SparkConfigurer extends ProgramConfigurer, DatasetConfigurer {
+public interface SparkConfigurer extends ProgramConfigurer, DatasetConfigurer, PluginConfigurer {
 
   /**
    * Sets the Spark job main class name in specification. The main method of this class will be called to run the

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.stream.Stream;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.stream.StreamEventDecoder;
 import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowToken;
@@ -177,6 +178,14 @@ public interface SparkContext extends RuntimeContext, DatasetContext {
    * @return {@link Serializable} {@link Metrics} for {@link Spark} programs
    */
   Metrics getMetrics();
+
+  /**
+   * Returns a {@link Serializable} {@link PluginContext} which can be used to request for plugins instances. The
+   * instance returned can also be used in Spark program's closures.
+   *
+   * @return A {@link Serializable} {@link PluginContext}.
+   */
+  PluginContext getPluginContext();
 
   /**
    * Override the resources, such as memory and virtual cores, to use for each executor process for the Spark program.

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkProgram.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkProgram.java
@@ -37,5 +37,5 @@ public interface SparkProgram extends Serializable {
    *
    * @param context {@link SparkContext} for this job
    */
-  void run(SparkContext context);
+  void run(SparkContext context) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
@@ -90,7 +90,7 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
 
   public DefaultAppConfigurer(Id.Artifact artifactId, Application app, String configuration,
                               ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
-    super(artifactRepository, pluginInstantiator, artifactId);
+    super(artifactId, artifactRepository, pluginInstantiator);
     this.name = app.getClass().getSimpleName();
     this.description = "";
     this.configuration = configuration;
@@ -146,12 +146,14 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
   @Override
   public void addSpark(Spark spark) {
     Preconditions.checkArgument(spark != null, "Spark cannot be null.");
-    DefaultSparkConfigurer configurer = new DefaultSparkConfigurer(spark);
+    DefaultSparkConfigurer configurer = new DefaultSparkConfigurer(spark, artifactId, artifactRepository,
+                                                                   pluginInstantiator);
     spark.configure(configurer);
 
     addStreams(configurer.getStreams());
     addDatasetModules(configurer.getDatasetModules());
     addDatasetSpecs(configurer.getDatasetSpecs());
+    addPlugins(configurer.getPlugins());
     SparkSpecification spec = configurer.createSpecification();
     sparks.put(spec.getName(), spec);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -157,7 +157,7 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
   private ProgramOptions createPluginSnapshot(ProgramOptions options, Id.Program programId, File tempDir,
                                               @Nullable ApplicationSpecification appSpec) throws IOException {
     // appSpec is null in an unit test
-    if (appSpec == null) {
+    if (appSpec == null || appSpec.getPlugins().isEmpty()) {
       return options;
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
@@ -32,10 +32,10 @@ import co.cask.cdap.internal.app.runtime.plugin.PluginNotExistsException;
 import co.cask.cdap.proto.Id;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -46,17 +46,17 @@ import javax.annotation.Nullable;
  */
 public class DefaultPluginConfigurer extends DefaultDatasetConfigurer implements PluginConfigurer {
 
+  private final Id.Artifact artifactId;
   private final ArtifactRepository artifactRepository;
   private final PluginInstantiator pluginInstantiator;
-  private final Id.Artifact artifactId;
   private final Map<String, Plugin> plugins;
 
-  public DefaultPluginConfigurer(ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator,
-                                 Id.Artifact artifactId) {
+  public DefaultPluginConfigurer(Id.Artifact artifactId,
+                                 ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
+    this.artifactId = artifactId;
     this.artifactRepository = artifactRepository;
     this.pluginInstantiator = pluginInstantiator;
-    this.artifactId = artifactId;
-    this.plugins = Maps.newHashMap();
+    this.plugins = new HashMap<>();
   }
 
   public Map<String, Plugin> getPlugins() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
@@ -47,7 +47,7 @@ public final class DefaultMapReduceConfigurer extends DefaultPluginConfigurer im
 
   public DefaultMapReduceConfigurer(MapReduce mapReduce, Id.Artifact artifactId, ArtifactRepository artifactRepository,
                                     PluginInstantiator pluginInstantiator) {
-    super(artifactRepository, pluginInstantiator, artifactId);
+    super(artifactId, artifactRepository, pluginInstantiator);
     this.className = mapReduce.getClass().getName();
     this.name = mapReduce.getClass().getSimpleName();
     this.description = "";

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractProgramRunnerWithPlugin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractProgramRunnerWithPlugin.java
@@ -35,12 +35,19 @@ public abstract class AbstractProgramRunnerWithPlugin implements ProgramRunner {
     this.cConf = cConf;
   }
 
+  /**
+   * Creates a {@link PluginInstantiator} based on the {@link ProgramOptionConstants#PLUGIN_DIR} in
+   * the system arguments in the given {@link ProgramOptions}.
+   *
+   * @param options the program runner options
+   * @param classLoader the parent ClassLoader for the {@link PluginInstantiator} to use
+   * @return A new {@link PluginInstantiator} or {@code null} if no plugin is available.
+   */
   @Nullable
   protected PluginInstantiator createPluginInstantiator(ProgramOptions options, ClassLoader classLoader) {
-    if (options.getArguments().getOption(ProgramOptionConstants.PLUGIN_DIR) == null) {
+    if (!options.getArguments().hasOption(ProgramOptionConstants.PLUGIN_DIR)) {
       return null;
     }
-
     return new PluginInstantiator(
       cConf, classLoader, new File(options.getArguments().getOption(ProgramOptionConstants.PLUGIN_DIR)));
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultPluginContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultPluginContext.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime;
+
+import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+
+import java.io.IOException;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * An implementation of {@link PluginContext} that uses {@link PluginInstantiator}.
+ */
+public class DefaultPluginContext implements PluginContext {
+
+  @Nullable
+  private final PluginInstantiator pluginInstantiator;
+  private final Id.Program programId;
+  private final Map<String, Plugin> plugins;
+
+  public DefaultPluginContext(@Nullable PluginInstantiator pluginInstantiator,
+                              Id.Program programId, Map<String, Plugin> plugins) {
+    this.pluginInstantiator = pluginInstantiator;
+    this.programId = programId;
+    this.plugins = plugins;
+  }
+
+  @Override
+  public PluginProperties getPluginProperties(String pluginId) {
+    return getPlugin(pluginId).getProperties();
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginId) {
+    try {
+      Plugin plugin = getPlugin(pluginId);
+      if (pluginInstantiator == null) {
+        throw new UnsupportedOperationException("Plugin is not supported");
+      }
+      return pluginInstantiator.loadClass(plugin);
+    } catch (ClassNotFoundException e) {
+      // Shouldn't happen, unless there is bug in file localization
+      throw new IllegalArgumentException("Plugin class not found", e);
+    } catch (IOException e) {
+      // This is fatal, since jar cannot be expanded.
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    try {
+      Plugin plugin = getPlugin(pluginId);
+      if (pluginInstantiator == null) {
+        throw new UnsupportedOperationException("Plugin is not supported");
+      }
+      return pluginInstantiator.newInstance(plugin);
+    } catch (ClassNotFoundException e) {
+      // Shouldn't happen, unless there is bug in file localization
+      throw new IllegalArgumentException("Plugin class not found", e);
+    } catch (IOException e) {
+      // This is fatal, since jar cannot be expanded.
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private Plugin getPlugin(String pluginId) {
+    Plugin plugin = plugins.get(pluginId);
+    Preconditions.checkArgument(plugin != null, "Plugin with id %s does not exist in program %s of application %s.",
+                                pluginId, programId.getId(), programId.getApplicationId());
+    return plugin;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -59,5 +59,13 @@ public final class ProgramOptionConstants {
 
   public static final String RESOURCES = "resources";
 
+  /**
+   * Option to a local file path of a directory containing plugins artifacts.
+   */
   public static final String PLUGIN_DIR = "pluginDir";
+
+  /**
+   * Option to a local file path of a JAR file containing plugins artifacts.
+   */
+  public static final String PLUGIN_ARCHIVE = "pluginArchive";
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -61,6 +61,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -371,6 +372,11 @@ public class ArtifactInspector {
       }
 
       for (Field field : type.getRawType().getDeclaredFields()) {
+        int modifiers = field.getModifiers();
+        if (Modifier.isTransient(modifiers) || Modifier.isStatic(modifiers) || field.isSynthetic()) {
+          continue;
+        }
+
         PluginPropertyField property = createPluginProperty(field, type);
         if (result.containsKey(property.getName())) {
           throw new IllegalArgumentException("Plugin config with name " + property.getName()

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -70,6 +71,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   private final Map<String, Dataset> outputDatasets;
   private final Map<String, OutputFormatProvider> outputFormatProviders;
   private final TransactionContext txContext;
+  private final File pluginArchive;
 
   private String inputDatasetName;
   private List<Split> inputDataSelection;
@@ -89,6 +91,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
                                MetricsCollectionService metricsCollectionService,
                                TransactionSystemClient txClient,
                                DatasetFramework dsFramework,
+                               @Nullable File pluginArchive,
                                @Nullable PluginInstantiator pluginInstantiator) {
     super(program, runId, runtimeArguments, Collections.<String>emptySet(),
           getMetricsCollector(program, runId.getId(), metricsCollectionService),
@@ -121,6 +124,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
 
     this.plugins = Maps.newHashMap(program.getApplicationSpecification().getPlugins());
     this.txContext = getDatasetCache().newTransactionContext();
+    this.pluginArchive = pluginArchive;
   }
 
   public TransactionContext getTransactionContext() {
@@ -381,4 +385,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     return reducerResources;
   }
 
+  public File getPluginArchive() {
+    return pluginArchive;
+  }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -91,7 +91,7 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
                                    TransactionSystemClient txClient,
                                    Transaction transaction,
                                    DatasetFramework dsFramework,
-                                   PluginInstantiator pluginInstantiator) {
+                                   @Nullable PluginInstantiator pluginInstantiator) {
     super(program, runId, runtimeArguments, datasets,
           getMetricCollector(program, runId.getId(), taskId, metricsCollectionService, type),
           dsFramework, txClient, discoveryServiceClient, false, pluginInstantiator);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
@@ -21,27 +21,19 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.lang.CombineClassLoader;
 import co.cask.cdap.common.lang.Delegators;
-import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.ProgramClassLoader;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.internal.app.runtime.batch.distributed.DistributedMapReduceTaskContextProvider;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerLauncher;
-import co.cask.cdap.internal.app.runtime.plugin.PluginClassLoader;
+import co.cask.cdap.internal.app.runtime.plugin.PluginClassLoaders;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.proto.ProgramType;
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.Injector;
 import org.apache.hadoop.conf.Configuration;
@@ -55,10 +47,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -72,12 +62,6 @@ import javax.annotation.Nullable;
 public class MapReduceClassLoader extends CombineClassLoader implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(MapReduceClassLoader.class);
-  private static final Function<String, String> CLASS_TO_RESOURCE_NAME = new Function<String, String>() {
-    @Override
-    public String apply(String className) {
-      return className.replace('.', '/') + ".class";
-    }
-  };
 
   private final Parameters parameters;
   // Supplier for MapReduceTaskContextProvider. Need to wrap it with a supplier to delay calling
@@ -161,6 +145,7 @@ public class MapReduceClassLoader extends CombineClassLoader implements AutoClos
   /**
    * Returns the {@link PluginInstantiator} associated with this ClassLoader.
    */
+  @Nullable
   public PluginInstantiator getPluginInstantiator() {
     return parameters.getPluginInstantiator();
   }
@@ -183,12 +168,11 @@ public class MapReduceClassLoader extends CombineClassLoader implements AutoClos
    * Creates the delegating list of ClassLoader.
    */
   private static List<ClassLoader> createDelegates(Parameters parameters) {
-    ImmutableList.Builder<ClassLoader> builder = ImmutableList.builder();
-    builder.add(parameters.getProgramClassLoader());
-    builder.addAll(parameters.getFilteredPluginClassLoaders());
-    builder.add(MapReduceClassLoader.class.getClassLoader());
-
-    return builder.build();
+    return ImmutableList.of(
+      parameters.getProgramClassLoader(),
+      parameters.getFilteredPluginsClassLoader(),
+      MapReduceClassLoader.class.getClassLoader()
+    );
   }
 
   /**
@@ -201,7 +185,7 @@ public class MapReduceClassLoader extends CombineClassLoader implements AutoClos
     private final Configuration hConf;
     private final ClassLoader programClassLoader;
     private final PluginInstantiator pluginInstantiator;
-    private final List<ClassLoader> filteredPluginClassLoaders;
+    private final ClassLoader filteredPluginsClassLoader;
 
     /**
      * Creates from the Job Configuration
@@ -216,7 +200,7 @@ public class MapReduceClassLoader extends CombineClassLoader implements AutoClos
 
     Parameters(MapReduceContextConfig contextConfig, ClassLoader programClassLoader) {
       this(contextConfig.getCConf(), contextConfig.getHConf(), programClassLoader, contextConfig.getPlugins(),
-           createPluginInstantiator(contextConfig, programClassLoader, new File(Constants.Plugin.DIRECTORY)));
+           createPluginInstantiator(contextConfig, programClassLoader));
     }
 
     /**
@@ -230,7 +214,8 @@ public class MapReduceClassLoader extends CombineClassLoader implements AutoClos
       this.hConf = hConf;
       this.programClassLoader = programClassLoader;
       this.pluginInstantiator = pluginInstantiator;
-      this.filteredPluginClassLoaders = createFilteredPluginClassLoaders(plugins, pluginInstantiator);
+      this.filteredPluginsClassLoader = PluginClassLoaders.createFilteredPluginsClassLoader(plugins,
+                                                                                            pluginInstantiator);
     }
 
     ClassLoader getProgramClassLoader() {
@@ -241,8 +226,8 @@ public class MapReduceClassLoader extends CombineClassLoader implements AutoClos
       return pluginInstantiator;
     }
 
-    List<ClassLoader> getFilteredPluginClassLoaders() {
-      return filteredPluginClassLoaders;
+    ClassLoader getFilteredPluginsClassLoader() {
+      return filteredPluginsClassLoader;
     }
 
     CConfiguration getCConf() {
@@ -286,53 +271,12 @@ public class MapReduceClassLoader extends CombineClassLoader implements AutoClos
      */
     @Nullable
     private static PluginInstantiator createPluginInstantiator(MapReduceContextConfig contextConfig,
-                                                               ClassLoader programClassLoader, File basePath) {
-      return new PluginInstantiator(contextConfig.getCConf(), programClassLoader, basePath);
-    }
-
-    /**
-     * Returns a list of {@link ClassLoader} for loading plugin classes. The ordering is:
-     *
-     * Plugin Lib ClassLoader, Plugin Export-Package ClassLoader, ...
-     */
-    private static List<ClassLoader> createFilteredPluginClassLoaders(Map<String, Plugin> plugins,
-                                                                      PluginInstantiator pluginInstantiator) {
-      if (plugins.isEmpty()) {
-        return ImmutableList.of();
+                                                               ClassLoader programClassLoader) {
+      String pluginArchive = contextConfig.getHConf().get(Constants.Plugin.ARCHIVE);
+      if (pluginArchive == null) {
+        return null;
       }
-
-      try {
-        Multimap<Plugin, String> artifactPluginClasses = getArtifactPluginClasses(plugins);
-        List<ClassLoader> pluginClassLoaders = Lists.newArrayList();
-        for (Plugin plugin : plugins.values()) {
-          ClassLoader pluginClassLoader = pluginInstantiator.getArtifactClassLoader(plugin.getArtifactId());
-          if (pluginClassLoader instanceof PluginClassLoader) {
-            Collection<String> allowedClasses = artifactPluginClasses.get(plugin);
-            if (!allowedClasses.isEmpty()) {
-              pluginClassLoaders.add(createClassFilteredClassLoader(allowedClasses, pluginClassLoader));
-            }
-            pluginClassLoaders.add(((PluginClassLoader) pluginClassLoader).getExportPackagesClassLoader());
-          }
-        }
-        return ImmutableList.copyOf(pluginClassLoaders);
-      } catch (IOException e) {
-        throw Throwables.propagate(e);
-      }
-    }
-
-    private static Multimap<Plugin, String> getArtifactPluginClasses(Map<String, Plugin> plugins) {
-      Multimap<Plugin, String> result = HashMultimap.create();
-      for (Map.Entry<String, Plugin> entry : plugins.entrySet()) {
-        result.put(entry.getValue(), entry.getValue().getPluginClass().getClassName());
-      }
-      return result;
-    }
-
-    private static ClassLoader createClassFilteredClassLoader(Iterable<String> allowedClasses,
-                                                              ClassLoader parentClassLoader) {
-      Set<String> allowedResources = ImmutableSet.copyOf(Iterables.transform(allowedClasses, CLASS_TO_RESOURCE_NAME));
-      return FilterClassLoader.create(Predicates.in(allowedResources),
-        Predicates.<String>alwaysTrue(), parentClassLoader);
+      return new PluginInstantiator(contextConfig.getCConf(), programClassLoader, new File(pluginArchive));
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -68,6 +68,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
+import java.io.File;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
@@ -180,7 +181,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
         new BasicMapReduceContext(program, runId, options.getUserArguments(), spec,
                                   logicalStartTime, programNameInWorkflow, workflowToken, discoveryServiceClient,
                                   metricsCollectionService, txSystemClient, datasetFramework,
-                                  pluginInstantiator);
+                                  getPluginArchive(options), pluginInstantiator);
 
       Reflections.visit(mapReduce, mapReduce.getClass(),
                         new PropertyFieldSetter(context.getSpecification().getProperties()),
@@ -287,5 +288,13 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
     for (Closeable c : closeables) {
       Closeables.closeQuietly(c);
     }
+  }
+
+  @Nullable
+  private File getPluginArchive(ProgramOptions options) {
+    if (!options.getArguments().hasOption(ProgramOptionConstants.PLUGIN_ARCHIVE)) {
+      return null;
+    }
+    return new File(options.getArguments().getOption(ProgramOptionConstants.PLUGIN_ARCHIVE));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -195,14 +195,12 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
         TransactionSystemClient txClient = injector.getInstance(TransactionSystemClient.class);
         Set<String> staticDatasets = getDatasets(program, contextConfig);
 
-        BasicMapReduceTaskContext context = new BasicMapReduceTaskContext(
+        return new BasicMapReduceTaskContext(
           program, taskType, contextConfig.getRunId(), key.getTaskAttemptID().getTaskID().toString(),
           contextConfig.getArguments(), staticDatasets, spec, contextConfig.getLogicalStartTime(),
           contextConfig.getWorkflowToken(), discoveryServiceClient, metricsCollectionService, txClient,
           contextConfig.getTx(), datasetFramework, classLoader.getPluginInstantiator()
         );
-
-        return context;
       }
     };
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -170,8 +170,8 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
       }
 
       Map<String, LocalizeResource> localizeResources = new HashMap<>();
-      final ProgramOptions options = program.getApplicationSpecification().getPlugins().isEmpty() ?
-        oldOptions : addArtifactPluginFiles(oldOptions, localizeResources, DirUtils.createTempDir(tempDir));
+      final ProgramOptions options = addArtifactPluginFiles(oldOptions, localizeResources,
+                                                            DirUtils.createTempDir(tempDir));
 
       // Copy config files and program jar to local temp, and ask Twill to localize it to container.
       // What Twill does is to save those files in HDFS and keep using them during the lifetime of application.
@@ -231,15 +231,23 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
 
   private ProgramOptions addArtifactPluginFiles(ProgramOptions options, Map<String, LocalizeResource> localizeResources,
                                                 File tempDir) throws IOException {
-    File localDir = new File(options.getArguments().getOption(ProgramOptionConstants.PLUGIN_DIR));
-    File archiveFile = new File(tempDir, Constants.Plugin.DIRECTORY);
-    BundleJarUtil.packDirFiles(localDir, Locations.toLocation(archiveFile), tempDir);
-    localizeResources.put(Constants.Plugin.DIRECTORY, new LocalizeResource(archiveFile, true));
-    LOG.debug("Localizing Resource {} here {}", localDir, archiveFile);
+    Arguments systemArgs = options.getArguments();
+    if (!systemArgs.hasOption(ProgramOptionConstants.PLUGIN_DIR)) {
+      return options;
+    }
 
-    Map<String, String> systemArgs = Maps.newHashMap(options.getArguments().asMap());
-    systemArgs.put(ProgramOptionConstants.PLUGIN_DIR, Constants.Plugin.DIRECTORY);
-    return new SimpleProgramOptions(options.getName(), new BasicArguments(systemArgs),
+    File localDir = new File(systemArgs.getOption(ProgramOptionConstants.PLUGIN_DIR));
+    File archiveFile = new File(tempDir, "artifacts.jar");
+    BundleJarUtil.createJar(localDir, archiveFile);
+
+    // Localize plugins to two files, one expanded into a directory, one not.
+    localizeResources.put("artifacts", new LocalizeResource(archiveFile, true));
+    localizeResources.put("artifacts_archive.jar", new LocalizeResource(archiveFile, false));
+
+    Map<String, String> newSystemArgs = Maps.newHashMap(((Arguments) systemArgs).asMap());
+    newSystemArgs.put(ProgramOptionConstants.PLUGIN_DIR, "artifacts");
+    newSystemArgs.put(ProgramOptionConstants.PLUGIN_ARCHIVE, "artifacts_archive.jar");
+    return new SimpleProgramOptions(options.getName(), new BasicArguments(newSystemArgs),
                                     options.getUserArguments(), options.isDebug());
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillApplication.java
@@ -29,6 +29,8 @@ import org.apache.twill.api.TwillRunnable;
 import org.apache.twill.api.TwillSpecification;
 import org.apache.twill.api.TwillSpecification.Builder;
 import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -36,6 +38,8 @@ import java.util.Map;
  * An abstract base class for all program {@link TwillApplication}.
  */
 public abstract class AbstractProgramTwillApplication implements TwillApplication {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractProgramTwillApplication.class);
 
   private final Program program;
   private final Map<String, LocalizeResource> localizeResources;
@@ -116,8 +120,10 @@ public abstract class AbstractProgramTwillApplication implements TwillApplicatio
   private Builder.RunnableSetter localizeFiles(Builder.LocalFileAdder fileAdder) {
     Location programLocation = program.getJarLocation();
 
+    LOG.debug("Localizing program jar for {}: {}", program.getName(), programLocation);
     Builder.MoreFile moreFile = fileAdder.add(programLocation.getName(), programLocation.toURI());
     for (Map.Entry<String, LocalizeResource> entry : localizeResources.entrySet()) {
+      LOG.debug("Localizing file for {}: {} {} {}", program.getName(), entry.getKey(), entry.getValue());
       moreFile.add(entry.getKey(), entry.getValue().getURI(), entry.getValue().isArchive());
     }
     return moreFile.apply();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginClassLoaders.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginClassLoaders.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.plugin;
+
+import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.common.lang.CombineClassLoader;
+import co.cask.cdap.common.lang.FilterClassLoader;
+import com.google.common.base.Function;
+import com.google.common.base.Predicates;
+import com.google.common.base.Throwables;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * A utility class to help constructing ClassLoaders for plugins in program context.
+ */
+public final class PluginClassLoaders {
+
+  private static final Function<String, String> CLASS_TO_RESOURCE_NAME = new Function<String, String>() {
+    @Override
+    public String apply(String className) {
+      return className.replace('.', '/') + ".class";
+    }
+  };
+
+  /**
+   * Returns a {@link ClassLoader} that only allows loading of plugin classes and plugin exported classes.
+   * It should only be used in context when a single ClassLoader is needed to load all different kinds of user classes
+   * (e.g. in MapReduce/Spark).
+   */
+  public static ClassLoader createFilteredPluginsClassLoader(Map<String, Plugin> plugins,
+                                                             @Nullable PluginInstantiator pluginInstantiator) {
+    if (plugins.isEmpty() || pluginInstantiator == null) {
+      return new CombineClassLoader(null, ImmutableList.<ClassLoader>of());
+    }
+
+    try {
+      // Gather all explicitly used plugin class names. It is needed for external plugin case.
+      Multimap<Plugin, String> artifactPluginClasses = getArtifactPluginClasses(plugins);
+
+      List<ClassLoader> pluginClassLoaders = new ArrayList<>();
+      for (Plugin plugin : plugins.values()) {
+        ClassLoader pluginClassLoader = pluginInstantiator.getArtifactClassLoader(plugin.getArtifactId());
+        if (pluginClassLoader instanceof PluginClassLoader) {
+
+          // A ClassLoader to allow loading of all plugin classes used by the program.
+          Collection<String> pluginClasses = artifactPluginClasses.get(plugin);
+          if (!pluginClasses.isEmpty()) {
+            pluginClassLoaders.add(createClassFilteredClassLoader(pluginClasses, pluginClassLoader));
+          }
+
+          // A ClassLoader to allow all export package classes to be loadable.
+          pluginClassLoaders.add(((PluginClassLoader) pluginClassLoader).getExportPackagesClassLoader());
+        }
+      }
+      return new CombineClassLoader(null, pluginClassLoaders);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /**
+   * Returns a {@link Multimap} from {@link Plugin} to set of classes used by the program.
+   */
+  private static Multimap<Plugin, String> getArtifactPluginClasses(Map<String, Plugin> plugins) {
+    Multimap<Plugin, String> result = HashMultimap.create();
+    for (Map.Entry<String, Plugin> entry : plugins.entrySet()) {
+      result.put(entry.getValue(), entry.getValue().getPluginClass().getClassName());
+    }
+    return result;
+  }
+
+  private static ClassLoader createClassFilteredClassLoader(Iterable<String> allowedClasses,
+                                                            ClassLoader parentClassLoader) {
+    Set<String> allowedResources = ImmutableSet.copyOf(Iterables.transform(allowedClasses, CLASS_TO_RESOURCE_NAME));
+    return FilterClassLoader.create(Predicates.in(allowedResources),
+                                    Predicates.<String>alwaysTrue(), parentClassLoader);
+  }
+
+  private PluginClassLoaders() {
+    // no-op
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -55,6 +55,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.concurrent.ExecutionException;
 
@@ -261,6 +262,11 @@ public class PluginInstantiator implements Closeable {
 
     @Override
     public void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
+      int modifiers = field.getModifiers();
+      if (Modifier.isTransient(modifiers) || Modifier.isStatic(modifiers) || field.isSynthetic()) {
+        return;
+      }
+
       TypeToken<?> declareTypeToken = TypeToken.of(declareType);
 
       if (PluginConfig.class.equals(declareTypeToken.getRawType())) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -31,15 +31,20 @@ import co.cask.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import co.cask.cdap.internal.app.runtime.DataFabricFacadeFactory;
 import co.cask.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.services.ServiceHttpServer;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
+import com.google.common.io.Closeables;
+import com.google.common.util.concurrent.Service;
 import com.google.inject.Inject;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.ServiceAnnouncer;
+import org.apache.twill.common.Threads;
 import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.internal.ServiceListenerAdapter;
 
 /**
  * A {@link ProgramRunner} that runs a component inside a Service (either a HTTP Server or a Worker).
@@ -97,16 +102,36 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
       ((ProgramContextAware) datasetFramework).initContext(new Id.Run(programId, runId.getId()));
     }
 
-    ServiceHttpServer component = new ServiceHttpServer(host, program, spec, runId, options.getUserArguments(),
-                                      instanceId, instanceCount, serviceAnnouncer,
-                                      metricsCollectionService, datasetFramework, dataFabricFacadeFactory,
-                                      txClient, discoveryServiceClient,
-                                      createPluginInstantiator(options, program.getClassLoader()));
+    final PluginInstantiator pluginInstantiator = createPluginInstantiator(options, program.getClassLoader());
+    try {
+      ServiceHttpServer component = new ServiceHttpServer(host, program, spec, runId, options.getUserArguments(),
+                                                          instanceId, instanceCount, serviceAnnouncer,
+                                                          metricsCollectionService, datasetFramework,
+                                                          dataFabricFacadeFactory, txClient, discoveryServiceClient,
+                                                          pluginInstantiator);
 
-    ProgramController controller = new ServiceProgramControllerAdapter(component, program.getId(), runId,
-                                                                       spec.getName() + "-" + instanceId);
-    component.start();
-    return controller;
+      // Add a service listener to make sure the plugin instantiator is closed when the worker driver finished.
+      component.addListener(new ServiceListenerAdapter() {
+        @Override
+        public void terminated(Service.State from) {
+          Closeables.closeQuietly(pluginInstantiator);
+        }
+
+        @Override
+        public void failed(Service.State from, Throwable failure) {
+          Closeables.closeQuietly(pluginInstantiator);
+        }
+      }, Threads.SAME_THREAD_EXECUTOR);
+
+
+      ProgramController controller = new ServiceProgramControllerAdapter(component, program.getId(), runId,
+                                                                         spec.getName() + "-" + instanceId);
+      component.start();
+      return controller;
+    } catch (Throwable t) {
+      Closeables.closeQuietly(pluginInstantiator);
+      throw t;
+    }
   }
 
   private static final class ServiceProgramControllerAdapter extends ProgramControllerServiceAdapter {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -31,7 +31,6 @@ import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.collect.Maps;
-import com.google.common.io.Closeables;
 import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -113,12 +112,6 @@ public class BasicHttpServiceContext extends AbstractContext implements Transact
   @Override
   public void dismissTransactionContext() {
     getDatasetCache().dismissTransactionContext();
-  }
-
-  @Override
-  public void close() {
-    super.close();
-    Closeables.closeQuietly(getPluginInstantiator());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextFactory.java
@@ -64,7 +64,8 @@ final class SparkContextFactory {
                                      clientContext.getLogicalStartTime(), clientContext.getRuntimeArguments(),
                                      transaction, datasetFramework, txClient, clientContext.getDiscoveryServiceClient(),
                                      clientContext.getMetricsContext(), clientContext.getLoggingContext(),
-                                     hConf, streamAdmin, clientContext.getWorkflowToken());
+                                     hConf, streamAdmin, clientContext.getPluginInstantiator(),
+                                     clientContext.getWorkflowToken());
   }
 
   private SparkSpecification updateSpecExecutorResources(SparkSpecification originalSpec, Resources executorResources) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkPluginContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkPluginContext.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark;
+
+import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.internal.app.runtime.DefaultPluginContext;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.proto.Id;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link Externalizable} implementation of {@link PluginContext} used in Spark program execution.
+ * It has no-op for serialize/deserialize operations. It uses {@link SparkContextProvider} to
+ * get the {@link ExecutionSparkContext} in the current execution context.
+ */
+public class SparkPluginContext implements PluginContext, Externalizable {
+
+  private final PluginContext delegate;
+
+  public SparkPluginContext() {
+    this(SparkContextProvider.getSparkContext());
+  }
+
+  public SparkPluginContext(ExecutionSparkContext context) {
+    this(context.getPluginInstantiator(), context.getProgramId(), context.getApplicationSpecification().getPlugins());
+  }
+
+  public SparkPluginContext(@Nullable PluginInstantiator pluginInstantiator,
+                            Id.Program programId, Map<String, Plugin> plugins) {
+    this.delegate = new DefaultPluginContext(pluginInstantiator, programId, plugins);
+  }
+
+  @Override
+  public PluginProperties getPluginProperties(String pluginId) {
+    return delegate.getPluginProperties(pluginId);
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginId) {
+    return delegate.loadPluginClass(pluginId);
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return delegate.newPluginInstance(pluginId);
+  }
+
+  @Override
+  public void writeExternal(ObjectOutput out) throws IOException {
+    // no-op
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    // no-op
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunner.java
@@ -25,7 +25,6 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
-import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -34,9 +33,11 @@ import co.cask.cdap.common.lang.PropertyFieldSetter;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import co.cask.cdap.internal.app.runtime.DataSetFieldSetter;
 import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
 import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.proto.Id;
@@ -44,6 +45,7 @@ import co.cask.cdap.proto.ProgramType;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.io.Closeables;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.Service;
 import com.google.gson.Gson;
@@ -56,12 +58,17 @@ import org.apache.twill.internal.ServiceListenerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * Runs {@link Spark} programs
  */
-public class SparkProgramRunner implements ProgramRunner {
+public class SparkProgramRunner extends AbstractProgramRunnerWithPlugin {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkProgramRunner.class);
   private static final Gson GSON = new Gson();
@@ -79,6 +86,7 @@ public class SparkProgramRunner implements ProgramRunner {
   public SparkProgramRunner(CConfiguration cConf, Configuration hConf, TransactionSystemClient txSystemClient,
                             DatasetFramework datasetFramework, MetricsCollectionService metricsCollectionService,
                             DiscoveryServiceClient discoveryServiceClient, StreamAdmin streamAdmin, Store store) {
+    super(cConf);
     this.hConf = hConf;
     this.datasetFramework = datasetFramework;
     this.cConf = cConf;
@@ -121,48 +129,60 @@ public class SparkProgramRunner implements ProgramRunner {
       ((ProgramContextAware) datasetFramework).initContext(new Id.Run(programId, runId.getId()));
     }
 
-    ClientSparkContext context = new ClientSparkContext(program, runId, logicalStartTime,
-                                                        options.getUserArguments().asMap(),
-                                                        txSystemClient, datasetFramework,
-                                                        discoveryServiceClient, metricsCollectionService,
-                                                        workflowToken);
-
-    Spark spark;
+    List<Closeable> closeables = new ArrayList<>();
     try {
-      spark = new InstantiatorFactory(false).get(TypeToken.of(program.<Spark>getMainClass())).create();
+      PluginInstantiator pluginInstantiator = createPluginInstantiator(options, program.getClassLoader());
+      if (pluginInstantiator != null) {
+        closeables.add(pluginInstantiator);
+      }
 
-      // Fields injection
-      Reflections.visit(spark, spark.getClass(),
-                        new PropertyFieldSetter(spec.getProperties()),
-                        new DataSetFieldSetter(context),
-                        new MetricsFieldSetter(context.getMetrics()));
-    } catch (Exception e) {
-      LOG.error("Failed to instantiate Spark class for {}", spec.getClassName(), e);
-      throw Throwables.propagate(e);
+      ClientSparkContext context = new ClientSparkContext(program, runId, logicalStartTime,
+                                                          options.getUserArguments().asMap(),
+                                                          txSystemClient, datasetFramework,
+                                                          discoveryServiceClient, metricsCollectionService,
+                                                          getPluginArchive(options), pluginInstantiator, workflowToken);
+      closeables.add(context);
+      Spark spark;
+      try {
+        spark = new InstantiatorFactory(false).get(TypeToken.of(program.<Spark>getMainClass())).create();
+
+        // Fields injection
+        Reflections.visit(spark, spark.getClass(),
+                          new PropertyFieldSetter(spec.getProperties()),
+                          new DataSetFieldSetter(context),
+                          new MetricsFieldSetter(context.getMetrics()));
+      } catch (Exception e) {
+        LOG.error("Failed to instantiate Spark class for {}", spec.getClassName(), e);
+        throw Throwables.propagate(e);
+      }
+
+      SparkSubmitter submitter = new SparkContextConfig(hConf).isLocal() ? new LocalSparkSubmitter()
+        : new DistributedSparkSubmitter();
+      Service sparkRuntimeService = new SparkRuntimeService(
+        cConf, hConf, spark, new SparkContextFactory(hConf, context, datasetFramework, txSystemClient, streamAdmin),
+        submitter, program.getJarLocation(), txSystemClient
+      );
+
+      sparkRuntimeService.addListener(
+        createRuntimeServiceListener(program.getId(), runId, arguments, options.getUserArguments(), closeables),
+        Threads.SAME_THREAD_EXECUTOR);
+      ProgramController controller = new SparkProgramController(sparkRuntimeService, context);
+
+      LOG.info("Starting Spark Job: {}", context.toString());
+      sparkRuntimeService.start();
+      return controller;
+    } catch (Throwable t) {
+      closeAll(closeables);
+      throw t;
     }
-
-    SparkSubmitter submitter = new SparkContextConfig(hConf).isLocal() ? new LocalSparkSubmitter()
-                                                                       : new DistributedSparkSubmitter();
-    Service sparkRuntimeService = new SparkRuntimeService(
-      cConf, hConf, spark, new SparkContextFactory(hConf, context, datasetFramework, txSystemClient, streamAdmin),
-      submitter, program.getJarLocation(), txSystemClient
-    );
-
-    sparkRuntimeService.addListener(
-      createRuntimeServiceListener(program.getId(), runId, arguments, options.getUserArguments()),
-      Threads.SAME_THREAD_EXECUTOR);
-    ProgramController controller = new SparkProgramController(sparkRuntimeService, context);
-
-    LOG.info("Starting Spark Job: {}", context.toString());
-    sparkRuntimeService.start();
-    return controller;
   }
 
   /**
    * Creates a service listener to reactor on state changes on {@link SparkRuntimeService}.
    */
   private Service.Listener createRuntimeServiceListener(final Id.Program programId, final RunId runId,
-                                                        Arguments arguments, final Arguments userArgs) {
+                                                        Arguments arguments, final Arguments userArgs,
+                                                        final List<Closeable> closeables) {
 
     final String twillRunId = arguments.getOption(ProgramOptionConstants.TWILL_RUN_ID);
     final String workflowName = arguments.getOption(ProgramOptionConstants.WORKFLOW_NAME);
@@ -190,6 +210,7 @@ public class SparkProgramRunner implements ProgramRunner {
 
       @Override
       public void terminated(Service.State from) {
+        closeAll(closeables);
         if (from == Service.State.STOPPING) {
           // Service was killed
           store.setStop(programId, runId.getId(), TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
@@ -203,9 +224,24 @@ public class SparkProgramRunner implements ProgramRunner {
 
       @Override
       public void failed(Service.State from, Throwable failure) {
+        closeAll(closeables);
         store.setStop(programId, runId.getId(), TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
                       ProgramController.State.ERROR.getRunStatus());
       }
     };
+  }
+
+  private void closeAll(List<Closeable> closeables) {
+    for (Closeable closeable : closeables) {
+      Closeables.closeQuietly(closeable);
+    }
+  }
+
+  @Nullable
+  private File getPluginArchive(ProgramOptions options) {
+    if (!options.getArguments().hasOption(ProgramOptionConstants.PLUGIN_ARCHIVE)) {
+      return null;
+    }
+    return new File(options.getArguments().getOption(ProgramOptionConstants.PLUGIN_ARCHIVE));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramWrapper.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * Class which wraps around user's program class to integrate the spark program with CDAP.
  * The first command line argument to this class is the name of the user's Spark program class.
  */
-public class SparkProgramWrapper implements Runnable {
+public class SparkProgramWrapper {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkProgramWrapper.class);
 
@@ -53,8 +53,7 @@ public class SparkProgramWrapper implements Runnable {
     this.userSparkProgram = loadUserSparkClass(args[0]).newInstance();
   }
 
-  @Override
-  public void run() {
+  public void run() throws Exception {
     ExecutionSparkContext context = setupSparkContext(userSparkProgram.getClass());
     LOG.debug("Launching user spark program {} from class {}", context, userSparkProgram.getClass().getName());
     userSparkProgram.run(context);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -45,7 +45,6 @@ import co.cask.tephra.TransactionFailureException;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
-import com.google.common.io.Closeables;
 import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
@@ -163,7 +162,6 @@ public class BasicWorkerContext extends AbstractContext implements WorkerContext
   public void close() {
     super.close();
     datasetCache.close();
-    Closeables.closeQuietly(getPluginInstantiator());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerDriver.java
@@ -27,7 +27,6 @@ import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
 import co.cask.cdap.internal.lang.Reflections;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.Closeables;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.common.util.concurrent.Service;
@@ -96,9 +95,6 @@ public class WorkerDriver extends AbstractExecutionThreadService {
       worker.destroy();
     } finally {
       ClassLoaders.setContextClassLoader(classLoader);
-      if (context.getPluginInstantiator() != null) {
-        Closeables.closeQuietly(context.getPluginInstantiator());
-      }
       context.close();
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -32,15 +32,20 @@ import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
 import co.cask.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import co.cask.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
+import com.google.common.io.Closeables;
+import com.google.common.util.concurrent.Service;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import org.apache.twill.api.RunId;
+import org.apache.twill.common.Threads;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.internal.RunIds;
+import org.apache.twill.internal.ServiceListenerAdapter;
 
 /**
  * A {@link ProgramRunner} that runs a {@link Worker}.
@@ -104,17 +109,35 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
       ((ProgramContextAware) datasetFramework).initContext(new Id.Run(programId, runId.getId()));
     }
 
-    BasicWorkerContext context = new BasicWorkerContext(
-      newWorkerSpec, program, runId, instanceId, instanceCount,
-      options.getUserArguments(), metricsCollectionService, datasetFramework,
-      txClient, discoveryServiceClient, streamWriterFactory,
-      createPluginInstantiator(options, program.getClassLoader()));
-    WorkerDriver worker = new WorkerDriver(program, newWorkerSpec, context);
+    final PluginInstantiator pluginInstantiator = createPluginInstantiator(options, program.getClassLoader());
+    try {
+      BasicWorkerContext context = new BasicWorkerContext(
+        newWorkerSpec, program, runId, instanceId, instanceCount,
+        options.getUserArguments(), metricsCollectionService, datasetFramework,
+        txClient, discoveryServiceClient, streamWriterFactory, pluginInstantiator);
+      WorkerDriver worker = new WorkerDriver(program, newWorkerSpec, context);
 
-    ProgramController controller = new WorkerControllerServiceAdapter(worker, program.getId(), runId,
-                                                                      workerSpec.getName() + "-" + instanceId);
-    worker.start();
-    return controller;
+      // Add a service listener to make sure the plugin instantiator is closed when the worker driver finished.
+      worker.addListener(new ServiceListenerAdapter() {
+        @Override
+        public void terminated(Service.State from) {
+          Closeables.closeQuietly(pluginInstantiator);
+        }
+
+        @Override
+        public void failed(Service.State from, Throwable failure) {
+          Closeables.closeQuietly(pluginInstantiator);
+        }
+      }, Threads.SAME_THREAD_EXECUTOR);
+
+      ProgramController controller = new WorkerControllerServiceAdapter(worker, program.getId(), runId,
+                                                                        workerSpec.getName() + "-" + instanceId);
+      worker.start();
+      return controller;
+    } catch (Throwable t) {
+      Closeables.closeQuietly(pluginInstantiator);
+      throw t;
+    }
   }
 
   private static final class WorkerControllerServiceAdapter extends ProgramControllerServiceAdapter {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
@@ -58,7 +58,7 @@ public class DefaultHttpServiceHandlerConfigurer extends DefaultPluginConfigurer
   public DefaultHttpServiceHandlerConfigurer(HttpServiceHandler handler, Id.Artifact artifactId,
                                              ArtifactRepository artifactRepository,
                                              PluginInstantiator pluginInstantiator) {
-    super(artifactRepository, pluginInstantiator, artifactId);
+    super(artifactId, artifactRepository, pluginInstantiator);
     this.propertyFields = Maps.newHashMap();
     this.className = handler.getClass().getName();
     this.name = handler.getClass().getSimpleName();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
@@ -66,7 +66,7 @@ public class DefaultServiceConfigurer extends DefaultPluginConfigurer implements
    */
   public DefaultServiceConfigurer(Service service, Id.Artifact artifactId, ArtifactRepository artifactRepository,
                                   PluginInstantiator pluginInstantiator) {
-    super(artifactRepository, pluginInstantiator, artifactId);
+    super(artifactId, artifactRepository, pluginInstantiator);
     this.className = service.getClass().getName();
     this.name = service.getClass().getSimpleName();
     this.description = "";

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/DefaultWorkerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/DefaultWorkerConfigurer.java
@@ -52,7 +52,7 @@ public class DefaultWorkerConfigurer extends DefaultPluginConfigurer implements 
 
   public DefaultWorkerConfigurer(Worker worker, Id.Artifact artifactId, ArtifactRepository artifactRepository,
                                  PluginInstantiator pluginInstantiator) {
-    super(artifactRepository, pluginInstantiator, artifactId);
+    super(artifactId, artifactRepository, pluginInstantiator);
     this.name = worker.getClass().getSimpleName();
     this.className = worker.getClass().getName();
     this.propertyFields = Maps.newHashMap();

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -162,7 +162,10 @@ public final class Constants {
    * Plugin Artifacts constants.
    */
   public static final class Plugin {
-    public static final String DIRECTORY = "artifacts.jar";
+    public static final String DIRECTORY = "artifacts";
+
+    // Key to be used in hConf to store location of the plugin artifact jar
+    public static final String ARCHIVE = "cdap.program.plugin.archive";
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/BundleJarUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/BundleJarUtil.java
@@ -17,23 +17,27 @@
 package co.cask.cdap.common.lang.jar;
 
 import co.cask.cdap.common.io.Locations;
-import co.cask.cdap.common.utils.DirUtils;
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 import com.google.common.io.InputSupplier;
+import com.google.common.io.OutputSupplier;
 import org.apache.twill.filesystem.Location;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.EnumSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
@@ -146,32 +150,55 @@ public class BundleJarUtil {
   }
 
   /**
-   * Creates an Archive including all the files present in the given input. If the given input is a file, then it alone
-   * is included in the archive. Doesn't support recursive dirs.
+   * Creates an JAR including all the files present in the given input. Same as calling
+   * {@link #createJar(File, OutputSupplier) createJar(input, Files.newOutputStreamSupplier(output)}.
+   */
+  public static void createJar(File input, File output) throws IOException {
+    createJar(input, Files.newOutputStreamSupplier(output));
+  }
+
+  /**
+   * Creates an JAR including all the files present in the given input. If the given input is a file, then it alone
+   * is included in the archive.
    *
    * @param input input directory (or file) whose contents needs to be archived
-   * @param destArchive location to which the archive needs to be written to
-   * @param tempDir temporary directory to help with archive generation
+   * @param outputSupplier An {@link OutputSupplier} for the JAR content to write to.
    * @throws IOException if there is failure in the archive creation
    */
-  public static void packDirFiles(File input, Location destArchive, File tempDir) throws IOException {
-    File jarFile = File.createTempFile("temp", ".jar", tempDir);
-    try (JarOutputStream output = new JarOutputStream(new FileOutputStream(jarFile))) {
-      List<File> files = new ArrayList<>();
-      if (input.isDirectory()) {
-        files.addAll(DirUtils.listFiles(input));
-      } else {
-        files.add(input);
-      }
+  public static void createJar(File input, OutputSupplier<? extends OutputStream> outputSupplier) throws IOException {
+    final URI baseURI = input.toURI();
+    try (
+      OutputStream os = outputSupplier.getOutput();
+      JarOutputStream output = new JarOutputStream(os)
+    ) {
+      java.nio.file.Files.walkFileTree(input.toPath(), EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
+                                       new SimpleFileVisitor<Path>() {
 
-      for (File file : files) {
-        if (file.isFile()) {
-          output.putNextEntry(new JarEntry(file.getName()));
-          Files.copy(file, output);
+        @Override
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+          URI uri = baseURI.relativize(dir.toUri());
+          if (!uri.getPath().isEmpty()) {
+            output.putNextEntry(new JarEntry(uri.getPath()));
+            output.closeEntry();
+          }
+          return FileVisitResult.CONTINUE;
         }
-      }
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+          URI uri = baseURI.relativize(file.toUri());
+          if (uri.getPath().isEmpty()) {
+            // Only happen if the given "input" is a file.
+            output.putNextEntry(new JarEntry(file.toFile().getName()));
+          } else {
+            output.putNextEntry(new JarEntry(uri.getPath()));
+          }
+          java.nio.file.Files.copy(file, output);
+          output.closeEntry();
+          return FileVisitResult.CONTINUE;
+        }
+      });
     }
-    Files.copy(jarFile, Locations.newOutputSupplier(destArchive));
   }
 
   /**

--- a/cdap-common/src/test/java/co/cask/cdap/common/lang/jar/BundleJarUtilTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/lang/jar/BundleJarUtilTest.java
@@ -17,14 +17,23 @@
 package co.cask.cdap.common.lang.jar;
 
 import co.cask.cdap.common.io.Locations;
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+import com.google.common.io.CharStreams;
+import com.google.common.io.Files;
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 /**
  * Unit Tests for {@link BundleJarUtil}.
@@ -32,7 +41,7 @@ import java.util.List;
 public class BundleJarUtilTest {
 
   @ClassRule
-  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
   @Test
   public void testPackingDir() throws IOException {
@@ -49,8 +58,33 @@ public class BundleJarUtilTest {
     testNumFiles(1, true);
   }
 
+  @Test
+  public void testRecursive() throws IOException {
+    // Create a file inside a sub-dir.
+    File dir = TEMP_FOLDER.newFolder();
+    File subDir = new File(dir, "subdir");
+    subDir.mkdirs();
+
+    String message = Strings.repeat("0123456789", 40);
+    File file1 = new File(subDir, "file1");
+    Files.write(message, file1, Charsets.UTF_8);
+
+    // Create a jar of the top level directory
+    File target = new File(TEMP_FOLDER.newFolder(), "target.jar");
+    BundleJarUtil.createJar(dir, Files.newOutputStreamSupplier(target));
+
+    JarFile jarFile = new JarFile(target);
+    Assert.assertTrue(jarFile.getJarEntry("subdir/").isDirectory());
+
+    JarEntry jarEntry = jarFile.getJarEntry("subdir/file1");
+    Assert.assertNotNull(jarEntry);
+    try (Reader reader = new InputStreamReader(jarFile.getInputStream(jarEntry), Charsets.UTF_8)) {
+      Assert.assertEquals(message, CharStreams.toString(reader));
+    }
+  }
+
   private void testNumFiles(int numFiles, boolean isFile) throws IOException {
-    File input = isFile ? File.createTempFile("abcd", "txt", tmpFolder.newFolder()) : tmpFolder.newFolder();
+    File input = isFile ? File.createTempFile("abcd", "txt", TEMP_FOLDER.newFolder()) : TEMP_FOLDER.newFolder();
     List<File> files = new ArrayList<>();
     if (!isFile) {
       for (int i = 0; i < numFiles; i++) {
@@ -60,8 +94,8 @@ public class BundleJarUtilTest {
       files.add(input);
     }
 
-    File destArchive = new File(tmpFolder.newFolder(), "myBundle.jar");
-    BundleJarUtil.packDirFiles(input, Locations.toLocation(destArchive), tmpFolder.newFolder());
+    File destArchive = new File(TEMP_FOLDER.newFolder(), "myBundle.jar");
+    BundleJarUtil.createJar(input, destArchive);
     for (File file : files) {
       BundleJarUtil.getEntry(Locations.toLocation(destArchive), file.getName()).getInput().close();
     }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -27,6 +27,8 @@ import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.lib.cube.AggregationFunction;
 import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.metrics.MetricDataQuery;
@@ -50,6 +52,7 @@ import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SlowTests;
+import co.cask.cdap.test.SparkManager;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.WorkerManager;
 import co.cask.cdap.test.WorkflowManager;
@@ -252,6 +255,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
       new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()));
 
     ApplicationManager appManager = deployApplication(appId, createRequest);
+
     WorkerManager workerManager = appManager.getWorkerManager(AppWithPlugin.WORKER);
     workerManager.start();
     workerManager.waitForStatus(false, 5, 1);
@@ -273,6 +277,34 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     mrManager.waitForFinish(10, TimeUnit.MINUTES);
     List<RunRecord> runRecords = mrManager.getHistory();
     Assert.assertNotEquals(ProgramRunStatus.FAILED, runRecords.get(0).getStatus());
+
+    // Testing Spark Plugins. First send some data to stream for the Spark program to process
+    StreamManager streamManager = getStreamManager(AppWithPlugin.SPARK_STREAM);
+    for (int i = 0; i < 5; i++) {
+      streamManager.send("Message " + i);
+    }
+
+    SparkManager sparkManager = appManager.getSparkManager(AppWithPlugin.SPARK).start();
+    sparkManager.waitForFinish(2, TimeUnit.MINUTES);
+
+    // Verify the Spark result.
+    DataSetManager<Table> dataSetManager = getDataset(AppWithPlugin.SPARK_TABLE);
+    Table table = dataSetManager.get();
+    Scanner scanner = table.scan(null, null);
+    try {
+      for (int i = 0; i < 5; i++) {
+        Row row = scanner.next();
+        Assert.assertNotNull(row);
+        String expected = "Message " + i + " " + AppWithPlugin.TEST;
+        Assert.assertEquals(expected, Bytes.toString(row.getRow()));
+        Assert.assertEquals(expected, Bytes.toString(row.get(expected)));
+      }
+      // There shouldn't be any more rows in the table.
+      Assert.assertNull(scanner.next());
+
+    } finally {
+      scanner.close();
+    }
   }
 
   @Test

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/artifacts/plugins/ToStringPlugin.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/artifacts/plugins/ToStringPlugin.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.plugin.PluginConfig;
 
+import java.io.Serializable;
 import javax.annotation.Nullable;
 
 /**
@@ -27,7 +28,9 @@ import javax.annotation.Nullable;
  */
 @Plugin(type = "t1")
 @Name("n1")
-public class ToStringPlugin {
+public class ToStringPlugin implements Serializable {
+
+  private static final long serialVersionUID = -4818590442766677617L;
 
   @Override
   public String toString() {
@@ -35,6 +38,8 @@ public class ToStringPlugin {
   }
 
   public static class Config extends PluginConfig {
+    private static final long serialVersionUID = -2563532875802323220L;
+
     @Nullable
     public String toString;
   }


### PR DESCRIPTION
- Added a serializable SparkPluginContext exposed through SparkContext
- Make plugins classes loadable through the SparkClassLoader
- Cleanup contract of plugin artifact files localization in distributed mode

Also fixed couple bugs, including:

- PluginInstantiator is not closed properly in Service
- (CDAP-3741) Excluding static and transient fields in PluginConfig