### PR TITLE
Fix inclusion of WiseApp.

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -612,7 +612,7 @@
     <name>app.connection.backlog</name>
     <value>20000</value>
     <description>
-      Max connection backlog of CDAP-Master
+      Max connection backlog of CDAP Master
     </description>
   </property>
 
@@ -809,7 +809,7 @@
     <name>master.collect.containers.log</name>
     <value>true</value>
     <description>
-      Determines if container logs are streamed back to the cdap-master process log
+      Determines if container logs are streamed back to the CDAP Master process log
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -25,7 +25,7 @@ CHECK_INCLUDES=${TRUE}
 
 function download_includes() {
   echo_red_bold "Check guarded files for changes"
-  test_an_include 59246a91e27091dd6d9a4263d37e5f38 "${DEFAULT_XML}"
+  test_an_include 85873da6fc79289d8238c74a747320f0 "${DEFAULT_XML}"
 
   echo "Building rst file from cdap-default.xml..."
   local includes_dir=${1}

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -106,9 +106,9 @@ function download_includes() {
   download_file $includes $project_main BounceCountsMapReduce.java 72f01be483fe6aa9a2d07bf2d324594f
   download_file $includes $project_main BounceCountStore.java      d476c15655c6a6c6cd7fe682dea4a8b7
   download_file $includes $project_main PageViewStore.java         7dc8d2fec04ce89fae4f0356db17e19d
-  download_file $includes $project_main WiseApp.java               1ee41e950a4b34b75fe0d2cd0ff94508
+  download_file $includes $project_main WiseApp.java               23371436b588c3262fec14ec5d7aa6df
   download_file $includes $project_test WiseAppTest.java           5145832dc315f4253fa6b2aac3ee9164
-  download_file $includes $project_main WiseFlow.java              2deba0633a0dcca14ef426929f543872
+  download_file $includes $project_main WiseFlow.java              94cb2ef13e10386d4c40c4252777d15e
   download_file $includes $project_main WiseWorkflow.java          d24a138d3a96bfb41e6d166866b72291
   download_file $includes $project_main WiseService.java           dccfeb2d5726a031b5aff9897ccf8257
 

--- a/cdap-docs/examples-manual/source/tutorials/wise.rst
+++ b/cdap-docs/examples-manual/source/tutorials/wise.rst
@@ -306,7 +306,7 @@ the stream and extracts useful information from it. Here is its implementation:
 
 .. literalinclude:: /../target/_includes/tutorial-wise/WiseFlow.java
    :language: java
-   :lines: 57-81   
+   :lines: 53-77   
    :dedent: 2
 
 A ``Flowlet`` class extends ``AbstractFlowlet``. The ``LogEventParserFlowlet`` class contains one
@@ -334,7 +334,7 @@ Its implementation is very brief:
 
 .. literalinclude:: /../target/_includes/tutorial-wise/WiseFlow.java
    :language: java
-   :lines: 86-102   
+   :lines: 82-99   
    :dedent: 2
 
 Here’s what to note about the ``PageViewCounterFlowlet`` flowlet class:
@@ -363,7 +363,7 @@ The flowlets are defined in the ``WiseFlow`` flow, which is defined by this smal
 
 .. literalinclude:: /../target/_includes/tutorial-wise/WiseFlow.java
    :language: java
-   :lines: 38-51   
+   :lines: 37-47   
 
 In the ``configure()`` method of the ``WiseFlow`` flow, we define the flowlets, giving them names:
 
@@ -492,7 +492,7 @@ The ``WiseWorkflow`` can then be scheduled in the ``WiseApp``:
 
 .. literalinclude:: /../target/_includes/tutorial-wise/WiseApp.java
    :language: java
-   :lines: 47-49   
+   :lines: 47-51   
    :prepend: . . . 
    :append: . . . 
    :dedent: 4


### PR DESCRIPTION
Running at [Quick Build](http://builds.cask.co/browse/CDAP-DOB44-2).

Fixes MD5 hashes and adjusts the inclusion of the WiseApp files based on the changes recently made.