### PR TITLE
CDAP-4147 make app update test more robust.

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ApplicationClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ApplicationClientTestRun.java
@@ -169,14 +169,15 @@ public class ApplicationClientTestRun extends ClientTestBase {
     Id.Artifact artifactIdV1 = Id.Artifact.from(Id.Namespace.DEFAULT, artifactName, "1.0.0");
     Id.Artifact artifactIdV2 = Id.Artifact.from(Id.Namespace.DEFAULT, artifactName, "2.0.0");
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "ProgramsApp");
-    try {
-      artifactClient.add(Id.Namespace.DEFAULT, artifactName,
-        Files.newInputStreamSupplier(createAppJarFile(ConfigurableProgramsApp.class)),
-        "1.0.0");
-      artifactClient.add(Id.Namespace.DEFAULT, artifactName,
-        Files.newInputStreamSupplier(createAppJarFile(ConfigurableProgramsApp2.class)),
-        "2.0.0");
 
+    artifactClient.add(Id.Namespace.DEFAULT, artifactName,
+      Files.newInputStreamSupplier(createAppJarFile(ConfigurableProgramsApp.class)),
+      "1.0.0");
+    artifactClient.add(Id.Namespace.DEFAULT, artifactName,
+      Files.newInputStreamSupplier(createAppJarFile(ConfigurableProgramsApp2.class)),
+      "2.0.0");
+
+    try {
       // deploy the app with just the worker
       ConfigurableProgramsApp.Programs conf =
         new ConfigurableProgramsApp.Programs(null, "worker1", "stream1", "dataset1");

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
@@ -65,7 +65,9 @@ public abstract class ClientTestBase {
   public void setUp() throws Throwable {
     StandaloneTester standalone = STANDALONE.get();
     ConnectionConfig connectionConfig = InstanceURIParser.DEFAULT.parse(standalone.getBaseURI().toString());
-    clientConfig = new ClientConfig.Builder().setConnectionConfig(connectionConfig).build();
+    clientConfig = new ClientConfig.Builder()
+      .setDefaultReadTimeout(60 * 1000)
+      .setConnectionConfig(connectionConfig).build();
   }
 
   protected ClientConfig getClientConfig() {

--- a/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
@@ -319,8 +319,8 @@ public class ClientConfig {
     public ClientConfig build() {
       return new ClientConfig(connectionConfig, verifySSLCert,
                               unavailableRetryLimit, apiVersion, accessToken,
-                              defaultConnectTimeout, defaultReadTimeout,
-                              uploadConnectTimeout, uploadReadTimeout);
+                              defaultReadTimeout, defaultConnectTimeout,
+                              uploadReadTimeout, uploadConnectTimeout);
     }
   }
 

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -238,7 +238,7 @@ public abstract class IntegrationTestBase {
     builder.setDefaultConnectTimeout(120000);
     builder.setDefaultReadTimeout(120000);
     builder.setUploadConnectTimeout(0);
-    builder.setUploadConnectTimeout(0);
+    builder.setUploadReadTimeout(0);
 
     return builder.build();
   }


### PR DESCRIPTION
The test fails on slow machines because artifact deployment takes
longer than the client read timeout. Fixing the test so that the
deployment exception shows up in the logs instead of the cleanup
exception. Also increasing the read timeout and fixing a bug in
the ClientConfig builder where read and connect timeouts were
getting swapped.