### PR TITLE
Fixes polling repeatedly for logs (avoids refreshing logs view every 10 seconds)

### DIFF
--- a/cdap-ui/app/features/adapters/controllers/tabs/log-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/tabs/log-ctrl.js
@@ -23,11 +23,10 @@ angular.module(PKG.name + '.feature.adapters')
     angular.copy(AdapterDetail.params, runsParams);
     angular.copy(AdapterDetail.logsParams, logsParams);
     logsParams.scope = $scope;
-
     AdapterDetail.logsApi.pollLatestRun(logsParams)
       .$promise
       .then(function (runs) {
-        if (runs.length === 0) { return; }
+        if (runs.length === 0 || (runs.length && logsParams.runId === runs[0].runid)) { return; }
 
         logsParams.runId = runs[0].runid;
 
@@ -53,6 +52,7 @@ angular.module(PKG.name + '.feature.adapters')
         .then(function (res) {
           $scope.logs = _.uniq($scope.logs.concat(res));
           $scope.loadingNext = false;
+
         });
     };
 


### PR DESCRIPTION
The UI should not refresh the logs view repeatedly unless there is a change in the latest run.

![logsview](https://cloud.githubusercontent.com/assets/1452845/10743243/0710113a-7bef-11e5-9741-504d1886e082.gif)
