### PR TITLE
CDAP-4217 deprecate static schedule creation methods

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/app/AbstractApplication.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/app/AbstractApplication.java
@@ -21,7 +21,6 @@ import co.cask.cdap.api.flow.Flow;
 import co.cask.cdap.api.mapreduce.MapReduce;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.schedule.Schedule;
-import co.cask.cdap.api.schedule.Schedules;
 import co.cask.cdap.api.service.BasicService;
 import co.cask.cdap.api.service.Service;
 import co.cask.cdap.api.service.http.HttpServiceHandler;
@@ -161,37 +160,6 @@ public abstract class AbstractApplication<T extends Config> extends AbstractPlug
     scheduleWorkflow(schedule, workflowName, Collections.<String, String>emptyMap());
   }
 
-  /**
-   * Schedules the specified {@link Workflow} using a time-based schedule.
-   * @param scheduleName the name of the Schedule
-   * @param cronTab the crontab entry for the Schedule
-   * @param workflowName the name of the Workflow
-   * @deprecated As of version 2.8.0, replaced by {@link #scheduleWorkflow(Schedule, String)}
-   */
-  @Deprecated
-  protected void scheduleWorkflow(String scheduleName, String cronTab, String workflowName) {
-    String scheduleDescription = scheduleName + " with crontab " + cronTab;
-    scheduleWorkflow(Schedules.createTimeSchedule(scheduleName, scheduleDescription, cronTab),
-                     workflowName, Collections.<String, String>emptyMap());
-  }
-
-  /**
-   * Schedules the specified {@link Workflow} using a time-based schedule.
-   * @param scheduleName the name of the Schedule
-   * @param cronTab the crontab entry for the Schedule
-   * @param workflowName the name of the Workflow
-   * @param properties properties to be added for the Schedule
-   * @deprecated As of version 2.8.0, replaced by 
-   *            {@link #scheduleWorkflow(Schedule, String, Map) 
-   *             scheduleWorkflow(Schedule, String, Map&lt;String, String&gt;)}
-   */
-  @Deprecated
-  protected void scheduleWorkflow(String scheduleName, String cronTab, String workflowName,
-                                  Map<String, String> properties) {
-    String scheduleDescription = scheduleName + " with crontab " + cronTab;
-    scheduleWorkflow(Schedules.createTimeSchedule(scheduleName, scheduleDescription, cronTab),
-                     workflowName, properties);
-  }
 
   /**
    * Schedule the specified {@link Workflow}

--- a/cdap-api/src/main/java/co/cask/cdap/api/schedule/Schedule.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/schedule/Schedule.java
@@ -30,24 +30,9 @@ public class Schedule {
 
   private final RunConstraints runConstraints;
 
-  // NOTE: the below attribute is left for backwards compatibility
-  private final String cronEntry;
-
-  /**
-   * @deprecated use {@link Schedules} instead.
-   */
-  @Deprecated
-  public Schedule(String name, String description, String cronEntry) {
-    this.name = name;
-    this.description = description;
-    this.cronEntry = cronEntry;
-    this.runConstraints = RunConstraints.NONE;
-  }
-
   protected Schedule(String name, String description, RunConstraints runConstraints) {
     this.name = name;
     this.description = description;
-    this.cronEntry = null;
     this.runConstraints = runConstraints;
   }
 
