### PR TITLE
Remove xterm from VM session, caused confusion

### DIFF
--- a/cdap-distributions/src/packer/scripts/lxde.sh
+++ b/cdap-distributions/src/packer/scripts/lxde.sh
@@ -84,7 +84,6 @@ cp /etc/welcome.txt ~cdap/Desktop
 for i in cdap-ui cdap-docs eclipse idea lxterminal ; do
   cp /usr/share/applications/${i}.desktop ~cdap/Desktop
 done
-echo '@xterm -e "cat /etc/welcome.txt; bash -l"' >> /etc/xdg/lxsession/LXDE/autostart
 
 # Customize look and feel
 sed -i \


### PR DESCRIPTION
There's an xterm in the startup, designed to show the user the `welcome.txt` file. It was never intended on being used as a terminal. It doesn't support copy and paste in a way that Windows/Mac users understand. This gets rid of it from starting up.
<img width="912" alt="screen shot 2015-11-12 at 6 35 14 pm" src="https://cloud.githubusercontent.com/assets/380021/11134718/f5841156-896c-11e5-82a2-e156efa0dfa7.png">
