### PR TITLE
CDAP-4240 fix version parse bug when name ends with a number

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/artifact/ArtifactVersion.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/artifact/ArtifactVersion.java
@@ -34,7 +34,9 @@ import javax.annotation.Nullable;
 @Beta
 public final class ArtifactVersion implements Comparable<ArtifactVersion> {
 
-  private static final Pattern PATTERN = Pattern.compile("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$");
+  private static final String VERSION_REGEX = "(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$";
+  private static final Pattern PATTERN = Pattern.compile(VERSION_REGEX);
+  private static final Pattern SUFFIX_PATTERN = Pattern.compile("\\-" + VERSION_REGEX);
 
   private final String version;
   private final Integer major;
@@ -67,11 +69,11 @@ public final class ArtifactVersion implements Comparable<ArtifactVersion> {
     Integer fix = null;
     String suffix = null;
     if (str != null) {
-      Matcher matcher = PATTERN.matcher(str);
+      Matcher matcher = matchSuffix ? SUFFIX_PATTERN.matcher(str) : PATTERN.matcher(str);
       boolean matches = matchSuffix ? (matcher.find()) : matcher.matches();
 
       if (matches) {
-        tmpVersion = matcher.group(0);
+        tmpVersion = matchSuffix ? matcher.group(0).substring(1) : matcher.group(0);
         major = valueOf(matcher.group(1));
         minor = valueOf(matcher.group(2));
         fix = valueOf(matcher.group(3));

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/api/artifact/ArtifactVersionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/api/artifact/ArtifactVersionTest.java
@@ -157,6 +157,29 @@ public class ArtifactVersionTest {
     assertInvalidVersion(new ArtifactVersion("xyz-v1.2.3"));
   }
 
+  @Test
+  public void testNumberInArtifactName() {
+    ArtifactVersion actual = new ArtifactVersion("test1-1.0-SNAPSHOT", true);
+    ArtifactVersion expected = new ArtifactVersion("1.0-SNAPSHOT");
+    Assert.assertEquals(expected, actual);
+
+    actual = new ArtifactVersion("1-test-1.0-SNAPSHOT", true);
+    expected = new ArtifactVersion("1.0-SNAPSHOT");
+    Assert.assertEquals(expected, actual);
+
+    actual = new ArtifactVersion("1-test123-1.0-SNAPSHOT", true);
+    expected = new ArtifactVersion("1.0-SNAPSHOT");
+    Assert.assertEquals(expected, actual);
+
+    actual = new ArtifactVersion("1-test123-1.0.0-1234567890", true);
+    expected = new ArtifactVersion("1.0.0-1234567890");
+    Assert.assertEquals(expected, actual);
+
+    actual = new ArtifactVersion("1-test123-1.0.0-5.4.3-1234567890", true);
+    expected = new ArtifactVersion("1.0.0-5.4.3-1234567890");
+    Assert.assertEquals(expected, actual);
+  }
+
   private void assertInvalidVersion(ArtifactVersion artifactVersion) {
     assertVersionEquals(null, null, null, null, null, artifactVersion);
   }


### PR DESCRIPTION
Fixing a bug in version parsing where the version for a string
like test1-1.0-SNAPSHOT gets parsed as 1-1.0-SNAPSHOT instead of
1.0-SNAPSHOT.