### PR TITLE
Two small doc fixes.

### DIFF
--- a/cdap-docs/_common/_source/index.rst
+++ b/cdap-docs/_common/_source/index.rst
@@ -33,9 +33,9 @@ the MapR Distribution. CDAP provides these essential capabilities:
 - Higher degrees of operational control in production through enterprise best practices.
 
 CDAP exposes developer APIs (Application Programming Interfaces) for creating applications
-and accessing core CDAP services. CDAP defines and implements a diverse collection of services that land
-applications and data on existing Hadoop infrastructure such as HBase, HDFS, YARN, MapReduce,
-Hive, and Spark.
+and accessing core CDAP services. CDAP defines and implements a diverse collection of
+services that support applications and data on existing Hadoop infrastructure such as
+HBase, HDFS, YARN, MapReduce, Hive, and Spark.
 
 These documents are your complete reference to the Cask Data Application Platform: they help
 you get started and set up your development environment; explain how CDAP works; and teach

--- a/cdap-docs/_common/_source/table-of-contents.rst
+++ b/cdap-docs/_common/_source/table-of-contents.rst
@@ -4,6 +4,8 @@
 
 :hide-relations: true
 
+:hide-global-toc: true
+
 ============================================
 CDAP Documentation Table of Contents
 ============================================


### PR DESCRIPTION
Adjusts the copy in the introduction and adds a missing hiding of the table of contents in the sidebar.

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB31-1)

Pages of interest:

- [Overview](http://builds.cask.co/artifact/CDAP-DOB31/shared/build-1/Docs-HTML/3.2.1/en/index.html)
- [Table of Contents](http://builds.cask.co/artifact/CDAP-DOB31/shared/build-1/Docs-HTML/3.2.1/en/table-of-contents.html) ...compared with [current Table of Contents](http://docs.cask.co/cdap/current/en/table-of-contents.html) which has three table of contents; two is enough!