### PR TITLE
CDAP-3694 fix examples poms

### DIFF
--- a/cdap-examples/StreamConversion/pom.xml
+++ b/cdap-examples/StreamConversion/pom.xml
@@ -33,11 +33,6 @@
   </properties>
 
   <dependencies>
-    <!-- to override hive-exec -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
     <!-- use a newer version of avro than the cdap platform
      in order to use mapreduce classes instead of mapred classes -->
     <dependency>
@@ -50,6 +45,17 @@
       <artifactId>avro-mapred</artifactId>
       <classifier>hadoop2</classifier>
       <version>1.7.7</version>
+      <exclusions>
+        <!-- to avoid conflicts with provided netty version from cdap -->
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/cdap-examples/WikipediaPipeline/pom.xml
+++ b/cdap-examples/WikipediaPipeline/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.10</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/cdap-examples/deploy_pom.xml
+++ b/cdap-examples/deploy_pom.xml
@@ -27,11 +27,19 @@
 
   <modules>
     <module>CountRandom</module>
+    <module>CubeService</module>
+    <module>DataCleansing</module>
+    <module>FileSetExample</module>
     <module>HelloWorld</module>
     <module>Purchase</module>
     <module>SparkKMeans</module>
     <module>SparkPageRank</module>
+    <module>LogAnalysis</module>
+    <module>SportResults</module>
+    <module>StreamConversion</module>
+    <module>UserProfiles</module>
     <module>WebAnalytics</module>
+    <module>WikipediaPipeline</module>
     <module>WordCount</module>
   </modules>
 
@@ -172,6 +180,13 @@
         <groupId>co.cask.common</groupId>
         <artifactId>common-http</artifactId>
         <version>${cask.common.version}</version>
+        <!-- exclude this, otherwise an old version of asm will get pulled in -->
+        <exclusions>
+          <exclusion>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-all</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>co.cask.http</groupId>

--- a/cdap-examples/pom.xml
+++ b/cdap-examples/pom.xml
@@ -29,6 +29,10 @@
   <packaging>pom</packaging>
   <name>CDAP Examples</name>
 
+  <!--
+    NOTE: This pom is not the one bundled in the cdap sdk.
+    When adding a new module here, be sure to add it to deploy_pom.xml too.
+  -->
   <modules>
     <module>CountRandom</module>
     <module>CubeService</module>

--- a/cdap-examples/pom.xml
+++ b/cdap-examples/pom.xml
@@ -186,6 +186,12 @@
         <groupId>co.cask.common</groupId>
         <artifactId>common-http</artifactId>
         <version>${cask.common.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-all</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>co.cask.http</groupId>


### PR DESCRIPTION
Exclude asm from the common-http dependency. Without this,
an old version of asm (4.0) gets pulled in instead of the version
the unit-test module requires, causing unit tests to break.
This was causing PurchaseHistory and Wikipedia example tests
to fail. The test failures are only seen when using the sdk.
In the cdap project, the correct version of asm is used.

Also excluding netty and jetty dependencies from StreamConversion
example to fix test failures.