### PR TITLE
CDAP-4133 Ability to get the hostname of a appfabric service as a part of live-info.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -60,6 +60,7 @@ import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.runtime.adapter.PluginRepository;
 import co.cask.cdap.internal.app.runtime.batch.InMemoryTransactionServiceManager;
+import co.cask.cdap.internal.app.runtime.distributed.AppFabricServiceManager;
 import co.cask.cdap.internal.app.runtime.distributed.TransactionServiceManager;
 import co.cask.cdap.internal.app.runtime.schedule.DistributedSchedulerService;
 import co.cask.cdap.internal.app.runtime.schedule.ExecutorThreadPool;
@@ -72,7 +73,7 @@ import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.StandaloneAppFabricServer;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.internal.pipeline.SynchronousPipelineFactory;
-import co.cask.cdap.logging.run.AppFabricServiceManager;
+import co.cask.cdap.logging.run.InMemoryAppFabricServiceManager;
 import co.cask.cdap.logging.run.InMemoryDatasetExecutorServiceManager;
 import co.cask.cdap.logging.run.InMemoryExploreServiceManager;
 import co.cask.cdap.logging.run.InMemoryLogSaverServiceManager;
@@ -143,7 +144,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                mapBinder.addBinding(Constants.Service.METRICS)
                                         .to(InMemoryMetricsServiceManager.class);
                                mapBinder.addBinding(Constants.Service.APP_FABRIC_HTTP)
-                                        .to(AppFabricServiceManager.class);
+                                        .to(InMemoryAppFabricServiceManager.class);
                                mapBinder.addBinding(Constants.Service.STREAMS)
                                         .to(InMemoryStreamServiceManager.class);
                                mapBinder.addBinding(Constants.Service.DATASET_EXECUTOR)
@@ -190,7 +191,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                mapBinder.addBinding(Constants.Service.METRICS)
                                         .to(InMemoryMetricsServiceManager.class);
                                mapBinder.addBinding(Constants.Service.APP_FABRIC_HTTP)
-                                        .to(AppFabricServiceManager.class);
+                                        .to(InMemoryAppFabricServiceManager.class);
                                mapBinder.addBinding(Constants.Service.STREAMS)
                                         .to(InMemoryStreamServiceManager.class);
                                mapBinder.addBinding(Constants.Service.DATASET_EXECUTOR)

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -90,6 +90,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
+import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -133,24 +134,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                bind(Scheduler.class).to(SchedulerService.class);
                                bind(MRJobInfoFetcher.class).to(LocalMRJobInfoFetcher.class);
 
-                               MapBinder<String, MasterServiceManager> mapBinder = MapBinder.newMapBinder(
-                                 binder(), String.class, MasterServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.LOGSAVER)
-                                        .to(InMemoryLogSaverServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.TRANSACTION)
-                                        .to(InMemoryTransactionServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.METRICS_PROCESSOR)
-                                        .to(InMemoryMetricsProcessorServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.METRICS)
-                                        .to(InMemoryMetricsServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.APP_FABRIC_HTTP)
-                                        .to(InMemoryAppFabricServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.STREAMS)
-                                        .to(InMemoryStreamServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.DATASET_EXECUTOR)
-                                        .to(InMemoryDatasetExecutorServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.EXPLORE_HTTP_USER_SERVICE)
-                                        .to(InMemoryExploreServiceManager.class);
+                               addInMemoryBindings(binder());
 
                                Multibinder<String> servicesNamesBinder =
                                  Multibinder.newSetBinder(binder(), String.class,
@@ -180,24 +164,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                bind(Scheduler.class).to(SchedulerService.class);
                                bind(MRJobInfoFetcher.class).to(LocalMRJobInfoFetcher.class);
 
-                               MapBinder<String, MasterServiceManager> mapBinder = MapBinder.newMapBinder(
-                                 binder(), String.class, MasterServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.LOGSAVER)
-                                        .to(InMemoryLogSaverServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.TRANSACTION)
-                                        .to(InMemoryTransactionServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.METRICS_PROCESSOR)
-                                        .to(InMemoryMetricsProcessorServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.METRICS)
-                                        .to(InMemoryMetricsServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.APP_FABRIC_HTTP)
-                                        .to(InMemoryAppFabricServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.STREAMS)
-                                        .to(InMemoryStreamServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.DATASET_EXECUTOR)
-                                        .to(InMemoryDatasetExecutorServiceManager.class);
-                               mapBinder.addBinding(Constants.Service.EXPLORE_HTTP_USER_SERVICE)
-                                        .to(InMemoryExploreServiceManager.class);
+                               addInMemoryBindings(binder());
 
                                Multibinder<String> servicesNamesBinder =
                                  Multibinder.newSetBinder(binder(), String.class,
@@ -212,6 +179,27 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                handlerHookNamesBinder.addBinding().toInstance(Constants.Stream.STREAM_HANDLER);
                              }
                            });
