### PR TITLE
CDAP-4209 add getSplits method to ObjectStore and ObjectMappedTable

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectMappedTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectMappedTable.java
@@ -20,9 +20,11 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.batch.BatchReadable;
 import co.cask.cdap.api.data.batch.BatchWritable;
 import co.cask.cdap.api.data.batch.RecordScannable;
+import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.Dataset;
 
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -107,4 +109,15 @@ public interface ObjectMappedTable<T> extends Dataset, BatchReadable<byte[], T>,
    * @param key key of the object to be deleted
    */
   void delete(byte[] key);
+
+  /**
+   * Returns splits for a range of keys in the table.
+   *
+   * @param numSplits Desired number of splits. If greater than zero, at most this many splits will be returned.
+   *                  If less than or equal to zero, any number of splits can be returned.
+   * @param start if non-null, the returned splits will only cover keys that are greater or equal
+   * @param stop if non-null, the returned splits will only cover keys that are less
+   * @return list of {@link Split}
+   */
+  List<Split> getSplits(int numSplits, byte[] start, byte[] stop);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectStore.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectStore.java
@@ -19,7 +19,10 @@ package co.cask.cdap.api.dataset.lib;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.batch.BatchReadable;
 import co.cask.cdap.api.data.batch.BatchWritable;
+import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.dataset.Dataset;
+
+import java.util.List;
 
 /**
  * A dataset that stores objects of a particular class into a table.
@@ -86,4 +89,15 @@ public interface ObjectStore<T> extends Dataset, BatchReadable<byte[], T>, Batch
    * @param key key of the object to be deleted
    */
   void delete(byte[] key);
+
+  /**
+   * Returns splits for a range of keys in the table.
+   *
+   * @param numSplits Desired number of splits. If greater than zero, at most this many splits will be returned.
+   *                  If less than or equal to zero, any number of splits can be returned.
+   * @param start if non-null, the returned splits will only cover keys that are greater or equal
+   * @param stop if non-null, the returned splits will only cover keys that are less
+   * @return list of {@link Split}
+   */
+  List<Split> getSplits(int numSplits, byte[] start, byte[] stop);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableDataset.java
@@ -164,6 +164,11 @@ public class ObjectMappedTableDataset<T> extends AbstractDataset implements Obje
   }
 
   @Override
+  public List<Split> getSplits(int numSplits, byte[] start, byte[] stop) {
+    return table.getSplits(numSplits, start, stop);
+  }
+
+  @Override
   public RecordScanner<StructuredRecord> createSplitRecordScanner(Split split) {
     return table.createSplitRecordScanner(split);
   }


### PR DESCRIPTION
Adds the version of getSplits that takes a number of splits and
start and end keys to ObjectStore and ObjectMappedTable.
ObjectStoreDataset already implements it, just didn't have it in
the interface.