### PR TITLE
CDAP-3902: Remove unnecessary remote calls when getting a dataset instance

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
@@ -18,6 +18,8 @@ package co.cask.cdap.data.runtime;
 
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.common.runtime.RuntimeModule;
+import co.cask.cdap.data2.datafabric.dataset.DatasetProvider;
+import co.cask.cdap.data2.datafabric.dataset.DefaultDatasetProvider;
 import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeClassLoaderFactory;
 import co.cask.cdap.data2.datafabric.dataset.type.DistributedDatasetTypeClassLoaderFactory;
@@ -46,6 +48,9 @@ public class DataSetsModules extends RuntimeModule {
                   .build(DatasetDefinitionRegistryFactory.class));
         bind(DatasetFramework.class).to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
         expose(DatasetFramework.class);
+
+        bind(DatasetProvider.class).to(DefaultDatasetProvider.class);
+        expose(DatasetProvider.class);
       }
     };
   }
@@ -62,6 +67,9 @@ public class DataSetsModules extends RuntimeModule {
         expose(DatasetTypeClassLoaderFactory.class);
         bind(DatasetFramework.class).to(RemoteDatasetFramework.class);
         expose(DatasetFramework.class);
+
+        bind(DatasetProvider.class).to(DefaultDatasetProvider.class);
+        expose(DatasetProvider.class);
       }
     };
 
