### PR TITLE
Fixes editing a draft - passing in the pipeline type instead of defaulting to etl-batch

### DIFF
--- a/cdap-ui/app/features/hydrator/templates/list.html
+++ b/cdap-ui/app/features/hydrator/templates/list.html
@@ -78,7 +78,7 @@
               <a ui-sref="hydrator.detail({ pipelineId: pipeline.name })" ng-if="!pipeline.isDraft">
                 {{pipeline.name}}
               </a>
-              <a ui-sref="hydrator.create.studio({ name: pipeline.name })" ng-if="pipeline.isDraft">
+              <a ui-sref="hydrator.create.studio({ name: pipeline.name, type:pipeline.artifact.name })" ng-if="pipeline.isDraft">
                 {{pipeline.name}}
               </a>
             </td>


### PR DESCRIPTION
While editing a draft (be it etl-batch or etl-realtime) we were not passing in the type of the pipeline. So the UI was defaulting to etl-batch. Fixed it by passing in the type while editing a pipeline.