### PR TITLE
Updates FileSetExample to use CLI and to explain HttpContentConsumer

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/services.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/services.rst
@@ -103,6 +103,8 @@ An example of calling this endpoint with the HTTP RESTful API is shown in the :r
 :ref:`percent-encoding <http-restful-api-conventions-reserved-unsafe-characters>`.
 See the next section, :ref:`services-path-parameters`.
 
+.. _services-content-consumer:
+
 Handling a Large Request Body
 =============================
 Sometimes the request body for a ``PUT`` or ``POST`` request can be huge and it is not feasible to keep all

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -141,7 +141,8 @@ function download_includes() {
   test_an_include 77d244f968d508d9ea2d91e463065b68 ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberSplitter.java
   test_an_include 9f963a17090976d2c15a4d092bd9e8de ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
   
-  test_an_include d2c5d88f05bc2616f3b3eff2aa0b202d ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+  test_an_include 16fabc25230c648f6aa157121145734f ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
+  test_an_include 92ee39ca2ae5940f2daa1fc31471aa8c ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
 
   test_an_include 8a7b4aacee88800cd82d96b07280cc64 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
   test_an_include 2c5094ecef8ca4fa8cadce5a70c88ee4 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
@@ -162,7 +163,7 @@ function download_includes() {
 
   test_an_include afe12d26b79607a846d3eaa58958ea5f ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
   test_an_include 8baaed27c21fe2dd96eddde108722ea6 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
-  test_an_include e5dcbfae4cd7a0cf7b1511288da9c9da ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
+  test_an_include 5f7838093050321c558a0eae4b802c5f ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
   
   test_an_include a33ca6df16ab5443d1d446f13d16348d ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
   test_an_include 91e8be60edf306d7403786d82a04f0c5 ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -144,7 +144,7 @@ function download_includes() {
   test_an_include d2c5d88f05bc2616f3b3eff2aa0b202d ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
 
   test_an_include 8a7b4aacee88800cd82d96b07280cc64 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
-  test_an_include 2fcac6306be022e94623dd1793c47d65 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
+  test_an_include 2c5094ecef8ca4fa8cadce5a70c88ee4 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
   test_an_include 738f54aa72df27c8a7022bd25c92e27f ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
   
   test_an_include f2eb96409a39f0cd1cfa09cb7c917946 ../../cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java

--- a/cdap-docs/examples-manual/source/examples/fileset-example.rst
+++ b/cdap-docs/examples-manual/source/examples/fileset-example.rst
@@ -61,7 +61,7 @@ file, and it opens an input stream for that location. ``Location`` is a file sys
 `Apache Twill Javadocs <http://twill.incubator.apache.org/apidocs/org/apache/twill/filesystem/Location.html>`__.
 
 The ``write`` method uses an ``HttpContentConsumer`` to stream the body of the request to the location specified
-by the ``path`` query parameter. See the section on :ref:`Handling Large Requests<services-content-consumers>`
+by the ``path`` query parameter. See the section on :ref:`Handling Large Requests<services-content-consumer>`
 and the :ref:`Sport Results Example <examples-sport-results>` for a more detailed explanation:
 
 .. literalinclude:: /../../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java

--- a/cdap-docs/examples-manual/source/examples/fileset-example.rst
+++ b/cdap-docs/examples-manual/source/examples/fileset-example.rst
@@ -48,7 +48,7 @@ For example, the ``read`` method returns the contents of the requested file for 
 
 .. literalinclude:: /../../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
     :language: java
-    :lines: 64-86
+    :lines: 64-87
     :dedent: 4
 
 It first instantiates the dataset specified by the first path parameter through its ``HttpServiceContext``.
@@ -60,6 +60,14 @@ file, and it opens an input stream for that location. ``Location`` is a file sys
 `Apache™ Twill® <http://twill.incubator.apache.org>`__; you can read more about its interface in the
 `Apache Twill Javadocs <http://twill.incubator.apache.org/apidocs/org/apache/twill/filesystem/Location.html>`__.
 
+The ``write`` method uses an ``HttpContentConsumer`` to stream the body of the request to the location specified
+by the ``path`` query parameter. See the section on :ref:`Handling Large Requests<services-content-consumers>`
+and the :ref:`Sport Results Example <examples-sport-results>` for a more detailed explanation:
+
+.. literalinclude:: /../../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
+     :language: java
+     :lines: 89-137
+     :dedent: 4
 
 MapReduce over Files
 ====================
@@ -98,19 +106,25 @@ First, we will upload a text file (``some.txt``) that we will use as input for t
 This is done by making a RESTful call to the *FileSetService*.
 A sample text file (``lines.txt``) is included in the ``resources`` directory of the example::
 
-  $ curl -w'\n' localhost:10000/v3/namespaces/default/apps/FileSetExample/services/FileSetService/methods/lines?path=some.txt \
-    -X PUT --data-binary @examples/FileSetExample/resources/lines.txt
+  $ cdap-cli.sh call service FileSetExample.FileSetService PUT "lines?path=some.txt" body:file examples/FileSetExample/resources/lines.txt
 
 Now, we start the MapReduce program and configure it to use the file ``some.txt`` as its input, and to write its output to
 ``counts.out``::
 
-  $ curl -w'\n' localhost:10000/v3/namespaces/default/apps/FileSetExample/mapreduce/WordCount/start \
-    -d '{ "dataset.lines.input.paths": "some.txt", "dataset.counts.output.path": "counts.out" }'
+  $ cdap-cli.sh start mapreduce FileSetExample.WordCount \"dataset.lines.input.paths=some.txt dataset.counts.output.path=counts.out\"
+  Successfully started MapReduce program 'WordCount' of application 'FileSetExample' with provided runtime arguments 'dataset.lines.input.paths=some.txt dataset.counts.output.path=counts.out'
 
-Wait for the MapReduce program to finish, and you can download the results of the computation::
+Check the status of the MapReduce program until it is completed::
 
-  $ curl -w'\n' localhost:10000/v3/namespaces/default/apps/FileSetExample/services/FileSetService/methods/counts?path=counts.out/part-r-00000
-  
+  $ cdap-cli.sh get mapreduce status FileSetExample.WordCount
+  STOPPED
+
+
+and you can download the results of the computation::
+
+  $ cdap-cli.sh call service FileSetExample.FileSetService GET "counts?path=counts.out/part-r-00000"
+  < 200 OK
+  < Content-Length: 60
   a:1
   five:1
   hello:4

--- a/cdap-docs/included-applications/build.sh
+++ b/cdap-docs/included-applications/build.sh
@@ -69,10 +69,10 @@ function download_includes() {
   # Transforms
   test_an_include 06ddd340ba65bbc068ab3e3cf2f346c1 "${cdap_etl}/transform/LogParserTransform.java"
   test_an_include 7b5386499cc1a646e5be38ab5269d076 "${cdap_etl}/transform/ProjectionTransform.java"
-  test_an_include f9e37259336245cf3124c5e75b732648 "${cdap_etl}/transform/ScriptFilterTransform.java"
-  test_an_include 5c854abafe3e629d19ed4ea3543de915 "${cdap_etl}/transform/ScriptTransform.java"
+  test_an_include 38b69087c8a8d58e72a317e78e3b5aea "${cdap_etl}/transform/ScriptFilterTransform.java"
+  test_an_include 8848b0552a3ded6b40007836e9ca7b49 "${cdap_etl}/transform/ScriptTransform.java"
   test_an_include c3eb291d7b7d4ca0934d151bed882dd3 "${cdap_etl}/transform/StructuredRecordToGenericRecordTransform.java"
-  test_an_include 3a8afee673d0f4554bc336bc05e6fc10 "${cdap_etl}/transform/ValidatorTransform.java"
+  test_an_include bb92e174cb13f0a450fd8bd1d2526d4a "${cdap_etl}/transform/ValidatorTransform.java"
 
   # Shared-Plugins
   test_an_include 4fc697d071e894cfce67dbf62c9709d0 "${cdap_etl}/validator/CoreValidator.java"

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
@@ -70,6 +70,7 @@ public class FileSetService extends AbstractService {
       try {
         fileSet = getContext().getDataset(set);
       } catch (DatasetInstantiationException e) {
+        LOG.warn("Error instantiating file set {}", set, e);
         responder.sendError(400, String.format("Invalid file set name '%s'", set));
         return;
       }
@@ -95,6 +96,7 @@ public class FileSetService extends AbstractService {
       try {
         fileSet = getContext().getDataset(set);
       } catch (DatasetInstantiationException e) {
+        LOG.warn("Error instantiating file set {}", set, e);
         responder.sendError(400, String.format("Invalid file set name '%s'", set));
         return null;
       }


### PR DESCRIPTION
- also fixes a bunch of other doc includes (broken MD5 hashes)
- also adds logging a warning in the FileSetService if the dataset can't be instantiated