### PR TITLE
Backport APT/YUM repository scripts from develop

### DIFF
--- a/cdap-distributions/bin/build_apt_repo.sh
+++ b/cdap-distributions/bin/build_apt_repo.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Logic:
+# Get version
+# s3cmd ls to see if repo exists
+# - yes, sync repo local
+# - no, create repo dir
+# copy new packages into repo dir
+# create repo
+# sign repo
+# create tarball
+
+# Find our location and base repo directory
+# Resolve links: $0 may be a link
+PRG=${0}
+# Need this for relative symlinks.
+while [ -h ${PRG} ]; do
+    ls=`ls -ld ${PRG}`
+    link=`expr ${ls} : '.*-> \(.*\)$'`
+    if expr ${link} : '/.*' > /dev/null; then
+        PRG=${link}
+    else
+        PRG=`dirname ${PRG}`/${link}
+    fi
+done
+cd `dirname ${PRG}`/.. >&-
+DISTRIBUTIONS_HOME=`pwd -P`
+cd `dirname ${DISTRIBUTIONS_HOME}` >&-
+REPO_HOME=`pwd -P`
+
+TARGET_DIR=${DISTRIBUTIONS_HOME}/target
+STAGE_DIR=${TARGET_DIR}/aptrepo
+
+S3_BUCKET=${S3_BUCKET:-repository.cask.co}
+S3_REPO_PATH=${S3_REPO_PATH:-ubuntu/precise/amd64/cdap} # No leading or trailing slashes
+VERSION=${VERSION:-$(basename ${TARGET_DIR}/cdap_*.deb | cut -d_ -f2 | cut -d- -f1)}
+__version=${VERSION/-SNAPSHOT/}
+__maj_min=$(echo ${__version} | cut -d. -f1,2)
+
+function die() { echo "ERROR: ${1}" 1>&2; exit 1; }
+
+function repo_exists() {
+  if [[ $(s3cmd ls s3://${S3_BUCKET}/${S3_REPO_PATH}/ | grep ${__maj_min}) ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function setup_repo_staging() {
+  mkdir -p ${STAGE_DIR} || return 1
+  # Create initial Freight repository
+  freight-init \
+    --gpg=${GPG_KEY_NAME} \
+    --conf=${STAGE_DIR}/freight.conf \
+    --libdir=${STAGE_DIR}/lib \
+    --cachedir=${STAGE_DIR}/${__maj_min} \
+    --archs=amd64 \
+    --origin=Cask \
+    --label=Cask \
+    ${STAGE_DIR} || return $?
+  # Sync old repository
+  if repo_exists; then
+    echo "Found existing repository at s3://${S3_BUCKET}/${S3_REPO_PATH}/${__maj_min}... copying to staging directory"
+    mkdir -p ${STAGE_DIR}/__tmpdir
+    s3cmd sync --no-preserve s3://${S3_BUCKET}/${S3_REPO_PATH}/${__maj_min} ${STAGE_DIR}/__tmpdir
+    return $?
+  fi
+  return 0
+}
+
+function add_packages_to_repo_staging() {
+  echo "Adding packages to freight library"
+  mkdir -p ${STAGE_DIR}/lib/apt/precise/cdap || return 1
+  # __old_repo = ${STAGE_DIR}/__tmpdir/${__maj_min}/pool/${UBUNTU_RELEASE_NAME}/${APT_COMPONENT}/[:alpha:]/${PACKAGE_NAME}/*.deb
+  local __old_repo=$(ls -1 ${STAGE_DIR}/__tmpdir/*/*/*/*/*/*/*.deb 2>/dev/null)
+  if [ -n "${__old_repo}" ]; then
+    for __deb in ${__old_repo}; do
+      cp -f ${__deb} ${STAGE_DIR}/lib/apt/precise/cdap
+    done
+  fi
+  for __deb in $(ls -1 ${REPO_HOME}/*/target/*.deb ${REPO_HOME}/target/*.deb 2>/dev/null); do
+    echo "- ${__deb}"
+    cp -f ${__deb} ${STAGE_DIR}/lib/apt/precise/cdap
+  done
+}
+
+function write_gpg_passphrase() {
+  echo ${GPG_PASSPHRASE} > ${STAGE_DIR}/gpgpass.tmp
+}
+
+function createrepo_in_repo_staging() {
+  write_gpg_passphrase || return 1
+  echo "Creating repository ${__maj_min} in staging directory"
+  freight-cache --conf=${STAGE_DIR}/freight.conf --gpg=${GPG_KEY_NAME} --passphrase-file=${STAGE_DIR}/gpgpass.tmp apt/precise || return 1
+  # Replace symlink
+  rm -rf ${STAGE_DIR}/${__maj_min}/dists/precise{/.refs,} && mv ${STAGE_DIR}/${__maj_min}/dists/precise{-*,} || return 1
+}
+
+function create_repo_tarball() {
+  cd ${STAGE_DIR}
+  echo "Create APT repository tarball"
+  # Delete any previous tarballs
+  rm -f ${TARGET_DIR}/cdap-aptrepo-${__maj_min}.tar.gz
+  tar zcf ${TARGET_DIR}/cdap-aptrepo-${__maj_min}.tar.gz ${__maj_min}
+}
+
+# Here we go!
+setup_repo_staging || die "Something went wrong setting up the staging directory"
+add_packages_to_repo_staging || die "Failed copying packages to staging directory"
+createrepo_in_repo_staging || die "Failed to create repository from staging directory"
+create_repo_tarball || die "Failed to create APT repository tarball"
+
+echo "Complete: cdap-aptrepo-${__maj_min}.tar.gz created"
+exit 0 # We made it!

--- a/cdap-distributions/bin/build_yum_repo.sh
+++ b/cdap-distributions/bin/build_yum_repo.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Logic:
+# Get version
+# s3cmd ls to see if repo exists
+# - yes, sync repo local
+# - no, create repo dir
+# copy new packages into repo dir
+# sign packages
+# create repo
+# create tarball
+
+# Find our location and base repo directory
+# Resolve links: $0 may be a link
+PRG=${0}
+# Need this for relative symlinks.
+while [ -h ${PRG} ]; do
+    ls=`ls -ld ${PRG}`
+    link=`expr ${ls} : '.*-> \(.*\)$'`
+    if expr ${link} : '/.*' > /dev/null; then
+        PRG=${link}
+    else
+        PRG=`dirname ${PRG}`/${link}
+    fi
+done
+cd `dirname ${PRG}`/.. >&-
+DISTRIBUTIONS_HOME=`pwd -P`
+cd `dirname ${DISTRIBUTIONS_HOME}` >&-
+REPO_HOME=`pwd -P`
+
+TARGET_DIR=${DISTRIBUTIONS_HOME}/target
+STAGE_DIR=${TARGET_DIR}/yumrepo
+
+S3_BUCKET=${S3_BUCKET:-repository.cask.co}
+S3_REPO_PATH=${S3_REPO_PATH:-centos/6/x86_64/cdap} # No leading or trailing slashes
+VERSION=${VERSION:-$(basename ${TARGET_DIR}/cdap-*.rpm | cut -d- -f2)}
+__version=${VERSION/-SNAPSHOT/}
+__maj_min=$(echo ${__version} | cut -d. -f1,2)
+
+function die() { echo "ERROR: ${1}" 1>&2; exit 1; }
+
+function repo_exists() {
+  if [[ $(s3cmd ls s3://${S3_BUCKET}/${S3_REPO_PATH}/ | grep ${__maj_min}) ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function setup_repo_staging() {
+  mkdir -p ${STAGE_DIR}/${__maj_min} || return 1
+  if repo_exists; then
+    echo "Found existing repository at s3://${S3_BUCKET}/${S3_REPO_PATH}/${__maj_min}... copying to staging directory"
+    s3cmd sync --no-preserve s3://${S3_BUCKET}/${S3_REPO_PATH}/${__maj_min} ${STAGE_DIR}
+    return $?
+  fi
+  return 0
+}
+
+function add_packages_to_repo_staging() {
+  mkdir -p ${STAGE_DIR}/${__maj_min}/rpms
+  echo "Copying packages to ${STAGE_DIR}/${__maj_min}/rpms"
+  for __rpm in $(ls -1 ${REPO_HOME}/*/target/*.rpm ${REPO_HOME}/target/*.rpm 2>/dev/null); do
+    echo "- ${__rpm}"
+    cp -f ${__rpm} ${STAGE_DIR}/${__maj_min}/rpms
+  done
+}
+
+function verify_signature_on_package() {
+  local __rpm=${1}
+  rpm --checksig ${__rpm} | grep -e pgp -e gpg # We want grep's return code, not rpm's
+}
+
+function sign_rpm_package() {
+  local __rpm=${1}
+  ${DISTRIBUTIONS_HOME}/bin/rpmsign.expect ${GPG_KEY_NAME} ${GPG_PASSPHRASE} ${__rpm}
+}
+
+function sign_packages_in_repo_staging() {
+  [ -z "${GPG_KEY_NAME}" -o -z "${GPG_PASSPHRASE}" ] && return
+  cd ${STAGE_DIR}/${__maj_min}/rpms
+  local __rpm __ret
+  for __rpm in $(ls -1 *.rpm); do
+    verify_signature_on_package ${__rpm}
+    __ret=$?
+    if [ ${__ret} -eq 0 ]; then
+      # Package is already signed, hooray!
+      echo "Signature verified for ${__rpm}"
+      continue
+    else
+      # Sign away
+      sign_rpm_package ${__rpm}
+    fi
+  done
+}
+
+function export_public_key() {
+  [ -z "${GPG_KEY_NAME}" -o -z "${GPG_PASSPHRASE}" ] && return
+  cd ${STAGE_DIR}/${__maj_min}
+  echo "Exporting GPG key to staging directory"
+  gpg --armor --export ${GPG_KEY_NAME} > pubkey.gpg
+}
+
+function createrepo_in_repo_staging() {
+  cd ${STAGE_DIR}
+  echo "Creating repository ${__maj_min} in staging directory"
+  createrepo ${__maj_min}
+}
+
+function create_repo_tarball() {
+  cd ${STAGE_DIR}
+  echo "Create YUM repository tarball"
+  # Delete any previous tarballs
+  rm -f ${TARGET_DIR}/cdap-yumrepo-${__maj_min}.tar.gz
+  tar zcf ${TARGET_DIR}/cdap-yumrepo-${__maj_min}.tar.gz ${__maj_min}
+}
+
+# Here we go!
+setup_repo_staging || die "Something went wrong setting up the staging directory"
+add_packages_to_repo_staging || die "Failed copying packages to staging directory"
+sign_packages_in_repo_staging
+export_public_key
+createrepo_in_repo_staging || die "Failed to create repository from staging directory"
+create_repo_tarball || die "Failed to create YUM repository tarball"
+
+echo "Complete: cdap-yumrepo-${__maj_min}.tar.gz created"
+exit 0 # We made it!

--- a/cdap-distributions/bin/rpmsign.expect
+++ b/cdap-distributions/bin/rpmsign.expect
@@ -1,0 +1,36 @@
+#!/usr/bin/expect -f
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# rpmsign.expect : expect powered rpm signing command
+#
+
+proc usage {} {
+        send_user "Usage: rpmsign.expect gpgname passphrase rpmfile\n\n"
+        exit
+}
+
+if {[llength $argv]!=3} usage
+
+set gpgname [lrange $argv 0 0]
+set passphrase [lrange $argv 1 1]
+set rpmfile [lrange $argv 2 2]
+
+send_user "Signing $rpmfile with $gpgname key\n"
+
+spawn rpm --addsign -D "_signature gpg" -D "_gpg_name $gpgname" $rpmfile
+expect -exact "Enter pass phrase: "
+send -- "$passphrase\r"
+expect eof

--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -1,0 +1,8 @@
+{
+  "cdap": {
+    "version": "{{VERSION}}",
+    "sdk": {
+      "url": "{{URI}}"
+    }
+  }
+}

--- a/cdap-distributions/src/packer/scripts/network-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/network-cleanup.sh
@@ -14,7 +14,19 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# Remove UDEV persistent network rules
+# Disable automatic udev rules for network interfaces in Ubuntu,
+# source: http://6.ptmc.org/164/
 rm -f /etc/udev/rules.d/70-persistent-net.rules
+mkdir -p /etc/udev/rules.d/70-persistent-net.rules
+rm -f /lib/udev/rules.d/75-persistent-net-generator.rules
+rm -rf /dev/.udev/ /var/lib/dhcp/*
+
+# Remove HWADDR/UUID from ifcfg-* files (RHEL-compatable)
+for ndev in /etc/sysconfig/network-scripts/ifcfg-*; do
+  [[ "${ndev##*/}" != "ifcfg-lo" ]] && sed -i '/^HWADDR/d;/^UUID/d' ${ndev}
+done
+
+# Adding a 2 sec delay to the interface up, to make the dhclient happy
+echo "pre-up sleep 2" >> /etc/network/interfaces
 
 exit 0


### PR DESCRIPTION
These files and scripts are backports from the develop branch, for use with the new [build pipeline](http://builds.cask.co/browse/CDAP-BUT)

Build: http://builds.cask.co/browse/CDAP-BUT811-1