@@ -63,15 +48,6 @@ public class Schedule {
    */
   public String getDescription() {
     return description;
-  }
-
-  /**
-   * @return Cron expression for the schedule.
-   * @deprecated As of version 2.8.0, do not use this method anymore
-   */
-  @Deprecated
-  public String getCronEntry() {
-    return cronEntry;
   }
 
   public RunConstraints getRunConstraints() {
@@ -92,13 +68,12 @@ public class Schedule {
 
     return Objects.equals(name, that.name) &&
       Objects.equals(description, that.description) &&
-      Objects.equals(cronEntry, that.cronEntry) &&
       Objects.equals(getRunConstraints(), that.getRunConstraints());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, description, cronEntry, getRunConstraints());
+    return Objects.hash(name, description, getRunConstraints());
   }
 
   @Override
@@ -106,7 +81,6 @@ public class Schedule {
     StringBuilder sb = new StringBuilder("Schedule{");
     sb.append("name='").append(name).append('\'');
     sb.append(", description='").append(description).append('\'');
-    sb.append(", cronEntry='").append(cronEntry).append('\'');
     sb.append(", runConstraints='").append(getRunConstraints()).append('\'');
     sb.append('}');
     return sb.toString();

--- a/cdap-api/src/main/java/co/cask/cdap/api/schedule/Schedules.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/schedule/Schedules.java
@@ -31,7 +31,9 @@ public final class Schedules {
    * @param description description of the schedule
    * @param cronExpression cron expression for the schedule
    * @return a schedule based on the given {@code cronExpression}
+   * @deprecated As of version 3.3.0, replaced by {@link #builder(String)}.
    */
+  @Deprecated
   public static Schedule createTimeSchedule(String name, String description, String cronExpression) {
     return new TimeSchedule(name, description, cronExpression);
   }
@@ -45,7 +47,9 @@ public final class Schedules {
    * @param sourceName name of the source of data the schedule is based on
    * @param dataTriggerMB the size of data, in MB, that the source has to receive to trigger an execution
    * @return a schedule based on data availability in the given {@code dataSourceName}
+   * @deprecated As of version 3.3.0, replaced by {@link #builder(String)}.
    */
+  @Deprecated
   public static Schedule createDataSchedule(String name, String description, Source source, String sourceName,
                                             int dataTriggerMB) {
     switch (source) {

--- a/cdap-api/src/main/java/co/cask/cdap/internal/schedule/TimeSchedule.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/schedule/TimeSchedule.java
@@ -35,11 +35,9 @@ public final class TimeSchedule extends Schedule {
     this.cronExpression = cronExpression;
   }
 
-
   /**
    * @return Cron expression for the schedule, if this schedule is a time based schedule.
    */
-  @Override
   public String getCronEntry() {
     return cronExpression;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
@@ -207,10 +207,6 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
     Preconditions.checkArgument(!schedules.containsKey(schedule.getName()), "Schedule with the name '" +
       schedule.getName()  + "' already exists.");
     Schedule realSchedule = schedule;
-    if (schedule.getClass().equals(Schedule.class)) {
-      realSchedule = Schedules.createTimeSchedule(schedule.getName(), schedule.getDescription(),
-                                                  schedule.getCronEntry());
-    }
     if (realSchedule instanceof StreamSizeSchedule) {
       Preconditions.checkArgument(((StreamSizeSchedule) schedule).getDataTriggerMB() > 0,
                                   "Schedule data trigger must be greater than 0.");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
@@ -29,7 +29,6 @@ import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.schedule.Schedule;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
-import co.cask.cdap.api.schedule.Schedules;
 import co.cask.cdap.api.service.Service;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.api.spark.Spark;
@@ -206,14 +205,13 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
     Preconditions.checkArgument(!programName.isEmpty(), "Program name cannot be empty.");
     Preconditions.checkArgument(!schedules.containsKey(schedule.getName()), "Schedule with the name '" +
       schedule.getName()  + "' already exists.");
-    Schedule realSchedule = schedule;
-    if (realSchedule instanceof StreamSizeSchedule) {
+    if (schedule instanceof StreamSizeSchedule) {
       Preconditions.checkArgument(((StreamSizeSchedule) schedule).getDataTriggerMB() > 0,
                                   "Schedule data trigger must be greater than 0.");
     }
 
     ScheduleSpecification spec =
-      new ScheduleSpecification(realSchedule, new ScheduleProgramInfo(programType, programName), properties);
+      new ScheduleSpecification(schedule, new ScheduleProgramInfo(programType, programName), properties);
 
     schedules.put(schedule.getName(), spec);
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithMultipleScheduledWorkflows.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithMultipleScheduledWorkflows.java
@@ -34,11 +34,11 @@ public class AppWithMultipleScheduledWorkflows extends AbstractApplication {
     setDescription("Sample application with multiple Workflows");
     addWorkflow(new SomeWorkflow());
     addWorkflow(new AnotherWorkflow());
-    scheduleWorkflow(Schedules.createTimeSchedule("SomeSchedule1", "", "0 4 * * *"), "SomeWorkflow");
-    scheduleWorkflow(Schedules.createTimeSchedule("SomeSchedule2", "", "0 5 * * *"), "SomeWorkflow");
-    scheduleWorkflow(Schedules.createTimeSchedule("AnotherSchedule1", "", "0 6 * * *"), "AnotherWorkflow");
-    scheduleWorkflow(Schedules.createTimeSchedule("AnotherSchedule2", "", "0 7 * * *"), "AnotherWorkflow");
-    scheduleWorkflow(Schedules.createTimeSchedule("AnotherSchedule3", "", "0 8 * * *"), "AnotherWorkflow");
+    scheduleWorkflow(Schedules.builder("SomeSchedule1").createTimeSchedule("0 4 * * *"), "SomeWorkflow");
+    scheduleWorkflow(Schedules.builder("SomeSchedule2").createTimeSchedule("0 5 * * *"), "SomeWorkflow");
+    scheduleWorkflow(Schedules.builder("AnotherSchedule1").createTimeSchedule("0 6 * * *"), "AnotherWorkflow");
+    scheduleWorkflow(Schedules.builder("AnotherSchedule2").createTimeSchedule("0 7 * * *"), "AnotherWorkflow");
+    scheduleWorkflow(Schedules.builder("AnotherSchedule3").createTimeSchedule("0 8 * * *"), "AnotherWorkflow");
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithSchedule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithSchedule.java
@@ -50,8 +50,11 @@ public class AppWithSchedule extends AbstractApplication {
       scheduleProperties.put("anotherKey", "anotherValue");
       scheduleProperties.put("someKey", "someValue");
 
-      scheduleWorkflow(Schedules.createTimeSchedule("SampleSchedule", "Sample schedule", "0/1 * * * * ?"),
-                       "SampleWorkflow", scheduleProperties);
+      scheduleWorkflow(Schedules.builder("SampleSchedule")
+                         .setDescription("Sample schedule")
+                         .createTimeSchedule("0/1 * * * * ?"),
+                       "SampleWorkflow",
+                       scheduleProperties);
     } catch (UnsupportedTypeException e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithStreamSizeSchedule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithStreamSizeSchedule.java
@@ -53,9 +53,9 @@ public class AppWithStreamSizeSchedule extends AbstractApplication {
       scheduleProperties.put("anotherKey", "anotherValue");
       scheduleProperties.put("someKey", "someValue");
 
-      scheduleWorkflow(Schedules.createDataSchedule("SampleSchedule1", "", Schedules.Source.STREAM, "stream", 1),
+      scheduleWorkflow(Schedules.builder("SampleSchedule1").createDataSchedule(Schedules.Source.STREAM, "stream", 1),
                        "SampleWorkflow", scheduleProperties);
-      scheduleWorkflow(Schedules.createDataSchedule("SampleSchedule2", "", Schedules.Source.STREAM, "stream", 2),
+      scheduleWorkflow(Schedules.builder("SampleSchedule2").createDataSchedule(Schedules.Source.STREAM, "stream", 2),
                        "SampleWorkflow", scheduleProperties);
     } catch (UnsupportedTypeException e) {
       throw Throwables.propagate(e);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/ConcurrentWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/ConcurrentWorkflowApp.java
@@ -40,12 +40,12 @@ public class ConcurrentWorkflowApp extends AbstractApplication {
     // Schedule Workflow
     Map<String, String> schedule1Properties = Maps.newHashMap();
     schedule1Properties.put("schedule.name", "concurrentWorkflowSchedule1");
-    scheduleWorkflow(Schedules.createTimeSchedule("concurrentWorkflowSchedule1", "", "* * * * *"),
+    scheduleWorkflow(Schedules.builder("concurrentWorkflowSchedule1").createTimeSchedule("* * * * *"),
                      "ConcurrentWorkflow", schedule1Properties);
 
     Map<String, String> schedule2Properties = Maps.newHashMap();
     schedule2Properties.put("schedule.name", "concurrentWorkflowSchedule2");
-    scheduleWorkflow(Schedules.createTimeSchedule("concurrentWorkflowSchedule2", "", "* * * * *"),
+    scheduleWorkflow(Schedules.builder("concurrentWorkflowSchedule2").createTimeSchedule("* * * * *"),
                      "ConcurrentWorkflow", schedule2Properties);
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/ScheduleAppWithMissingWorkflow.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/ScheduleAppWithMissingWorkflow.java
@@ -29,7 +29,9 @@ public class ScheduleAppWithMissingWorkflow extends AbstractApplication {
     setName("ScheduleAppWithMissingWorkflow");
     setDescription("App that schedules a missing Workflow");
     addMapReduce(new NoOpMR());
-    scheduleWorkflow(Schedules.createTimeSchedule("EveryOneMinuteSchedule", "", "* * * * *"), "NonExistentWorkflow");
+    scheduleWorkflow(Schedules.builder("EveryOneMinuteSchedule")
+                       .createTimeSchedule("* * * * *"),
+                     "NonExistentWorkflow");
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowSchedulesWithSameNameApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowSchedulesWithSameNameApp.java
@@ -29,9 +29,11 @@ public class WorkflowSchedulesWithSameNameApp extends AbstractApplication {
     setName("WorkflowSchedulesWithSameNameApp");
     setDescription("Application with Workflow containing multiple schedules with the same name");
     addWorkflow(new WorkflowSchedulesWithSameName());
-    scheduleWorkflow(Schedules.createTimeSchedule("DailySchedule", "", "0 4 * * *"), "WorkflowSchedulesWithSameName");
+    scheduleWorkflow(Schedules.builder("DailySchedule").createTimeSchedule("0 4 * * *"),
+                     "WorkflowSchedulesWithSameName");
     // configuring Workflow with the same schedule name again should fail
-    scheduleWorkflow(Schedules.createTimeSchedule("DailySchedule", "", "0 5 * * *"), "WorkflowSchedulesWithSameName");
+    scheduleWorkflow(Schedules.builder("DailySchedule").createTimeSchedule("0 5 * * *"),
+                     "WorkflowSchedulesWithSameName");
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
@@ -60,22 +60,30 @@ public class SchedulerServiceTest {
                                                            AppWithWorkflow.SampleWorkflow.NAME);
   private static final SchedulableProgramType programType = SchedulableProgramType.WORKFLOW;
   private static final Id.Stream STREAM_ID = Id.Stream.from(namespace, "stream");
-  private static final Schedule TIME_SCHEDULE_0 =
-    Schedules.createTimeSchedule("Schedule0", "Next 10 minutes", getCron(10, TimeUnit.MINUTES));
-  private static final Schedule TIME_SCHEDULE_1 =
-    Schedules.createTimeSchedule("Schedule1", "Next hour", getCron(1, TimeUnit.HOURS));
-  private static final Schedule TIME_SCHEDULE_2 =
-    Schedules.createTimeSchedule("Schedule2", "Next day", getCron(1, TimeUnit.DAYS));
-  private static final Schedule TIME_SCHEDULE_3 =
-    Schedules.createTimeSchedule("Schedule3", "Next Week", getCron(7, TimeUnit.DAYS));
-  private static final Schedule DATA_SCHEDULE_1 =
-    Schedules.createDataSchedule("Schedule3", "Every 1M", Schedules.Source.STREAM, STREAM_ID.getId(), 1);
-  private static final Schedule DATA_SCHEDULE_2 =
-    Schedules.createDataSchedule("Schedule4", "Every 10M", Schedules.Source.STREAM, STREAM_ID.getId(), 10);
-  private static final Schedule UPDATED_TIME_SCHEDULE_1 =
-    Schedules.createTimeSchedule("Schedule1", "Next 2 Hour", getCron(2, TimeUnit.HOURS));
-  private static final Schedule UPDATED_DATA_SCHEDULE_2 =
-    Schedules.createDataSchedule("Schedule4", "Every 5M", Schedules.Source.STREAM, STREAM_ID.getId(), 5);
+  private static final Schedule TIME_SCHEDULE_0 = Schedules.builder("Schedule0")
+    .setDescription("Next 10 minutes")
+    .createTimeSchedule(getCron(10, TimeUnit.MINUTES));
+  private static final Schedule TIME_SCHEDULE_1 = Schedules.builder("Schedule1")
+    .setDescription("Next hour")
+    .createTimeSchedule(getCron(1, TimeUnit.HOURS));
+  private static final Schedule TIME_SCHEDULE_2 = Schedules.builder("Schedule2")
+    .setDescription("Next day")
+    .createTimeSchedule(getCron(1, TimeUnit.DAYS));
+  private static final Schedule TIME_SCHEDULE_3 = Schedules.builder("Schedule3")
+    .setDescription("Next Week")
+    .createTimeSchedule(getCron(7, TimeUnit.DAYS));
+  private static final Schedule DATA_SCHEDULE_1 = Schedules.builder("Schedule3")
+    .setDescription("Every 1M")
+    .createDataSchedule(Schedules.Source.STREAM, STREAM_ID.getId(), 1);
+  private static final Schedule DATA_SCHEDULE_2 = Schedules.builder("Schedule4")
+    .setDescription("Every 10M")
+    .createDataSchedule(Schedules.Source.STREAM, STREAM_ID.getId(), 10);
+  private static final Schedule UPDATED_TIME_SCHEDULE_1 = Schedules.builder("Schedule1")
+    .setDescription("Next 2 Hour")
+    .createTimeSchedule(getCron(2, TimeUnit.HOURS));
+  private static final Schedule UPDATED_DATA_SCHEDULE_2 = Schedules.builder("Schedule4")
+   .setDescription("Every 5M")
+    .createDataSchedule(Schedules.Source.STREAM, STREAM_ID.getId(), 5);
   private ApplicationSpecification applicationSpecification;
 
   @Rule

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
@@ -62,8 +62,9 @@ public abstract class SchedulerTestBase {
   private static final String SCHEDULE_NAME_2 = "SampleSchedule2";
   private static final SchedulableProgramType PROGRAM_TYPE = SchedulableProgramType.WORKFLOW;
   private static final Id.Stream STREAM_ID = Id.Stream.from(Id.Namespace.DEFAULT, "stream");
-  private static final Schedule UPDATE_SCHEDULE_2 =
-    Schedules.createDataSchedule(SCHEDULE_NAME_2, "Every 1M", Schedules.Source.STREAM, STREAM_ID.getId(), 1);
+  private static final Schedule UPDATE_SCHEDULE_2 = Schedules.builder(SCHEDULE_NAME_2)
+    .setDescription("Every 1M")
+    .createDataSchedule(Schedules.Source.STREAM, STREAM_ID.getId(), 1);
 
   protected interface StreamMetricsPublisher {
     void increment(long size) throws Exception;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -795,10 +795,15 @@ public class DefaultStoreTest {
   private static final Id.Program program = new Id.Program(appId, ProgramType.WORKFLOW,
                                                            AppWithWorkflow.SampleWorkflow.NAME);
   private static final SchedulableProgramType programType = SchedulableProgramType.WORKFLOW;
-  private static final Schedule schedule1 = Schedules.createTimeSchedule("Schedule1", "Every minute", "* * * * ?");
-  private static final Schedule schedule2 = Schedules.createTimeSchedule("Schedule2", "Every Hour", "0 * * * ?");
-  private static final Schedule scheduleWithSameName = Schedules.createTimeSchedule("Schedule2", "Every minute",
-                                                                                    "* * * * ?");
+  private static final Schedule schedule1 = Schedules.builder("Schedule1")
+    .setDescription("Every minute")
+    .createTimeSchedule("* * * * ?");
+  private static final Schedule schedule2 = Schedules.builder("Schedule2")
+    .setDescription("Every Hour")
+    .createTimeSchedule("0 * * * ?");
+  private static final Schedule scheduleWithSameName = Schedules.builder("Schedule2")
+    .setDescription("Every minute")
+    .createTimeSchedule("* * * * ?");
   private static final Map<String, String> properties1 = ImmutableMap.of();
   private static final Map<String, String> properties2 = ImmutableMap.of();
   private static final ScheduleSpecification scheduleSpec1 =

--- a/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/DataQualityApp.java
+++ b/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/DataQualityApp.java
@@ -129,9 +129,10 @@ public class DataQualityApp extends AbstractApplication<DataQualityApp.DataQuali
     addService(new DataQualityService(configObj.datasetName));
     addWorkflow(new DataQualityWorkflow());
     String schedule = "*/" + scheduleMinutes + " * * * *";
-    scheduleWorkflow(Schedules.createTimeSchedule("aggregatorSchedule",
-                                                  "Schedule execution every " + scheduleMinutes
-                                                    + " min", schedule), "DataQualityWorkflow");
+    scheduleWorkflow(Schedules.builder("aggregatorSchedule")
+                       .setDescription("Schedule execution every " + scheduleMinutes + " min")
+                      .createTimeSchedule(schedule),
+                     "DataQualityWorkflow");
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/ETLBatchApplication.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/ETLBatchApplication.java
@@ -33,7 +33,9 @@ public class ETLBatchApplication extends AbstractApplication<ETLBatchConfig> {
     setDescription(DEFAULT_DESCRIPTION);
     addMapReduce(new ETLMapReduce(config));
     addWorkflow(new ETLWorkflow(config));
-    scheduleWorkflow(Schedules.createTimeSchedule(SCHEDULE_NAME, "ETL Batch schedule", config.getSchedule()),
+    scheduleWorkflow(Schedules.builder(SCHEDULE_NAME)
+                       .setDescription("ETL Batch schedule")
+                       .createTimeSchedule(config.getSchedule()),
                      ETLWorkflow.NAME);
   }
 }

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeApp.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeApp.java
@@ -60,9 +60,10 @@ public class FakeApp extends AbstractApplication {
     addFlow(new FakeFlow());
     addSpark(new FakeSpark());
     addWorkflow(new FakeWorkflow());
-    scheduleWorkflow(Schedules.createTimeSchedule(SCHEDULE_NAME, "", SCHEDULE_CRON), FakeWorkflow.NAME);
-    scheduleWorkflow(Schedules.createDataSchedule(STREAM_SCHEDULE_NAME, "", Schedules.Source.STREAM,
-                                                  STREAM_NAME, STREAM_TRIGGER_MB), FakeWorkflow.NAME);
+    scheduleWorkflow(Schedules.builder(SCHEDULE_NAME).createTimeSchedule(SCHEDULE_CRON), FakeWorkflow.NAME);
+    scheduleWorkflow(Schedules.builder(STREAM_SCHEDULE_NAME)
+                       .createDataSchedule(Schedules.Source.STREAM, STREAM_NAME, STREAM_TRIGGER_MB),
+                     FakeWorkflow.NAME);
     addService(PingService.NAME, new PingService());
     addService(PrefixedEchoHandler.NAME, new PrefixedEchoHandler());
   }

--- a/cdap-docs/developers-manual/source/building-blocks/schedules.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/schedules.rst
@@ -13,7 +13,7 @@ can add a schedule to a workflow using the ``scheduleWorkflow`` method of the
 `AbstractApplication class <../../reference-manual/javadocs/co/cask/cdap/api/app/AbstractApplication.html#scheduleWorkflow(co.cask.cdap.api.schedule.Schedule,%20java.lang.String)>`__
 
 The `Schedules <../../reference-manual/javadocs/co/cask/cdap/api/schedule/Schedules.html>`__
-class contains static methods to create schedules based on time, or schedules based on data availability.
+class contains a builder to create schedules based on time, or schedules based on data availability.
 
 The name of a schedule must be unique in the application that it is in; the same name can
 be used in different applications.
@@ -30,10 +30,12 @@ Time Schedules
 ==============
 
 **Time schedules** will execute based on a
-`crontab schedule <../../reference-manual/javadocs/co/cask/cdap/api/schedule/Schedules.html#createTimeSchedule(java.lang.String,%20java.lang.String,%20java.lang.String)>`__.
+`crontab schedule <../../reference-manual/javadocs/co/cask/cdap/api/schedule/Schedules.Builder.html#createTimeSchedule(java.lang.String)>`__.
 You can add such a schedule to a workflow::
 
-    scheduleWorkflow(Schedules.createTimeSchedule("FiveHourSchedule", "Schedule running every 5 hours", "0 */5 * * *"),
+    scheduleWorkflow(Schedules.builder("FiveHourSchedule")
+                       .setDescription("Schedule running every 5 hours")
+                       .createTimeSchedule("0 */5 * * *"),
                      "MyWorkflow");
 
 The ``MyWorkflow`` will then be executed every 5 hours.
@@ -45,7 +47,9 @@ Optionally, you can specify the properties for the schedule::
     scheduleProperties.put("myProperty", "10");
     scheduleProperties.put("anotherProperty", "anotherValue");
 
-    scheduleWorkflow(Schedules.createTimeSchedule("FiveHourSchedule", "Schedule running every 5 hours", "0 */5 * * *"),
+    scheduleWorkflow(Schedules.builder("FiveHourSchedule")
+                       .setDescription("Schedule running every 5 hours")
+                       .createTimeSchedule("0 */5 * * *"),
                      "MyWorkflow", scheduleProperties);
     ...
 
@@ -60,12 +64,13 @@ Stream-size Schedules
 .. rubric:: Definition and Usage
 
 **Stream-size schedules** will execute based on data ingested in :ref:`streams <streams>`, using the
-`createDataSchedule API <../../reference-manual/javadocs/co/cask/cdap/api/schedule/Schedules.html#createDataSchedule(java.lang.String,%20java.lang.String,%20co.cask.cdap.api.schedule.Source,%20java.lang.String,%20int)>`__.
+`createDataSchedule API <../../reference-manual/javadocs/co/cask/cdap/api/schedule/Schedules.Builder.html#createDataSchedule(co.cask.cdap.api.schedule.Schedules.Source,%20java.lang.String,%20int)>`__.
 Here is an example to add a stream-size schedule based on a stream named ``purchaseStream`` that triggers
 every time the stream has ingested 1MB of data::
 
-    scheduleWorkflow(Schedules.createDataSchedule("1MBStreamSchedule", "Schedule triggered every 1MB of ingested data",
-                                                  Schedules.Source.STREAM, "purchaseStream", 1),
+    scheduleWorkflow(Schedules.builder("1MBStreamSchedule")
+                       .setDescription("Schedule triggered every 1MB of ingested data")
+                       .createDataSchedule(Schedules.Source.STREAM, "purchaseStream", 1),
                      "MyWorkflow");
 
 The ``purchaseStream`` will either have to already exist in CDAP when deploying your application, or you will have to
@@ -80,8 +85,9 @@ You can optionally specify the properties for the schedule::
     scheduleProperties.put("myProperty", "10");
     scheduleProperties.put("anotherProperty", "anotherValue");
 
-    scheduleWorkflow(Schedules.createDataSchedule("1MBStreamSchedule", "Schedule triggered every 1MB of ingested data",
-                                                  Schedules.Source.STREAM, "purchaseStream", 1),
+    scheduleWorkflow(Schedules.builder("1MBStreamSchedule")
+                       .setDescription("Schedule triggered every 1MB of ingested data")
+                       .createDataSchedule(Schedules.Source.STREAM, "purchaseStream", 1),
                      "MyWorkflow", scheduleProperties);
     ...
 
@@ -98,7 +104,7 @@ information by querying the metric system, which is the canonical source of info
 
 A stream-size schedule will execute a workflow every time the stream it references ingests an increment of data,
 also defined in the
-`schedule <../../reference-manual/javadocs/co/cask/cdap/api/schedule/Schedules.html#createDataSchedule(java.lang.String,%20java.lang.String,%20co.cask.cdap.api.schedule.Source,%20java.lang.String,%20int)>`__.
+`schedule <../../reference-manual/javadocs/co/cask/cdap/api/schedule/Schedules.Builder.html#createDataSchedule(co.cask.cdap.api.schedule.Schedules.Source,%20java.lang.String,%20int)>`__.
 
 When a stream-size schedule is first created, during the deployment of an application, it will wait for the
 increment of data that it defined, starting from the current size of the stream as given by the Metric system.

--- a/cdap-docs/developers-manual/source/building-blocks/workflows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/workflows.rst
@@ -48,9 +48,8 @@ Executing MapReduce or Spark Programs
 -------------------------------------
 To execute MapReduce or Spark programs in a workflow, you will need to add them in your
 application along with the workflow. You can optionally add a :ref:`schedule <schedules>` 
-(such as a `crontab schedule 
-<../../reference-manual/javadocs/co/cask/cdap/api/app/AbstractApplication.html#scheduleWorkflow(java.lang.String,%20java.lang.String,%20java.lang.String)>`__)
-to the workflow::
+to the workflow using the `java api 
+<../../reference-manual/javadocs/co/cask/cdap/api/app/AbstractApplication.html#scheduleWorkflow(co.cask.cdap.api.schedule.Schedule,%20java.lang.String)>`__::
 
   public void configure() {
     ...
@@ -58,9 +57,9 @@ to the workflow::
     addMapReduce(new AnotherMapReduce());
     addSpark(new MySpark());
     addWorkflow(new MyWorkflow());
-    scheduleWorkflow(Schedules.createTimeSchedule("FiveHourSchedule", 
-                                                  "Schedule running every 5 hours", 
-                                                  "0 */5 * * *"),
+    scheduleWorkflow(Schedules.builder("FiveHourSchedule")
+                       .setDescription("Schedule running every 5 hours")
+                       .createTimeSchedule("0 */5 * * *"),
                      "MyWorkflow");
     ...
   }

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -151,7 +151,7 @@ function download_includes() {
 
   test_an_include a9a7fd53c199defff09e6e3c73e4e71f ../../cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
   
-  test_an_include cdd3edfefe86857da8f41889d433d434 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
+  test_an_include 38245f25cef322b873b729a1e1286235 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
   test_an_include b53dd493c4e9c2cb89b593baa4139087 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
   test_an_include 80216a08a2b3d480e4a081722408222f ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
@@ -164,7 +164,7 @@ function download_includes() {
   test_an_include 8baaed27c21fe2dd96eddde108722ea6 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
   test_an_include 5f7838093050321c558a0eae4b802c5f ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
   
-  test_an_include a33ca6df16ab5443d1d446f13d16348d ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
+  test_an_include 41db6b1cd160fd92bf03395454414206 ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
   test_an_include 91e8be60edf306d7403786d82a04f0c5 ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
   
   test_an_include 2260781c7cef2938aa36c946f3a34341 ../../cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfiles.java

--- a/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
+++ b/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
@@ -41,7 +41,9 @@ public class StreamConversionApp extends AbstractApplication {
     addStream(new Stream("events"));
     addMapReduce(new StreamConversionMapReduce());
     addWorkflow(new StreamConversionWorkflow());
-    scheduleWorkflow(Schedules.createTimeSchedule("every5min", "runs every 5 minutes", "*/5 * * * *"),
+    scheduleWorkflow(Schedules.builder("every5min")
+                       .setDescription("runs every 5 minutes")
+                       .createTimeSchedule("*/5 * * * *"),
                      "StreamConversionWorkflow");
 
     // create the time-partitioned file set, configure it to work with MapReduce and with Explore

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/ScheduleSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/ScheduleSpecificationCodec.java
@@ -80,7 +80,6 @@ public class ScheduleSpecificationCodec extends AbstractSpecificationCodec<Sched
     return jsonObj;
   }
 
-  @SuppressWarnings("deprecation")
   @Override
   public ScheduleSpecification deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
     throws JsonParseException {
@@ -97,8 +96,11 @@ public class ScheduleSpecificationCodec extends AbstractSpecificationCodec<Sched
 
     Schedule schedule = null;
     if (scheduleType == null) {
-      schedule = context.deserialize(jsonObj.get("schedule"), Schedule.class);
-      schedule = Schedules.createTimeSchedule(schedule.getName(), schedule.getDescription(), schedule.getCronEntry());
+      JsonObject scheduleObj = jsonObj.get("schedule").getAsJsonObject();
+      String name = context.deserialize(scheduleObj.get("name"), String.class);
+      String description = context.deserialize(scheduleObj.get("description"), String.class);
+      String cronEntry = context.deserialize(scheduleObj.get("cronEntry"), String.class);
+      schedule = Schedules.builder(name).setDescription(description).createTimeSchedule(cronEntry);
     } else {
       switch (scheduleType) {
         case TIME:

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithSchedule.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithSchedule.java
@@ -44,7 +44,7 @@ public class AppWithSchedule extends AbstractApplication {
       ObjectStores.createObjectStore(getConfigurer(), "input", String.class);
       ObjectStores.createObjectStore(getConfigurer(), "output", String.class);
       addWorkflow(new SampleWorkflow());
-      scheduleWorkflow(Schedules.createTimeSchedule("SampleSchedule", "", "0/1 * * * * ?"), "SampleWorkflow");
+      scheduleWorkflow(Schedules.builder("SampleSchedule").createTimeSchedule("0/1 * * * * ?"), "SampleWorkflow");
     } catch (UnsupportedTypeException e) {
       throw Throwables.propagate(e);
     }


### PR DESCRIPTION
removing the static creation methods in Schedules in favor of the
builder that was recently added. Also removing usage of those
methods in the codebase.

Also removing schedule methods that have been deprecated since 2.8.0.