### PR TITLE
CDAP-4202 Provide user ability to configure resources for MapReduce d…

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
@@ -79,6 +79,13 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
   }
 
   /**
+   * Sets the resources requirement for the driver of the {@link MapReduce}.
+   */
+  protected final void setDriverResources(Resources resources) {
+    configurer.setDriverResources(resources);
+  }
+
+  /**
    * Sets the resources requirement for Mapper task of the {@link MapReduce}.
    */
   protected final void setMapperResources(Resources resources) {

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceConfigurer.java
@@ -44,6 +44,11 @@ public interface MapReduceConfigurer extends DatasetConfigurer, ProgramConfigure
   void setOutputDataset(String dataset);
 
   /**
+   * Sets the resources requirement for the driver of the MapReduce.
+   */
+  void setDriverResources(Resources resources);
+
+  /**
    * Sets the resources requirement for Mapper task of the {@link MapReduce}.
    */
   void setMapperResources(Resources resources);

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceSpecification.java
@@ -39,12 +39,14 @@ public class MapReduceSpecification implements ProgramSpecification, PropertyPro
   private final Map<String, String> properties;
   private final String inputDataSet;
   private final String outputDataSet;
+  private final Resources driverResources;
   private final Resources mapperResources;
   private final Resources reducerResources;
 
   public MapReduceSpecification(String className, String name, String description, String inputDataSet,
                                 String outputDataSet, Set<String> dataSets, Map<String, String> properties,
-                                Resources mapperResources, Resources reducerResources) {
+                                @Nullable Resources driverResources,
+                                @Nullable Resources mapperResources, @Nullable Resources reducerResources) {
     this.className = className;
     this.name = name;
     this.description = description;
@@ -52,6 +54,7 @@ public class MapReduceSpecification implements ProgramSpecification, PropertyPro
     this.outputDataSet = outputDataSet;
     this.properties = Collections.unmodifiableMap(properties == null ? Collections.<String, String>emptyMap()
                                                     : new HashMap<>(properties));
+    this.driverResources = driverResources;
     this.mapperResources = mapperResources;
     this.reducerResources = reducerResources;
     this.dataSets = getAllDatasets(dataSets, inputDataSet, outputDataSet);
@@ -106,6 +109,14 @@ public class MapReduceSpecification implements ProgramSpecification, PropertyPro
   @Nullable
   public String getInputDataSet() {
     return inputDataSet;
+  }
+
+  /**
+   * @return Resources requirement for driver or {@code null} if not specified.
+   */
+  @Nullable
+  public Resources getDriverResources() {
+    return driverResources;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
@@ -42,6 +42,7 @@ public final class DefaultMapReduceConfigurer extends DefaultPluginConfigurer im
   private Set<String> datasets;
   private String inputDataset;
   private String outputDataset;
+  private Resources driverResources;
   private Resources mapperResources;
   private Resources reducerResources;
 
@@ -85,6 +86,11 @@ public final class DefaultMapReduceConfigurer extends DefaultPluginConfigurer im
   }
 
   @Override
+  public void setDriverResources(Resources resources) {
+    this.driverResources = resources;
+  }
+
+  @Override
   public void setMapperResources(Resources resources) {
     this.mapperResources = resources;
   }
@@ -96,6 +102,6 @@ public final class DefaultMapReduceConfigurer extends DefaultPluginConfigurer im
 
   public MapReduceSpecification createSpecification() {
     return new MapReduceSpecification(className, name, description, inputDataset, outputDataset, datasets,
-                                      properties, mapperResources, reducerResources);
+                                      properties, driverResources, mapperResources, reducerResources);
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduce.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduce.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.batch;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.annotation.UseDataSet;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.common.Bytes;
@@ -48,12 +49,15 @@ public class AppWithMapReduce extends AbstractApplication {
    *
    */
   public static final class ClassicWordCount extends AbstractMapReduce {
+    public static final int MEMORY_MB = 1024;
+
     @UseDataSet("jobConfig")
     private KeyValueTable table;
 
     @Override
     protected void configure() {
       createDataset("jobConfig", KeyValueTable.class);
+      setDriverResources(new Resources(MEMORY_MB));
     }
 
     @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -29,6 +29,7 @@ import co.cask.cdap.api.dataset.lib.TimeseriesTable;
 import co.cask.cdap.api.dataset.lib.cube.AggregationFunction;
 import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.metrics.MetricDataQuery;
 import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricTimeSeries;
@@ -368,6 +369,14 @@ public class MapReduceProgramRunnerTest {
     }
   }
 
+  @Test
+  public void testMapReduceDriverResources() throws Exception {
+    final ApplicationWithPrograms app =
+      AppFabricTestHelper.deployApplicationWithManager(AppWithMapReduce.class, TEMP_FOLDER_SUPPLIER);
+    MapReduceSpecification mrSpec =
+      app.getSpecification().getMapReduce().get(AppWithMapReduce.ClassicWordCount.class.getSimpleName());
+    Assert.assertEquals(AppWithMapReduce.ClassicWordCount.MEMORY_MB, mrSpec.getDriverResources().getMemoryMB());
+  }
 
   @Test
   public void testMapreduceWithObjectStore() throws Exception {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/MapReduceSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/MapReduceSpecificationCodec.java
@@ -41,6 +41,9 @@ public final class MapReduceSpecificationCodec extends AbstractSpecificationCode
     jsonObj.addProperty("name", src.getName());
     jsonObj.addProperty("description", src.getDescription());
 
+    if (src.getDriverResources() != null) {
+      jsonObj.add("driverResources", context.serialize(src.getDriverResources()));
+    }
     if (src.getMapperResources() != null) {
       jsonObj.add("mapperResources", context.serialize(src.getMapperResources()));
     }
@@ -67,6 +70,7 @@ public final class MapReduceSpecificationCodec extends AbstractSpecificationCode
     String className = jsonObj.get("className").getAsString();
     String name = jsonObj.get("name").getAsString();
     String description = jsonObj.get("description").getAsString();
+    Resources driverResources = deserializeResources(jsonObj, "driver", context);
     Resources mapperResources = deserializeResources(jsonObj, "mapper", context);
     Resources reducerResources = deserializeResources(jsonObj, "reducer", context);
     JsonElement inputDataSetElem = jsonObj.get("inputDataSet");
@@ -77,7 +81,7 @@ public final class MapReduceSpecificationCodec extends AbstractSpecificationCode
     Set<String> dataSets = deserializeSet(jsonObj.get("datasets"), context, String.class);
     Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
     return new MapReduceSpecification(className, name, description, inputDataSet, outputDataSet,
-                                      dataSets, properties, mapperResources, reducerResources);
+                                      dataSets, properties, driverResources, mapperResources, reducerResources);
   }
 
   /**


### PR DESCRIPTION
CDAP-4202 Provide user ability to configure resources for MapReduce driver.
This is needed in case MapReduceRuntimeService (driver of MapReduce job) needs more than the previously-static amount of memory of 512mb.

https://issues.cask.co/browse/CDAP-4202
http://builds.cask.co/browse/CDAP-DUT3095-2 [GREEN]