### PR TITLE
fixes dashboard tab styling issues

### DIFF
--- a/cdap-ui/app/directives/tooltip-toggle/tooltip-toggle.js
+++ b/cdap-ui/app/directives/tooltip-toggle/tooltip-toggle.js
@@ -39,20 +39,22 @@ angular.module(PKG.name + '.commons')
     return {
       restrict: 'A',
       scope: {
-        ellipsis: '='
+        ellipsis: '=',
+        offsetValue: '='
       },
-      link: function (scope, element, attrs) {
+      link: function (scope, element) {
         function isEllipsisActive(e) {
-          return (e[0].offsetWidth > e[0].parentElement.offsetWidth - 20);
+          return (e[0].offsetWidth > e[0].parentElement.offsetWidth - scope.offsetValue);
         }
 
-        scope.$watch(attrs.tooltipEllipsis, function () {
-          if (attrs.tooltipEllipsis) {
-            if (isEllipsisActive(element)) {
-              scope.ellipsis = true;
-            } else {
-              scope.ellipsis = false;
-            }
+        scope.$watch(function () {
+          return element[0].parentElement.offsetWidth;
+        }, function () {
+          console.log('parent width: ', element[0].parentElement.offsetWidth - scope.offsetValue);
+          if (isEllipsisActive(element)) {
+            scope.ellipsis = true;
+          } else {
+            scope.ellipsis = false;
           }
         });
 

--- a/cdap-ui/app/directives/tooltip-toggle/tooltip-toggle.js
+++ b/cdap-ui/app/directives/tooltip-toggle/tooltip-toggle.js
@@ -46,11 +46,10 @@ angular.module(PKG.name + '.commons')
         function isEllipsisActive(e) {
           return (e[0].offsetWidth > e[0].parentElement.offsetWidth - scope.offsetValue);
         }
-
+        // FIXME: Find more efficient approach
         scope.$watch(function () {
           return element[0].parentElement.offsetWidth;
         }, function () {
-          console.log('parent width: ', element[0].parentElement.offsetWidth - scope.offsetValue);
           if (isEllipsisActive(element)) {
             scope.ellipsis = true;
           } else {

--- a/cdap-ui/app/features/dashboard/style.less
+++ b/cdap-ui/app/features/dashboard/style.less
@@ -145,20 +145,11 @@ body.state-dashboard {
           overflow: hidden;
           text-overflow: ellipsis;
           min-width: 80px;
-          max-width: 200px;
-
           // A
           color: @cdap-gray;
-
-          .dtitle::after {
-            display: inline-block;
-            width: 0;
-            height: 0;
-            vertical-align: middle;
-            border-top: 4px solid;
-            border-right: 4px solid transparent;
-            border-left: 4px solid transparent;
-            content: '';
+          span.fa {
+            position: relative;
+            z-index: 5;
           }
         }
       }

--- a/cdap-ui/app/features/dashboard/style.less
+++ b/cdap-ui/app/features/dashboard/style.less
@@ -74,8 +74,12 @@ body.state-dashboard {
         }
       }
     }
+
     .cdap-subnav-end + ul.slanted-tabs {
       li.active {
+        > a, > a:hover, > a:focus {
+          cursor: pointer;
+        }
         .dropdown-menu {
           background-color: transparent;
           border: 0;
@@ -145,10 +149,17 @@ body.state-dashboard {
           overflow: hidden;
           text-overflow: ellipsis;
           min-width: 80px;
+          text-align: center;
+
           // A
           color: @cdap-gray;
-          span.fa {
+          span.dtitle {
             position: relative;
+          }
+          span.fa {
+            position: absolute;
+            top: 1px;
+            left: -10px;
             z-index: 5;
           }
         }

--- a/cdap-ui/app/features/dashboard/style.less
+++ b/cdap-ui/app/features/dashboard/style.less
@@ -144,20 +144,27 @@ body.state-dashboard {
       display: flex;
 
       > li {
-        > a {
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          min-width: 80px;
-
-          // A
-          color: @cdap-gray;
-          span.dtitle {
-            width: 92%;
-          }
-          span.fa {
-            margin-left: 0;
-            width: 8%;
+        // Exclude System tab
+        &:not(:first-child) {
+          > a {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            min-width: 80px;
+            height: 42px;
+            // A
+            color: @cdap-gray;
+            span.dtitle {
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              position: relative;
+              z-index: 5;
+            }
+            span.fa {
+              line-height: 20px;
+              vertical-align: top;
+            }
           }
         }
       }

--- a/cdap-ui/app/features/dashboard/style.less
+++ b/cdap-ui/app/features/dashboard/style.less
@@ -149,18 +149,15 @@ body.state-dashboard {
           overflow: hidden;
           text-overflow: ellipsis;
           min-width: 80px;
-          text-align: center;
 
           // A
           color: @cdap-gray;
           span.dtitle {
-            position: relative;
+            width: 92%;
           }
           span.fa {
-            position: absolute;
-            top: 1px;
-            left: -10px;
-            z-index: 5;
+            margin-left: 0;
+            width: 8%;
           }
         }
       }

--- a/cdap-ui/app/features/dashboard/templates/dashboard.html
+++ b/cdap-ui/app/features/dashboard/templates/dashboard.html
@@ -35,9 +35,13 @@
     <a role="tab"
         href=""
         ng-click="activeTabClick($event, $index)">
-        <span class="dtitle">
-        {{dashboard.title}}
+        <span class="dtitle"
+              tooltip="{{dashboard.title}}"
+              tooltip-placement="top"
+              tooltip-append-to-body="true"
+              tooltip-enable="dashboard.title.length > 21">{{dashboard.title | myEllipsis: 21}}
         </span>
+        <span class="fa fa-caret-down"></span>
     </a>
     <div is-open="dashboard.isopen"
           dropdown>

--- a/cdap-ui/app/features/dashboard/templates/dashboard.html
+++ b/cdap-ui/app/features/dashboard/templates/dashboard.html
@@ -24,7 +24,6 @@
 </aside>
 
 <div class="cdap-subnav-end"></div>
-
 <ul class="nav nav-tabs slanted-tabs" role="tablist">
   <li role="presentation" ng-class="{'active': dashboards.activeIndex == 'system'}">
     <a href="" ng-click="activeTabClick($event, 'system')" role="tab" data-toggle="tab"> System </a>
@@ -40,8 +39,9 @@
               tooltip-placement="top"
               tooltip-append-to-body="true"
               tooltip-enable="dashboard.title.length > 21">{{dashboard.title | myEllipsis: 21}}
+          <span class="fa fa-caret-down"></span>
         </span>
-        <span class="fa fa-caret-down"></span>
+
     </a>
     <div is-open="dashboard.isopen"
           dropdown>
@@ -49,6 +49,5 @@
     </div>
   </li>
 </ul>
-
 
 <ui-view role="tabpanel"/>

--- a/cdap-ui/app/features/dashboard/templates/dashboard.html
+++ b/cdap-ui/app/features/dashboard/templates/dashboard.html
@@ -26,7 +26,11 @@
 <div class="cdap-subnav-end"></div>
 <ul class="nav nav-tabs slanted-tabs" role="tablist">
   <li role="presentation" ng-class="{'active': dashboards.activeIndex == 'system'}">
-    <a href="" ng-click="activeTabClick($event, 'system')" role="tab" data-toggle="tab" class="dtab"> System </a>
+    <a href=""
+       ng-click="activeTabClick($event, 'system')"
+       role="tab"
+       data-toggle="tab"
+       class="dtab">System</a>
   </li>
   <li role="presentation"
       ng-class="{'active': dashboards.activeIndex === $index, 'bottom-border-tab': dashboard.columns.length !== 0}"
@@ -40,6 +44,7 @@
               tooltip="{{dashboard.title}}"
               tooltip-ellipsis="{{dashboard.title}}"
               data-ellipsis="isEllipsis"
+              data-offset-value="40"
               tooltip-enable="isEllipsis"
               tooltip-placement="top"
               tooltip-append-to-body="true">{{dashboard.title}}</span>

--- a/cdap-ui/app/features/dashboard/templates/dashboard.html
+++ b/cdap-ui/app/features/dashboard/templates/dashboard.html
@@ -26,22 +26,23 @@
 <div class="cdap-subnav-end"></div>
 <ul class="nav nav-tabs slanted-tabs" role="tablist">
   <li role="presentation" ng-class="{'active': dashboards.activeIndex == 'system'}">
-    <a href="" ng-click="activeTabClick($event, 'system')" role="tab" data-toggle="tab"> System </a>
+    <a href="" ng-click="activeTabClick($event, 'system')" role="tab" data-toggle="tab" class="dtab"> System </a>
   </li>
   <li role="presentation"
       ng-class="{'active': dashboards.activeIndex === $index, 'bottom-border-tab': dashboard.columns.length !== 0}"
       ng-repeat="dashboard in dashboards | orderBy:$index">
     <a role="tab"
         href=""
-        ng-click="activeTabClick($event, $index)">
+        ng-click="activeTabClick($event, $index)"
+        class="dtab">
+        <span class="fa fa-caret-down"></span>
         <span class="dtitle"
               tooltip="{{dashboard.title}}"
+              tooltip-ellipsis="{{dashboard.title}}"
+              data-ellipsis="isEllipsis"
+              tooltip-enable="isEllipsis"
               tooltip-placement="top"
-              tooltip-append-to-body="true"
-              tooltip-enable="dashboard.title.length > 21">{{dashboard.title | myEllipsis: 21}}
-          <span class="fa fa-caret-down"></span>
-        </span>
-
+              tooltip-append-to-body="true">{{dashboard.title}}</span>
     </a>
     <div is-open="dashboard.isopen"
           dropdown>
@@ -49,5 +50,5 @@
     </div>
   </li>
 </ul>
-
 <ui-view role="tabpanel"/>
+

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-input-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-input-schema.html
@@ -35,6 +35,7 @@
               <span tooltip="{{ schema.name }}"
                     tooltip-ellipsis="{{ schema.name }}"
                     data-ellipsis="isEllipsis"
+                    data-offset-value="20"
                     tooltip-enable="isEllipsis"
                     tooltip-append-to-body="true">
                 {{schema.name}}


### PR DESCRIPTION
*  Adds tooltip-ellipsis directive to watch for when dashboard title length exceeds parent element length
*  Fixes issue where long dashboard titles would cause tab's dropdown caret not to display

![tabs](https://cloud.githubusercontent.com/assets/5335210/11102023/ecd2cd6c-886e-11e5-9bd7-635c1589e129.gif)

