### PR TITLE
specify idea download version to get around broken default

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
@@ -86,7 +86,8 @@
           "url": "http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/luna/SR2/eclipse-jee-luna-SR2-linux-gtk-x86_64.tar.gz"
         },
         "idea": {
-          "setup_dir": "/opt"
+          "setup_dir": "/opt",
+          "version": "14.1.4"
         },
         "hadoop": {
           "distribution": "hdp",


### PR DESCRIPTION
cherry-pick fix from https://github.com/caskdata/cdap/pull/4495

currently, the default attributes in the idea cookbook no longer work. It appears Jetbrains may have removed previous version downloads. So setting this attr to get around it for now.