### PR TITLE
CDAP-4023 CLI program lifecycle commands for application programs

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -60,6 +60,7 @@ public enum ArgumentName {
   DATASET_MODULE_JAR_CLASSNAME("module-jar-classname"),
   QUERY("query"),
   APP("app-id"),
+  PROGRAM_TYPES("program-types"),
   VIEW("view-id"),
   HTTP_METHOD("http-method"),
   ENDPOINT("endpoint"),

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
@@ -264,7 +264,10 @@ public class CLIMain {
       String[] commandArgs = cliMainArgs.getCommandTokens();
 
       try {
-        ClientConfig clientConfig = ClientConfig.builder().setConnectionConfig(null).build();
+        ClientConfig clientConfig = ClientConfig.builder()
+          .setConnectionConfig(null)
+          .setDefaultReadTimeout(60 * 1000)
+          .build();
         final CLIConfig cliConfig = new CLIConfig(clientConfig, output, new AltStyleTableRenderer());
         CLIMain cliMain = new CLIMain(launchOptions, cliConfig);
         CLI cli = cliMain.getCLI();

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/BaseBatchCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/BaseBatchCommand.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command.app;
+
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.util.AbstractAuthCommand;
+import co.cask.cdap.client.ApplicationClient;
+import co.cask.cdap.common.ApplicationNotFoundException;
+import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.proto.BatchProgram;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRecord;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.common.cli.Arguments;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Base class for commands that work on multiple programs in an application.
+ *
+ * @param <T> the type of input object for the batch request
+ */
+public abstract class BaseBatchCommand<T extends BatchProgram> extends AbstractAuthCommand {
+  private final ApplicationClient appClient;
+
+  protected BaseBatchCommand(ApplicationClient appClient, CLIConfig cliConfig) {
+    super(cliConfig);
+    this.appClient = appClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream output) throws Exception {
+    Args<T> args = readArgs(arguments);
+    if (args.programs.isEmpty()) {
+      output.printf(String.format("application '%s' contains no programs of type '%s'",
+        args.appId.getId(), Joiner.on(',').join(args.programTypes)));
+      return;
+    }
+
+    runBatchCommand(output, args);
+  }
+
+  /**
+   * Reads arguments to get app id, program types, and list of input programs.
+   */
+  protected Args<T> readArgs(Arguments arguments)
+    throws ApplicationNotFoundException, UnauthorizedException, IOException {
+
+    String appName = arguments.get(ArgumentName.APP.getName());
+    Id.Application appId = Id.Application.from(cliConfig.getCurrentNamespace(), appName);
+
+    Set<ProgramType> programTypes = getDefaultProgramTypes();
+    if (arguments.hasArgument(ArgumentName.PROGRAM_TYPES.getName())) {
+      programTypes.clear();
+      String programTypesStr = arguments.get(ArgumentName.PROGRAM_TYPES.getName());
+      for (String programTypeStr : Splitter.on(',').trimResults().split(programTypesStr)) {
+        ProgramType programType = ProgramType.valueOf(programTypeStr.toUpperCase());
+        programTypes.add(programType);
+      }
+    }
+
+    List<T> programs = new ArrayList<>();
+    Map<ProgramType, List<ProgramRecord>> appPrograms = appClient.listProgramsByType(appId);
+    for (ProgramType programType : programTypes) {
+      List<ProgramRecord> programRecords = appPrograms.get(programType);
+      if (programRecords != null) {
+        for (ProgramRecord programRecord : programRecords) {
+          programs.add(createProgram(programRecord));
+        }
+      }
+    }
+    return new Args<>(appId, programTypes, programs);
+  }
+
+  protected Set<ProgramType> getDefaultProgramTypes() {
+    Set<ProgramType> types = new HashSet<>();
+    types.add(ProgramType.FLOW);
+    types.add(ProgramType.SERVICE);
+    types.add(ProgramType.WORKER);
+    return types;
+  }
+
+  protected String getDescription(String action) {
+    return String.format("Command to %s one or more programs of %s. " +
+        "By default, %s all flows, services, and workers. A comma separated list of program types can be " +
+        "specified, which will start all programs of those types. For example, specifying \"flow,workflow\" will %s " +
+        "all flows and workflows in the %s.",
+      action, Fragment.of(Article.A, ElementType.APP.getName()), action, action, ElementType.APP.getName());
+  }
+
+  /**
+   * Create an input object from a ProgramRecord.
+   */
+  protected abstract T createProgram(ProgramRecord programRecord);
+
+  /**
+   * Run the batch command on all programs.
+   */
+  protected abstract void runBatchCommand(PrintStream printStream, Args<T> args) throws Exception;
+
+  /**
+   * Container for command arguments.
+   * @param <T> type of input object
+   */
+  protected static class Args<T> {
+    protected final Id.Application appId;
+    protected final Set<ProgramType> programTypes;
+    protected final List<T> programs;
+
+    public Args(Id.Application appId, Set<ProgramType> programTypes, List<T> programs) {
+      this.appId = appId;
+      this.programTypes = programTypes;
+      this.programs = programs;
+    }
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/RestartProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/RestartProgramsCommand.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Starts one or more programs in an application.
+ * Restarts one or more programs in an application.
  */
 public class RestartProgramsCommand extends BaseBatchCommand<BatchProgram> {
   private final ProgramClient programClient;

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/RestartProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/RestartProgramsCommand.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command.app;
+
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.client.ApplicationClient;
+import co.cask.cdap.client.ProgramClient;
+import co.cask.cdap.proto.BatchProgram;
+import co.cask.cdap.proto.BatchProgramStart;
+import co.cask.cdap.proto.ProgramRecord;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Starts one or more programs in an application.
+ */
+public class RestartProgramsCommand extends BaseBatchCommand<BatchProgram> {
+  private final ProgramClient programClient;
+
+  @Inject
+  public RestartProgramsCommand(ApplicationClient appClient, ProgramClient programClient, CLIConfig cliConfig) {
+    super(appClient, cliConfig);
+    this.programClient = programClient;
+  }
+
+  @Override
+  protected BatchProgram createProgram(ProgramRecord programRecord) {
+    return new BatchProgram(programRecord.getApp(), programRecord.getType(), programRecord.getName());
+  }
+
+  @Override
+  protected void runBatchCommand(PrintStream printStream, Args<BatchProgram> args) throws Exception {
+    printStream.print("Stopping programs...\n");
+    programClient.stop(args.appId.getNamespace(), args.programs);
+
+    printStream.print("Starting programs...\n");
+    List<BatchProgramStart> startList = new ArrayList<>(args.programs.size());
+    for (BatchProgram program : args.programs) {
+      startList.add(new BatchProgramStart(program));
+    }
+    programClient.start(args.appId.getNamespace(), startList);
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("restart app <%s> programs [of type <%s>]", ArgumentName.APP, ArgumentName.PROGRAM_TYPES);
+  }
+
+  @Override
+  public String getDescription() {
+    return getDescription("restart");
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StartProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StartProgramsCommand.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command.app;
+
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.util.RowMaker;
+import co.cask.cdap.cli.util.table.Table;
+import co.cask.cdap.client.ApplicationClient;
+import co.cask.cdap.client.ProgramClient;
+import co.cask.cdap.proto.BatchProgramResult;
+import co.cask.cdap.proto.BatchProgramStart;
+import co.cask.cdap.proto.ProgramRecord;
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import java.util.List;
+
+/**
+ * Starts one or more programs in an application.
+ */
+public class StartProgramsCommand extends BaseBatchCommand<BatchProgramStart> {
+  private final ProgramClient programClient;
+
+  @Inject
+  public StartProgramsCommand(ApplicationClient appClient, ProgramClient programClient, CLIConfig cliConfig) {
+    super(appClient, cliConfig);
+    this.programClient = programClient;
+  }
+
+  @Override
+  protected BatchProgramStart createProgram(ProgramRecord programRecord) {
+    return new BatchProgramStart(programRecord.getApp(), programRecord.getType(), programRecord.getName());
+  }
+
+  @Override
+  protected void runBatchCommand(PrintStream printStream, Args<BatchProgramStart> args) throws Exception {
+    List<BatchProgramResult> results = programClient.start(args.appId.getNamespace(), args.programs);
+
+    Table table = Table.builder()
+      .setHeader("name", "type", "statusCode", "error")
+      .setRows(results, new RowMaker<BatchProgramResult>() {
+        @Override
+        public List<?> makeRow(BatchProgramResult result) {
+          return Lists.newArrayList(
+            result.getProgramId(), result.getProgramType(), result.getStatusCode(), result.getError());
+        }
+      }).build();
+    cliConfig.getTableRenderer().render(cliConfig, printStream, table);
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("start app <%s> programs [of type <%s>]", ArgumentName.APP, ArgumentName.PROGRAM_TYPES);
+  }
+
+  @Override
+  public String getDescription() {
+    return getDescription("start");
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StatusProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StatusProgramsCommand.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command.app;
+
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.util.RowMaker;
+import co.cask.cdap.cli.util.table.Table;
+import co.cask.cdap.client.ApplicationClient;
+import co.cask.cdap.client.ProgramClient;
+import co.cask.cdap.proto.BatchProgram;
+import co.cask.cdap.proto.BatchProgramStart;
+import co.cask.cdap.proto.BatchProgramStatus;
+import co.cask.cdap.proto.ProgramRecord;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Gets status of one or more programs in an application.
+ */
+public class StatusProgramsCommand extends BaseBatchCommand<BatchProgram> {
+  private final ProgramClient programClient;
+
+  @Inject
+  public StatusProgramsCommand(ApplicationClient appClient, ProgramClient programClient, CLIConfig cliConfig) {
+    super(appClient, cliConfig);
+    this.programClient = programClient;
+  }
+
+  @Override
+  protected BatchProgramStart createProgram(ProgramRecord programRecord) {
+    return new BatchProgramStart(programRecord.getApp(), programRecord.getType(), programRecord.getName());
+  }
+
+  @Override
+  protected void runBatchCommand(PrintStream printStream, Args<BatchProgram> args) throws Exception {
+    List<BatchProgramStatus> results = programClient.getStatus(args.appId.getNamespace(), args.programs);
+
+    Table table = Table.builder()
+      .setHeader("name", "type", "status", "statusCode", "error")
+      .setRows(results, new RowMaker<BatchProgramStatus>() {
+        @Override
+        public List<?> makeRow(BatchProgramStatus result) {
+          return Lists.newArrayList(
+            result.getProgramId(), result.getProgramType(), result.getStatus(),
+            result.getStatusCode(), result.getError());
+        }
+      }).build();
+    cliConfig.getTableRenderer().render(cliConfig, printStream, table);
+  }
+
+  @Override
+  protected Set<ProgramType> getDefaultProgramTypes() {
+    Set<ProgramType> types = new HashSet<>();
+    types.add(ProgramType.FLOW);
+    types.add(ProgramType.MAPREDUCE);
+    types.add(ProgramType.SERVICE);
+    types.add(ProgramType.SPARK);
+    types.add(ProgramType.WORKER);
+    types.add(ProgramType.WORKFLOW);
+    return types;
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("get app <%s> programs status [of type <%s>]", ArgumentName.APP, ArgumentName.PROGRAM_TYPES);
+  }
+
+  @Override
+  public String getDescription() {
+    return getDescription("get status of");
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StopProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StopProgramsCommand.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command.app;
+
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.util.RowMaker;
+import co.cask.cdap.cli.util.table.Table;
+import co.cask.cdap.client.ApplicationClient;
+import co.cask.cdap.client.ProgramClient;
+import co.cask.cdap.proto.BatchProgram;
+import co.cask.cdap.proto.BatchProgramResult;
+import co.cask.cdap.proto.ProgramRecord;
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import java.util.List;
+
+/**
+ * Starts one or more programs in an application.
+ */
+public class StopProgramsCommand extends BaseBatchCommand<BatchProgram> {
+  private final ProgramClient programClient;
+
+  @Inject
+  public StopProgramsCommand(ApplicationClient appClient, ProgramClient programClient, CLIConfig cliConfig) {
+    super(appClient, cliConfig);
+    this.programClient = programClient;
+  }
+
+  @Override
+  protected BatchProgram createProgram(ProgramRecord programRecord) {
+    return new BatchProgram(programRecord.getApp(), programRecord.getType(), programRecord.getName());
+  }
+
+  @Override
+  protected void runBatchCommand(PrintStream printStream, Args<BatchProgram> args) throws Exception {
+    List<BatchProgramResult> results = programClient.stop(args.appId.getNamespace(), args.programs);
+
+    Table table = Table.builder()
+      .setHeader("name", "type", "statusCode", "error")
+      .setRows(results, new RowMaker<BatchProgramResult>() {
+        @Override
+        public List<?> makeRow(BatchProgramResult result) {
+          return Lists.newArrayList(
+            result.getProgramId(), result.getProgramType(), result.getStatusCode(), result.getError());
+        }
+      }).build();
+    cliConfig.getTableRenderer().render(cliConfig, printStream, table);
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("stop app <%s> programs [of type <%s>]", ArgumentName.APP, ArgumentName.PROGRAM_TYPES);
+  }
+
+  @Override
+  public String getDescription() {
+    return getDescription("stop");
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ApplicationCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ApplicationCommands.java
@@ -23,6 +23,10 @@ import co.cask.cdap.cli.command.app.DeleteAppCommand;
 import co.cask.cdap.cli.command.app.DeployAppCommand;
 import co.cask.cdap.cli.command.app.DescribeAppCommand;
 import co.cask.cdap.cli.command.app.ListAppsCommand;
+import co.cask.cdap.cli.command.app.RestartProgramsCommand;
+import co.cask.cdap.cli.command.app.StartProgramsCommand;
+import co.cask.cdap.cli.command.app.StatusProgramsCommand;
+import co.cask.cdap.cli.command.app.StopProgramsCommand;
 import co.cask.cdap.cli.command.app.UpdateAppCommand;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
@@ -39,11 +43,15 @@ public class ApplicationCommands extends CommandSet<Command> implements Categori
   public ApplicationCommands(Injector injector) {
     super(
       ImmutableList.<Command>builder()
-        .add(injector.getInstance(ListAppsCommand.class))
+        .add(injector.getInstance(CreateAppCommand.class))
         .add(injector.getInstance(DeleteAppCommand.class))
         .add(injector.getInstance(DeployAppCommand.class))
         .add(injector.getInstance(DescribeAppCommand.class))
-        .add(injector.getInstance(CreateAppCommand.class))
+        .add(injector.getInstance(ListAppsCommand.class))
+        .add(injector.getInstance(RestartProgramsCommand.class))
+        .add(injector.getInstance(StartProgramsCommand.class))
+        .add(injector.getInstance(StatusProgramsCommand.class))
+        .add(injector.getInstance(StopProgramsCommand.class))
         .add(injector.getInstance(UpdateAppCommand.class))
         .build());
   }

--- a/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
@@ -470,14 +470,11 @@ public class ApplicationClient {
     URL url = config.resolveNamespacedURLV3(app.getNamespace(), path);
     HttpRequest request = HttpRequest.get(url).build();
 
-    ObjectResponse<ApplicationDetail> response = ObjectResponse.fromJsonBody(
-      restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND),
-      new TypeToken<ApplicationDetail>() { });
-
+    HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new ApplicationNotFoundException(app);
     }
 
-    return response.getResponseObject().getPrograms();
+    return ObjectResponse.fromJsonBody(response, ApplicationDetail.class).getResponseObject().getPrograms();
   }
 }


### PR DESCRIPTION
Adding commands that stop, start, restart, and get status of all
programs in an application. By default, stop, start, and restart
work on long running programs, which means all flows, services,
and workers. Status will work on all programs.

Also fixing a small bug in ApplicationClient when listing programs
for a non-existent app. Will now correctly throw a
NotFoundException instead of some json parsing exception.