+  }
+
+  private void addInMemoryBindings(Binder binder) {
+    MapBinder<String, MasterServiceManager> mapBinder = MapBinder.newMapBinder(
+      binder, String.class, MasterServiceManager.class);
+    mapBinder.addBinding(Constants.Service.LOGSAVER)
+      .to(InMemoryLogSaverServiceManager.class);
+    mapBinder.addBinding(Constants.Service.TRANSACTION)
+      .to(InMemoryTransactionServiceManager.class);
+    mapBinder.addBinding(Constants.Service.METRICS_PROCESSOR)
+      .to(InMemoryMetricsProcessorServiceManager.class);
+    mapBinder.addBinding(Constants.Service.METRICS)
+      .to(InMemoryMetricsServiceManager.class);
+    mapBinder.addBinding(Constants.Service.APP_FABRIC_HTTP)
+      .to(InMemoryAppFabricServiceManager.class);
+    mapBinder.addBinding(Constants.Service.STREAMS)
+      .to(InMemoryStreamServiceManager.class);
+    mapBinder.addBinding(Constants.Service.DATASET_EXECUTOR)
+      .to(InMemoryDatasetExecutorServiceManager.class);
+    mapBinder.addBinding(Constants.Service.EXPLORE_HTTP_USER_SERVICE)
+      .to(InMemoryExploreServiceManager.class);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AppFabricServiceManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AppFabricServiceManager.java
@@ -59,8 +59,8 @@ public class AppFabricServiceManager extends AbstractDistributedMasterServiceMan
     SystemServiceLiveInfo.Builder builder = SystemServiceLiveInfo.builder();
 
     Containers.ContainerInfo containerInfo = new Containers.ContainerInfo(Containers.ContainerType.SYSTEM_SERVICE,
-                                                                          serviceName, 0, "N/A", hostname.getHostName(),
-                                                                          0, 0, null);
+                                                                          serviceName, null, null,
+                                                                          hostname.getHostName(), null, null, null);
     builder.addContainer(containerInfo);
     return builder.build();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AppFabricServiceManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AppFabricServiceManager.java
@@ -16,32 +16,25 @@
 
 package co.cask.cdap.internal.app.runtime.distributed;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.twill.AbstractDistributedMasterServiceManager;
+import co.cask.cdap.common.twill.MasterServiceManager;
 import co.cask.cdap.proto.Containers;
 import co.cask.cdap.proto.SystemServiceLiveInfo;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import org.apache.twill.api.TwillRunnerService;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.net.InetAddress;
 
 /**
  * App Fabric Service Management in Distributed Mode.
  */
