### PR TITLE
CDAP-4072 fix up lifecycle docs and add sections for multi stop/start

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/schedules.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/schedules.rst
@@ -20,7 +20,7 @@ be used in different applications.
 
 Schedules can be controlled by the :ref:`CDAP CLI <cli>` and the :ref:`Lifecycle HTTP
 RESTful API <http-restful-api-lifecycle>`. The :ref:`status of a schedule
-<http-restful-api-lifecycle-start-stop-status>` can be retrieved, and individual schedules
+<http-restful-api-lifecycle-status>` can be retrieved, and individual schedules
 :ref:`resumed or suspended <http-restful-api-lifecycle-schedules-suspend-resume>`. 
 
 When a schedule is initially deployed, it is in a *suspended* state; a *resume* command needs to be

--- a/cdap-docs/developers-manual/source/building-blocks/workflows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/workflows.rst
@@ -33,8 +33,9 @@ either a simple series of nodes or a more complicated :ref:`parallel workflow <w
 
 Workflows can be controlled by the :ref:`CDAP CLI <cli>` and the :ref:`Lifecycle HTTP
 RESTful API <http-restful-api-lifecycle>`. The :ref:`status of a workflow
-<http-restful-api-lifecycle-start-stop-status>` can be retrieved, workflows
-:ref:`started or stopped <http-restful-api-lifecycle-start-stop-status>`, and
+<http-restful-api-lifecycle-status>` can be retrieved, workflows
+:ref:`started <http-restful-api-lifecycle-start>` or
+:ref:`stopped <http-restful-api-lifecycle-stop>`, and
 individual runs of a workflow :ref:`suspended or resumed 
 <http-restful-api-lifecycle-workflow-runs-suspend-resume>`. 
 

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -256,9 +256,9 @@ with a JSON array in the request body consisting of multiple JSON objects with t
    * - ``"appId"``
      - Name of the application being called
    * - ``"programType"``
-     - One of ``flow``, ``mapreduce``, ``spark``, ``workflow``, ``worker`` or ``service``
+     - One of ``flow``, ``mapreduce``, ``spark``, ``workflow``, ``worker``, or ``service``
    * - ``"programId"``
-     - Name of the *flow*, *MapReduce*, *Spark*, *workflow*, *worker* or *custom service*
+     - Name of the *flow*, *MapReduce*, *Spark*, *workflow*, *worker*, or *custom service*
        being called
    * - ``"runtimeargs"``
      - Optional JSON object containing a string to string mapping of runtime arguments to start the program with
@@ -275,9 +275,9 @@ Each JSON object will contain these parameters:
    * - ``"appId"``
      - Name of the application being called
    * - ``"programType"``
-     - One of ``flow``, ``mapreduce``, ``spark``, ``workflow``, ``worker`` or ``service``
+     - One of ``flow``, ``mapreduce``, ``spark``, ``workflow``, ``worker``, or ``service``
    * - ``"programId"``
-     - Name of the *flow*, *MapReduce*, *Spark*, *workflow*, *worker* or *custom service*
+     - Name of the *flow*, *MapReduce*, *Spark*, *workflow*, *worker*, or *custom service*
        being called
    * - ``"statusCode"``
      - The status code from starting an individual JSON object.
@@ -391,9 +391,9 @@ with a JSON array in the request body consisting of multiple JSON objects with t
    * - ``"appId"``
      - Name of the application being called
    * - ``"programType"``
-     - One of ``flow``, ``mapreduce``, ``spark``, ``workflow``, ``worker`` or ``service``
+     - One of ``flow``, ``mapreduce``, ``spark``, ``workflow``, ``worker``, or ``service``
    * - ``"programId"``
-     - Name of the *flow*, *MapReduce*, *Spark*, *workflow*, *worker* or *custom service*
+     - Name of the *flow*, *MapReduce*, *Spark*, *workflow*, *worker*, or *custom service*
        being called
 
 The response will be a JSON array containing a JSON object corresponding to each object in the input.
@@ -408,9 +408,9 @@ Each JSON object will contain these parameters:
    * - ``"appId"``
      - Name of the application being called
    * - ``"programType"``
-     - One of ``flow``, ``mapreduce``, ``spark``, ``workflow``, ``worker`` or ``service``
+     - One of ``flow``, ``mapreduce``, ``spark``, ``workflow``, ``worker``, or ``service``
    * - ``"programId"``
-     - Name of the *flow*, *MapReduce*, *Spark*, *workflow*, *worker* or *custom service*
+     - Name of the *flow*, *MapReduce*, *Spark*, *workflow*, *worker*, or *custom service*
        being called
    * - ``"statusCode"``
      - The status code from stopping an individual JSON object.

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -14,6 +14,9 @@ flows, MapReduce programs, workflows, workers, and custom services.
 
 .. highlight:: console
 
+Application Lifecycle
+=====================
+
 .. _http-restful-api-lifecycle-create-app:
 
 Create an Application
@@ -196,6 +199,8 @@ This does not delete the streams and datasets associated with the application
 because they belong to the namespace, not the application.
 Also, this does not delete the artifact used to create the application.
 
+Program Lifecycle
+=================
 
 .. _http-restful-api-lifecycle-start:
 
@@ -363,7 +368,7 @@ You can stop a specific run of a program by submitting an HTTP POST request::
      - Name of the *flow*, *MapReduce*, *schedule*, *Spark*, *workflow*, *worker*, or *custom service*
        being called
    * - ``<run-id>``
-     - Run id of the run
+     - Run id of the run being called
 
 For example::
 
@@ -524,7 +529,7 @@ will get the status of two programs. It will get a response like::
 .. _http-restful-api-lifecycle-container-information:
 
 Container Information
----------------------
+=====================
 
 To find out the address of an program's container host and the container’s debug port, you can query
 CDAP for a flow or service’s live info via an HTTP GET method::
@@ -557,7 +562,7 @@ The response is formatted in JSON; an example of this is shown in
 .. _http-restful-api-lifecycle-scale:
 
 Scaling
--------
+=======
 
 You can retrieve the instance count executing different components from various applications and
 different program types using an HTTP POST method::
@@ -634,7 +639,7 @@ The response will be the same JSON array with additional parameters for each of 
 .. _rest-scaling-flowlets:
 
 Scaling Flowlets
-................
+----------------
 You can query and set the number of instances executing a given flowlet
 by using the ``instances`` parameter with HTTP GET and PUT methods::
 
@@ -692,7 +697,7 @@ with the arguments as a JSON string in the body::
        application *HelloWorld* in the namespace *default*
 
 Scaling Services
-................
+----------------
 You can query or change the number of instances of a service
 by using the ``instances`` parameter with HTTP GET or PUT methods::
 
@@ -730,7 +735,7 @@ with the arguments as a JSON string in the body::
        *PurchaseHistory* in the namespace *default*
 
 Scaling Workers
-...............
+---------------
 You can query or change the number of instances of a worker by using the ``instances``
 parameter with HTTP GET or PUT methods::
 
@@ -772,7 +777,7 @@ Example
 .. _rest-program-runs:
 
 Run Records and Schedules
--------------------------
+=========================
 
 To see all the runs of a selected program (flows, MapReduce programs, Spark programs, workflows, and
 services), issue an HTTP GET to the program’s URL with the ``runs`` parameter.
@@ -844,7 +849,7 @@ Use that runid in subsequent calls to obtain additional information.
 
 
 Retrieving Specific Run Information
-...................................
+-----------------------------------
 
 To fetch the run record for a particular run of a program, use::
 
@@ -987,7 +992,7 @@ For workflows, you can retrieve:
 .. _http-restful-api-lifecycle-schedules-suspend-resume:
 
 Schedules: Suspend and Resume
-.............................
+-----------------------------
 
 For schedules, you can suspend and resume them using the RESTful API.
 
@@ -1044,7 +1049,7 @@ where:
 .. _http-restful-api-lifecycle-workflow-runs-suspend-resume:
 
 Workflow Runs: Suspend and Resume
-.................................
+---------------------------------
 
 For workflows, in addition to :ref:`starting <http-restful-api-lifecycle-start>` and
 :ref:`stopping <http-restful-api-lifecycle-stop>`, you can suspend and resume individual

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -238,7 +238,7 @@ will start the *WhoFlow* flow in the *HelloWorld* application with two runtime a
 
 .. _http-restful-api-lifecycle-start-multiple:
 
-Start multiple Programs
+Start Multiple Programs
 -----------------------
 You can start multiple programs from different applications and program types
 by submitting an HTTP POST request::
@@ -373,7 +373,7 @@ will stop the specific run of the *PurchaseHistoryBuilder* mapreduce in the *Pur
 
 .. _http-restful-api-lifecycle-stop-multiple:
 
-Stop multiple Programs
+Stop Multiple Programs
 ----------------------
 You can stop multiple programs from different applications and program types
 by submitting an HTTP POST request::

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -285,9 +285,9 @@ Each JSON object will contain these parameters:
      - Name of the *flow*, *MapReduce*, *Spark*, *workflow*, *worker*, or *custom service*
        being called
    * - ``"statusCode"``
-     - The status code from starting an individual JSON object.
+     - The status code from starting an individual JSON object
    * - ``"error"``
-     - If an error, a description of why the program could not be started (the specified program was not found, etc.)
+     - If an error, a description of why the program could not be started (for example, the specified program was not found)
 
 For example::
 
@@ -418,9 +418,9 @@ Each JSON object will contain these parameters:
      - Name of the *flow*, *MapReduce*, *Spark*, *workflow*, *worker*, or *custom service*
        being called
    * - ``"statusCode"``
-     - The status code from stopping an individual JSON object.
+     - The status code from stopping an individual JSON object
    * - ``"error"``
-     - If an error, a description of why the program could not be stopped (the specified program was not found, etc.)
+     - If an error, a description of why the program could not be stopped (for example, the specified program was not found)
 
 For example::
 
@@ -502,11 +502,11 @@ The response will be the same JSON array with additional parameters for each of 
      - Description
    * - ``"status"``
      - Maps to the status of an individual JSON object's queried program
-       if the query is valid and the program was found.
+       if the query is valid and the program was found
    * - ``"statusCode"``
-     - The status code from retrieving the status of an individual JSON object.
+     - The status code from retrieving the status of an individual JSON object
    * - ``"error"``
-     - If an error, a description of why the status was not retrieved (the specified program was not found, etc.)
+     - If an error, a description of why the status was not retrieved (for example, the specified program was not found)
 
 The ``status`` and ``error`` fields are mutually exclusive meaning if there is an error,
 then there will never be a status and vice versa.
@@ -608,10 +608,10 @@ The response will be the same JSON array with additional parameters for each of 
    * - ``"provisioned"``
      - Number of instances that are actually running for the program defined by the individual JSON object's parameters.
    * - ``"statusCode"``
-     - The status code from retrieving the instance count of an individual JSON object.
+     - The status code from retrieving the instance count of an individual JSON object
    * - ``"error"``
-     - If an error, a description of why the status was not retrieved (the specified program was not found,
-       the requested JSON object was missing a parameter, etc.)
+     - If an error, a description of why the status was not retrieved (for example, the specified program was not found, or
+       the requested JSON object was missing a parameter)
 
 **Note:** The ``requested`` and ``provisioned`` fields are mutually exclusive of the ``error`` field.
 


### PR DESCRIPTION
Adding documentation for the new stop and start multiple programs
restful apis. As part of this, restructuring the docs a little bit
to have individual sections for each action rather than clumping
stop, start, and status into the same section. Also fixing some
descriptions to include the worker program type.