### PR TITLE
PartititionedFileSet#consumePartitions should support a limit and partition filter

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
  * Describes a filter over partition keys.
  */
 public class PartitionFilter {
-  public static PartitionFilter ALWAYS_MATCH =
+  public static final PartitionFilter ALWAYS_MATCH =
     new PartitionFilter(new LinkedHashMap<String, Condition<? extends Comparable>>());
 
   private final Map<String, Condition<? extends Comparable>> conditions;

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
@@ -25,6 +25,8 @@ import javax.annotation.Nullable;
  * Describes a filter over partition keys.
  */
 public class PartitionFilter {
+  public static PartitionFilter ALWAYS_MATCH =
+    new PartitionFilter(new LinkedHashMap<String, Condition<? extends Comparable>>());
 
   private final Map<String, Condition<? extends Comparable>> conditions;
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -105,7 +105,9 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    *
    * @param partitionConsumerState the state from which to start consuming from
    * @param partitionFilter a filter which must match the partitions to be consumed
-   * @param limit the maximum number of partitions to consume
+   * @param limit number of partitions, which once reached, will not add add more partitions committed by other
+   *              transactions; the limit is checked after adding consuming all partitions of a transaction, so
+   *              the total number of consumed partitions may be greater than this limit
    * @return {@link PartitionConsumerResult} which holds the state of consumption as well as an iterator to the consumed
    * {@link Partition}s
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -99,6 +99,20 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
   PartitionConsumerResult consumePartitions(PartitionConsumerState partitionConsumerState);
 
   /**
+   * Incrementally consumes partitions. This method can be used to retrieve partitions that have been created since the
+   * last call to this method. Note that it is the client's responsibility to maintain state of the partitions processed
+   * in the iterator returned in the PartitionConsumerResult.
+   *
+   * @param partitionConsumerState the state from which to start consuming from
+   * @param partitionFilter a filter which must match the partitions to be consumed
+   * @param limit the maximum number of partitions to consume
+   * @return {@link PartitionConsumerResult} which holds the state of consumption as well as an iterator to the consumed
+   * {@link Partition}s
+   */
+  PartitionConsumerResult consumePartitions(PartitionConsumerState partitionConsumerState,
+                                            PartitionFilter partitionFilter, int limit);
+
+  /**
    * Return a partition output for a specific partition key, in preparation for creating a new partition.
    * Obtain the location to write from the PartitionOutput, then call the {@link PartitionOutput#addPartition}
    * to add the partition to this dataset.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumer.java
@@ -19,12 +19,14 @@ package co.cask.cdap.data2.dataset2.lib.partitioned;
 import co.cask.cdap.api.dataset.lib.Partition;
 import co.cask.cdap.api.dataset.lib.PartitionConsumerResult;
 import co.cask.cdap.api.dataset.lib.PartitionConsumerState;
+import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 
 import java.util.Iterator;
 
 /**
- * A simple consumer for {@link Partition}s of a {@link PartitionedFileSet}
+ * A simple consumer for {@link Partition}s of a {@link PartitionedFileSet}, which maintains the PartitionConsumerState
+ * in memory.
  */
 public class PartitionConsumer {
   private final PartitionedFileSet partitionedFileSet;
@@ -52,12 +54,24 @@ public class PartitionConsumer {
   }
 
   /**
-   * @return an iterator to {@link Partition}s of the underlying {@link PartitionedFileSet} created since the last
-   * call to this method. This excludes partitions created in in-progress transactions including the one in which the
-   * call to this method is made.
+   * @return an iterator to {@link Partition}s of the underlying {@link PartitionedFileSet} created since the last call
+   *         to this method. This excludes partitions created in in-progress transactions including the one in which the
+   *         call to this method is made.
    */
   public Iterator<Partition> consumePartitions() {
-    PartitionConsumerResult partitionConsumerResult = partitionedFileSet.consumePartitions(partitionConsumerState);
+    return consumePartitions(PartitionFilter.ALWAYS_MATCH, Integer.MAX_VALUE);
+  }
+
+  /**
+   * @param filter PartitionFilter to be applied while consuming partitions
+   * @param limit limit to be applied while consuming partitions
+   * @return an iterator to {@link Partition}s of the underlying {@link PartitionedFileSet} created since the last call
+   *         to this method. This excludes partitions created in in-progress transactions including the one in which the
+   *         call to this method is made.
+   */
+  public Iterator<Partition> consumePartitions(PartitionFilter filter, int limit) {
+    PartitionConsumerResult partitionConsumerResult =
+      partitionedFileSet.consumePartitions(partitionConsumerState, filter, limit);
     partitionConsumerState = partitionConsumerResult.getPartitionConsumerState();
     return partitionConsumerResult.getPartitionIterator();
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -60,6 +60,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -202,24 +203,102 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
 
   @Override
   public PartitionConsumerResult consumePartitions(PartitionConsumerState partitionConsumerState) {
+    return consumePartitions(partitionConsumerState, PartitionFilter.ALWAYS_MATCH, Integer.MAX_VALUE);
+  }
+
+  /**
+   * While applying a partition filter and a limit, parse partitions from the rows of a scanner and add them to a list.
+   * Note that multiple partitions can have the same transaction write pointer. For each set of partitions with the same
+   * write pointer, we either add the entire set or exclude the entire set. The limit is applied after adding each such
+   * set of partitions to the list.
+   *
+   * @param scanner the scanner on the partitions table from which to read partitions
+   * @param partitions list to add the qualifying partitions to
+   * @param filter partition filter to apply before adding to the partitions list
+   * @param limit limit, which once reached, partitions committed by other transactions will not be added
+   * @return Transaction ID of the partition that we reached in the scanner, but did not add to the list. This value
+   *         can be useful in future scans.
+   */
+  @Nullable
+  private Long scannerToPartitions(Scanner scanner, List<Partition> partitions, PartitionFilter filter, int limit) {
+    Long prevTxId = null;
+    try {
+      Row row;
+      while ((row = scanner.next()) != null) {
+        PartitionKey key = parseRowKey(row.getRow(), partitioning);
+        if (!filter.match(key)) {
+          continue;
+        }
+
+        String relativePath = Bytes.toString(row.get(RELATIVE_PATH));
+        Long txId = Bytes.toLong(row.get(WRITE_PTR_COL));
+
+        // if we are on a partition written by a different transaction, check if we are over the limit
+        // we don't want to do a check on every partition because we want to either add all partitions written
+        // by a transaction or none, since we keep our marker based upon transaction id.
+        if (prevTxId != null && !prevTxId.equals(txId)) {
+          if (partitions.size() >= limit) {
+            return txId;
+          }
+        }
+        prevTxId = txId;
+
+        BasicPartitionDetail partitionDetail =
+          new BasicPartitionDetail(PartitionedFileSetDataset.this, relativePath, key, metadataFromRow(row));
+        partitions.add(partitionDetail);
+      }
+      return null;
+    } finally {
+      scanner.close();
+    }
+  }
+
+  // PartitionConsumerState consists of two things:
+  //   1) A list of transaction IDs representing the list of transactions in progress during the previous call.
+  //      Each of these transaction IDs need to be checked for new partitions because there may be partitions created by
+  //      those partitions since the previous call.
+  //   2) A transaction ID from which to start scanning for new partitions. This is an exclusive end range that the
+  //      previous call stopped scanning partitions at.
+  //   Note that each of the transactions IDs in (1) will be smaller than the transactionId in (2).
+  @Override
+  public PartitionConsumerResult consumePartitions(PartitionConsumerState partitionConsumerState,
+                                                   PartitionFilter filter, int limit) {
     List<Long> previousInProgress = partitionConsumerState.getVersionsToCheck();
     Set<Long> noLongerInProgress = setDiff(previousInProgress, tx.getInProgress());
 
-    List<Iterator<Partition>> partitionIterators = Lists.newArrayList();
+    List<Partition> partitions = Lists.newArrayList();
+
     for (Long txId : noLongerInProgress) {
+      if (partitions.size() >= limit) {
+        break;
+      }
       Scanner scanner = partitionsTable.readByIndex(WRITE_PTR_COL, Bytes.toBytes(txId));
-      partitionIterators.add(new PartitionIterator(scanner));
+      scannerToPartitions(scanner, partitions, filter, limit);
+      // remove the txIds as they are added to the partitions list already
+      // if they're not removed, they will be persisted in the state for the next scan
+      noLongerInProgress.remove(txId);
     }
 
-    // exclusive scan end
-    long scanUpTo = Math.min(tx.getWritePointer(), tx.getReadPointer() + 1);
-    // no read your own writes (partitions)
-    Scanner scanner = partitionsTable.scanByIndex(WRITE_PTR_COL,
-                                                  Bytes.toBytes(partitionConsumerState.getStartVersion()),
-                                                  Bytes.toBytes(scanUpTo));
-    partitionIterators.add(new PartitionIterator(scanner));
+    // exclusive scan end, to be used as the start for a next call to consumePartitions
+    long scanUpTo;
+    if (partitions.size() < limit) {
+      scanUpTo = Math.min(tx.getWritePointer(), tx.getReadPointer() + 1);
+      // no read your own writes (partitions)
+      Scanner scanner = partitionsTable.scanByIndex(WRITE_PTR_COL,
+                                                    Bytes.toBytes(partitionConsumerState.getStartVersion()),
+                                                    Bytes.toBytes(scanUpTo));
+      Long endTxId = scannerToPartitions(scanner, partitions, filter, limit);
+      if (endTxId != null) {
+        // nonnull means that the scanner was not exhausted
+        scanUpTo = endTxId;
+      }
+    } else {
+      // if we have already hit the limit, don't scan; instead, use the startVersion as the startVersion to the next
+      // call to consumePartitions
+      scanUpTo = partitionConsumerState.getStartVersion();
+    }
 
-    List<Long> inProgressBeforeScanEnd = Lists.newArrayList();
+    List<Long> inProgressBeforeScanEnd = Lists.newArrayList(noLongerInProgress);
     for (long txId : tx.getInProgress()) {
       if (txId >= scanUpTo) {
         break;
@@ -227,7 +306,7 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
       inProgressBeforeScanEnd.add(txId);
     }
     return new PartitionConsumerResult(new PartitionConsumerState(scanUpTo, inProgressBeforeScanEnd),
-                                       Iterators.concat(partitionIterators.iterator()));
+                                       partitions.iterator());
   }
 
   // returns the set of Longs that are in oldLongs, but not in newLongs (oldLongs - newLongs)
@@ -237,46 +316,6 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
       oldLongsSet.remove(newLong);
     }
     return oldLongsSet;
-  }
-
-  private final class PartitionIterator implements Iterator<Partition> {
-    private final Scanner scanner;
-    private Partition partition;
-
-    public PartitionIterator(Scanner scanner) {
-      this.scanner = scanner;
-      this.partition = getNextPartition();
-    }
-
-    @Override
-    public boolean hasNext() {
-      return partition != null;
-    }
-
-    @Override
-    public Partition next() {
-      if (partition == null) {
-        throw new NoSuchElementException();
-      }
-      Partition partitionToReturn = partition;
-      partition = getNextPartition();
-      return partitionToReturn;
-    }
-
-    @Override
-    public void remove() {
-      throw new UnsupportedOperationException();
-    }
-
-    private Partition getNextPartition() {
-      Row row = scanner.next();
-      if (row == null) {
-        return null;
-      }
-      PartitionKey key = parseRowKey(row.getRow(), partitioning);
-      String relativePath = Bytes.toString(row.get(RELATIVE_PATH));
-      return new BasicPartitionDetail(PartitionedFileSetDataset.this, relativePath, key, metadataFromRow(row));
-    }
   }
 
   @Override
@@ -402,8 +441,7 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
         if (metadata == null) {
           metadata = new PartitionMetadata(Collections.<String, String>emptyMap(), 0L);
         }
-        partitionDetails.add(new BasicPartitionDetail(PartitionedFileSetDataset.this, path, key, metadata
-        ));
+        partitionDetails.add(new BasicPartitionDetail(PartitionedFileSetDataset.this, path, key, metadata));
       }
     });
     return partitionDetails;


### PR DESCRIPTION
PartititionedFileSet#consumePartitions should support a limit and partition filter.

In order to support a limit and filter, the scanner on the partitions table has to be scanned during the consumePartitions call, in order for the appropriate PartitionConsumerState to be returned.
Previously, an iterator was returned that lazily did the scanning.

Note:
This PR contains the changes to PartitionedFileSetDataset as well as test cases to test it.
Exposing this functionality to the user (via a PartitionConsumer class to be used from a worker or mapreduce) is not in this PR.

https://issues.cask.co/browse/CDAP-3102
https://issues.cask.co/browse/CDAP-3103

http://builds.cask.co/browse/CDAP-DUT3109-2