### PR TITLE
(CDAP-3644) Made metadata datasets upgradable by adding them to the I…

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
@@ -18,9 +18,11 @@ package co.cask.cdap.data2.metadata.lineage;
 
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
@@ -31,6 +33,7 @@ import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -226,5 +229,14 @@ public class LineageStore {
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  /**
+   * Adds datasets and types to the given {@link DatasetFramework}. Used by the upgrade tool to upgrade Lineage Dataset.
+   *
+   * @param framework framework to add types and datasets to
+   */
+  public static void setupDatasets(DatasetFramework framework) throws IOException, DatasetManagementException {
+    framework.addInstance(LineageDataset.class.getName(), LINEAGE_DATASET_ID, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/DefaultBusinessMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/DefaultBusinessMetadataStore.java
@@ -22,6 +22,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.metadata.dataset.BusinessMetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.BusinessMetadataRecord;
 import co.cask.cdap.data2.metadata.publisher.MetadataChangePublisher;
@@ -39,6 +40,7 @@ import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -443,5 +445,16 @@ public class DefaultBusinessMetadataStore implements BusinessMetadataStore {
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  /**
+   * Adds datasets and types to the given {@link DatasetFramework}. Used by the upgrade tool to upgrade Business
+   * Metadata Datasets
+   *
+   * @param framework Dataset framework to add types and datasets to
+   */
+  public static void setupDatasets(DatasetFramework framework) throws IOException, DatasetManagementException {
+    framework.addInstance(BusinessMetadataDataset.class.getName(), BUSINESS_METADATA_INSTANCE_ID,
+                          DatasetProperties.EMPTY);
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -45,7 +45,9 @@ import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
+import co.cask.cdap.data2.metadata.lineage.LineageStore;
 import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
+import co.cask.cdap.data2.metadata.service.DefaultBusinessMetadataStore;
 import co.cask.cdap.data2.metadata.service.NoOpBusinessMetadataStore;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.NoOpLineageWriter;
@@ -431,8 +433,10 @@ public class UpgradeTool {
     // dataset service
     DatasetMetaTableUtil.setupDatasets(datasetFramework);
     if (includeNewDatasets) {
-      // artifacts meta data was added in 3.2
+      // artifact and metadata datasets were added in 3.2
       ArtifactStore.setupDatasets(datasetFramework);
+      DefaultBusinessMetadataStore.setupDatasets(datasetFramework);
+      LineageStore.setupDatasets(datasetFramework);
     }
     // app metadata
     DefaultStore.setupDatasets(datasetFramework);


### PR DESCRIPTION
…nMemoryDatasetFramework used in the UpgradeTool.

Jira: [CDAP-3644](https://issues.cask.co/browse/CDAP-3644)
Build: http://builds.cask.co/browse/CDAP-RBT523

Here is the output after running the upgrade tool as ``$ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade_hbase`` to upgrade from CDH 5.3 (HBase 0.98) to CDH 5.4 (HBase 1.0-cdh)

```
hbase(main):002:0> describe 'cdap_system:lineage.access_registry'
Table cdap_system:lineage.access_registry is ENABLED
cdap_system:lineage.access_registry, {TABLE_ATTRIBUTES => {coprocessor$1 => 'hdfs://HOST:8020/cdap/cdap/lib/coprocessor-
3.2.1-1447460814860-6f19de274a3c4fe54f5fbf8c933b6ff1.jar|co.cask.cdap.data2.transaction.coprocessor.hbase10cdh.DefaultTransactionProcessor|1073741823|', MET
ADATA => {'cdap.version' => '3.2.1-1447460814860'}}
COLUMN FAMILIES DESCRIPTION
{NAME => 'd', DATA_BLOCK_ENCODING => 'NONE', BLOOMFILTER => 'ROW', REPLICATION_SCOPE => '0', COMPRESSION => 'SNAPPY', VERSIONS => '2147483647', TTL => 'FORE
VER', MIN_VERSIONS => '0', KEEP_DELETED_CELLS => 'FALSE', BLOCKSIZE => '65536', IN_MEMORY => 'false', BLOCKCACHE => 'true'}
1 row(s) in 0.0910 seconds

hbase(main):003:0> describe 'cdap_system:business.metadata.metadata_index.d'
Table cdap_system:business.metadata.metadata_index.d is DISABLED
cdap_system:business.metadata.metadata_index.d, {TABLE_ATTRIBUTES => {coprocessor$2 => 'hdfs://HOST:8020/cdap/cdap/lib/c
oprocessor-3.2.1-1447460814860-6f19de274a3c4fe54f5fbf8c933b6ff1.jar|co.cask.cdap.data2.transaction.coprocessor.hbase10cdh.DefaultTransactionProcessor|107374
1823|', METADATA => {'cdap.version' => '3.2.1-1447460814860'}}
COLUMN FAMILIES DESCRIPTION
{NAME => 'd', DATA_BLOCK_ENCODING => 'NONE', BLOOMFILTER => 'ROW', REPLICATION_SCOPE => '0', COMPRESSION => 'SNAPPY', VERSIONS => '2147483647', TTL => 'FORE
VER', MIN_VERSIONS => '0', KEEP_DELETED_CELLS => 'false', BLOCKSIZE => '65536', IN_MEMORY => 'false', BLOCKCACHE => 'true'}
1 row(s) in 0.0190 seconds

hbase(main):004:0> describe 'cdap_system:business.metadata.metadata_index.i'
Table cdap_system:business.metadata.metadata_index.i is DISABLED
cdap_system:business.metadata.metadata_index.i, {TABLE_ATTRIBUTES => {coprocessor$2 => 'hdfs://HOST:8020/cdap/cdap/lib/coprocessor-3.2.1-1447460814860-6f19de274a3c4fe54f5fbf8c933b6ff1.jar|co.cask.cdap.data2.transaction.coprocessor.hbase10cdh.DefaultTransactionProcessor|107374
1823|', METADATA => {'cdap.version' => '3.2.1-1447460814860'}}
COLUMN FAMILIES DESCRIPTION
{NAME => 'd', DATA_BLOCK_ENCODING => 'NONE', BLOOMFILTER => 'ROW', REPLICATION_SCOPE => '0', COMPRESSION => 'SNAPPY', VERSIONS => '2147483647', TTL => 'FORE
VER', MIN_VERSIONS => '0', KEEP_DELETED_CELLS => 'false', BLOCKSIZE => '65536', IN_MEMORY => 'false', BLOCKCACHE => 'true'}
1 row(s) in 0.0170 seconds
```