-public class AppFabricServiceManager extends AbstractDistributedMasterServiceManager {
+public class AppFabricServiceManager implements MasterServiceManager {
 
   private final InetAddress hostname;
 
   @Inject
-  public AppFabricServiceManager(CConfiguration cConf, TwillRunnerService twillRunnerService,
-                                 @Named(Constants.AppFabric.SERVER_ADDRESS) InetAddress hostname,
-                                 DiscoveryServiceClient discoveryServiceClient) {
-    super(cConf, Constants.Service.APP_FABRIC_HTTP, twillRunnerService, discoveryServiceClient);
+  public AppFabricServiceManager(@Named(Constants.AppFabric.SERVER_ADDRESS) InetAddress hostname) {
     this.hostname = hostname;
-
   }
 
   @Override
@@ -59,7 +52,7 @@ public class AppFabricServiceManager extends AbstractDistributedMasterServiceMan
     SystemServiceLiveInfo.Builder builder = SystemServiceLiveInfo.builder();
 
     Containers.ContainerInfo containerInfo = new Containers.ContainerInfo(Containers.ContainerType.SYSTEM_SERVICE,
-                                                                          serviceName, null, null,
+                                                                          Constants.Service.APP_FABRIC_HTTP, null, null,
                                                                           hostname.getHostName(), null, null, null);
     builder.addContainer(containerInfo);
     return builder.build();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AppFabricServiceManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AppFabricServiceManager.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.distributed;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.twill.AbstractDistributedMasterServiceManager;
+import co.cask.cdap.proto.Containers;
+import co.cask.cdap.proto.SystemServiceLiveInfo;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import org.apache.twill.api.TwillRunnerService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.net.InetAddress;
+
+/**
+ * App Fabric Service Management in Distributed Mode.
+ */
+public class AppFabricServiceManager extends AbstractDistributedMasterServiceManager {
+
+  private final InetAddress hostname;
+
+  @Inject
+  public AppFabricServiceManager(CConfiguration cConf, TwillRunnerService twillRunnerService,
+                                 @Named(Constants.AppFabric.SERVER_ADDRESS) InetAddress hostname,
+                                 DiscoveryServiceClient discoveryServiceClient) {
+    super(cConf, Constants.Service.APP_FABRIC_HTTP, twillRunnerService, discoveryServiceClient);
+    this.hostname = hostname;
+
+  }
+
+  @Override
+  public String getDescription() {
+    return Constants.AppFabric.SERVICE_DESCRIPTION;
+  }
+
+  @Override
+  public int getMaxInstances() {
+    return 1;
+  }
+
+  @Override
+  public SystemServiceLiveInfo getLiveInfo() {
+    SystemServiceLiveInfo.Builder builder = SystemServiceLiveInfo.builder();
+
+    Containers.ContainerInfo containerInfo = new Containers.ContainerInfo(Containers.ContainerType.SYSTEM_SERVICE,
+                                                                          serviceName, 0, "N/A", hostname.getHostName(),
+                                                                          0, 0, null);
+    builder.addContainer(containerInfo);
+    return builder.build();
+  }
+
+  @Override
+  public int getInstances() {
+    return 1;
+  }
+
+  @Override
+  public boolean setInstances(int instanceCount) {
+    return false;
+  }
+
+  @Override
+  public int getMinInstances() {
+    return 1;
+  }
+
+  @Override
+  public boolean isLogAvailable() {
+    return true;
+  }
+
+  @Override
+  public boolean canCheckStatus() {
+    return true;
+  }
+
+  @Override
+  public boolean isServiceAvailable() {
+    return true;
+  }
+
+  @Override
+  public boolean isServiceEnabled() {
+    return true;
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Containers.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Containers.java
@@ -46,15 +46,15 @@ public interface Containers {
   public static final class ContainerInfo {
     private final String type;
     private final String name;
-    private final int instance;
+    private final Integer instance;
     private final String container;
     private final String host;
-    private final int memory;
-    private final int virtualCores;
+    private final Integer memory;
+    private final Integer virtualCores;
     private final Integer debugPort;
 
-    public ContainerInfo(ContainerType type, String name, int instance, String container,
-                  String host, int memory, int virtualCores, Integer debugPort) {
+    public ContainerInfo(ContainerType type, String name, Integer instance, String container,
+                  String host, Integer memory, Integer virtualCores, Integer debugPort) {
       this.type = type.name().toLowerCase();
       this.name = name;
       this.instance = instance;
@@ -88,7 +88,7 @@ public interface Containers {
       return name;
     }
 
-    public int getInstance() {
+    public Integer getInstance() {
       return instance;
     }
 
@@ -100,11 +100,11 @@ public interface Containers {
       return host;
     }
 
-    public int getMemory() {
+    public Integer getMemory() {
       return memory;
     }
 
-    public int getVirtualCores() {
+    public Integer getVirtualCores() {
       return virtualCores;
     }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Containers.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Containers.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.proto;
 
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Containers define methods to get and add information about YARN containers.
@@ -53,8 +54,8 @@ public interface Containers {
     private final Integer virtualCores;
     private final Integer debugPort;
 
-    public ContainerInfo(ContainerType type, String name, Integer instance, String container,
-                  String host, Integer memory, Integer virtualCores, Integer debugPort) {
+    public ContainerInfo(ContainerType type, String name, @Nullable Integer instance, @Nullable String container,
+                  String host, @Nullable Integer memory, @Nullable Integer virtualCores, @Nullable Integer debugPort) {
       this.type = type.name().toLowerCase();
       this.name = name;
       this.instance = instance;
@@ -88,10 +89,12 @@ public interface Containers {
       return name;
     }
 
+    @Nullable
     public Integer getInstance() {
       return instance;
     }
 
+    @Nullable
     public String getContainer() {
       return container;
     }
@@ -100,14 +103,17 @@ public interface Containers {
       return host;
     }
 
+    @Nullable
     public Integer getMemory() {
       return memory;
     }
 
+    @Nullable
     public Integer getVirtualCores() {
       return virtualCores;
     }
 
+    @Nullable
     public Integer getDebugPort() {
       return debugPort;
     }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryAppFabricServiceManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryAppFabricServiceManager.java
@@ -22,7 +22,7 @@ import co.cask.cdap.common.twill.AbstractInMemoryMasterServiceManager;
 /**
  * Service for managing app fabric service.
  */
-public class AppFabricServiceManager extends AbstractInMemoryMasterServiceManager {
+public class InMemoryAppFabricServiceManager extends AbstractInMemoryMasterServiceManager {
 
   @Override
   public String getDescription() {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-4133

live-info for the app fabric now returns the following information instead of empty object:
```java
{
    "containers": [
        {
            "container": "N/A", 
            "host": "x.y.z", 
            "instance": 0, 
            "memory": 0, 
            "name": "appfabric", 
            "type": "system_service", 
            "virtualCores": 0
        }
    ]
}
```

This allows us to locate the leader in HA setup.