### PR TITLE
(CDAP-4177) The packaging of data quality app is wrong

### DIFF
--- a/cdap-app-templates/cdap-data-quality/pom.xml
+++ b/cdap-app-templates/cdap-data-quality/pom.xml
@@ -56,7 +56,6 @@
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>


### PR DESCRIPTION
- cdap-etl-api shouldn’t be in provided scope.