### PR TITLE
Fixes batch metrics to take up mapreduce runid instead of workflow

### DIFF
--- a/cdap-ui/app/features/hydrator/controllers/detail/tabs/metrics-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/detail/tabs/metrics-ctrl.js
@@ -20,7 +20,6 @@ angular.module(PKG.name + '.feature.hydrator')
     var currentRunId;
     this.setState = function() {
       this.state = {
-        runId: (DetailRunsStore.getLatestRun() && DetailRunsStore.getLatestRun().runId) || null,
         metrics: MetricsStore.getMetrics()
       };
     };
@@ -67,11 +66,10 @@ angular.module(PKG.name + '.feature.hydrator')
     checkAndPollForMetrics.call(this);
 
     function getMetricsForLatestRunId(isPoll) {
-      var latestRunId = DetailRunsStore.getLatestRun();
+      var latestRunId = DetailRunsStore.getLatestMericRunId();
       if (!latestRunId) {
         return;
       }
-      latestRunId = latestRunId.runid;
       if (latestRunId === currentRunId) {
         return;
       }

--- a/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-runs-store.js
+++ b/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-runs-store.js
@@ -51,6 +51,22 @@ angular.module(PKG.name + '.feature.hydrator')
     this.getLatestRun = function() {
       return this.state.runs.list[0];
     };
+    this.getLatestMericRunId = function() {
+      var appType = this.getAppType();
+      var metricRunId;
+      if (!this.state.runs.count) {
+        return false;
+      }
+
+      if (appType === GLOBALS.etlBatch) {
+        // TODO: Make it generic so that we can choose between spark and mapreduce.
+        // We will get a flag from backend called 'engine'. This can be chosen based on that.
+        metricRunId = this.state.runs.list[0].properties.ETLMapReduce;
+      } else if (appType === GLOBALS.etlRealtime) {
+        metricRunId = this.state.runs.list[0].runid;
+      }
+      return metricRunId;
+    };
     this.getHistory = this.getRuns;
 
     this.getStatus = function() {


### PR DESCRIPTION
- Fixes batch metrics to use mapreduce run id instead of workflow runid.

![batchmetrics](https://cloud.githubusercontent.com/assets/1452845/11130668/144e3076-893b-11e5-97cf-21c215c3bbe1.gif)


Bamboo Build: http://builds.cask.co/browse/CDAP-DRC2941-1