### PR TITLE
Remove dependency on repository.continuuity.com

### DIFF
--- a/cdap-data-fabric-tests/pom.xml
+++ b/cdap-data-fabric-tests/pom.xml
@@ -38,7 +38,7 @@
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.hbase</groupId>
+          <groupId>co.cask.hbase</groupId>
           <artifactId>hbase</artifactId>
         </exclusion>
       </exclusions>

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -89,7 +89,7 @@
       <artifactId>hadoop-mapreduce-client-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
     </dependency>
     <dependency>
@@ -111,7 +111,7 @@
       <artifactId>hadoop-minicluster</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
       <classifier>tests</classifier>
     </dependency>

--- a/cdap-hbase-compat-0.94/pom.xml
+++ b/cdap-hbase-compat-0.94/pom.xml
@@ -51,7 +51,7 @@
       <artifactId>hadoop-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
     </dependency>
 
@@ -77,7 +77,7 @@
       <artifactId>hadoop-minicluster</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
       <classifier>tests</classifier>
     </dependency>

--- a/cdap-hbase-compat-0.96/pom.xml
+++ b/cdap-hbase-compat-0.96/pom.xml
@@ -46,6 +46,10 @@
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>co.cask.hbase</groupId>
+          <artifactId>hbase</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/cdap-hbase-compat-0.98/pom.xml
+++ b/cdap-hbase-compat-0.98/pom.xml
@@ -46,6 +46,10 @@
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>co.cask.hbase</groupId>
+          <artifactId>hbase</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -106,7 +106,7 @@
       <artifactId>hadoop-minicluster</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
       <scope>test</scope>
     </dependency>
@@ -116,7 +116,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
       <classifier>tests</classifier>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,6 @@
       <id>sonatype</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
-    <repository>
-      <id>continuuity-public</id>
-      <url>https://repository.continuuity.com/content/repositories/public</url>
-    </repository>
   </repositories>
 
 
@@ -108,7 +104,7 @@
     <guava.version>13.0.1</guava.version>
     <guice.version>3.0</guice.version>
     <hadoop.version>2.3.0</hadoop.version>
-    <hbase94.version>0.94.6.1.continuuity</hbase94.version>
+    <hbase94.version>0.94.6.1.cask</hbase94.version>
     <hbase96.version>0.96.2-hadoop2</hbase96.version>
     <hbase98.version>0.98.6.1-hadoop2</hbase98.version>
     <hive.version>0.13.0</hive.version>
@@ -684,7 +680,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.hbase</groupId>
+        <groupId>co.cask.hbase</groupId>
         <artifactId>hbase</artifactId>
         <version>${hbase94.version}</version>
         <exclusions>
@@ -1090,7 +1086,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.hbase</groupId>
+        <groupId>co.cask.hbase</groupId>
         <artifactId>hbase</artifactId>
         <classifier>tests</classifier>
         <version>${hbase94.version}</version>


### PR DESCRIPTION
Background:
* Repository.continuuity.com hosts hbase-94.6.1 compiled against hadoop-2 which is needed to support versions 2.8.x - 3.0.x
* We wanted to remove the dependency on repository.continuuity.com 

Solution:
* Moved the hbase-0.94.6.1 jars to maven central under co.cask.hbase and updated the version to 0.94.6.1.cask (from 0.94.6.1.continuuity)
* Updated the pom with required changes


Tests:
* Build passes: https://builds.cask.co/browse/CDAP-RB3010-4
* Also able to create a cluster with hbase-0.94.6.1 from the feature branch.