### PR TITLE
Fix flaky testTrameworkTest#runTestAppWithPlugin

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunnerTest.java
@@ -171,7 +171,7 @@ public class WorkerProgramRunnerTest {
             }
           });
       }
-    }, 5, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+    }, 5, TimeUnit.SECONDS);
 
     stopProgram(controller);
 
@@ -240,7 +240,7 @@ public class WorkerProgramRunnerTest {
         }
         return controller.getState();
       }
-    }, 30, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+    }, 30, TimeUnit.SECONDS);
 
     return controller;
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -640,7 +640,7 @@ public abstract class AppFabricTestBase {
         }
         return status.get("status").getAsString();
       }
-    }, 60, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+    }, 60, TimeUnit.SECONDS);
   }
 
   private static void createNamespaces() throws Exception {
@@ -721,7 +721,7 @@ public abstract class AppFabricTestBase {
       public Boolean call() throws Exception {
         return getProgramRuns(program, status).size() > expected;
       }
-    }, 60, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+    }, 60, TimeUnit.SECONDS);
   }
 
   protected List<RunRecord> getProgramRuns(Id.Program program, String status) throws Exception {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -95,7 +95,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
       public Integer call() throws Exception {
         return runningProgramCount(program, runId);
       }
-    }, 10, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+    }, 10, TimeUnit.SECONDS);
   }
 
   private Integer runningProgramCount(Id.Program program, String runId) throws Exception {
@@ -404,7 +404,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
         }
         return true;
       }
-    }, 180, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+    }, 180, TimeUnit.SECONDS);
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/ETLWorkerTest.java
@@ -321,7 +321,7 @@ public class ETLWorkerTest extends ETLRealtimeBaseTest {
         // need to wait for information to get to the table, not just for the row to be created
         return row.getColumns().size() != 0;
       }
-    }, 10, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+    }, 10, TimeUnit.SECONDS);
   }
 
   public static void setUp() throws IOException {

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/RealtimeCubeSinkTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/RealtimeCubeSinkTest.java
@@ -88,7 +88,7 @@ public class RealtimeCubeSinkTest extends ETLRealtimeBaseTest {
         Collection<TimeSeries> result = cube.query(buildCubeQuery(startTs));
         return !result.isEmpty();
       }
-    }, 10, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+    }, 10, TimeUnit.SECONDS);
     workerManager.stop();
 
     // verify

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/Tasks.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/Tasks.java
@@ -61,7 +61,25 @@ public final class Tasks {
       Thread.sleep(sleepDelayMs);
     }
     throw new TimeoutException();
+  }
 
+
+  /**
+   * Calls callable, waiting 50 milliseconds between each call,
+   * until it returns the desiredValue or the timeout has passed.
+   *
+   * @param desiredValue the desired value to get from callable
+   * @param callable the callable to check
+   * @param timeout time until we timeout
+   * @param timeoutUnit unit of time for timeout
+   * @param <T> type of desiredValue
+   * @throws TimeoutException if timeout has passed, but didn't get the desiredValue
+   * @throws InterruptedException if something interrupted this waiting operation
+   * @throws ExecutionException if there was an exception in calling the callable
+   */
+  public static <T> void waitFor(T desiredValue, Callable<T> callable, long timeout, TimeUnit timeoutUnit)
+    throws TimeoutException, InterruptedException, ExecutionException {
+    waitFor(desiredValue, callable, timeout, timeoutUnit, 50, TimeUnit.MILLISECONDS);
   }
 }
 

--- a/cdap-examples/WikipediaPipeline/src/test/java/co/cask/cdap/examples/wikipedia/WikipediaPipelineAppTest.java
+++ b/cdap-examples/WikipediaPipeline/src/test/java/co/cask/cdap/examples/wikipedia/WikipediaPipelineAppTest.java
@@ -135,7 +135,7 @@ public class WikipediaPipelineAppTest extends TestBase {
         List<StreamEvent> streamEvents = streamManager.getEvents(0, Long.MAX_VALUE, Integer.MAX_VALUE);
         return streamEvents.size();
       }
-    }, 10, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+    }, 10, TimeUnit.SECONDS);
   }
 
   private void testWorkflow(WorkflowManager workflowManager,

--- a/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
+++ b/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
@@ -255,7 +255,7 @@ public abstract class NotificationTest {
               txContext.finish();
             }
           }
-        }, 5, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+        }, 5, TimeUnit.SECONDS);
       } finally {
         cancellable.cancel();
       }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppUsingGetServiceURL.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppUsingGetServiceURL.java
@@ -245,7 +245,7 @@ public class AppUsingGetServiceURL extends AbstractApplication {
         public Boolean call() throws Exception {
           return getContext().getServiceURL(CENTRAL_SERVICE) != null;
         }
-      }, 10, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+      }, 10, TimeUnit.SECONDS);
     }
 
     private void waitForSuccessfulPing(final URL serviceUrl) throws InterruptedException, ExecutionException,
@@ -260,7 +260,7 @@ public class AppUsingGetServiceURL extends AbstractApplication {
             conn.disconnect();
           }
         }
-      }, 10, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+      }, 10, TimeUnit.SECONDS);
     }
   }
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -641,7 +641,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
       public Integer call() throws Exception {
         return workerManager.getInstances();
       }
-    }, 15, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
+    }, 15, TimeUnit.SECONDS);
   }
 
   @Category(SlowTests.class)

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -256,21 +256,29 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     ApplicationManager appManager = deployApplication(appId, createRequest);
 
-    WorkerManager workerManager = appManager.getWorkerManager(AppWithPlugin.WORKER);
+    final WorkerManager workerManager = appManager.getWorkerManager(AppWithPlugin.WORKER);
     workerManager.start();
     workerManager.waitForStatus(false, 5, 1);
-    List<RunRecord> workerRun = workerManager.getHistory(ProgramRunStatus.COMPLETED);
-    Assert.assertFalse(workerRun.isEmpty());
+    Tasks.waitFor(false, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        return workerManager.getHistory(ProgramRunStatus.COMPLETED).isEmpty();
+      }
+    }, 5, TimeUnit.SECONDS, 10, TimeUnit.MILLISECONDS);
 
-    ServiceManager serviceManager = appManager.getServiceManager(AppWithPlugin.SERVICE);
+    final ServiceManager serviceManager = appManager.getServiceManager(AppWithPlugin.SERVICE);
     serviceManager.start();
     serviceManager.waitForStatus(true, 1, 10);
     URL serviceURL = serviceManager.getServiceURL(5, TimeUnit.SECONDS);
     callServiceGet(serviceURL, "dummy");
     serviceManager.stop();
     serviceManager.waitForStatus(false, 1, 10);
-    List<RunRecord> serviceRun = serviceManager.getHistory(ProgramRunStatus.KILLED);
-    Assert.assertFalse(serviceRun.isEmpty());
+    Tasks.waitFor(false, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        return serviceManager.getHistory(ProgramRunStatus.KILLED).isEmpty();
+      }
+    }, 5, TimeUnit.SECONDS, 10, TimeUnit.MILLISECONDS);
 
     MapReduceManager mrManager = appManager.getMapReduceManager(AppWithPlugin.MAPREDUCE);
     mrManager.start();


### PR DESCRIPTION
The issue is that a program could stop 'RUNNING' (go into 'STOPPING') state, but the run record for it being stopped hasn't been written yet.
So, retry for up to 5 seconds for the stopped run record.

Also had a Tasks#waitFor with a default retry interval of 50 milliseconds, since it is a commonly used value.

https://issues.cask.co/browse/CDAP-4210
http://builds.cask.co/browse/CDAP-DUT3110-2