### PR TITLE
PartitionedFileSet#addMetadata now throws PartitionNotFoundException,…

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/PartitionNotFoundException.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/PartitionNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/PartitionNotFoundException.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/PartitionNotFoundException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.dataset;
+
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+
+/**
+ * Thrown when a {@link co.cask.cdap.api.dataset.lib.Partition} is not found on a PartitionedFileSet.
+ */
+public class PartitionNotFoundException extends DataSetException {
+  private final PartitionKey partitionKey;
+  private final String partitionedFileSetName;
+
+  public PartitionNotFoundException(PartitionKey partitionKey, String partitionedFileSetName) {
+    super(String.format("Dataset '%s' does not have a partition for key: %s", partitionedFileSetName, partitionKey));
+    this.partitionKey = partitionKey;
+    this.partitionedFileSetName = partitionedFileSetName;
+  }
+
+  public PartitionKey getPartitionKey() {
+    return partitionKey;
+  }
+
+  public String getPartitionedFileSetName() {
+    return partitionedFileSetName;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -59,27 +59,27 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    * Adds a new metadata entry for a particular partition.
    * Note that existing entries cannot be updated.
    * 
-   * @throws DataSetException when an attempt is made to either update an existing entry or add an entry for a
-   *         partition that does not exist
+   * @throws DataSetException when an attempt is made to either update an existing entry
+   *         PartitionNotFoundException when a partition for the given key is not found
    */
   void addMetadata(PartitionKey key, String metadataKey, String metadataValue);
 
   /**
    * Adds a set of new metadata entries for a particular partition.
    * Note that existing entries cannot be updated.
-   * 
-   * @throws DataSetException when an attempt is made to either update existing entries or add entries for a
-   *         partition that does not exist
+   *
+   * @throws DataSetException when an attempt is made to either update existing entries
+   *         PartitionNotFoundException when a partition for the given key is not found
    */
   void addMetadata(PartitionKey key, Map<String, String> metadata);
 
   /**
-   * Remove a partition for a given partition key.
+   * Remove a partition for a given partition key, silently ignoring if the key is not found.
    */
   void dropPartition(PartitionKey key);
 
   /**
-   * Return the partition for a specific partition key.
+   * Return the partition for a specific partition key, or null if key is not found.
    */
   @Nullable
   PartitionDetail getPartition(PartitionKey key);

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.PartitionNotFoundException;
 
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +61,7 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    * Note that existing entries cannot be updated.
    * 
    * @throws DataSetException when an attempt is made to either update an existing entry
-   *         PartitionNotFoundException when a partition for the given key is not found
+   * @throws PartitionNotFoundException when a partition for the given key is not found
    */
   void addMetadata(PartitionKey key, String metadataKey, String metadataValue);
 
@@ -69,7 +70,7 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    * Note that existing entries cannot be updated.
    *
    * @throws DataSetException when an attempt is made to either update existing entries
-   *         PartitionNotFoundException when a partition for the given key is not found
+   * @throws PartitionNotFoundException when a partition for the given key is not found
    */
   void addMetadata(PartitionKey key, Map<String, String> metadata);
 
@@ -98,7 +99,7 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    *
    * @param partitionConsumerState the state from which to start consuming from
    * @return {@link PartitionConsumerResult} which holds the state of consumption as well as an iterator to the consumed
-   * {@link Partition}s
+   *         {@link Partition}s
    */
   PartitionConsumerResult consumePartitions(PartitionConsumerState partitionConsumerState);
 
@@ -113,7 +114,7 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    *              transactions; the limit is checked after adding consuming all partitions of a transaction, so
    *              the total number of consumed partitions may be greater than this limit
    * @return {@link PartitionConsumerResult} which holds the state of consumption as well as an iterator to the consumed
-   * {@link Partition}s
+   *         {@link Partition}s
    */
   PartitionConsumerResult consumePartitions(PartitionConsumerState partitionConsumerState,
                                             PartitionFilter partitionFilter, int limit);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.data.batch.DatasetOutputCommitter;
 import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.PartitionNotFoundException;
 import co.cask.cdap.api.dataset.lib.AbstractDataset;
 import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.dataset.lib.FileSetArguments;
@@ -335,7 +336,7 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     final byte[] rowKey = generateRowKey(key, partitioning);
     Row row = partitionsTable.get(rowKey);
     if (row.isEmpty()) {
-      throw new DataSetException(String.format("Dataset '%s' does not have a partition for key: %s", getName(), key));
+      throw new PartitionNotFoundException(key, getName());
     }
 
     // ensure that none of the entries already exist in the metadata

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -153,9 +153,9 @@ public class PartitionedFileSetTest {
       // didn't add any partitions to the dataset, so any partition key should throw a PartitionNotFoundException
       pfs.addMetadata(key, "metaKey", "metaValue");
       Assert.fail("Expected not to find key: " + key);
-    } catch (PartitionNotFoundException expected) {
-      Assert.assertEquals(pfsInstance.getId(), expected.getPartitionedFileSetName());
-      Assert.assertEquals(key, expected.getPartitionKey());
+    } catch (PartitionNotFoundException e) {
+      Assert.assertEquals(pfsInstance.getId(), e.getPartitionedFileSetName());
+      Assert.assertEquals(key, e.getPartitionKey());
     }
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.dataset2.lib.partitioned;
 
 import co.cask.cdap.api.dataset.DataSetException;
+import co.cask.cdap.api.dataset.PartitionNotFoundException;
 import co.cask.cdap.api.dataset.lib.Partition;
 import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
@@ -26,6 +27,7 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.TransactionAware;
@@ -52,6 +54,7 @@ import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -140,6 +143,20 @@ public class PartitionedFileSetTest {
   public void testDecodeIncomplete() {
     byte[] rowKey = PartitionedFileSetDataset.generateRowKey(PARTITION_KEY, PARTITIONING_1);
     PartitionedFileSetDataset.parseRowKey(rowKey, PARTITIONING_2);
+  }
+
+  @Test
+  public void testMetadataForNonexistentPartition() throws Exception {
+    PartitionedFileSet pfs = dsFrameworkUtil.getInstance(pfsInstance);
+    PartitionKey key = generateUniqueKey();
+    try {
+      // didn't add any partitions to the dataset, so any partition key should throw a PartitionNotFoundException
+      pfs.addMetadata(key, "metaKey", "metaValue");
+      Assert.fail("Expected not to find key: " + key);
+    } catch (PartitionNotFoundException expected) {
+      Assert.assertEquals(pfsInstance.getId(), expected.getPartitionedFileSetName());
+      Assert.assertEquals(key, expected.getPartitionKey());
+    }
   }
 
   @Test


### PR DESCRIPTION
PartitionedFileSet#addMetadata now throws PartitionNotFoundException, for a nonexistent partition key.

Related PR: https://github.com/caskdata/cdap/pull/4564

https://issues.cask.co/browse/CDAP-4260
http://builds.cask.co/browse/CDAP-DUT3251-1