### PR TITLE
removes myEllipsis from app description

### DIFF
--- a/cdap-ui/app/features/apps/applications.less
+++ b/cdap-ui/app/features/apps/applications.less
@@ -17,37 +17,45 @@
 @import "../../styles/variables.less";
 @import '../../styles/themes/cdap/mixins.less';
 
-body.state-apps-detail {
-  &.theme-cdap {
+body {
+  &.state-apps-detail {
+    &.theme-cdap {
 
-    .table {
-      tbody {
-        a:hover, a:focus {
-          text-decoration: none;
+      .table {
+        tbody {
+          a:hover, a:focus {
+            text-decoration: none;
+          }
         }
       }
-    }
 
-    .dag-link {
-      width: 100%;
-      display: inline-block;
-    }
+      .dag-link {
+        width: 100%;
+        display: inline-block;
+      }
 
-    my-dag {
-      width: 100%;
-      height: 300px;
-    }
+      my-dag {
+        width: 100%;
+        height: 300px;
+      }
 
-    td > span {
-      display: inline-block;
-      width: 10px;
-      height: 10px;
-      margin-right: 5px;
-      .border-radius(25px);
-      &.status-green { background-color: @brand-success; }
-      &.status-grey { background-color: @cdap-gray; }
-      &.status-yellow { background-color: @brand-warning; }
+      td > span {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        margin-right: 5px;
+        .border-radius(25px);
+        &.status-green { background-color: @brand-success; }
+        &.status-grey { background-color: @cdap-gray; }
+        &.status-yellow { background-color: @brand-warning; }
+      }
     }
-
+  }
+  &.state-apps-list {
+    .table {
+      tbody > tr > td:last-child {
+        width: 45%;
+      }
+    }
   }
 }

--- a/cdap-ui/app/features/apps/templates/list.html
+++ b/cdap-ui/app/features/apps/templates/list.html
@@ -62,12 +62,6 @@
   </div>
 </div>
 
-<div ng-if="ListController.apps.length === 0">
-  <div class="well well-lg text-center">
-    <h3>You haven't deployed any apps.</h3>
-  </div>
-</div>
-
 <div class="table-responsive"  ng-if="ListController.apps.length > 0">
   <table class="table table-curved" cask-sortable>
     <thead>
@@ -118,11 +112,7 @@
         </td>
         <td>{{ ::app.version }}</td>
         <td>
-          <span tooltip="{{app.description}}"
-                tooltip-enable="app.description.length > 50"
-                tooltip-append-to-body="true">
-            {{ ::app.description | myEllipsis:50}}
-          </span>
+          <span>{{ ::app.description }}</span>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
*  Removes myEllipsis from app description
*  Keeps description column with at 45% to prevent longer descriptions from reducing the width of the other table columns

<img width="1274" alt="screen shot 2015-11-02 at 3 29 11 pm" src="https://cloud.githubusercontent.com/assets/5335210/10897565/718e6164-8177-11e5-819b-f0f22dd091b7.png">
