### PR TITLE
Bump tephra version from '0.6.3-SNAPSHOT' to '0.6.3'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <snappy.version>1.1.1.7</snappy.version>
     <shiro.version>1.2.1</shiro.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <tephra.version>0.6.3-SNAPSHOT</tephra.version>
+    <tephra.version>0.6.3</tephra.version>
     <thrift.version>0.9.0</thrift.version>
     <twill.version>0.6.0-incubating</twill.version>
     <unboundid.version>2.3.6</unboundid.version>


### PR DESCRIPTION
Trying to build CDAP on a machine without 0.6.3-SNAPSHOT already in maven cache will have this issue:
`[ERROR] Failed to execute goal on project cdap-api: Could not resolve dependencies for project co.cask.cdap:cdap-api:jar:3.3.0-SNAPSHOT: Could not find artifact co.cask.tephra:tephra-api:jar:0.6.3-SNAPSHOT in sonatype (https://oss.sonatype.org/content/repositories/snapshots/) -> [Help 1]`
since 0.6.3 was recently released.

http://builds.cask.co/browse/CDAP-DUT3115-1