### PR TITLE
(CDAP-4216) Added support for localizing files in Hydrator. Pipelines…

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/TransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/TransformContext.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.api;
 
+import co.cask.cdap.api.TaskLocalizationContext;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
@@ -25,7 +26,7 @@ import co.cask.cdap.api.plugin.PluginProperties;
  * Context passed to ETL stages.
  */
 @Beta
-public interface TransformContext extends PluginContext, LookupProvider {
+public interface TransformContext extends PluginContext, LookupProvider, TaskLocalizationContext {
 
   /**
    * Gets the {@link PluginProperties} associated with the stage.

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/config/ETLBatchConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/config/ETLBatchConfig.java
@@ -20,8 +20,10 @@ import co.cask.cdap.api.Resources;
 import co.cask.cdap.etl.common.ETLConfig;
 import co.cask.cdap.etl.common.ETLStage;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * ETL Batch Configuration.
@@ -29,34 +31,49 @@ import java.util.List;
 public final class ETLBatchConfig extends ETLConfig {
   private final String schedule;
   private final List<ETLStage> actions;
+  private final List<LocalizeResourceInfo> resourcesToLocalize;
 
   public ETLBatchConfig(String schedule, ETLStage source, List<ETLStage> sinks, List<ETLStage> transforms,
-                        Resources resources, List<ETLStage> actions) {
+                        @Nullable Resources resources, @Nullable List<ETLStage> actions,
+                        @Nullable List<LocalizeResourceInfo> resourcesToLocalize) {
     super(source, sinks, transforms, resources);
     this.schedule = schedule;
     this.actions = actions;
+    this.resourcesToLocalize = resourcesToLocalize;
   }
 
   public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink, List<ETLStage> transforms,
-                        Resources resources, List<ETLStage> actions) {
+                        @Nullable Resources resources, @Nullable List<ETLStage> actions,
+                        @Nullable List<LocalizeResourceInfo> resourcesToLocalize) {
     super(source, sink, transforms, resources);
     this.schedule = schedule;
     this.actions = actions;
+    this.resourcesToLocalize = resourcesToLocalize;
+  }
+
+  public ETLBatchConfig(String schedule, ETLStage source, List<ETLStage> sinks, List<ETLStage> transforms,
+                        @Nullable Resources resources, List<ETLStage> actions) {
+    this(schedule, source, sinks, transforms, resources, actions, null);
   }
 
   public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink, List<ETLStage> transforms,
-                        Resources resources) {
-    this(schedule, source, sink, transforms, resources, null);
+                        @Nullable Resources resources, List<ETLStage> actions) {
+    this(schedule, source, sink, transforms, resources, actions, null);
+  }
+
+  public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink, List<ETLStage> transforms,
+                        @Nullable Resources resources) {
+    this(schedule, source, sink, transforms, resources, null, null);
   }
 
   public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink,
                         List<ETLStage> transforms, List<ETLStage> actions) {
-    this(schedule, source, sink, transforms, null, actions);
+    this(schedule, source, sink, transforms, null, actions, null);
   }
 
   @VisibleForTesting
   public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink, List<ETLStage> transforms) {
-    this(schedule, source, sink, transforms, null, null);
+    this(schedule, source, sink, transforms, null, null, null);
   }
 
   @VisibleForTesting
@@ -70,5 +87,9 @@ public final class ETLBatchConfig extends ETLConfig {
 
   public List<ETLStage> getActions() {
     return actions;
+  }
+
+  public List<LocalizeResourceInfo> getResourcesToLocalize() {
+    return resourcesToLocalize;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/config/LocalizeResourceInfo.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/config/LocalizeResourceInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.config;
+
+/**
+ * Object to represent resources to localize in an ETL Pipeline Config.
+ */
+public class LocalizeResourceInfo {
+  private final String name;
+  private final String uri;
+  private final boolean archive;
+
+  public LocalizeResourceInfo(String name, String uri) {
+    this(name, uri, false);
+  }
+
+  public LocalizeResourceInfo(String name, String uri, boolean archive) {
+    this.name = name;
+    this.uri = uri;
+    this.archive = archive;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getURI() {
+    return uri;
+  }
+
+  public boolean isArchive() {
+    return archive;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/test/transform/RepeaterTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/test/transform/RepeaterTransform.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.test.transform;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.TransformContext;
+import co.cask.cdap.etl.batch.source.FileBatchSource;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Properties;
+
+/**
+ * Created by bhooshanmogal on 11/8/15.
+ */
+@Plugin(type = "transform")
+@Name("Repeater")
+@Description("The Repeater transform repeat a record a specified number of times based on a local properties file.")
+public class RepeaterTransform extends Transform<StructuredRecord, StructuredRecord> {
+
+  private final Config config;
+  private final Properties properties;
+
+  public RepeaterTransform(Config config) {
+    this.config = config;
+    this.properties = new Properties();
+  }
+
+  @Override
+  public void initialize(TransformContext context) throws Exception {
+    File propsFile = context.getLocalFile(config.propsFile);
+    properties.load(new FileInputStream(propsFile));
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
+    String body = input.get("body");
+    int repeatCount = Integer.parseInt(properties.getProperty(body));
+    StringBuilder repeated = new StringBuilder();
+    for (int i = 0; i < repeatCount; i++) {
+      repeated.append(body);
+    }
+    StructuredRecord output = StructuredRecord.builder(FileBatchSource.DEFAULT_SCHEMA)
+      .set("ts", System.currentTimeMillis())
+      .set("body", repeated.toString())
+      .build();
+    emitter.emit(output);
+  }
+
+  public static final class Config extends PluginConfig {
+    @Name("propertiesFile")
+    @Description("Name of the properties file to use in this transform.")
+    String propsFile;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/MapReduceBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/MapReduceBatchContext.java
@@ -22,14 +22,14 @@ import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.batch.BatchContext;
-import co.cask.cdap.etl.common.AbstractTransformContext;
+import co.cask.cdap.etl.common.ClientTransformContext;
 
 import java.util.Map;
 
 /**
  * Abstract implementation of {@link BatchContext} using {@link MapReduceContext}.
  */
-public abstract class MapReduceBatchContext extends AbstractTransformContext implements BatchContext {
+public abstract class MapReduceBatchContext extends ClientTransformContext implements BatchContext {
 
   protected final MapReduceContext mrContext;
   protected final LookupProvider lookup;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/MapReduceRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/MapReduceRuntimeContext.java
@@ -22,21 +22,23 @@ import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
-import co.cask.cdap.etl.common.AbstractTransformContext;
+import co.cask.cdap.etl.common.ExecutionTransformContext;
 
+import java.io.File;
 import java.util.Map;
 
 /**
  * Batch runtime context that delegates most operations to MapReduceTaskContext. It also extends
- * {@link AbstractTransformContext} in order to provide plugin isolation between pipeline plugins. This means sources,
+ * {@link ExecutionTransformContext} in order to provide plugin isolation between pipeline plugins. This means sources,
  * transforms, and sinks don't need to worry that plugins they use conflict with plugins other sources, transforms,
  * or sinks use.
  */
-public class MapReduceRuntimeContext extends AbstractTransformContext implements BatchRuntimeContext {
+public class MapReduceRuntimeContext extends ExecutionTransformContext implements BatchRuntimeContext {
   private final MapReduceTaskContext context;
 
-  public MapReduceRuntimeContext(MapReduceTaskContext context, Metrics metrics, LookupProvider lookup, String stageId) {
-    super(context, metrics, lookup, stageId);
+  public MapReduceRuntimeContext(MapReduceTaskContext context, Metrics metrics, LookupProvider lookup, String stageId,
+                                 Map<String, File> localizedResources) {
+    super(context, metrics, lookup, stageId, localizedResources);
     this.context = context;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ClientTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ClientTransformContext.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.etl.api.LookupProvider;
+import co.cask.cdap.etl.api.TransformContext;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Map;
+
+/**
+ * A {@link TransformContext} for use on the client side in the prepareRun method.
+ * In this context, users are not allowed access resources localized for this pipeline.
+ */
+public class ClientTransformContext extends AbstractTransformContext {
+  public ClientTransformContext(PluginContext pluginContext, Metrics metrics, LookupProvider lookup, String stageId) {
+    super(pluginContext, metrics, lookup, stageId);
+  }
+
+  @Override
+  public File getLocalFile(String name) throws FileNotFoundException {
+    throw new UnsupportedOperationException("Access to local files is not permitted in prepareRun.");
+  }
+
+  @Override
+  public Map<String, File> getAllLocalFiles() {
+    throw new UnsupportedOperationException("Access to local files is not permitted in prepareRun.");
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Constants.java
@@ -83,4 +83,11 @@ public final class Constants {
     public static final String TIMESTAMP = "errTimestamp";
     public static final String INVALIDENTRY = "invalidRecord";
   }
+
+  /**
+   * Constants related to the pipeline configuration
+   */
+  public static final class Pipeline {
+    public static final String LOCAL_RESOURCES = "localResources";
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ExecutionTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ExecutionTransformContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.etl.api.LookupProvider;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Map;
+
+/**
+ * A {@link ExecutionTransformContext} for that is available to plugins in the initialize() method.
+ * Plugins can access resources localized for a pipeline using this context.
+ */
+public class ExecutionTransformContext extends AbstractTransformContext {
+
+  private final Map<String, File> localizedResources;
+
+  public ExecutionTransformContext(PluginContext pluginContext, Metrics metrics, LookupProvider lookup,
+                                   String stageId, Map<String, File> localizedResources) {
+    super(pluginContext, metrics, lookup, stageId);
+    this.localizedResources = localizedResources;
+  }
+
+  @Override
+  public File getLocalFile(String name) throws FileNotFoundException {
+    if (!localizedResources.containsKey(name)) {
+      throw new FileNotFoundException(String.format("Resource %s was not localized for this pipeline", name));
+    }
+    return localizedResources.get(name);
+  }
+
+  @Override
+  public Map<String, File> getAllLocalFiles() {
+    return localizedResources;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/WorkerRealtimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/WorkerRealtimeContext.java
@@ -21,12 +21,12 @@ import co.cask.cdap.api.worker.Worker;
 import co.cask.cdap.api.worker.WorkerContext;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.realtime.RealtimeContext;
-import co.cask.cdap.etl.common.AbstractTransformContext;
+import co.cask.cdap.etl.common.ClientTransformContext;
 
 /**
  * Implementation of {@link RealtimeContext} for {@link Worker} driver.
  */
-public class WorkerRealtimeContext extends AbstractTransformContext implements RealtimeContext {
+public class WorkerRealtimeContext extends ClientTransformContext implements RealtimeContext {
   private final WorkerContext context;
 
   public WorkerRealtimeContext(WorkerContext context, Metrics metrics, LookupProvider lookup, String pluginPrefix) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/common/MockRealtimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/common/MockRealtimeContext.java
@@ -22,6 +22,8 @@ import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.api.realtime.RealtimeContext;
 import com.google.common.collect.Maps;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Map;
 
 /**
@@ -81,5 +83,15 @@ public class MockRealtimeContext implements RealtimeContext {
   @Override
   public <T> Lookup<T> provide(String table, Map<String, String> arguments) {
     return null;
+  }
+
+  @Override
+  public File getLocalFile(String name) throws FileNotFoundException {
+    throw new UnsupportedOperationException("File localization is not supported in Realtime pipelines.");
+  }
+
+  @Override
+  public Map<String, File> getAllLocalFiles() {
+    throw new UnsupportedOperationException("File localization is not supported in Realtime pipelines.");
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/ScriptTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/ScriptTransformTest.java
@@ -179,7 +179,7 @@ public class ScriptTransformTest {
       ));
     Transform<StructuredRecord, StructuredRecord> transform = new ScriptTransform(config);
     transform.initialize(new MockTransformContext(
-      Maps.<String, String>newHashMap(), new MockMetrics(), "", new MockLookupProvider(TEST_LOOKUP)));
+      new HashMap<String, String>(), new MockMetrics(), "", new MockLookupProvider(TEST_LOOKUP)));
 
     MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(STRING_RECORD, emitter);


### PR DESCRIPTION
… can now have the option to send an extra config "localResources" with a list of objects containing keys 'name', 'uri' and 'archive' for each resource that the pipeline needs to localize.

The local resources will be available in each plugin's initialize() method.
Also created two different implementations of TransformContext:
1. ClientTransformContext: Used in prepareRun, onRunFinish. This context does not have access to localized files.
2. ExecutionTransformContext: Used in initialize, transform. Users can retrieve localized files using this context.

Jira: [CDAP-4216](https://issues.cask.co/browse/CDAP-4216)
Build: http://builds.cask.co/browse/CDAP-DUT3114