### PR TITLE
Fixes polling repeatedly for logs (avoids refreshing logs view every 10 seconds)

### DIFF
--- a/cdap-ui/app/features/hydrator/controllers/tabs/log-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/tabs/log-ctrl.js
@@ -29,7 +29,7 @@
      HydratorDetail.logsApi.pollLatestRun(logsParams)
        .$promise
        .then(function (runs) {
-         if (runs.length === 0) { return; }
+         if (runs.length === 0 || (runs.length && $scope.logsGenericParams.runId ===runs[0].runid)) { return; }
          $scope.logsGenericParams.runId = runs[0].runid;
        });
 


### PR DESCRIPTION
Same PR (https://github.com/caskdata/cdap/pull/4397) but for develop (3.3)