### PR TITLE
CDAP-4180: Caching for lookup

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/CacheConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/CacheConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api;
+
+/**
+ * Cache configuration.
+  */
+public final class CacheConfig {
+  private final long expirySeconds;
+  private final int maxSize;
+
+  public CacheConfig(long expirySeconds, int maxSize) {
+    this.expirySeconds = expirySeconds;
+    this.maxSize = maxSize;
+  }
+
+  public CacheConfig() {
+    this(0, 0);
+  }
+
+  /**
+   * @return expiry after write in seconds
+   */
+  public long getExpirySeconds() {
+    return expirySeconds;
+  }
+
+  /**
+   * @return maximum number of elements in the cache
+   */
+  public int getMaxSize() {
+    return maxSize;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/LookupTableConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/LookupTableConfig.java
@@ -15,10 +15,11 @@
  */
 package co.cask.cdap.etl.api;
 
-import co.cask.cdap.api.dataset.DatasetProperties;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Configuration for a particular {@link Lookup} table.
@@ -32,41 +33,20 @@ public class LookupTableConfig {
     DATASET
   }
 
-  /**
-   * When type is DATASET, {@link #properties} is interpreted as {@link DatasetProperties}.
-   */
   private final TableType type;
-  private final Map<String, Object> properties;
+  private final Map<String, String> datasetProperties;
 
-  public LookupTableConfig(TableType type, Map<String, Object> properties) {
+  public LookupTableConfig(TableType type, @Nullable Map<String, String> datasetProperties) {
     this.type = type;
-    this.properties = properties;
+    this.datasetProperties = datasetProperties;
   }
 
   public TableType getType() {
     return type;
   }
 
-  public Map<String, Object> getProperties() {
-    return properties;
-  }
-
-  public DatasetProperties getDatasetProperties() {
+  public Map<String, String> getDatasetProperties() {
     Preconditions.checkArgument(type == TableType.DATASET);
-
-    Object argumentsObj = properties.get("arguments");
-    if (argumentsObj == null) {
-      return DatasetProperties.EMPTY;
-    }
-
-    if (!(argumentsObj instanceof Map)) {
-      throw new IllegalArgumentException("Expected 'arguments' property to be a map of string to string");
-    }
-
-    @SuppressWarnings("unchecked")
-    Map<String, String> arguments = (Map<String, String>) argumentsObj;
-    return DatasetProperties.builder()
-      .addAll(arguments)
-      .build();
+    return datasetProperties == null ? ImmutableMap.<String, String>of() : datasetProperties;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/LookupTableConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/LookupTableConfig.java
@@ -13,13 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.etl.api;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * Configuration for a particular {@link Lookup} table.
@@ -34,11 +33,30 @@ public class LookupTableConfig {
   }
 
   private final TableType type;
-  private final Map<String, String> datasetProperties;
 
-  public LookupTableConfig(TableType type, @Nullable Map<String, String> datasetProperties) {
+  private final Map<String, String> datasetProperties;
+  private final CacheConfig cacheConfig;
+  private final boolean cacheEnabled;
+
+  /**
+   * @param type type of lookup table
+   * @param cacheConfig cache config
+   * @param datasetProperties runtime dataset properties
+   * @param cacheEnabled true if caching is desired
+   */
+  public LookupTableConfig(TableType type, CacheConfig cacheConfig,
+                           Map<String, String> datasetProperties, boolean cacheEnabled) {
     this.type = type;
+    this.cacheConfig = cacheConfig;
     this.datasetProperties = datasetProperties;
+    this.cacheEnabled = cacheEnabled;
+  }
+
+  /**
+   * @param type type of lookup table
+   */
+  public LookupTableConfig(TableType type) {
+    this(type, new CacheConfig(), ImmutableMap.<String, String>of(), false);
   }
 
   public TableType getType() {
@@ -46,7 +64,14 @@ public class LookupTableConfig {
   }
 
   public Map<String, String> getDatasetProperties() {
-    Preconditions.checkArgument(type == TableType.DATASET);
-    return datasetProperties == null ? ImmutableMap.<String, String>of() : datasetProperties;
+    return datasetProperties;
+  }
+
+  public boolean isCacheEnabled() {
+    return cacheEnabled;
+  }
+
+  public CacheConfig getCacheConfig() {
+    return cacheConfig;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/CachingLookup.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/CachingLookup.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.transform;
+
+import co.cask.cdap.etl.api.CacheConfig;
+import co.cask.cdap.etl.api.Lookup;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link Lookup} that provides caching over a delegate.
+ *
+ * @param <T> the type of object that will be returned for a lookup
+ */
+public class CachingLookup<T> implements Lookup<T> {
+
+  private final Lookup<T> delegate;
+  private final LoadingCache<String, T> cache;
+
+  public CachingLookup(final Lookup<T> delegate, CacheConfig cacheConfig) {
+    this.delegate = delegate;
+    this.cache = CacheBuilder.newBuilder()
+      .maximumSize(cacheConfig.getMaxSize())
+      .expireAfterWrite(cacheConfig.getExpirySeconds(), TimeUnit.SECONDS)
+      .build(new CacheLoader<String, T>() {
+        @Override
+        public T load(String key) throws Exception {
+          return delegate.lookup(key);
+        }
+      });
+  }
+
+  @Override
+  public T lookup(String key) {
+    return cache.getUnchecked(key);
+  }
+
+  @Override
+  public Map<String, T> lookup(String... keys) {
+    return lookup(ImmutableSet.copyOf(keys));
+  }
+
+  @Override
+  public Map<String, T> lookup(Set<String> keys) {
+    ImmutableMap<String, T> cached = cache.getAllPresent(keys);
+
+    Set<String> missingKeys = Sets.difference(keys, cached.keySet());
+    Map<String, T> missing = delegate.lookup(missingKeys);
+    cache.putAll(missing);
+
+    return ImmutableMap.<String, T>builder()
+      .putAll(cached)
+      .putAll(missing)
+      .build();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptLookup.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptLookup.java
@@ -31,14 +31,13 @@ public class ScriptLookup {
   private final LookupTableConfig config;
 
   public ScriptLookup(Lookup<Object> delegate, LookupTableConfig config, JavaTypeConverters js) {
-    this.delegate = delegate;
     this.config = config;
     this.js = js;
+    this.delegate = config.isCacheEnabled() ? new CachingLookup<>(delegate, config.getCacheConfig()) : delegate;
   }
 
   public Object lookup(String key) {
     // TODO: CDAP-4171 handle ObjectMappedTable
-    // TODO: CDAP-4180 implement caching, configured by config
     return delegate.lookup(key);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptLookupProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptLookupProvider.java
@@ -16,13 +16,9 @@
 package co.cask.cdap.etl.transform;
 
 import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.LookupConfig;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.LookupTableConfig;
-
-import java.util.Map;
-import java.util.Set;
 
 /**
  * {@link LookupProvider} implementation for {@link ScriptTransform}.
@@ -48,7 +44,7 @@ public class ScriptLookupProvider {
       throw new RuntimeException(String.format("Dataset %s not declared in configuration", table));
     }
 
-    DatasetProperties arguments = tableConfig.getDatasetProperties();
+    DatasetProperties arguments = DatasetProperties.builder().addAll(tableConfig.getDatasetProperties()).build();
     return new ScriptLookup(delegate.provide(table, arguments.getProperties()), tableConfig, converters);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/CachingLookupTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/CachingLookupTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.transform;
+
+import co.cask.cdap.etl.api.CacheConfig;
+import co.cask.cdap.etl.api.Lookup;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ *
+ */
+public class CachingLookupTest {
+
+  @Test
+  public void testExpiryByTime() throws InterruptedException {
+    Map<String, String> backing = new HashMap<>();
+    backing.put("foo", "1");
+
+    Lookup<String> delegate = new MapLookup<>(backing);
+    CacheConfig config = new CacheConfig(1, 10);
+    CachingLookup<String> lookup = new CachingLookup<>(delegate, config);
+
+    Assert.assertEquals("1", lookup.lookup("foo"));
+
+    backing.put("foo", "2");
+    Assert.assertEquals("1", lookup.lookup("foo"));
+    Thread.sleep(1100);
+    Assert.assertEquals("2", lookup.lookup("foo"));
+  }
+
+  @Test
+  public void testExpiryByFull() {
+    Map<String, String> backing = new HashMap<>();
+    for (int i = 1; i <= 100; i++) {
+      backing.put("foo" + i, Integer.toString(i));
+    }
+
+    Lookup<String> delegate = new MapLookup<>(backing);
+    CacheConfig config = new CacheConfig(0, 10);
+    CachingLookup<String> lookup = new CachingLookup<>(delegate, config);
+
+    Assert.assertEquals("1", lookup.lookup("foo1"));
+
+    // fill the cache and check that the first values cached are removed
+    for (int i = 1; i <= 100; i++) {
+      Assert.assertEquals(Integer.toString(i), lookup.lookup("foo" + i));
+    }
+
+    backing.put("foo1", "sdf");
+    Assert.assertEquals("sdf", lookup.lookup("foo1"));
+  }
+
+  @Test
+  public void testBatch() throws InterruptedException {
+    Map<String, String> backing = new HashMap<>();
+    for (int i = 1; i <= 100; i++) {
+      backing.put("foo" + i, Integer.toString(i));
+    }
+
+    Lookup<String> delegate = new MapLookup<>(backing);
+    CacheConfig config = new CacheConfig(1, 10);
+    CachingLookup<String> lookup = new CachingLookup<>(delegate, config);
+
+    Assert.assertEquals(
+      ImmutableMap.of("foo1", "1", "foo2", "2", "foo4", "4"),
+      lookup.lookup("foo1", "foo4", "foo2"));
+
+    backing.put("foo2", "sdf");
+    Assert.assertEquals(
+      ImmutableMap.of("foo1", "1", "foo2", "2", "foo4", "4"),
+      lookup.lookup("foo1", "foo4", "foo2"));
+    Thread.sleep(1100);
+    Assert.assertEquals(
+      ImmutableMap.of("foo1", "1", "foo2", "sdf", "foo4", "4"),
+      lookup.lookup("foo1", "foo4", "foo2"));
+  }
+
+  private static class MapLookup<T> implements Lookup<T> {
+
+    private final Map<String, T> backing;
+
+    public MapLookup(Map<String, T> backing) {
+      this.backing = backing;
+    }
+
+    @Override
+    public T lookup(String key) {
+      return backing.get(key);
+    }
+
+    @Override
+    public Map<String, T> lookup(String... keys) {
+      return lookup(ImmutableSet.copyOf(keys));
+    }
+
+    @Override
+    public Map<String, T> lookup(Set<String> keys) {
+      return Maps.filterKeys(backing, Predicates.in(keys));
+    }
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/ScriptTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/ScriptTransformTest.java
@@ -175,7 +175,7 @@ public class ScriptTransformTest {
       null,
       new LookupConfig(
         ImmutableMap.of(
-          "purchases", new LookupTableConfig(LookupTableConfig.TableType.DATASET, ImmutableMap.<String, Object>of()))
+          "purchases", new LookupTableConfig(LookupTableConfig.TableType.DATASET))
       ));
     Transform<StructuredRecord, StructuredRecord> transform = new ScriptTransform(config);
     transform.initialize(new MockTransformContext(

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/ETLWorkerTest.java
@@ -176,7 +176,7 @@ public class ETLWorkerTest extends ETLRealtimeBaseTest {
       "script", "function transform(x, ctx) { " +
         "x.name = x.name + '..hi..' + ctx.getLookup('lookupTable').lookup(x.name); return x; }",
       "lookup", GSON.toJson(new LookupConfig(ImmutableMap.of(
-        "lookupTable", new LookupTableConfig(LookupTableConfig.TableType.DATASET, ImmutableMap.<String, Object>of())
+        "lookupTable", new LookupTableConfig(LookupTableConfig.TableType.DATASET)
       )))
     ));
     ETLStage sink = new ETLStage("Table", ImmutableMap.of(Properties.Table.NAME, "testScriptLookup_table1",

--- a/cdap-docs/included-applications/source/etl/plugins/transforms/script.rst
+++ b/cdap-docs/included-applications/source/etl/plugins/transforms/script.rst
@@ -80,7 +80,7 @@ operations with that lookup table in your script: ``context.getLookup('purchases
       "lookup": "{
         \"purchases\":{
           \"type\":\"DATASET\",
-          \"properties\":{
+          \"datasetProperties\":{
             \"dataset_argument1\":\"foo\",
             \"dataset_argument2\":\"bar\"
           }

--- a/cdap-docs/included-applications/source/etl/plugins/transforms/scriptfilter.rst
+++ b/cdap-docs/included-applications/source/etl/plugins/transforms/scriptfilter.rst
@@ -43,7 +43,7 @@ operations with that lookup table in your script: ``context.getLookup('purchases
       "lookup": "{
         \"purchases\":{
           \"type\":\"DATASET\",
-          \"properties\":{
+          \"datasetProperties\":{
             \"dataset_argument1\":\"foo\",
             \"dataset_argument2\":\"bar\"
           }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-4180

* Add 'cache' property to LookupTableConfig
* If 'cache' property is present, caching is enabled, and ScriptLookup wraps its Lookup delegate in a CachingLookup instance
* CachingLookup uses Guava's LoadingCache/CacheBuilder to provide caching mechanisms. It uses expireAfterWrite and maximumSize. Both are configurable using the 'cache' property.