### PR TITLE
[CDAP-4049] Feature/ui schema propagation inconsistencies

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -253,7 +253,7 @@ angular.module(PKG.name + '.commons')
         if (targetOuputSchema) {
           targetNode.outputSchema = targetOuputSchema;
         } else {
-          targetNode.outputSchema = sourceNode.outputSchema;
+          targetNode.outputSchema = targetNode.outputSchema || sourceNode.outputSchema;
         }
       });
     }

--- a/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -140,11 +140,9 @@ angular.module(PKG.name + '.feature.hydrator')
           if (!$scope.plugin.outputSchema && input) {
             $scope.plugin.outputSchema = JSON.stringify(input) || null;
           }
-
           if ($scope.plugin.type === artifactTypeExtension.source) {
             $scope.isSource = true;
           }
-
           if ($scope.plugin.type === artifactTypeExtension.sink) {
             $scope.isSink = true;
           }

--- a/cdap-ui/app/features/hydrator/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/detail-ctrl.js
@@ -279,7 +279,6 @@ angular.module(PKG.name + '.feature.hydrator')
       $scope.nodes.forEach(function(node) {
         MyAppDAGService.addNodes(node, node.type);
       });
-
       MyAppDAGService.connections = CanvasFactory.getConnectionsBasedOnNodes($scope.nodes, rPipelineDetail.artifact.name);
     }
 

--- a/cdap-ui/app/features/hydrator/services/canvas-factory.js
+++ b/cdap-ui/app/features/hydrator/services/canvas-factory.js
@@ -25,7 +25,8 @@ angular.module(PKG.name + '.feature.hydrator')
         name: config.source.name,
         label: config.source.label || config.source.name,
         type: GLOBALS.pluginTypes[type].source,
-        properties: config.source.properties
+        properties: config.source.properties,
+        outputSchema: config.source.outputSchema
       });
       config.transforms.forEach(function(transform) {
         nodes.push({
@@ -35,7 +36,8 @@ angular.module(PKG.name + '.feature.hydrator')
           type: 'transform',
           properties: transform.properties,
           errorDatasetName: transform.errorDatasetName,
-          validationFields: transform.validationFields
+          validationFields: transform.validationFields,
+          outputSchema: transform.outputSchema
         });
       });
       config.sinks.forEach(function(sink) {
@@ -44,7 +46,8 @@ angular.module(PKG.name + '.feature.hydrator')
           name: sink.name,
           label: sink.label || sink.name,
           type: GLOBALS.pluginTypes[type].sink,
-          properties: sink.properties
+          properties: sink.properties,
+          outputSchema: sink.outputSchema
         });
       });
       return nodes;

--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -482,7 +482,6 @@ angular.module(PKG.name + '.services')
       var nodes = angular.copy(this.nodes);
 
       function addPluginToConfig(plugin, id) {
-
         var pluginConfig =  {
           // Solely adding id and _backendProperties for validation.
           // Should be removed while saving it to backend.
@@ -490,7 +489,8 @@ angular.module(PKG.name + '.services')
           name: plugin.name,
           label: plugin.label,
           properties: plugin.properties,
-          _backendProperties: plugin._backendProperties
+          _backendProperties: plugin._backendProperties,
+          outputSchema: plugin.outputSchema
         };
 
         if (plugin.type === artifactTypeExtension.source) {
@@ -618,6 +618,7 @@ angular.module(PKG.name + '.services')
       if (!angular.isObject(errors)) {
         EventPipe.emit('showLoadingIcon', 'Publishing Pipeline to CDAP');
         var data = this.getConfigForBackend();
+
         myPipelineApi.save(
           {
             namespace: $state.params.namespace,


### PR DESCRIPTION
Fixing schema propagation inconsistencies, where the output schema is not the same as what the user set during creation.

Solution is to save the output schema to the backend.

Build - http://builds.cask.co/browse/CDAP-DRC2876/

![schema](https://cloud.githubusercontent.com/assets/4398643/10897194/f25461c6-8173-11e5-8ff5-d12304262f7b.gif)
