### PR TITLE
Added the ability to add/retrieve local resources in MapReduce and Spark Programs

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/ClientLocalizationContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/ClientLocalizationContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api;
+
+import co.cask.cdap.api.annotation.Beta;
+
+import java.net.URI;
+
+/**
+ * Context that adds the capability to localize resources in programs.
+ */
+@Beta
+public interface ClientLocalizationContext {
+
+  /**
+   * Localizes a file with the given name. The localized file can be retrieved at program runtime using
+   * {@link TaskLocalizationContext#getLocalFile(String)}.
+   *
+   * @param name the name for the localized file. The localized file can be retrieved using this name at program
+   *             runtime using {@link TaskLocalizationContext#getLocalFile(String)}
+   * @param uri the {@link URI} of the file to localize
+   */
+  void localize(String name, URI uri);
+
+  /**
+   * Localizes a file with the given name. The localized file can be retrieved at program runtime using
+   * {@link TaskLocalizationContext#getLocalFile(String)}.
+   *
+   * @param name the name for the localized file. The localized file can be retrieved using this name at program
+   *             runtime using {@link TaskLocalizationContext#getLocalFile(String)}
+   * @param uri the {@link URI} of the file to localize
+   * @param archive indicates if the file is an archive
+   */
+  void localize(String name, URI uri, boolean archive);
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/TaskLocalizationContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/TaskLocalizationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,27 +16,28 @@
 
 package co.cask.cdap.api;
 
-import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.annotation.Beta;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Map;
 
 /**
- * This interface represents a context for a processor or elements of a processor.
+ * Localization context for Program Tasks.
  */
-public interface RuntimeContext {
+@Beta
+public interface TaskLocalizationContext {
 
   /**
-   * @return The application specification
+   * Returns a {@link File} representing the path to a localized file localized with the given name.
+   *
+   * @param name the local file's name
+   * @return a {@link File} for the localized file
    */
-  ApplicationSpecification getApplicationSpecification();
+  File getLocalFile(String name) throws FileNotFoundException;
 
   /**
-   * @return A map of argument key and value.
+   * @return a map of file name to {@link File} for files localized for this program
    */
-  Map<String, String> getRuntimeArguments();
-
-  /**
-   * @return The application namespace
-   */
-  String getNamespace();
+  Map<String, File> getAllLocalFiles();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
@@ -151,7 +151,7 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
   /**
    * Sets the name of the Dataset used as output for the {@link MapReduce}.
    *
-   * Deprecated as of 3.2.0. Use {@link MapReduceContext#setOutput(String datasetName)}
+   * Deprecated as of 3.2.0. Use {@link MapReduceContext#addOutput(String datasetName)}
    * in {@link #beforeSubmit}, instead.
    */
   @Deprecated

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.mapreduce;
 
+import co.cask.cdap.api.ClientLocalizationContext;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
@@ -37,7 +38,8 @@ import javax.annotation.Nullable;
 /**
  * MapReduce job execution context.
  */
-public interface MapReduceContext extends RuntimeContext, DatasetContext, ServiceDiscoverer, PluginContext {
+public interface MapReduceContext
+  extends RuntimeContext, DatasetContext, ServiceDiscoverer, PluginContext, ClientLocalizationContext {
 
   /**
    * @return The specification used to configure this {@link MapReduce} job instance.

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
@@ -18,6 +18,7 @@ package co.cask.cdap.api.mapreduce;
 
 import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
+import co.cask.cdap.api.TaskLocalizationContext;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.plugin.PluginContext;
@@ -35,7 +36,7 @@ import javax.annotation.Nullable;
  */
 @Beta
 public interface MapReduceTaskContext<KEYOUT, VALUEOUT> extends RuntimeContext, DatasetContext,
-  ServiceDiscoverer, PluginContext {
+  ServiceDiscoverer, PluginContext, TaskLocalizationContext {
 
   /**
    * Write key and value to the named output Dataset. This method must only be used if the MapReduce writes to

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
@@ -16,9 +16,11 @@
 
 package co.cask.cdap.api.spark;
 
+import co.cask.cdap.api.ClientLocalizationContext;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
+import co.cask.cdap.api.TaskLocalizationContext;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.stream.Stream;
@@ -46,7 +48,7 @@ import javax.annotation.Nullable;
  * method acts.
  */
 @Beta
-public interface SparkContext extends RuntimeContext, DatasetContext {
+public interface SparkContext extends RuntimeContext, DatasetContext, ClientLocalizationContext {
   /**
    * @return The specification used to configure this {@link Spark} job instance.
    */
@@ -211,4 +213,12 @@ public interface SparkContext extends RuntimeContext, DatasetContext {
    */
   @Nullable
   WorkflowToken getWorkflowToken();
+
+  /**
+   * Returns a {@link Serializable} {@link TaskLocalizationContext} which can be used to retrieve files localized to
+   * task containers. The instance returned can also be used in Spark program's closures.
+   *
+   * @return the {@link TaskLocalizationContext} for the {@link Spark} program
+   */
+  TaskLocalizationContext getTaskLocalizationContext();
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -62,9 +62,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   private final RunId runId;
   private final List<Id> owners;
   private final Map<String, String> runtimeArguments;
-
   private final MetricsContext programMetrics;
-
   private final DiscoveryServiceClient discoveryServiceClient;
   private final PluginInstantiator pluginInstantiator;
   private final PluginContext pluginContext;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultTaskLocalizationContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultTaskLocalizationContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime;
+
+import co.cask.cdap.api.TaskLocalizationContext;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Map;
+
+/**
+ * An implementation of {@link TaskLocalizationContext} that can be initialized with some localized resources.
+ */
+public class DefaultTaskLocalizationContext implements TaskLocalizationContext {
+
+  private final Map<String, File> localizedResources;
+
+  public DefaultTaskLocalizationContext(Map<String, File> localizedResources) {
+    this.localizedResources = ImmutableMap.copyOf(localizedResources);
+  }
+
+  @Override
+  public File getLocalFile(String name) throws FileNotFoundException {
+    if (!localizedResources.containsKey(name)) {
+      throw new FileNotFoundException(String.format("The specified file %s was not found. Please make sure it was " +
+                                                      "localized using context.localize().", name));
+    }
+    return localizedResources.get(name);
+  }
+
+  @Override
+  public Map<String, File> getAllLocalFiles() {
+    return localizedResources;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -38,6 +38,7 @@ import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.batch.dataset.DataSetOutputFormat;
+import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.logging.context.MapReduceLoggingContext;
 import co.cask.cdap.proto.Id;
@@ -50,6 +51,7 @@ import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -72,6 +74,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   private final Map<String, OutputFormatProvider> outputFormatProviders;
   private final TransactionContext txContext;
   private final File pluginArchive;
+  private final Map<String, LocalizeResource> resourcesToLocalize;
 
   private String inputDatasetName;
   private List<Split> inputDataSelection;
@@ -125,6 +128,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     this.plugins = Maps.newHashMap(program.getApplicationSpecification().getPlugins());
     this.txContext = getDatasetCache().newTransactionContext();
     this.pluginArchive = pluginArchive;
+    this.resourcesToLocalize = new HashMap<>();
   }
 
   public TransactionContext getTransactionContext() {
@@ -387,5 +391,19 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
 
   public File getPluginArchive() {
     return pluginArchive;
+  }
+
+  @Override
+  public void localize(String name, URI uri) {
+    localize(name, uri, false);
+  }
+
+  @Override
+  public void localize(String name, URI uri, boolean archive) {
+    resourcesToLocalize.put(name, new LocalizeResource(uri, archive));
+  }
+
+  Map<String, LocalizeResource> getResourcesToLocalize() {
+    return resourcesToLocalize;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -31,7 +31,11 @@ import co.cask.cdap.api.workflow.WorkflowToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -199,5 +203,25 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   @Override
   public void setReducerResources(Resources resources) {
     LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
+  }
+
+  @Override
+  public void localize(String name, URI uri) {
+    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
+  }
+
+  @Override
+  public void localize(String name, URI uri, boolean archive) {
+    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
+  }
+
+  @Override
+  public File getLocalFile(String name) throws FileNotFoundException {
+    return delegate.getLocalFile(name);
+  }
+
+  @Override
+  public Map<String, File> getAllLocalFiles() {
+    return delegate.getAllLocalFiles();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -54,6 +54,8 @@ import co.cask.cdap.internal.app.runtime.batch.dataset.UnsupportedOutputFormat;
 import co.cask.cdap.internal.app.runtime.batch.distributed.ContainerLauncherGenerator;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerLauncher;
+import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
+import co.cask.cdap.internal.app.runtime.spark.LocalizationUtils;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.tephra.Transaction;
@@ -202,6 +204,9 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
 
       beforeSubmit(job);
 
+      // Localize additional resources that users have requested via BasicMapReduceContext.localize methods
+      Map<String, String> localizedUserResources = localizeUserResources(job, tempDir);
+
       // Override user-defined job name, since we set it and depend on the name.
       // https://issues.cask.co/browse/CDAP-2441
       String jobName = job.getJobName();
@@ -274,7 +279,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       try {
         // We remember tx, so that we can re-use it in mapreduce tasks
         CConfiguration cConfCopy = cConf;
-        contextConfig.set(context, cConfCopy, tx, programJar.toURI());
+        contextConfig.set(context, cConfCopy, tx, programJar.toURI(), localizedUserResources);
 
         LOG.info("Submitting MapReduce Job: {}", context);
         // submits job and returns immediately. Shouldn't need to set context ClassLoader.
@@ -1004,5 +1009,48 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
   private ClassLoader setContextCombinedClassLoader(BasicMapReduceContext context) {
     return ClassLoaders.setContextClassLoader(new CombineClassLoader(
       null, ImmutableList.of(context.getProgram().getClassLoader(), getClass().getClassLoader())));
+  }
+
+  /**
+   * Localizes resources requested by users in the MapReduce Program's beforeSubmit phase.
+   * In Local mode, also copies resources to a temporary directory.
+   *
+   * @param job the {@link Job} for this MapReduce program
+   * @param targetDir in local mode, a temporary directory to copy the resources to
+   * @return a {@link Map} of resource name to the resource path. The resource path will be absolute in local mode,
+   * while it will just contain the file name in distributed mode.
+   */
+  private Map<String, String> localizeUserResources(Job job, File targetDir) throws IOException {
+    Map<String, String> localizedResources = new HashMap<>();
+    Map<String, LocalizeResource> resourcesToLocalize = context.getResourcesToLocalize();
+    for (Map.Entry<String, LocalizeResource> entry : resourcesToLocalize.entrySet()) {
+      String localizedFilePath;
+      String name = entry.getKey();
+      Configuration mapredConf = job.getConfiguration();
+      if (MapReduceTaskContextProvider.isLocal(mapredConf)) {
+        // in local mode, also add localize resources in a temporary directory
+        localizedFilePath =
+          LocalizationUtils.localizeResource(entry.getKey(), entry.getValue(), targetDir).getAbsolutePath();
+      } else {
+        URI uri = entry.getValue().getURI();
+        // in distributed mode, use the MapReduce Job object to localize resources
+        URI actualURI;
+        try {
+          actualURI = new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), uri.getQuery(), name);
+        } catch (URISyntaxException e) {
+          // Most of the URI is constructed from the passed URI. So ideally, this should not happen.
+          // If it does though, there is nothing that clients can do to recover, so not propagating a checked exception.
+          throw Throwables.propagate(e);
+        }
+        if (entry.getValue().isArchive()) {
+          job.addCacheArchive(actualURI);
+        } else {
+          job.addCacheFile(actualURI);
+        }
+        localizedFilePath = name;
+      }
+      localizedResources.put(name, localizedFilePath);
+    }
+    return localizedResources;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -199,7 +199,8 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
           program, taskType, contextConfig.getRunId(), key.getTaskAttemptID().getTaskID().toString(),
           contextConfig.getArguments(), staticDatasets, spec, contextConfig.getLogicalStartTime(),
           contextConfig.getWorkflowToken(), discoveryServiceClient, metricsCollectionService, txClient,
-          contextConfig.getTx(), datasetFramework, classLoader.getPluginInstantiator()
+          contextConfig.getTx(), datasetFramework, classLoader.getPluginInstantiator(),
+          contextConfig.getLocalizedResources()
         );
       }
     };

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -244,7 +244,7 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
     localizeResources.put("artifacts", new LocalizeResource(archiveFile, true));
     localizeResources.put("artifacts_archive.jar", new LocalizeResource(archiveFile, false));
 
-    Map<String, String> newSystemArgs = Maps.newHashMap(((Arguments) systemArgs).asMap());
+    Map<String, String> newSystemArgs = Maps.newHashMap(systemArgs.asMap());
     newSystemArgs.put(ProgramOptionConstants.PLUGIN_DIR, "artifacts");
     newSystemArgs.put(ProgramOptionConstants.PLUGIN_ARCHIVE, "artifacts_archive.jar");
     return new SimpleProgramOptions(options.getName(), new BasicArguments(newSystemArgs),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
@@ -81,6 +81,7 @@ final class BasicFlowletContext extends AbstractContext implements FlowletContex
     this.userMetrics = new ProgramUserMetrics(getMetricCollector(metricsCollectionService, program,
                                                                  flowletId, runId.getId(), instanceId));
     // TODO - does this have to cache the metric collectors? Metrics framework itself has a cache [CDAP-2334]
+    //noinspection NullableProblems
     this.queueMetrics = CacheBuilder.newBuilder()
       .expireAfterAccess(1, TimeUnit.HOURS)
       .build(new CacheLoader<String, MetricsContext>() {
@@ -90,6 +91,7 @@ final class BasicFlowletContext extends AbstractContext implements FlowletContex
         }
       });
 
+    //noinspection NullableProblems
     this.producerMetrics = CacheBuilder.newBuilder()
       .expireAfterAccess(1, TimeUnit.HOURS)
       .build(new CacheLoader<ImmutablePair<String, String>, MetricsContext>() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -119,6 +119,7 @@ public class BasicHttpServiceContext extends AbstractContext implements Transact
     return plugins;
   }
 
+  @Nullable
   private static MetricsContext getMetricCollector(MetricsCollectionService service,
                                                      Program program, String handlerName,
                                                      String runId, int instanceId) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime.spark;
 
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.ServiceDiscoverer;
+import co.cask.cdap.api.TaskLocalizationContext;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.common.Scope;
@@ -50,6 +51,7 @@ import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.io.Closeable;
+import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/LocalizationUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/LocalizationUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark;
+
+import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
+import com.google.common.io.Files;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Utilities for file localization.
+ */
+public final class LocalizationUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(LocalizationUtils.class);
+
+  /**
+   * Used in local mode to copy resources to a temporary local directory.
+   * TODO: CDAP-4178 Also handle decompression of archives.
+   *
+   * @param name the name of the resource to copy
+   * @param resource the {@link LocalizeResource} for the resource to localize
+   * @param targetDir the destination directory to localize the resource in
+   * @return {@link File} pointing to the localized resource
+   */
+  public static File localizeResource(String name, LocalizeResource resource, File targetDir) throws IOException {
+    File tempFile = new File(targetDir, name);
+    File localizedFile = new File(resource.getURI().getPath());
+    LOG.debug("Copy file from {} to {}", resource.getURI(), tempFile);
+    Files.copy(localizedFile, tempFile);
+    return localizedFile;
+  }
+
+  private LocalizationUtils() {
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextConfig.java
@@ -180,7 +180,7 @@ public class SparkContextConfig {
     hConf.set(HCONF_ATTR_NEW_TX, GSON.toJson(tx));
   }
 
-  public void setWorkflowToken(@Nullable WorkflowToken workflowToken) {
+  private void setWorkflowToken(@Nullable WorkflowToken workflowToken) {
     hConf.set(HCONF_ATTR_WORKFLOW_TOKEN, GSON.toJson(workflowToken));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextFactory.java
@@ -24,6 +24,9 @@ import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionSystemClient;
 import org.apache.hadoop.conf.Configuration;
 
+import java.io.File;
+import java.util.Map;
+
 /**
  * Factory for creating {@link ExecutionSparkContext} by referencing properties in {@link ClientSparkContext}.
  */
@@ -54,9 +57,10 @@ final class SparkContextFactory {
   /**
    * Creates a new instance of {@link ExecutionSparkContext} based on the {@link ClientSparkContext} in this factory.
    *
-   * @param transaction the transaction for the spark execution.
+   * @param transaction the transaction for the spark execution
+   * @param localizedResources the resources localized for the spark program
    */
-  ExecutionSparkContext createExecutionContext(Transaction transaction) {
+  ExecutionSparkContext createExecutionContext(Transaction transaction, Map<String, File> localizedResources) {
     SparkSpecification spec = updateSpecExecutorResources(clientContext.getSpecification(),
                                                           clientContext.getExecutorResources());
     return new ExecutionSparkContext(clientContext.getApplicationSpecification(), spec, clientContext.getProgramId(),
@@ -64,8 +68,8 @@ final class SparkContextFactory {
                                      clientContext.getLogicalStartTime(), clientContext.getRuntimeArguments(),
                                      transaction, datasetFramework, txClient, clientContext.getDiscoveryServiceClient(),
                                      clientContext.getMetricsContext(), clientContext.getLoggingContext(),
-                                     hConf, streamAdmin, clientContext.getPluginInstantiator(),
-                                     clientContext.getWorkflowToken());
+                                     hConf, streamAdmin, localizedResources,
+                                     clientContext.getPluginInstantiator(), clientContext.getWorkflowToken());
   }
 
   private SparkSpecification updateSpecExecutorResources(SparkSpecification originalSpec, Resources executorResources) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkLocalizationContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkLocalizationContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark;
+
+import co.cask.cdap.api.TaskLocalizationContext;
+import co.cask.cdap.internal.app.runtime.DefaultTaskLocalizationContext;
+
+import java.io.Externalizable;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Map;
+
+/**
+ * An {@link Externalizable} implementation of {@link TaskLocalizationContext} that can be used by Spark programs
+ * to retrieve localized resources in Spark Executors. It uses {@link SparkContextProvider} to
+ * get the {@link ExecutionSparkContext} in the current execution context.
+ */
+public class SparkLocalizationContext implements TaskLocalizationContext, Externalizable {
+
+  private final TaskLocalizationContext delegate;
+
+  public SparkLocalizationContext() {
+    this.delegate = SparkContextProvider.getSparkContext().getTaskLocalizationContext();
+  }
+
+  public SparkLocalizationContext(Map<String, File> localizedResources) {
+    this.delegate = new DefaultTaskLocalizationContext(localizedResources);
+  }
+
+  @Override
+  public File getLocalFile(String name) throws FileNotFoundException {
+    return delegate.getLocalFile(name);
+  }
+
+  @Override
+  public Map<String, File> getAllLocalFiles() {
+    return delegate.getAllLocalFiles();
+  }
+
+  @Override
+  public void writeExternal(ObjectOutput out) throws IOException {
+    //no-op
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    //no-op
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithLocalFiles.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithLocalFiles.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch;
+
+import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.lang.jar.BundleJarUtil;
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+/**
+ * App to test local files in programs.
+ */
+public class AppWithLocalFiles extends AbstractApplication {
+  public static final String MR_INPUT_DATASET = "input";
+  public static final String MR_OUTPUT_DATASET = "output";
+  public static final String STOPWORDS_FILE_ARG = "stopwords.file";
+  public static final String STOPWORDS_FILE_ALIAS = "stopwords.txt";
+  private static final String LOCAL_ARCHIVE_ALIAS = "archive.jar";
+
+  @Override
+  public void configure() {
+    createDataset(MR_INPUT_DATASET, KeyValueTable.class);
+    createDataset(MR_OUTPUT_DATASET, KeyValueTable.class);
+    addStream("LocalFileStream");
+    addMapReduce(new MapReduceWithLocalFiles());
+  }
+
+  public static class MapReduceWithLocalFiles extends AbstractMapReduce {
+
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      Map<String, String> args = context.getRuntimeArguments();
+      if (args.containsKey(STOPWORDS_FILE_ARG)) {
+        context.localize(STOPWORDS_FILE_ALIAS, URI.create(args.get(STOPWORDS_FILE_ARG)));
+      }
+      context.localize(LOCAL_ARCHIVE_ALIAS, createTemporaryArchiveFile(), true);
+      context.setInput(args.get(MR_INPUT_DATASET));
+      context.addOutput(args.get(MR_OUTPUT_DATASET));
+      Job job = context.getHadoopJob();
+      job.setMapperClass(TokenizerMapper.class);
+      job.setReducerClass(IntSumReducer.class);
+    }
+
+    private URI createTemporaryArchiveFile() throws IOException {
+      File tmpDir1 = com.google.common.io.Files.createTempDir();
+      List<File> files = new ArrayList<>();
+      for (int i = 0; i < 3; i++) {
+        File tmpFile = File.createTempFile("abcd" + i, "txt", tmpDir1);
+        files.add(tmpFile);
+      }
+
+      File tmpDir2 = com.google.common.io.Files.createTempDir();
+      File destArchive = new File(tmpDir2, "myBundle.jar");
+      BundleJarUtil.createJar(tmpDir1, destArchive);
+      for (File file : files) {
+        BundleJarUtil.getEntry(Locations.toLocation(destArchive), file.getName()).getInput().close();
+      }
+      return destArchive.toURI();
+    }
+
+    public static class TokenizerMapper extends Mapper<byte[], byte[], Text, IntWritable>
+      implements ProgramLifecycle<MapReduceTaskContext> {
+
+      private static final IntWritable ONE = new IntWritable(1);
+      private Text word = new Text();
+      private final List<String> stopWords = new ArrayList<>();
+
+      @Override
+      public void map(byte[] key, byte[] value, Context context) throws IOException, InterruptedException {
+        StringTokenizer itr = new StringTokenizer(Bytes.toString(value));
+
+        while (itr.hasMoreTokens()) {
+          String token = itr.nextToken();
+          if (!stopWords.contains(token)) {
+            word.set(token);
+            context.write(word, ONE);
+          }
+        }
+      }
+
+      @Override
+      public void initialize(MapReduceTaskContext context) throws Exception {
+        Map<String, File> localFiles = context.getAllLocalFiles();
+        Preconditions.checkState(localFiles.size() == 2, "Expected 2 files to have been localized.");
+        Map<String, String> args = context.getRuntimeArguments();
+        Preconditions.checkArgument(args.containsKey(STOPWORDS_FILE_ARG),
+                                    "Runtime argument %s must be set.", STOPWORDS_FILE_ARG);
+        String localFilePath = URI.create(args.get(STOPWORDS_FILE_ARG)).getPath();
+        // will throw FileNotFoundException if stopwords file does not exist
+        File stopWordsFile = context.getLocalFile(STOPWORDS_FILE_ALIAS);
+        Preconditions.checkState(stopWordsFile.exists(), "Stopwords file %s must exist", localFilePath);
+        Preconditions.checkState(context.getLocalFile(LOCAL_ARCHIVE_ALIAS).exists(),
+                                 "Local archive %s must exist", LOCAL_ARCHIVE_ALIAS);
+        try (BufferedReader reader = Files.newBufferedReader(stopWordsFile.toPath(), Charsets.UTF_8)) {
+          String line;
+          while ((line = reader.readLine()) != null) {
+            stopWords.add(line);
+          }
+        }
+      }
+
+      @Override
+      public void destroy() {
+      }
+    }
+
+    /**
+     *
+     */
+    public static class IntSumReducer extends Reducer<Text, IntWritable, byte[], byte[]> {
+      @Override
+      public void reduce(Text key, Iterable<IntWritable> values, Context context)
+        throws IOException, InterruptedException {
+        int sum = 0;
+        for (IntWritable val : values) {
+          sum += val.get();
+        }
+        context.write(Bytes.toBytes(key.toString()), Bytes.toBytes(sum));
+      }
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkAppUsingLocalFiles.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkAppUsingLocalFiles.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark;
+
+import co.cask.cdap.api.TaskLocalizationContext;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.spark.AbstractSpark;
+import co.cask.cdap.api.spark.JavaSparkProgram;
+import co.cask.cdap.api.spark.SparkContext;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.lang.jar.BundleJarUtil;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.PairFunction;
+import scala.Tuple2;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * App to test local files in Spark programs.
+ */
+public class SparkAppUsingLocalFiles extends AbstractApplication {
+  static final String OUTPUT_DATASET_NAME = "output";
+  static final String LOCAL_FILE_RUNTIME_ARG = "local.file";
+  static final String LOCAL_FILE_ALIAS = "local.properties";
+  static final String LOCAL_ARCHIVE_ALIAS = "archive.jar";
+
+  @Override
+  public void configure() {
+    createDataset(OUTPUT_DATASET_NAME, KeyValueTable.class);
+    addSpark(new JavaSparkUsingLocalFiles());
+    addSpark(new ScalaSparkUsingLocalFiles());
+  }
+
+  public static class JavaSparkUsingLocalFiles extends AbstractSpark {
+    @Override
+    protected void configure() {
+      setMainClass(JavaSparkProgramUsingLocalFiles.class);
+    }
+
+    @Override
+    public void beforeSubmit(SparkContext context) throws Exception {
+      Map<String, String> args = context.getRuntimeArguments();
+      String localFilePath = args.get(LOCAL_FILE_RUNTIME_ARG);
+      Preconditions.checkArgument(localFilePath != null, "Runtime argument %s must be set.", LOCAL_FILE_RUNTIME_ARG);
+      context.localize(LOCAL_FILE_ALIAS, URI.create(localFilePath));
+      context.localize(LOCAL_ARCHIVE_ALIAS, createTemporaryArchiveFile(), true);
+    }
+  }
+
+  public static class JavaSparkProgramUsingLocalFiles implements JavaSparkProgram {
+
+    @Override
+    public void run(SparkContext context) {
+      Map<String, String> args = context.getRuntimeArguments();
+      Preconditions.checkArgument(args.containsKey(LOCAL_FILE_RUNTIME_ARG),
+                                  "Runtime argument %s must be set.", LOCAL_FILE_RUNTIME_ARG);
+      final String localFilePath = URI.create(args.get(LOCAL_FILE_RUNTIME_ARG)).getPath();
+      JavaSparkContext sc = context.getOriginalSparkContext();
+      JavaRDD<String> fileContents = sc.textFile(localFilePath, 1);
+      final TaskLocalizationContext taskLocalizationContext = context.getTaskLocalizationContext();
+      JavaPairRDD<byte[], byte[]> rows = fileContents.mapToPair(new PairFunction<String, byte[], byte[]>() {
+        @Override
+        public Tuple2<byte[], byte[]> call(String line) throws Exception {
+          Map<String, File> localFiles = taskLocalizationContext.getAllLocalFiles();
+          Preconditions.checkState(localFiles.containsKey(LOCAL_FILE_ALIAS),
+                                   "File %s should have been localized with the name %s.",
+                                   localFilePath, LOCAL_FILE_ALIAS);
+          Preconditions.checkState(localFiles.containsKey(LOCAL_ARCHIVE_ALIAS),
+                                   "A temporary archive should have been localized with the name %s.",
+                                   LOCAL_ARCHIVE_ALIAS);
+          boolean localFileFound = false;
+          for (File localFile : localFiles.values()) {
+            if (localFilePath.equals(localFile.toString())) {
+              localFileFound = true;
+              break;
+            }
+          }
+          Preconditions.checkState(localFileFound, "Local file must be found.");
+          File localFile = taskLocalizationContext.getLocalFile(LOCAL_FILE_ALIAS);
+          Preconditions.checkState(localFile.exists(), "Local file %s must exist.", localFile);
+          File localArchive = taskLocalizationContext.getLocalFile(LOCAL_ARCHIVE_ALIAS);
+          Preconditions.checkState(localArchive.exists(), "Local archive %s must exist.", LOCAL_ARCHIVE_ALIAS);
+          Iterator<String> splitter = Splitter.on("=").omitEmptyStrings().trimResults().split(line).iterator();
+          Preconditions.checkArgument(splitter.hasNext());
+          String key = splitter.next();
+          Preconditions.checkArgument(splitter.hasNext());
+          String value = splitter.next();
+          return new Tuple2<>(Bytes.toBytes(key), Bytes.toBytes(value));
+        }
+      });
+
+      context.writeToDataset(rows, OUTPUT_DATASET_NAME, byte[].class, byte[].class);
+    }
+  }
+
+  public static class ScalaSparkUsingLocalFiles extends AbstractSpark {
+    @Override
+    protected void configure() {
+      setMainClass(ScalaSparkProgramUsingLocalFiles.class);
+    }
+
+    @Override
+    public void beforeSubmit(SparkContext context) throws Exception {
+      Map<String, String> args = context.getRuntimeArguments();
+      String localFilePath = args.get(LOCAL_FILE_RUNTIME_ARG);
+      Preconditions.checkArgument(localFilePath != null, "Runtime argument %s must be set.", LOCAL_FILE_RUNTIME_ARG);
+      context.localize(LOCAL_FILE_ALIAS, URI.create(localFilePath));
+      context.localize(LOCAL_ARCHIVE_ALIAS, createTemporaryArchiveFile(), true);
+    }
+  }
+
+  private static URI createTemporaryArchiveFile() throws IOException {
+    File tmpDir1 = com.google.common.io.Files.createTempDir();
+    List<File> files = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      File tmpFile = File.createTempFile("abcd" + i, "txt", tmpDir1);
+      files.add(tmpFile);
+    }
+
+    File tmpDir2 = com.google.common.io.Files.createTempDir();
+    File destArchive = new File(tmpDir2, "myBundle.jar");
+    BundleJarUtil.createJar(tmpDir1, destArchive);
+    for (File file : files) {
+      BundleJarUtil.getEntry(Locations.toLocation(destArchive), file.getName()).getInput().close();
+    }
+    return destArchive.toURI();
+  }
+}

--- a/cdap-app-fabric/src/test/scala/co/cask/cdap/internal/app/runtime/spark/ScalaSparkProgramUsingLocalFiles.scala
+++ b/cdap-app-fabric/src/test/scala/co/cask/cdap/internal/app/runtime/spark/ScalaSparkProgramUsingLocalFiles.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark
+
+import java.io.File
+import java.net.URI
+import java.util
+
+import co.cask.cdap.api.TaskLocalizationContext
+import co.cask.cdap.api.common.Bytes
+import co.cask.cdap.api.spark.{ScalaSparkProgram, SparkContext}
+import com.google.common.base.Splitter
+import org.apache.spark
+import org.apache.spark.rdd.RDD
+
+import scala.collection.JavaConversions
+
+/**
+ * Spark program that uses local files in Scala.
+ */
+class ScalaSparkProgramUsingLocalFiles extends ScalaSparkProgram {
+  override def run(context: SparkContext): Unit = {
+    val args: util.Map[String, String] = context.getRuntimeArguments
+    val localFilePath: String = URI.create(args.get(SparkAppUsingLocalFiles.LOCAL_FILE_RUNTIME_ARG)).getPath
+    val taskLocalizationContext: TaskLocalizationContext = context.getTaskLocalizationContext
+    val localFiles: util.Collection[File] = taskLocalizationContext.getAllLocalFiles.values()
+    JavaConversions.collectionAsScalaIterable(localFiles).find(_.toURI.getPath == localFilePath).get
+    val sc: spark.SparkContext = context.getOriginalSparkContext.asInstanceOf[spark.SparkContext]
+    val fileContents: RDD[String] = sc.textFile(localFilePath, 1)
+    val rows: RDD[(Array[Byte], Array[Byte])] = fileContents.map {
+      case line =>
+        taskLocalizationContext.getLocalFile(SparkAppUsingLocalFiles.LOCAL_FILE_ALIAS).exists().==(true)
+        taskLocalizationContext.getLocalFile(SparkAppUsingLocalFiles.LOCAL_ARCHIVE_ALIAS).exists().==(true)
+        val splitter: util.Iterator[String] = Splitter.on("=").omitEmptyStrings().trimResults().split(line).iterator()
+        val key: String = splitter.next()
+        val value: String = splitter.next()
+        (Bytes.toBytes(key), Bytes.toBytes(value))
+    }
+    context.writeToDataset(
+      rows, SparkAppUsingLocalFiles.OUTPUT_DATASET_NAME, classOf[Array[Byte]], classOf[Array[Byte]])
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -1175,7 +1175,6 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     }
   }
 
-
   @Category(XSlowTests.class)
   @Test
   public void testByteCodeClassLoader() throws Exception {
@@ -1233,4 +1232,3 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     }
   }
 }
-


### PR DESCRIPTION
Exposed via 
- ``ClientLocalizationContext`` - Allows to localize resources. Available in ``MapReduceContext`` and ``SparkContext``.
- ``TaskLocalizationContext`` - Allows to retrieve localized resources. Available in ``MapReduceTaskContext`` and ``ExecutorSparkContext``.

Jira: [CDAP-4135](https://issues.cask.co/browse/CDAP-4135)
Build: http://builds.cask.co/browse/CDAP-DUT3030
