### PR TITLE
Fix typos.

### DIFF
--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -32,7 +32,7 @@ Follow these instructions only if you aren't using a cluster manager such as :re
 Manager <cloudera-configuring>` or :ref:`Apache Ambari <ambari-configuring>`. For the Mapr
 distribution, we have :ref:`additional instructions <mapr-configuring>` to start with;
 please read those before continuing. These instructions *do not apply* to the
-:ref:`standalone SDK <standalone-index>`
+:ref:`standalone SDK <standalone-index>`.
 
 .. _install-these-are-the-cdap-components:
 

--- a/cdap-docs/admin-manual/source/installation/quick-start.rst
+++ b/cdap-docs/admin-manual/source/installation/quick-start.rst
@@ -14,7 +14,7 @@ CDAP on a Hadoop cluster, through the running of a verification application in C
 .. "Follow these instructions"
 
 .. include:: installation.rst 
-   :start-after: .. _install-follow-these-instructions
+   :start-after: .. _install-follow-these-instructions:
    :end-before:  .. _install-these-are-the-cdap-components:
 
 .. highlight:: console


### PR DESCRIPTION
Fixes two very minor typos, one of which is causing an included paragraph of text to not be included correctly.