### PR TITLE
Add consolidation of outer-level messages.

### DIFF
--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -334,7 +334,8 @@ function build_docs_outer_level() {
   if [ "x${google_code}" != "x" ]; then
     google_options="-D googleanalytics_id=${google_code} -D googleanalytics_enabled=1"
   fi
-  ${SPHINX_BUILD} ${google_options} ${TARGET_PATH}/${SOURCE} ${TARGET_PATH}/${HTML}
+  ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_options} ${TARGET_PATH}/${SOURCE} ${TARGET_PATH}/${HTML}
+  consolidate_messages
   echo
 }
   


### PR DESCRIPTION
Fixes a problem where any messages that occurred in the Sphinx build of the outer-most layer of the docs don't get surfaced to the end of the log and to Bamboo.

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB45-1).