### PR TITLE
CDAP-4247 .DS_Store files should be ignored

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/DefaultNamespacedLocationFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/DefaultNamespacedLocationFactory.java
@@ -33,26 +33,13 @@ import javax.annotation.Nullable;
  */
 public class DefaultNamespacedLocationFactory implements NamespacedLocationFactory {
 
-  private final CConfiguration cConf;
   private final LocationFactory locationFactory;
+  private final String namespaceDir;
 
   @Inject
   public DefaultNamespacedLocationFactory(CConfiguration cConf, LocationFactory locationFactory) {
-    this.cConf = cConf;
+    this.namespaceDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
     this.locationFactory = locationFactory;
-  }
-
-  @Override
-  public Map<Id.Namespace, Location> list() throws IOException {
-    String namespacesDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
-    Location namespacesLocation = locationFactory.create(namespacesDir);
-    Map<Id.Namespace, Location> namespaceLocations = Maps.newHashMap();
-    if (namespacesLocation.exists()) {
-      for (Location namespaceLocation : namespacesLocation.list()) {
-        namespaceLocations.put(Id.Namespace.from(namespaceLocation.getName()), namespaceLocation);
-      }
-    }
-    return namespaceLocations;
   }
 
   @Override
@@ -62,8 +49,7 @@ public class DefaultNamespacedLocationFactory implements NamespacedLocationFacto
 
   @Override
   public Location get(Id.Namespace namespaceId, @Nullable String subPath) throws IOException {
-    String namespacesDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
-    Location namespaceLocation = locationFactory.create(namespacesDir).append(namespaceId.getId());
+    Location namespaceLocation = locationFactory.create(namespaceDir).append(namespaceId.getId());
     if (subPath != null) {
       namespaceLocation = namespaceLocation.append(subPath);
     }

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/InMemoryNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/InMemoryNamespaceClient.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.NamespaceNotFoundException;
+import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -64,7 +65,12 @@ public class InMemoryNamespaceClient extends AbstractNamespaceClient {
 
   @Override
   public boolean exists(Id.Namespace namespaceId) throws Exception {
-    return get(namespaceId) != null;
+    try {
+      get(namespaceId);
+    } catch (NotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   @Override

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespacedLocationFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespacedLocationFactory.java
@@ -30,11 +30,6 @@ import javax.annotation.Nullable;
 public interface NamespacedLocationFactory {
 
   /**
-   * @return a Map of {@link Id.Namespace} to its {@link Location} on the filesystem
-   */
-  Map<Id.Namespace, Location> list() throws IOException;
-
-  /**
    * Returns the base {@link Location} for the specified namespace on the filesystem
    *
    * @param namespaceId the namespace for which base location is desired
@@ -52,8 +47,7 @@ public interface NamespacedLocationFactory {
   Location get(Id.Namespace namespaceId, @Nullable String subPath) throws IOException;
 
   /**
-   * Returns the base {@link Location} for all CDAP data. This location contains all
-   * the namespace locations.
+   * Returns the base {@link Location} for all CDAP data.
    */
   Location getBaseLocation() throws IOException;
 

--- a/cdap-common/src/test/java/co/cask/cdap/common/namespace/DefaultNamespacedLocationFactoryTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/namespace/DefaultNamespacedLocationFactoryTest.java
@@ -18,7 +18,6 @@ package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.proto.Id;
-import com.google.common.collect.ImmutableMap;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -28,9 +27,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import java.util.Map;
 
 /**
+ * Tests for {@link DefaultNamespacedLocationFactory}.
  */
 public class DefaultNamespacedLocationFactoryTest {
 
@@ -43,24 +42,12 @@ public class DefaultNamespacedLocationFactoryTest {
     NamespacedLocationFactory namespacedLocationFactory =
       new DefaultNamespacedLocationFactory(CConfiguration.create(), locationFactory);
 
-    // should not be any locations
-    Assert.assertTrue(namespacedLocationFactory.list().isEmpty());
-
     Location defaultLoc = namespacedLocationFactory.get(Id.Namespace.DEFAULT);
     Id.Namespace ns1 = Id.Namespace.from("ns1");
     Location ns1Loc = namespacedLocationFactory.get(ns1);
 
     // test these are not the same
     Assert.assertNotEquals(defaultLoc, ns1Loc);
-
-    // should be 2 in the map now
-    defaultLoc.mkdirs();
-    ns1Loc.mkdirs();
-    Map<Id.Namespace, Location> expected = ImmutableMap.of(
-      Id.Namespace.DEFAULT, defaultLoc,
-      ns1, ns1Loc
-    );
-    Assert.assertEquals(expected, namespacedLocationFactory.list());
 
     // test subdirectories in a namespace
     Location sub1 = namespacedLocationFactory.get(ns1, "sub1");

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
@@ -22,10 +22,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.io.FileContextLocationFactory;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
 import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
-import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -42,6 +39,8 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.store.DefaultNamespaceStore;
+import co.cask.cdap.store.NamespaceStore;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -66,7 +65,7 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
   private static MiniDFSCluster dfsCluster;
   private static StreamFileWriterFactory fileWriterFactory;
   private static StreamCoordinatorClient streamCoordinatorClient;
-  private static AbstractNamespaceClient namespaceClient;
+  private static NamespaceStore namespaceStore;
 
   @BeforeClass
   public static void init() throws IOException {
@@ -112,14 +111,14 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
         protected void configure() {
           // We don't need notification in this test, hence inject an no-op one
           bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
-          bind(AbstractNamespaceClient.class).to(InMemoryNamespaceClient.class);
+          bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
         }
       }
     );
 
     locationFactory = injector.getInstance(LocationFactory.class);
     namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
-    namespaceClient = injector.getInstance(AbstractNamespaceClient.class);
+    namespaceStore = injector.getInstance(NamespaceStore.class);
     streamAdmin = injector.getInstance(StreamAdmin.class);
     fileWriterFactory = injector.getInstance(StreamFileWriterFactory.class);
     streamCoordinatorClient = injector.getInstance(StreamCoordinatorClient.class);
@@ -148,8 +147,8 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
   }
 
   @Override
-  protected AbstractNamespaceClient getNamespaceClient() {
-    return namespaceClient;
+  protected NamespaceStore getNamespaceStore() {
+    return namespaceStore;
   }
 
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
@@ -22,7 +22,10 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.io.FileContextLocationFactory;
+import co.cask.cdap.common.namespace.AbstractNamespaceClient;
 import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
+import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -63,6 +66,7 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
   private static MiniDFSCluster dfsCluster;
   private static StreamFileWriterFactory fileWriterFactory;
   private static StreamCoordinatorClient streamCoordinatorClient;
+  private static AbstractNamespaceClient namespaceClient;
 
   @BeforeClass
   public static void init() throws IOException {
@@ -108,12 +112,14 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
         protected void configure() {
           // We don't need notification in this test, hence inject an no-op one
           bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
+          bind(AbstractNamespaceClient.class).to(InMemoryNamespaceClient.class);
         }
       }
     );
 
     locationFactory = injector.getInstance(LocationFactory.class);
     namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
+    namespaceClient = injector.getInstance(AbstractNamespaceClient.class);
     streamAdmin = injector.getInstance(StreamAdmin.class);
     fileWriterFactory = injector.getInstance(StreamFileWriterFactory.class);
     streamCoordinatorClient = injector.getInstance(StreamCoordinatorClient.class);
@@ -139,6 +145,11 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
   @Override
   protected StreamAdmin getStreamAdmin() {
     return streamAdmin;
+  }
+
+  @Override
+  protected AbstractNamespaceClient getNamespaceClient() {
+    return namespaceClient;
   }
 
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
@@ -22,9 +22,6 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
-import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
@@ -40,6 +37,8 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.store.DefaultNamespaceStore;
+import co.cask.cdap.store.NamespaceStore;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -60,7 +59,7 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
   private static StreamAdmin streamAdmin;
   private static StreamFileWriterFactory fileWriterFactory;
   private static StreamCoordinatorClient streamCoordinatorClient;
-  private static AbstractNamespaceClient namespaceClient;
+  private static NamespaceStore namespaceStore;
 
   @BeforeClass
   public static void init() throws IOException {
@@ -87,14 +86,14 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
         protected void configure() {
           // We don't need notification in this test, hence inject an no-op one
           bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
-          bind(AbstractNamespaceClient.class).to(InMemoryNamespaceClient.class);
+          bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
         }
       }
     );
 
     locationFactory = injector.getInstance(LocationFactory.class);
     namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
-    namespaceClient = injector.getInstance(AbstractNamespaceClient.class);
+    namespaceStore = injector.getInstance(NamespaceStore.class);
     streamAdmin = injector.getInstance(StreamAdmin.class);
     fileWriterFactory = injector.getInstance(StreamFileWriterFactory.class);
     streamCoordinatorClient = injector.getInstance(StreamCoordinatorClient.class);
@@ -122,8 +121,8 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
   }
 
   @Override
-  protected AbstractNamespaceClient getNamespaceClient() {
-    return namespaceClient;
+  protected NamespaceStore getNamespaceStore() {
+    return namespaceStore;
   }
 
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
@@ -22,6 +22,9 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.namespace.AbstractNamespaceClient;
+import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
@@ -57,6 +60,7 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
   private static StreamAdmin streamAdmin;
   private static StreamFileWriterFactory fileWriterFactory;
   private static StreamCoordinatorClient streamCoordinatorClient;
+  private static AbstractNamespaceClient namespaceClient;
 
   @BeforeClass
   public static void init() throws IOException {
@@ -83,12 +87,14 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
         protected void configure() {
           // We don't need notification in this test, hence inject an no-op one
           bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
+          bind(AbstractNamespaceClient.class).to(InMemoryNamespaceClient.class);
         }
       }
     );
 
     locationFactory = injector.getInstance(LocationFactory.class);
     namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
+    namespaceClient = injector.getInstance(AbstractNamespaceClient.class);
     streamAdmin = injector.getInstance(StreamAdmin.class);
     fileWriterFactory = injector.getInstance(StreamFileWriterFactory.class);
     streamCoordinatorClient = injector.getInstance(StreamCoordinatorClient.class);
@@ -113,6 +119,11 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
   @Override
   protected StreamAdmin getStreamAdmin() {
     return streamAdmin;
+  }
+
+  @Override
+  protected AbstractNamespaceClient getNamespaceClient() {
+    return namespaceClient;
   }
 
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileJanitorTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileJanitorTestBase.java
@@ -19,14 +19,13 @@ package co.cask.cdap.data.stream;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.store.NamespaceStore;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 import org.junit.Assert;
@@ -54,7 +53,7 @@ public abstract class StreamFileJanitorTestBase {
 
   protected abstract StreamAdmin getStreamAdmin();
 
-  protected abstract AbstractNamespaceClient getNamespaceClient();
+  protected abstract NamespaceStore getNamespaceStore();
 
   protected abstract CConfiguration getCConfiguration();
 
@@ -64,7 +63,7 @@ public abstract class StreamFileJanitorTestBase {
   public void setup() throws Exception {
     // FileStreamAdmin expects namespace directory to exist.
     // Simulate namespace create, since its an inmemory-namespace admin
-    getNamespaceClient().create(NamespaceMeta.DEFAULT);
+    getNamespaceStore().create(NamespaceMeta.DEFAULT);
     getNamespacedLocationFactory().get(Id.Namespace.DEFAULT).mkdirs();
   }
 
@@ -78,7 +77,7 @@ public abstract class StreamFileJanitorTestBase {
     streamAdmin.create(streamId);
     StreamConfig streamConfig = streamAdmin.getConfig(streamId);
     StreamFileJanitor janitor = new StreamFileJanitor(getCConfiguration(), getStreamAdmin(),
-                                                      getNamespacedLocationFactory(), getNamespaceClient());
+                                                      getNamespacedLocationFactory(), getNamespaceStore());
 
     for (int i = 0; i < 5; i++) {
       FileWriter<StreamEvent> writer = createWriter(streamId);
@@ -113,7 +112,7 @@ public abstract class StreamFileJanitorTestBase {
 
     StreamAdmin streamAdmin = getStreamAdmin();
     StreamFileJanitor janitor = new StreamFileJanitor(getCConfiguration(), getStreamAdmin(),
-                                                      getNamespacedLocationFactory(), getNamespaceClient());
+                                                      getNamespacedLocationFactory(), getNamespaceStore());
 
     Properties properties = new Properties();
     properties.setProperty(Constants.Stream.PARTITION_DURATION, "2000");
@@ -153,7 +152,7 @@ public abstract class StreamFileJanitorTestBase {
     Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, "cleanupDelete");
     StreamAdmin streamAdmin = getStreamAdmin();
     StreamFileJanitor janitor = new StreamFileJanitor(getCConfiguration(), streamAdmin, getNamespacedLocationFactory(),
-                                                      getNamespaceClient());
+                                                      getNamespaceStore());
     streamAdmin.create(streamId);
 
     // Write some data

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
@@ -25,8 +25,9 @@ import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
+import co.cask.cdap.common.namespace.AbstractNamespaceClient;
+import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -133,9 +134,11 @@ public class DFSStreamHeartbeatsTest {
         // that performs heartbeats aggregation
         new StreamServiceRuntimeModule().getDistributedModules(),
         new StreamAdminModules().getInMemoryModules()).with(new AbstractModule() {
+
         @Override
         protected void configure() {
           bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
+          bind(AbstractNamespaceClient.class).to(InMemoryNamespaceClient.class);
 
           bind(StreamConsumerStateStoreFactory.class).to(LevelDBStreamConsumerStateStoreFactory.class)
             .in(Singleton.class);
@@ -147,8 +150,7 @@ public class DFSStreamHeartbeatsTest {
           bind(StreamMetaStore.class).to(InMemoryStreamMetaStore.class).in(Scopes.SINGLETON);
           bind(HeartbeatPublisher.class).to(MockHeartbeatPublisher.class).in(Scopes.SINGLETON);
         }
-      }),
-      new NamespaceClientRuntimeModule().getDistributedModules());
+      }));
 
     zkClient = injector.getInstance(ZKClientService.class);
     txManager = injector.getInstance(TransactionManager.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileJanitor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileJanitor.java
@@ -19,13 +19,12 @@ package co.cask.cdap.data.stream;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.store.NamespaceStore;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import org.apache.twill.filesystem.Location;
@@ -34,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Performs deletion of unused stream files.
@@ -46,23 +44,23 @@ public final class StreamFileJanitor {
   private final StreamAdmin streamAdmin;
   private final NamespacedLocationFactory namespacedLocationFactory;
   private final String streamBaseDirPath;
-  private final NamespaceAdmin namespaceAdmin;
+  private final NamespaceStore namespaceStore;
 
   @Inject
   public StreamFileJanitor(CConfiguration cConf, StreamAdmin streamAdmin,
                            NamespacedLocationFactory namespacedLocationFactory,
-                           AbstractNamespaceClient namespaceClient) {
+                           NamespaceStore namespaceStore) {
     this.streamAdmin = streamAdmin;
     this.streamBaseDirPath = cConf.get(Constants.Stream.BASE_DIR);
     this.namespacedLocationFactory = namespacedLocationFactory;
-    this.namespaceAdmin = namespaceClient;
+    this.namespaceStore = namespaceStore;
   }
 
   /**
    * Performs file cleanup for all streams.
    */
   public void cleanAll() throws Exception {
-    List<NamespaceMeta> namespaces = namespaceAdmin.list();
+    List<NamespaceMeta> namespaces = namespaceStore.list();
 
     for (NamespaceMeta namespace : namespaces) {
       Location streamBaseLocation =

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileJanitor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileJanitor.java
@@ -19,10 +19,13 @@ package co.cask.cdap.data.stream;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.namespace.AbstractNamespaceClient;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import org.apache.twill.filesystem.Location;
@@ -30,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -42,26 +46,27 @@ public final class StreamFileJanitor {
   private final StreamAdmin streamAdmin;
   private final NamespacedLocationFactory namespacedLocationFactory;
   private final String streamBaseDirPath;
+  private final NamespaceAdmin namespaceAdmin;
 
   @Inject
   public StreamFileJanitor(CConfiguration cConf, StreamAdmin streamAdmin,
-                           NamespacedLocationFactory namespacedLocationFactory) {
+                           NamespacedLocationFactory namespacedLocationFactory,
+                           AbstractNamespaceClient namespaceClient) {
     this.streamAdmin = streamAdmin;
     this.streamBaseDirPath = cConf.get(Constants.Stream.BASE_DIR);
     this.namespacedLocationFactory = namespacedLocationFactory;
+    this.namespaceAdmin = namespaceClient;
   }
 
   /**
    * Performs file cleanup for all streams.
    */
-  public void cleanAll() throws IOException {
-    Map<Id.Namespace, Location> namespaceLocations = namespacedLocationFactory.list();
-    if (namespaceLocations.size() == 0) {
-      return;
-    }
+  public void cleanAll() throws Exception {
+    List<NamespaceMeta> namespaces = namespaceAdmin.list();
 
-    for (Location namespaceDir : namespaceLocations.values()) {
-      Location streamBaseLocation = namespaceDir.append(streamBaseDirPath);
+    for (NamespaceMeta namespace : namespaces) {
+      Location streamBaseLocation =
+        namespacedLocationFactory.get(Id.Namespace.from(namespace.getName())).append(streamBaseDirPath);
       if (!streamBaseLocation.exists()) {
         continue;
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
@@ -479,7 +479,7 @@ public final class StreamUtils {
     return Iterables.filter(streamRootLocation.list(), new Predicate<Location>() {
       @Override
       public boolean apply(Location location) {
-        // Any directories started with "." is special system directory, which is not regular stream directory
+        // Any directories started with "." is special system file, which is not regular stream directory
         return !location.getName().startsWith(".");
       }
     });

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/LocalStreamFileJanitorService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/LocalStreamFileJanitorService.java
@@ -68,7 +68,6 @@ public final class LocalStreamFileJanitorService extends AbstractService impleme
           LOG.debug("Completed stream file cleanup.");
         } catch (Throwable e) {
           LOG.warn("Failed to cleanup stream file: {}", e.getMessage());
-          LOG.debug("Failed to cleanup stream file.", e);
         } finally {
           // Compute the next cleanup time. It is aligned to work clock based on the period.
           long now = System.currentTimeMillis();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
@@ -21,6 +21,8 @@ import co.cask.cdap.data.stream.StreamViewHttpHandler;
 import co.cask.cdap.data.stream.service.heartbeat.HeartbeatPublisher;
 import co.cask.cdap.data.stream.service.heartbeat.NotificationHeartbeatPublisher;
 import co.cask.cdap.gateway.handlers.CommonHandlers;
+import co.cask.cdap.store.DefaultNamespaceStore;
+import co.cask.cdap.store.NamespaceStore;
 import co.cask.http.HttpHandler;
 import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.AbstractService;
@@ -80,6 +82,7 @@ public final class StreamServiceRuntimeModule extends RuntimeModule {
         CommonHandlers.add(handlerBinder);
 
         bind(HeartbeatPublisher.class).to(NotificationHeartbeatPublisher.class).in(Scopes.SINGLETON);
+        bind(NamespaceStore.class).to(DefaultNamespaceStore.class).in(Scopes.SINGLETON);
 
         bind(StreamHttpService.class).in(Scopes.SINGLETON);
         bind(Key.get(new TypeLiteral<Supplier<Discoverable>>() { })).to(StreamHttpService.class);

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
@@ -89,12 +89,12 @@ public class StreamHandlerRunnable extends AbstractMasterTwillRunnable {
         new DataSetsModules().getDistributedModules(),
         new LoggingModules().getDistributedModules(),
         new ExploreClientModule(),
+        new NamespaceClientRuntimeModule().getDistributedModules(),
         new StreamServiceRuntimeModule().getDistributedModules(),
         new ViewAdminModules().getDistributedModules(),
         new StreamAdminModules().getDistributedModules(),
         new NotificationFeedClientModule(),
-        new NotificationServiceRuntimeModule().getDistributedModules(),
-        new NamespaceClientRuntimeModule().getDistributedModules()
+        new NotificationServiceRuntimeModule().getDistributedModules()
       );
 
       injector.getInstance(LogAppenderInitializer.class).initialize();

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
@@ -89,12 +89,12 @@ public class StreamHandlerRunnable extends AbstractMasterTwillRunnable {
         new DataSetsModules().getDistributedModules(),
         new LoggingModules().getDistributedModules(),
         new ExploreClientModule(),
-        new NamespaceClientRuntimeModule().getDistributedModules(),
         new StreamServiceRuntimeModule().getDistributedModules(),
         new ViewAdminModules().getDistributedModules(),
         new StreamAdminModules().getDistributedModules(),
         new NotificationFeedClientModule(),
-        new NotificationServiceRuntimeModule().getDistributedModules()
+        new NotificationServiceRuntimeModule().getDistributedModules(),
+        new NamespaceClientRuntimeModule().getDistributedModules()
       );
 
       injector.getInstance(LogAppenderInitializer.class).initialize();


### PR DESCRIPTION
The approach is to use namespace client to list namespaces, and only scan directories for existing namespaces (instead of all directories under the `../data/namespaces/` directory).

Note that this changes the Stream Janitor to now have a dependency on app-fabric (namespace service).

https://issues.cask.co/browse/CDAP-4247
http://builds.cask.co/browse/CDAP-DUT3143-5