@@ -79,6 +87,9 @@ public class DataSetsModules extends RuntimeModule {
         expose(DatasetTypeClassLoaderFactory.class);
         bind(DatasetFramework.class).to(RemoteDatasetFramework.class);
         expose(DatasetFramework.class);
+
+        bind(DatasetProvider.class).to(DefaultDatasetProvider.class);
+        expose(DatasetProvider.class);
       }
     };
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/AbstractDatasetProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/AbstractDatasetProvider.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.common.exception.NotFoundException;
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeClassLoaderFactory;
+import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
+import co.cask.cdap.data2.dataset2.module.lib.DatasetModules;
+import co.cask.cdap.proto.DatasetMeta;
+import co.cask.cdap.proto.DatasetModuleMeta;
+import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Objects;
+import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides {@link Dataset} instances using methods implemented by subclasses.
+ * Used by {@link RemoteDatasetFramework} and
+ * {@link co.cask.cdap.data2.datafabric.dataset.service.DatasetInstanceHandler}.
+ * Use this when you want to control how dataset instances are created. For example, when
+ * you want to obtain a {@link Dataset} instance without having to make remote calls.
+ */
+public abstract class AbstractDatasetProvider implements DatasetProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractDatasetProvider.class);
+  private final DatasetDefinitionRegistryFactory registryFactory;
+  private final DatasetTypeClassLoaderFactory typeLoader;
+
+  protected AbstractDatasetProvider(DatasetDefinitionRegistryFactory registryFactory,
+                                    DatasetTypeClassLoaderFactory typeLoader) {
+    this.registryFactory = registryFactory;
+    this.typeLoader = typeLoader;
+  }
+
+  /**
+   * Gets the {@link DatasetMeta} for a dataset.
+   *
+   * @param instance the dataset
+   * @return the {@link DatasetMeta}
+   */
+  public abstract DatasetMeta getMeta(Id.DatasetInstance instance) throws Exception;
+
+  /**
+   * Creates the dataset if it doesn't already exist.
+   *
+   * @param instance the dataset
+   * @param type the type of dataset to create
+   * @param creationProps creation properties
+   */
+  public abstract void createIfNotExists(Id.DatasetInstance instance, String type,
+                                         DatasetProperties creationProps) throws Exception;
+
+  @Override
+  public <T extends Dataset> T getOrCreate(
+    Id.DatasetInstance instance, String type,
+    DatasetProperties creationProps,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception {
+
+    try {
+      T result = get(instance, classLoader, arguments);
+      if (result != null) {
+        return result;
+      }
+    } catch (NotFoundException e) {
+      // fall-through to create
+    }
+
+    createIfNotExists(instance, type, creationProps);
+    return get(instance, classLoader, arguments);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception {
+
+    DatasetMeta meta = getMeta(instance);
+    DatasetType type = getDatasetType(meta.getType(), classLoader);
+    return (T) type.getDataset(
+      DatasetContext.from(instance.getNamespaceId()), meta.getSpec(), arguments);
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    DatasetTypeMeta typeMeta, DatasetSpecification spec,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws IOException {
+
+    DatasetType type = getDatasetType(typeMeta, classLoader);
+    return (T) type.getDataset(DatasetContext.from(instance.getNamespaceId()), spec, arguments);
+  }
+
+
+  // can be used directly if DatasetTypeMeta is known, like in create dataset by dataset ops executor service
+  public <T extends DatasetType> T getDatasetType(
+    DatasetTypeMeta implementationInfo,
+    ClassLoader classLoader) {
+
+    if (classLoader == null) {
+      classLoader = Objects.firstNonNull(Thread.currentThread().getContextClassLoader(), getClass().getClassLoader());
+    }
+
+    DatasetDefinitionRegistry registry = registryFactory.create();
+    List<DatasetModuleMeta> modulesToLoad = implementationInfo.getModules();
+    for (DatasetModuleMeta moduleMeta : modulesToLoad) {
+      // adding dataset module jar to classloader
+      try {
+        classLoader = typeLoader.create(moduleMeta, classLoader);
+      } catch (IOException e) {
+        LOG.error("Was not able to init classloader for module {} while trying to load type {}",
+                  moduleMeta, implementationInfo, e);
+        throw Throwables.propagate(e);
+      }
+
+      Class<?> moduleClass;
+
+      // try program class loader then cdap class loader
+      try {
+        moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), classLoader, this);
+      } catch (ClassNotFoundException e) {
+        try {
+          moduleClass = ClassLoaders.loadClass(moduleMeta.getClassName(), null, this);
+        } catch (ClassNotFoundException e2) {
+          LOG.error("Was not able to load dataset module class {} while trying to load type {}",
+                    moduleMeta.getClassName(), implementationInfo, e);
+          throw Throwables.propagate(e);
+        }
+      }
+
+      try {
+        DatasetModule module = DatasetModules.getDatasetModule(moduleClass);
+        module.register(registry);
+      } catch (Exception e) {
+        LOG.error("Was not able to load dataset module class {} while trying to load type {}",
+                  moduleMeta.getClassName(), implementationInfo, e);
+        throw Throwables.propagate(e);
+      }
+    }
+
+    return (T) new DatasetType(registry.get(implementationInfo.getName()), classLoader);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.proto.Id;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides {@link Dataset} instances.
+ */
+public interface DatasetProvider {
+
+  /**
+   * Gets a dataset.
+   *
+   * @param instance the dataset ID
+   * @param classLoader the classloader to use
+   * @param arguments the runtime arguments for the dataset
+   * @param <T> the type of dataset
+   * @return the dataset
+   */
+  <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception;
+
+  /**
+   * Gets a dataset, and creates it first if it doesn't yet exist.
+   *
+   * @param instance the dataset ID
+   * @param type the type of dataset
+   * @param creationProps the creation properties
+   * @param classLoader the classloader to use
+   * @param arguments the runtime arguments for the dataset
+   * @param <T> the type of dataset
+   * @return the dataset
+   */
+  <T extends Dataset> T getOrCreate(
+    Id.DatasetInstance instance,
+    String type,
+    DatasetProperties creationProps,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception;
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DefaultDatasetProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DefaultDatasetProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.proto.Id;
+import com.google.inject.Inject;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides {@link Dataset} instances using {@link DatasetFramework}. Default implementation.
+ */
+public class DefaultDatasetProvider implements DatasetProvider {
+
+  private final DatasetFramework framework;
+
+  @Inject
+  public DefaultDatasetProvider(DatasetFramework framework) {
+    this.framework = framework;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T extends Dataset> T get(
+    Id.DatasetInstance instance,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception {
+
+    return framework.getDataset(instance, arguments, classLoader);
+  }
+
+  @Override
+  public <T extends Dataset> T getOrCreate(
+    Id.DatasetInstance instance, String type, DatasetProperties creationProps,
+    @Nullable ClassLoader classLoader,
+    @Nullable Map<String, String> arguments) throws Exception {
+
+    return DatasetsUtil.getOrCreateDataset(framework, instance, type, creationProps, arguments, classLoader);
+  }
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -26,11 +26,13 @@ import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.MDSDatasetsRegistry;
+import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeClassLoaderFactory;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
+import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.http.NettyHttpService;
+import co.cask.tephra.TransactionExecutorFactory;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -85,13 +87,16 @@ public class DatasetService extends AbstractExecutionThreadService {
                         ExploreFacade exploreFacade,
                         Set<DatasetMetricsReporter> metricReporters,
                         StorageProviderNamespaceAdmin storageProviderNamespaceAdmin,
-                        UsageRegistry usageRegistry) throws Exception {
+                        TransactionExecutorFactory txFactory,
+                        DatasetDefinitionRegistryFactory registryFactory,
+                        DatasetTypeClassLoaderFactory typeLoader) throws Exception {
 
     this.typeManager = typeManager;
     DatasetTypeHandler datasetTypeHandler = new DatasetTypeHandler(typeManager, cConf, namespacedLocationFactory);
     DatasetInstanceHandler datasetInstanceHandler = new DatasetInstanceHandler(typeManager, instanceManager,
                                                                                opExecutorClient, exploreFacade, cConf,
-                                                                               usageRegistry);
+                                                                               txFactory, registryFactory,
+                                                                               typeLoader);
     UnderlyingSystemNamespaceHandler underlyingSystemNamespaceHandler =
       new UnderlyingSystemNamespaceHandler(storageProviderNamespaceAdmin);
     NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -19,13 +19,14 @@ package co.cask.cdap.data2.registry;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.datafabric.dataset.DatasetProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterators;
@@ -53,14 +54,16 @@ public class UsageRegistry {
   private final Transactional<UsageDatasetIterable, UsageDataset> txnl;
 
   @Inject
-  public UsageRegistry(TransactionExecutorFactory txExecutorFactory, final DatasetFramework datasetFramework) {
+  public UsageRegistry(TransactionExecutorFactory txExecutorFactory, final DatasetProvider provider) {
     txnl = Transactional.of(txExecutorFactory, new Supplier<UsageDatasetIterable>() {
       @Override
       public UsageDatasetIterable get() {
         try {
-          Object usageDataset = DatasetsUtil.getOrCreateDataset(datasetFramework, USAGE_INSTANCE_ID,
-                                                                UsageDataset.class.getSimpleName(),
-                                                                DatasetProperties.EMPTY, null, null);
+          Object usageDataset = Preconditions.checkNotNull(
+            provider.getOrCreate(USAGE_INSTANCE_ID, UsageDataset.class.getSimpleName(),
+                                 DatasetProperties.EMPTY, null, null),
+            "Couldn't get/create usage registry dataset");
+
           // Backward compatible check for version <= 3.0.0
           if (usageDataset instanceof UsageDataset) {
             return new UsageDatasetIterable((UsageDataset) usageDataset);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -42,7 +42,6 @@ import co.cask.cdap.data2.dataset2.SingleTypeModule;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.gateway.auth.NoAuthenticator;
@@ -136,7 +135,9 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                  new HashSet<DatasetMetricsReporter>(),
                                  new LocalStorageProviderNamespaceAdmin(cConf, namespacedLocationFactory,
                                                                         exploreFacade),
-                                 new UsageRegistry(txExecutorFactory, framework));
+                                 txExecutorFactory,
+                                 registryFactory,
+                                 new LocalDatasetTypeClassLoaderFactory());
     // Start dataset service, wait for it to be discoverable
     service.start();
     final CountDownLatch startLatch = new CountDownLatch(1);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -42,7 +42,6 @@ import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.gateway.auth.NoAuthenticator;
@@ -184,7 +183,9 @@ public abstract class DatasetServiceTestBase {
                                  new HashSet<DatasetMetricsReporter>(),
                                  new LocalStorageProviderNamespaceAdmin(cConf, namespacedLocationFactory,
                                                                         exploreFacade),
-                                 new UsageRegistry(txExecutorFactory, dsFramework));
+                                 txExecutorFactory,
+                                 registryFactory,
+                                 new LocalDatasetTypeClassLoaderFactory());
 
     // Start dataset service, wait for it to be discoverable
     service.start();

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -38,6 +38,8 @@ import co.cask.cdap.data.runtime.DataFabricDistributedModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
+import co.cask.cdap.data2.datafabric.dataset.DatasetProvider;
+import co.cask.cdap.data2.datafabric.dataset.DefaultDatasetProvider;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
@@ -195,6 +197,7 @@ public class UpgradeTool {
           bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
           bind(MetricStore.class).to(DefaultMetricStore.class);
           bind(DatasetFramework.class).to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
+          bind(DatasetProvider.class).to(DefaultDatasetProvider.class);
         }
 
         @Provides


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-3902
http://builds.cask.co/browse/CDAP-RBT518

- [x] Integration tests (NamespaceTest,DatasetTest,StreamTest)
- [x] Manually test purchase example

Merged to develop (3.3): https://github.com/caskdata/cdap/pull/4325
Merged to release/3.1 (3.2.1): https://github.com/caskdata/cdap/pull/4340

---

# Performance

## Config

```
    <property>
      <name>dataset.service.exec.threads</name>
      <value>300</value>
    </property>
    <property>
      <name>dataset.service.worker.threads</name>
      <value>30</value>
    </property>
    <property>
      <name>app.exec.threads</name>
      <value>20</value>
    </property>
```

## Test results

N threads, each making 1 get dataset request with 1 owner

*Without fix*
N=100: ~11000 ms
N=300: ~139000 ms
N=500: ~230000 ms
N=1000: ~441000 ms

*With fix*
N=100: ~8000 ms
N=300: ~123000 ms
N=500: ~195000 ms
N=1000: ~444000 ms