### PR TITLE
Document that DataSetException is thrown if #addMetadata is…

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -57,17 +57,19 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
 
   /**
    * Adds a new metadata entry for a particular partition.
-   * Note that existing entries can not be updated.
-   * @throws DataSetException in case an attempt is made to update existing entries, or to entries for partitions that
-   *         do not exist.
+   * Note that existing entries cannot be updated.
+   * 
+   * @throws DataSetException when an attempt is made to either update an existing entry or add an entry for a
+   *         partition that does not exist
    */
   void addMetadata(PartitionKey key, String metadataKey, String metadataValue);
 
   /**
-   * Adds a set of new metadata entries for a particular partition
-   * Note that existing entries can not be updated.
-   * @throws DataSetException in case an attempt is made to update existing entries, or to entries for partitions that
-   *         do not exist.
+   * Adds a set of new metadata entries for a particular partition.
+   * Note that existing entries cannot be updated.
+   * 
+   * @throws DataSetException when an attempt is made to either update existing entries or add entries for a
+   *         partition that does not exist
    */
   void addMetadata(PartitionKey key, Map<String, String> metadata);
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -58,14 +58,16 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
   /**
    * Adds a new metadata entry for a particular partition.
    * Note that existing entries can not be updated.
-   * @throws DataSetException in case an attempt is made to update existing entries.
+   * @throws DataSetException in case an attempt is made to update existing entries, or to entries for partitions that
+   *         do not exist.
    */
   void addMetadata(PartitionKey key, String metadataKey, String metadataValue);
 
   /**
    * Adds a set of new metadata entries for a particular partition
    * Note that existing entries can not be updated.
-   * @throws DataSetException in case an attempt is made to update existing entries.
+   * @throws DataSetException in case an attempt is made to update existing entries, or to entries for partitions that
+   *         do not exist.
    */
   void addMetadata(PartitionKey key, Map<String, String> metadata);
 


### PR DESCRIPTION
Document that DataSetException is thrown if #addMetadata is called for a partition that doesn't exist.

https://issues.cask.co/browse/CDAP-4260