### PR TITLE
Feature/ui fix secure cluster

### DIFF
--- a/cdap-ui/app/main.js
+++ b/cdap-ui/app/main.js
@@ -254,12 +254,16 @@ angular
    * attached to the <body> tag, mostly responsible for
    *  setting the className based events from $state and caskTheme
    */
-  .controller('BodyCtrl', function ($scope, $cookies, $cookieStore, caskTheme, CASK_THEME_EVENT, $rootScope, $state, $log, MYSOCKET_EVENT, MyCDAPDataSource, MY_CONFIG, MYAUTH_EVENT, EventPipe) {
+  .controller('BodyCtrl', function ($scope, $cookies, $cookieStore, caskTheme, CASK_THEME_EVENT, $rootScope, $state, $log, MYSOCKET_EVENT, MyCDAPDataSource, MY_CONFIG, MYAUTH_EVENT, EventPipe, myAuth) {
 
     var activeThemeClass = caskTheme.getClassName();
     var dataSource = new MyCDAPDataSource($scope);
     if (MY_CONFIG.securityEnabled) {
-      $rootScope.$on(MYAUTH_EVENT.loginSuccess, getVersion);
+      if (myAuth.isAuthenticated()) {
+        getVersion();
+      } else {
+        $rootScope.$on(MYAUTH_EVENT.loginSuccess, getVersion);
+      }
     } else {
       getVersion();
     }

--- a/cdap-ui/app/services/service-status-factory.js
+++ b/cdap-ui/app/services/service-status-factory.js
@@ -15,13 +15,12 @@
  */
 
 angular.module(PKG.name + '.services')
-  .service('ServiceStatusFactory', function(MyCDAPDataSource, $timeout, EventPipe, $state, myAuth) {
+  .service('ServiceStatusFactory', function(MyCDAPDataSource, $timeout, EventPipe, $state, myAuth, $rootScope, MYAUTH_EVENT) {
     this.systemStatus = 'green';
-
     // Apart from invalid token there should be no scenario
     // when we should stop this poll.
     var dataSrc = new MyCDAPDataSource();
-    dataSrc.poll({
+    var poll = dataSrc.poll({
       _cdapPath: '/system/services/status',
       interval: 10000
     },
@@ -51,4 +50,7 @@ angular.module(PKG.name + '.services')
       }
     }
     );
+    $rootScope.$on(MYAUTH_EVENT.logoutSuccess, function() {
+      dataSrc.stopPoll(poll.__pollId__);
+    });
   });

--- a/cdap-ui/app/services/status-factory.js
+++ b/cdap-ui/app/services/status-factory.js
@@ -17,18 +17,28 @@
 angular.module(PKG.name + '.services')
   .service('StatusFactory', function($http, EventPipe, myAuth, $rootScope, MYAUTH_EVENT, MY_CONFIG, $timeout) {
 
+    var isLoggedIn = true;
     this.startPolling = function () {
-      beginPolling.bind(this)();
+      if (isLoggedIn){
+        beginPolling.bind(this)();
+      }
     };
+    this.stopPolling = function() {
+      isLoggedIn = false;
+    };
+    $rootScope.$on(MYAUTH_EVENT.logoutSuccess, this.stopPolling.bind(this));
+
     function beginPolling() {
 
       _.debounce(function() {
-        $http.get(
-          (MY_CONFIG.sslEnabled? 'https://': 'http://') + window.location.host + '/backendstatus',
-          {ignoreLoadingBar: true}
-        )
-             .success(success.bind(this))
-             .error(error.bind(this));
+        if (isLoggedIn) {
+          $http.get(
+            (MY_CONFIG.sslEnabled? 'https://': 'http://') + window.location.host + '/backendstatus',
+            {ignoreLoadingBar: true}
+          )
+               .success(success.bind(this))
+               .error(error.bind(this));
+        }
       }.bind(this), 2000)();
 
     }


### PR DESCRIPTION
- Fixes polling for backend status and services. Stops polling in secure mode when logged out.
- Fixes fetching version once logged in. Previously we just fetched version of cdap on login success. If the user is already logged in we don't fetch the version and this affected hydrator as it required cdap version.

Cluster: http://secure3874-1000.dev.continuuity.net:9999/ns/default
Bamboo Build for RAT checkstyle: http://builds.cask.co/browse/CDAP-DRC2921-1
