### PR TITLE
fixes button padding issue for consistent styling

### DIFF
--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -356,10 +356,9 @@ body.theme-cdap {
     }
     .modal-footer {
       border-top: 0;
-      .btn-default { .cask-btn(@color: white, @background: @cdap-gray, @border: 0, @padding: 10px 20px); }
+      .btn-default { .cask-btn(@color: white, @background: @cdap-gray, @border: 0, @padding: 6px 12px); }
       .btn-primary, .btn-success {
-        .cask-btn(@color: white, @background: @brand-success, @border: 0, @padding: 10px 20px);
-        margin-left: 30px;
+        .cask-btn(@color: white, @background: @brand-success, @border: 0, @padding: 6px 12px);
       }
     }
     .form-control {
@@ -407,7 +406,7 @@ body.theme-cdap {
         .box-shadow(none);
       }
       .modal-footer {
-        .btn-primary { .cask-btn(@color: white, @background: @brand-danger, @border: 0, @padding: 10px 20px); }
+        .btn-primary { .cask-btn(@color: white, @background: @brand-danger, @border: 0, @padding: 6px 12px); }
       }
     }
     .modal-dialog {
@@ -425,8 +424,7 @@ body.theme-cdap {
 
         .modal-footer {
           .btn-primary, .btn-success {
-            .cask-btn(@color: white, @background: @brand-success, @border: 0, @padding: 10px 20px);
-            margin-left: 30px;
+            .cask-btn(@color: white, @background: @brand-success, @border: 0, @padding: 6px 12px);
           }
         }
       }


### PR DESCRIPTION
*  Adds default padding (padding: 6px 12px) to modal footer buttons
*  Removes 30px left margin from between 2 footer buttons (spacing was excessive)

![buttons](https://cloud.githubusercontent.com/assets/5335210/10743480/a1dbfb92-7bf0-11e5-8f69-6a245b5b6436.gif)
