### PR TITLE
(CDAP-4140) Fix test in Java8

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/guava/ClassPath.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/guava/ClassPath.java
@@ -218,9 +218,9 @@ public final class ClassPath {
     }
 
     /** Returns the url identifying the resource. */
+    @Nullable
     public final URL url() {
-      return checkNotNull(loader.getResource(resourceName),
-          "Failed to load resource: %s", resourceName);
+      return loader.getResource(resourceName);
     }
 
     /** Returns the fully qualified name of the resource. Such as "com/mycomp/foo/bar.txt". */

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramResources.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramResources.java
@@ -198,7 +198,11 @@ final class ProgramResources {
 
       if (include) {
         result.add(resultTransform.apply(classInfo));
-        resourcesBaseURLs.add(getClassPathURL(classInfo.getResourceName(), classInfo.url()));
+        URL url = classInfo.url();
+        // URL shouldn't be null for ".class" file. Since url() is @Nullable, hence the check
+        if (url != null) {
+          resourcesBaseURLs.add(getClassPathURL(classInfo.getResourceName(), url));
+        }
       }
     }
 
@@ -210,7 +214,11 @@ final class ProgramResources {
       }
       // See if the resource base URL is already accepted through class filtering.
       // If it does, adds the resource name to the collection as well.
-      if (resourcesBaseURLs.contains(getClassPathURL(resourceInfo.getResourceName(), resourceInfo.url()))) {
+      URL url = resourceInfo.url();
+      // The url returned might be null under Java8. Apparently some resources that are inside lib/ext jars
+      // are not loadable through the underlying ClassLoader (ExtClassLoader).
+      // Since those resources won't be loadable anyway, hence it's ok to be ignored from the include list.
+      if (url != null && resourcesBaseURLs.contains(getClassPathURL(resourceInfo.getResourceName(), url))) {
         result.add(resultTransform.apply(resourceInfo));
       }
     }

--- a/cdap-common/src/test/java/co/cask/cdap/common/lang/FilterClassLoaderTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/lang/FilterClassLoaderTest.java
@@ -52,7 +52,7 @@ public class FilterClassLoaderTest {
   @Test
   public void testBootstrapResourcesVisible() throws IOException {
     FilterClassLoader classLoader = FilterClassLoader.create(this.getClass().getClassLoader());
-    Assert.assertNotNull(classLoader.getResource("META-INF/services/" + ScriptEngineFactory.class.getName()));
+    Assert.assertNotNull(classLoader.getResource("java/lang/String.class"));
   }
 
   @Test


### PR DESCRIPTION
- The ScriptEngineFactory service resource is no longer available in Java 8
- Use a standard class file to test resource loading.