### PR TITLE
CDAP-4289 adding ability to set properties on an artifact

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -48,6 +48,7 @@ import co.cask.cdap.proto.artifact.PluginSummary;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HttpResponder;
+import com.google.common.base.Charsets;
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
@@ -56,9 +57,11 @@ import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
@@ -66,7 +69,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -81,6 +87,7 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
@@ -97,6 +104,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   private static final String PLUGINS_HEADER = "Artifact-Plugins";
   private static final Type APPCLASS_SUMMARIES_TYPE = new TypeToken<List<ApplicationClassSummary>>() { }.getType();
   private static final Type APPCLASS_INFOS_TYPE = new TypeToken<List<ApplicationClassInfo>>() { }.getType();
+  private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .registerTypeAdapter(PluginClass.class, new PluginClassDeserializer())
@@ -190,13 +198,180 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
       ArtifactDetail detail = artifactRepository.getArtifact(artifactId);
       ArtifactDescriptor descriptor = detail.getDescriptor();
       // info hides some fields that are available in detail, such as the location of the artifact
-      ArtifactInfo info = new ArtifactInfo(descriptor.getArtifactId(), detail.getMeta().getClasses());
+      ArtifactInfo info = new ArtifactInfo(descriptor.getArtifactId(),
+                                           detail.getMeta().getClasses(), detail.getMeta().getProperties());
       responder.sendJson(HttpResponseStatus.OK, info, ArtifactInfo.class, GSON);
     } catch (ArtifactNotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
     } catch (IOException e) {
       LOG.error("Exception reading artifacts named {} for namespace {} from the store.", artifactName, namespaceId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error reading artifact metadata from the store.");
+    }
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}/properties")
+  public void getProperties(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId,
+                            @PathParam("artifact-name") String artifactName,
+                            @PathParam("artifact-version") String artifactVersion,
+                            @QueryParam("scope") @DefaultValue("user") String scope,
+                            @QueryParam("keys") @Nullable String keys)
+    throws NamespaceNotFoundException, BadRequestException {
+
+    Id.Namespace namespace = validateAndGetNamespace(namespaceId, scope);
+    Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
+
+    try {
+      ArtifactDetail artifactDetail = artifactRepository.getArtifact(artifactId);
+      Map<String, String> properties = artifactDetail.getMeta().getProperties();
+      Map<String, String> result;
+
+      if (keys != null && !keys.isEmpty()) {
+        result = new HashMap<>();
+        for (String key : Splitter.on(',').trimResults().split(keys)) {
+          result.put(key, properties.get(key));
+        }
+      } else {
+        result = properties;
+      }
+      responder.sendJson(HttpResponseStatus.OK, result);
+    } catch (ArtifactNotFoundException e) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
+    } catch (IOException e) {
+      LOG.error("Exception reading artifacts named {} for namespace {} from the store.", artifactName, namespaceId, e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                           "Error reading artifact properties from the store.");
+    }
+  }
+
+  @PUT
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}/properties")
+  public void writeProperties(HttpRequest request, HttpResponder responder,
+                              @PathParam("namespace-id") String namespaceId,
+                              @PathParam("artifact-name") String artifactName,
+                              @PathParam("artifact-version") String artifactVersion)
+    throws NamespaceNotFoundException, BadRequestException {
+
+    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
+      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
+    Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
+
+    Map<String, String> properties;
+    try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(request.getContent()), Charsets.UTF_8)) {
+      properties = GSON.fromJson(reader, MAP_STRING_STRING_TYPE);
+    } catch (JsonSyntaxException e) {
+      throw new BadRequestException("Json Syntax Error while parsing properties from request. " +
+                                      "Please check that the properties are a json map from string to string.", e);
+    } catch (IOException e) {
+      throw new BadRequestException("Unable to read properties from the request.", e);
+    }
+
+    try {
+      artifactRepository.writeArtifactProperties(artifactId, properties);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (ArtifactNotFoundException e) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
+    } catch (IOException e) {
+      LOG.error("Exception updating properties for artifact {}.", artifactId, e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error adding properties to artifact.");
+    }
+  }
+
+  @PUT
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}/properties/{property}")
+  public void writeProperty(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId,
+                            @PathParam("artifact-name") String artifactName,
+                            @PathParam("artifact-version") String artifactVersion,
+                            @PathParam("property") String key)
+    throws NamespaceNotFoundException, BadRequestException {
+
+    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
+      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
+    Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
+
+    String value = request.getContent().toString(Charsets.UTF_8);
+
+    try {
+      artifactRepository.writeArtifactProperty(artifactId, key, value);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (ArtifactNotFoundException e) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
+    } catch (IOException e) {
+      LOG.error("Exception updating properties for artifact {}.", artifactId, e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error writing property to artifact.");
+    }
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}/properties/{property}")
+  public void getProperty(HttpRequest request, HttpResponder responder,
+                          @PathParam("namespace-id") String namespaceId,
+                          @PathParam("artifact-name") String artifactName,
+                          @PathParam("artifact-version") String artifactVersion,
+                          @PathParam("property") String key)
+    throws NamespaceNotFoundException, BadRequestException {
+
+    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
+      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
+    Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
+
+    try {
+      ArtifactDetail detail = artifactRepository.getArtifact(artifactId);
+      responder.sendString(HttpResponseStatus.OK, detail.getMeta().getProperties().get(key));
+    } catch (ArtifactNotFoundException e) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
+    } catch (IOException e) {
+      LOG.error("Exception updating properties for artifact {}.", artifactId, e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error reading properties for artifact.");
+    }
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}/properties")
+  public void deleteProperties(HttpRequest request, HttpResponder responder,
+                               @PathParam("namespace-id") String namespaceId,
+                               @PathParam("artifact-name") String artifactName,
+                               @PathParam("artifact-version") String artifactVersion)
+    throws NamespaceNotFoundException, BadRequestException {
+
+    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
+      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
+    Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
+
+    try {
+      artifactRepository.deleteArtifactProperties(artifactId);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (ArtifactNotFoundException e) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
+    } catch (IOException e) {
+      LOG.error("Exception updating properties for artifact {}.", artifactId, e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error deleting properties for artifact.");
+    }
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}/properties/{property}")
+  public void deleteProperty(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") String namespaceId,
+                             @PathParam("artifact-name") String artifactName,
+                             @PathParam("artifact-version") String artifactVersion,
+                             @PathParam("property") String key)
+    throws NamespaceNotFoundException, BadRequestException {
+
+    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
+      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
+    Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
+
+    try {
+      artifactRepository.deleteArtifactProperty(artifactId, key);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (ArtifactNotFoundException e) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
+    } catch (IOException e) {
+      LOG.error("Exception updating properties for artifact {}.", artifactId, e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error deleting properties for artifact.");
     }
   }
 
@@ -394,7 +569,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
             Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, version);
 
             // add the artifact to the repo
-            artifactRepository.addArtifact(artifactId, uploadedFile, parentArtifacts, additionalPluginClasses);
+            artifactRepository.addArtifact(artifactId, uploadedFile, parentArtifacts, additionalPluginClasses, null);
             responder.sendString(HttpResponseStatus.OK, "Artifact added successfully");
           } catch (ArtifactRangeNotFoundException e) {
             responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -273,7 +273,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     } catch (ArtifactNotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
     } catch (IOException e) {
-      LOG.error("Exception updating properties for artifact {}.", artifactId, e);
+      LOG.error("Exception writing properties for artifact {}.", artifactId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error adding properties to artifact.");
     }
   }
@@ -292,6 +292,10 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     String value = request.getContent().toString(Charsets.UTF_8);
+    if (value == null) {
+      responder.sendStatus(HttpResponseStatus.OK);
+      return;
+    }
 
     try {
       artifactRepository.writeArtifactProperty(artifactId, key, value);
@@ -299,7 +303,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     } catch (ArtifactNotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
     } catch (IOException e) {
-      LOG.error("Exception updating properties for artifact {}.", artifactId, e);
+      LOG.error("Exception writing properties for artifact {}.", artifactId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error writing property to artifact.");
     }
   }
@@ -323,7 +327,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     } catch (ArtifactNotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
     } catch (IOException e) {
-      LOG.error("Exception updating properties for artifact {}.", artifactId, e);
+      LOG.error("Exception reading property for artifact {}.", artifactId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error reading properties for artifact.");
     }
   }
@@ -346,7 +350,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     } catch (ArtifactNotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
     } catch (IOException e) {
-      LOG.error("Exception updating properties for artifact {}.", artifactId, e);
+      LOG.error("Exception deleting properties for artifact {}.", artifactId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error deleting properties for artifact.");
     }
   }
@@ -371,7 +375,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
       responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
     } catch (IOException e) {
       LOG.error("Exception updating properties for artifact {}.", artifactId, e);
-      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error deleting properties for artifact.");
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error deleting property for artifact.");
     }
   }
 
@@ -569,7 +573,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
             Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, version);
 
             // add the artifact to the repo
-            artifactRepository.addArtifact(artifactId, uploadedFile, parentArtifacts, additionalPluginClasses, null);
+            artifactRepository.addArtifact(artifactId, uploadedFile, parentArtifacts, additionalPluginClasses);
             responder.sendString(HttpResponseStatus.OK, "Artifact added successfully");
           } catch (ArtifactRangeNotFoundException e) {
             responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
@@ -18,8 +18,10 @@ package co.cask.cdap.internal.app.runtime.artifact;
 
 import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -31,17 +33,24 @@ import java.util.Set;
  * as information about which versions of the etl-batch artifact can use the plugins it contains.
  */
 public class ArtifactMeta {
+  private static final Map<String, String> EMPTY_MAP = ImmutableMap.of();
   private final ArtifactClasses classes;
   // can't call this 'extends' since that's a reserved keyword
   private final Set<ArtifactRange> usableBy;
+  private final Map<String, String> properties;
 
   public ArtifactMeta(ArtifactClasses classes) {
     this(classes, ImmutableSet.<ArtifactRange>of());
   }
 
   public ArtifactMeta(ArtifactClasses classes, Set<ArtifactRange> usableBy) {
+    this(classes, usableBy, EMPTY_MAP);
+  }
+
+  public ArtifactMeta(ArtifactClasses classes, Set<ArtifactRange> usableBy, Map<String, String> properties) {
     this.classes = classes;
     this.usableBy = usableBy;
+    this.properties = ImmutableMap.copyOf(properties);
   }
 
   public ArtifactClasses getClasses() {
@@ -50,6 +59,11 @@ public class ArtifactMeta {
 
   public Set<ArtifactRange> getUsableBy() {
     return usableBy;
+  }
+
+  public Map<String, String> getProperties() {
+    // null check for backwards compatibility, when properties did not exist
+    return properties == null ? EMPTY_MAP : properties;
   }
 
   @Override
@@ -63,12 +77,14 @@ public class ArtifactMeta {
 
     ArtifactMeta that = (ArtifactMeta) o;
 
-    return Objects.equals(classes, that.classes) && Objects.equals(usableBy, that.usableBy);
+    return Objects.equals(classes, that.classes) &&
+      Objects.equals(usableBy, that.usableBy) &&
+      Objects.equals(getProperties(), that.getProperties());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(classes, usableBy);
+    return Objects.hash(classes, usableBy, getProperties());
   }
 
   @Override
@@ -76,6 +92,7 @@ public class ArtifactMeta {
     return "ArtifactMeta{" +
       "classes=" + classes +
       ", usableBy=" + usableBy +
+      ", properties=" + getProperties() +
       '}';
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -39,6 +39,7 @@ import co.cask.cdap.proto.artifact.ApplicationClassSummary;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -53,6 +54,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -309,7 +311,7 @@ public class ArtifactRepository {
     throws IOException, ArtifactRangeNotFoundException, WriteConflictException,
     ArtifactAlreadyExistsException, InvalidArtifactException {
 
-    return addArtifact(artifactId, artifactFile, parentArtifacts, null);
+    return addArtifact(artifactId, artifactFile, parentArtifacts, null, null);
   }
 
   /**
@@ -324,12 +326,14 @@ public class ArtifactRepository {
    *                        If null, the given artifact does not extend another artifact
    * @param additionalPlugins the set of additional plugin classes to add to the plugins found through inspection.
    *                          If null, no additional plugin classes will be added
+   * @param properties properties for the artifact
    * @throws IOException if there was an exception reading from the artifact store
    * @throws ArtifactRangeNotFoundException if none of the parent artifacts could be found
    */
   public ArtifactDetail addArtifact(Id.Artifact artifactId, File artifactFile,
                                     @Nullable Set<ArtifactRange> parentArtifacts,
-                                    @Nullable Set<PluginClass> additionalPlugins)
+                                    @Nullable Set<PluginClass> additionalPlugins,
+                                    @Nullable Map<String, String> properties)
     throws IOException, ArtifactAlreadyExistsException, WriteConflictException,
     InvalidArtifactException, ArtifactRangeNotFoundException {
 
@@ -349,11 +353,90 @@ public class ArtifactRepository {
 
     try {
       ArtifactClasses artifactClasses = inspectArtifact(artifactId, artifactFile, additionalPlugins, parentClassLoader);
-      ArtifactMeta meta = new ArtifactMeta(artifactClasses, parentArtifacts);
+      Map<String, String> artifactProperties = properties == null ? Collections.<String, String>emptyMap() : properties;
+      ArtifactMeta meta = new ArtifactMeta(artifactClasses, parentArtifacts, artifactProperties);
       return artifactStore.write(artifactId, meta, Files.newInputStreamSupplier(artifactFile));
     } finally {
       parentClassLoader.close();
     }
+  }
+
+  /**
+   * Writes properties of an artifact. Any existing properties will be overwritten
+   *
+   * @param artifactId the id of the artifact to add properties to
+   * @param properties the artifact properties to add
+   * @throws IOException if there was an exception writing to the artifact store
+   * @throws ArtifactNotFoundException if the artifact does not exist
+   */
+  public void writeArtifactProperties(Id.Artifact artifactId, final Map<String, String> properties)
+    throws IOException, ArtifactNotFoundException {
+    artifactStore.updateArtifactProperties(artifactId, new Function<Map<String, String>, Map<String, String>>() {
+      @Override
+      public Map<String, String> apply(Map<String, String> oldProperties) {
+        return properties;
+      }
+    });
+  }
+
+  /**
+   * Writes a property to an artifact. If the property already exists, it will be overwritten. If it does not exist,
+   * it will be added.
+   *
+   * @param artifactId the id of the artifact to write a property to
+   * @param key the property key to write
+   * @param value the property value to write
+   * @throws IOException if there was an exception writing to the artifact store
+   * @throws ArtifactNotFoundException if the artifact does not exist
+   */
+  public void writeArtifactProperty(Id.Artifact artifactId, final String key, final String value)
+    throws IOException, ArtifactNotFoundException {
+    artifactStore.updateArtifactProperties(artifactId, new Function<Map<String, String>, Map<String, String>>() {
+      @Override
+      public Map<String, String> apply(Map<String, String> oldProperties) {
+        Map<String, String> updated = new HashMap<>();
+        updated.putAll(oldProperties);
+        updated.put(key, value);
+        return updated;
+      }
+    });
+  }
+
+  /**
+   * Deletes a property from an artifact. If the property does not exist, this will be a no-op.
+   *
+   * @param artifactId the id of the artifact to delete a property from
+   * @param key the property to delete
+   * @throws IOException if there was an exception writing to the artifact store
+   * @throws ArtifactNotFoundException if the artifact does not exist
+   */
+  public void deleteArtifactProperty(Id.Artifact artifactId, final String key)
+    throws IOException, ArtifactNotFoundException {
+    artifactStore.updateArtifactProperties(artifactId, new Function<Map<String, String>, Map<String, String>>() {
+      @Override
+      public Map<String, String> apply(Map<String, String> oldProperties) {
+        Map<String, String> updated = new HashMap<>();
+        updated.putAll(oldProperties);
+        updated.remove(key);
+        return updated;
+      }
+    });
+  }
+
+  /**
+   * Deletes all properties from an artifact. If no properties exist, this will be a no-op.
+   *
+   * @param artifactId the id of the artifact to delete properties from
+   * @throws IOException if there was an exception writing to the artifact store
+   * @throws ArtifactNotFoundException if the artifact does not exist
+   */
+  public void deleteArtifactProperties(Id.Artifact artifactId) throws IOException, ArtifactNotFoundException {
+    artifactStore.updateArtifactProperties(artifactId, new Function<Map<String, String>, Map<String, String>>() {
+      @Override
+      public Map<String, String> apply(Map<String, String> oldProperties) {
+        return new HashMap<>();
+      }
+    });
   }
 
   private ArtifactClasses inspectArtifact(Id.Artifact artifactId, File artifactFile,
@@ -463,9 +546,10 @@ public class ArtifactRepository {
       }
 
       addArtifact(artifactId,
-        systemArtifactInfo.getArtifactFile(),
-        systemArtifactInfo.getConfig().getParents(),
-        systemArtifactInfo.getConfig().getPlugins());
+                  systemArtifactInfo.getArtifactFile(),
+                  systemArtifactInfo.getConfig().getParents(),
+                  systemArtifactInfo.getConfig().getPlugins(),
+                  systemArtifactInfo.getConfig().getProperties());
     } catch (ArtifactAlreadyExistsException e) {
       // shouldn't happen... but if it does for some reason it's fine, it means it was added some other way already.
     } catch (ArtifactRangeNotFoundException e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -561,7 +561,7 @@ public class ArtifactStore {
                                                       updateFunction.apply(old.meta.getProperties()));
           ArtifactData updatedData = new ArtifactData(locationFactory.create(old.locationURI), updatedMeta);
           // write artifact metadata
-          writeMeta(table, artifactId, updatedData);
+          table.put(artifactCell.rowkey, artifactCell.column, Bytes.toBytes(gson.toJson(updatedData)));
           return true;
         }
       });

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -48,6 +48,7 @@ import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionFailureException;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Supplier;
@@ -204,7 +205,7 @@ public class ArtifactStore {
           addArtifactsToList(artifacts, row);
         }
         scanner.close();
-        
+
         return Collections.unmodifiableList(artifacts);
       }
     });
@@ -528,6 +529,49 @@ public class ArtifactStore {
       throw new PluginNotExistsException(parentArtifactId.getNamespace(), type, name);
     }
     return Collections.unmodifiableSortedMap(plugins);
+  }
+
+  /**
+   * Update artifact properties using an update function. Functions will receive an immutable map.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param updateFunction the function used to update existing properties
+   * @throws ArtifactNotFoundException if the artifact does not exist
+   * @throws IOException if there was an exception writing the properties to the metastore
+   */
+  public void updateArtifactProperties(final Id.Artifact artifactId,
+                                       final Function<Map<String, String>, Map<String, String>> updateFunction)
+    throws ArtifactNotFoundException, IOException {
+    try {
+      boolean exists = metaTable.execute(new TransactionExecutor.Function<DatasetContext<Table>, Boolean>() {
+
+        @Override
+        public Boolean apply(DatasetContext<Table> context) throws Exception {
+          Table table = context.get();
+
+          ArtifactCell artifactCell = new ArtifactCell(artifactId);
+          byte[] existingMetaBytes = table.get(artifactCell.rowkey, artifactCell.column);
+          if (existingMetaBytes == null) {
+            return false;
+          }
+
+          ArtifactData old = gson.fromJson(Bytes.toString(existingMetaBytes), ArtifactData.class);
+
+          ArtifactMeta updatedMeta = new ArtifactMeta(old.meta.getClasses(), old.meta.getUsableBy(),
+                                                      updateFunction.apply(old.meta.getProperties()));
+          ArtifactData updatedData = new ArtifactData(locationFactory.create(old.locationURI), updatedMeta);
+          // write artifact metadata
+          writeMeta(table, artifactId, updatedData);
+          return true;
+        }
+      });
+
+      if (!exists) {
+        throw new ArtifactNotFoundException(artifactId);
+      }
+    } catch (TransactionFailureException | InterruptedException e) {
+      throw new IOException(e);
+    }
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -157,7 +157,8 @@ public class ArtifactRepositoryTest {
       ImmutableSet.of(new ArtifactRange(
         Id.Namespace.SYSTEM, "PluginTest", new ArtifactVersion("0.9.0"), new ArtifactVersion("2.0.0"))),
       // add a dummy plugin to test explicit addition of plugins through the config file
-      manuallyAddedPlugins1
+      manuallyAddedPlugins1,
+      ImmutableMap.of("k1", "v1", "k2", "v2")
     );
     try (BufferedWriter writer = Files.newWriter(pluginConfigFile, Charsets.UTF_8)) {
       writer.write(pluginConfig1.toString());
@@ -178,7 +179,8 @@ public class ArtifactRepositoryTest {
     ArtifactConfig pluginConfig2 = new ArtifactConfig(
       ImmutableSet.of(new ArtifactRange(
         Id.Namespace.SYSTEM, "PluginTest", new ArtifactVersion("0.9.0"), new ArtifactVersion("2.0.0"))),
-      manuallyAddedPlugins2
+      manuallyAddedPlugins2,
+      ImmutableMap.of("k3", "v3")
     );
     try (BufferedWriter writer = Files.newWriter(pluginConfigFile, Charsets.UTF_8)) {
       writer.write(pluginConfig2.toString());
@@ -208,6 +210,8 @@ public class ArtifactRepositoryTest {
                         pluginArtifactDetail.getDescriptor().getArtifactId().getVersion());
     // check manually added plugins are there
     Assert.assertTrue(pluginArtifactDetail.getMeta().getClasses().getPlugins().containsAll(manuallyAddedPlugins1));
+    // check properties are there
+    Assert.assertEquals(pluginConfig1.getProperties(), pluginArtifactDetail.getMeta().getProperties());
 
     // check other plugin artifact added correctly
     pluginArtifactDetail = artifactRepository.getArtifact(pluginArtifactId2);
@@ -216,6 +220,8 @@ public class ArtifactRepositoryTest {
       pluginArtifactDetail.getDescriptor().getArtifactId().getVersion());
     // check manually added plugins are there
     Assert.assertTrue(pluginArtifactDetail.getMeta().getClasses().getPlugins().containsAll(manuallyAddedPlugins2));
+    // check properties are there
+    Assert.assertEquals(pluginConfig2.getProperties(), pluginArtifactDetail.getMeta().getProperties());
   }
 
   @Test
@@ -364,6 +370,46 @@ public class ArtifactRepositoryTest {
       childId.getNamespace(), childId.getName(),
       new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0")));
     artifactRepository.addArtifact(grandchildId, jarFile, parents);
+  }
+
+  @Test
+  public void testArtifactProperties() throws Exception {
+    // test adding properties
+    Map<String, String> properties = ImmutableMap.of("k1", "v1", "k2", "v2");
+    artifactRepository.writeArtifactProperties(APP_ARTIFACT_ID, properties);
+    ArtifactDetail detail = artifactRepository.getArtifact(APP_ARTIFACT_ID);
+    Assert.assertEquals(properties, detail.getMeta().getProperties());
+
+    // test properties are overwritten
+    properties = ImmutableMap.of("k2", "v2-2", "k3", "v3");
+    artifactRepository.writeArtifactProperties(APP_ARTIFACT_ID, properties);
+    detail = artifactRepository.getArtifact(APP_ARTIFACT_ID);
+    Assert.assertEquals(properties, detail.getMeta().getProperties());
+
+    // test deleting a property
+    artifactRepository.deleteArtifactProperty(APP_ARTIFACT_ID, "k2");
+    detail = artifactRepository.getArtifact(APP_ARTIFACT_ID);
+    Assert.assertEquals(ImmutableMap.of("k3", "v3"), detail.getMeta().getProperties());
+
+    // test deleting a non-existant property is a no-op
+    artifactRepository.deleteArtifactProperty(APP_ARTIFACT_ID, "k2");
+    detail = artifactRepository.getArtifact(APP_ARTIFACT_ID);
+    Assert.assertEquals(ImmutableMap.of("k3", "v3"), detail.getMeta().getProperties());
+
+    // test updating one property
+    artifactRepository.writeArtifactProperty(APP_ARTIFACT_ID, "k3", "v3-2");
+    detail = artifactRepository.getArtifact(APP_ARTIFACT_ID);
+    Assert.assertEquals(ImmutableMap.of("k3", "v3-2"), detail.getMeta().getProperties());
+
+    // test writing one new property
+    artifactRepository.writeArtifactProperty(APP_ARTIFACT_ID, "k2", "v2-3");
+    detail = artifactRepository.getArtifact(APP_ARTIFACT_ID);
+    Assert.assertEquals(ImmutableMap.of("k2", "v2-3", "k3", "v3-2"), detail.getMeta().getProperties());
+
+    // test deleting all properties
+    artifactRepository.deleteArtifactProperties(APP_ARTIFACT_ID);
+    detail = artifactRepository.getArtifact(APP_ARTIFACT_ID);
+    Assert.assertEquals(0, detail.getMeta().getProperties().size());
   }
 
   private static ClassLoader createAppClassLoader(File jarFile) throws IOException {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTest.java
@@ -147,7 +147,8 @@ public class ArtifactHttpHandlerTest extends AppFabricTestBase {
     ArtifactClasses classes = ArtifactClasses.builder()
       .addApp(new ApplicationClass(ConfigTestApp.class.getName(), "", appConfigSchema))
       .build();
-    ArtifactInfo expectedInfo = new ArtifactInfo("cfgtest", "1.0.0", ArtifactScope.USER, classes);
+    ArtifactInfo expectedInfo = new ArtifactInfo("cfgtest", "1.0.0", ArtifactScope.USER,
+                                                 classes, ImmutableMap.<String, String>of());
     ArtifactInfo actualInfo = getArtifact(configTestAppId);
     Assert.assertEquals(expectedInfo, actualInfo);
   }
@@ -204,12 +205,14 @@ public class ArtifactHttpHandlerTest extends AppFabricTestBase {
     ArtifactClasses classes = ArtifactClasses.builder()
       .addApp(new ApplicationClass(WordCountApp.class.getName(), "", null))
       .build();
-    ArtifactInfo expectedInfo = new ArtifactInfo("wordcount", "1.0.0", ArtifactScope.USER, classes);
+    ArtifactInfo expectedInfo = new ArtifactInfo("wordcount", "1.0.0", ArtifactScope.USER,
+                                                 classes, ImmutableMap.<String, String>of());
     ArtifactInfo actualInfo = getArtifact(defaultId, ArtifactScope.USER);
     Assert.assertEquals(expectedInfo, actualInfo);
 
     // test get /artifacts/wordcount/versions/1.0.0?scope=system
-    expectedInfo = new ArtifactInfo("wordcount", "1.0.0", ArtifactScope.SYSTEM, classes);
+    expectedInfo = new ArtifactInfo("wordcount", "1.0.0", ArtifactScope.SYSTEM,
+                                    classes, ImmutableMap.<String, String>of());
     actualInfo = getArtifact(defaultId, ArtifactScope.SYSTEM);
     Assert.assertEquals(expectedInfo, actualInfo);
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
@@ -23,28 +23,27 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.english.Article;
 import co.cask.cdap.cli.english.Fragment;
 import co.cask.cdap.cli.util.AbstractAuthCommand;
+import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.ArtifactClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactInfo;
 import co.cask.common.cli.Arguments;
-import com.google.common.collect.ImmutableList;
-import com.google.gson.Gson;
 import com.google.inject.Inject;
 
 import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
- * Shows information about an artifact.
+ * Loads an artifact into CDAP.
  */
-public class DescribeArtifactCommand extends AbstractAuthCommand {
-
-  private static final Gson GSON = new Gson();
+public class GetArtifactPropertiesCommand extends AbstractAuthCommand {
   private final ArtifactClient artifactClient;
 
   @Inject
-  public DescribeArtifactCommand(ArtifactClient artifactClient, CLIConfig cliConfig) {
+  public GetArtifactPropertiesCommand(ArtifactClient artifactClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.artifactClient = artifactClient;
   }
@@ -65,30 +64,32 @@ public class DescribeArtifactCommand extends AbstractAuthCommand {
       info = artifactClient.getArtifactInfo(artifactId, scope);
     }
 
+    List<Map.Entry<String, String>> rows = new ArrayList<>(info.getProperties().size());
+    rows.addAll(info.getProperties().entrySet());
     Table table = Table.builder()
-      .setHeader("name", "version", "scope", "app classes", "plugin classes", "properties")
-      .setRows(ImmutableList.of((List<String>) ImmutableList.of(
-        info.getName(),
-        info.getVersion(),
-        info.getScope().name(),
-        GSON.toJson(info.getClasses().getApps()),
-        GSON.toJson(info.getClasses().getPlugins()),
-        GSON.toJson(info.getProperties())))
-      )
+      .setHeader("key", "value")
+      .setRows(rows, new RowMaker<Map.Entry<String, String>>() {
+        @Override
+        public List<String> makeRow(Map.Entry<String, String> entry) {
+          List<String> columns = new ArrayList<>(2);
+          columns.add(entry.getKey());
+          columns.add(entry.getValue());
+          return columns;
+        }
+      })
       .build();
     cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override
   public String getPattern() {
-    return String.format("describe artifact <%s> <%s> [<%s>]",
+    return String.format("get artifact properties <%s> <%s> [<%s>]",
                          ArgumentName.ARTIFACT_NAME, ArgumentName.ARTIFACT_VERSION, ArgumentName.SCOPE);
   }
 
   @Override
   public String getDescription() {
-    return String.format("Shows information about %s. If no scope is given, the user scope will be used. " +
-      "Includes information about application and plugin classes contained in the artifact.",
-      Fragment.of(Article.A, ElementType.ARTIFACT.getName()));
+    return String.format("Gets properties of %s. If no scope is given, the user scope will be used. ",
+                         Fragment.of(Article.A, ElementType.ARTIFACT.getName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Loads an artifact into CDAP.
+ * Gets properties for an artifact.
  */
 public class GetArtifactPropertiesCommand extends AbstractAuthCommand {
   private final ArtifactClient artifactClient;

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/LoadArtifactCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/LoadArtifactCommand.java
@@ -30,6 +30,7 @@ import com.google.inject.Inject;
 
 import java.io.File;
 import java.io.PrintStream;
+import java.util.Map;
 
 /**
  * Loads an artifact into CDAP.
@@ -74,6 +75,11 @@ public class LoadArtifactCommand extends AbstractAuthCommand {
       ArtifactConfig artifactConfig = configReader.read(artifactId.getNamespace(), configFile);
       artifactClient.add(artifactId.getNamespace(), artifactId.getName(), Files.newInputStreamSupplier(artifactFile),
         artifactId.getVersion().getVersion(), artifactConfig.getParents(), artifactConfig.getPlugins());
+
+      Map<String, String> properties = artifactConfig.getProperties();
+      if (properties != null && !properties.isEmpty()) {
+        artifactClient.writeProperties(artifactId, properties);
+      }
     }
 
     output.printf("Successfully added artifact with name '%s'\n", artifactId.getName());
@@ -103,10 +109,14 @@ public class LoadArtifactCommand extends AbstractAuthCommand {
       "          \"name\": \"mysql\",\n" +
       "          \"className\": \"com.mysql.jdbc.Driver\"\n" +
       "        }\n" +
-      "      ]\n" +
+      "      ],\n" +
+      "      \"properties\":{\n" +
+      "        \"prop1\": \"val1\"\n" +
+      "      }\n" +
       "    }\n" +
       "This config specifies that the artifact contains one JDBC third-party plugin that should be " +
       "available to the app1 artifact (versions 1.0.0 inclusive to 2.0.0 exclusive) and app2 artifact " +
-      "(versions 1.2.0 inclusive to 1.3.0 inclusive).";
+      "(versions 1.2.0 inclusive to 1.3.0 inclusive). The config may also include a 'properties' field specifying " +
+      "properties for the artifact.";
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/SetArtifactPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/SetArtifactPropertiesCommand.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command.artifact;
+
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.util.AbstractAuthCommand;
+import co.cask.cdap.cli.util.FilePathResolver;
+import co.cask.cdap.client.ArtifactClient;
+import co.cask.cdap.proto.Id;
+import co.cask.common.cli.Arguments;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Inject;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.PrintStream;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Loads an artifact into CDAP.
+ */
+public class SetArtifactPropertiesCommand extends AbstractAuthCommand {
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private final ArtifactClient artifactClient;
+  private final FilePathResolver resolver;
+
+  @Inject
+  public SetArtifactPropertiesCommand(ArtifactClient artifactClient, CLIConfig cliConfig, FilePathResolver resolver) {
+    super(cliConfig);
+    this.artifactClient = artifactClient;
+    this.resolver = resolver;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream output) throws Exception {
+
+    String artifactName = arguments.get(ArgumentName.ARTIFACT_NAME.toString());
+    String artifactVersion = arguments.get(ArgumentName.ARTIFACT_VERSION.toString());
+    String scopeStr = arguments.get(ArgumentName.SCOPE.toString());
+    ArtifactScope scope = ArtifactScope.valueOf(scopeStr.toUpperCase());
+
+    Id.Namespace namespace = scope == ArtifactScope.SYSTEM ? Id.Namespace.SYSTEM : cliConfig.getCurrentNamespace();
+    Id.Artifact artifactId = Id.Artifact.from(namespace, artifactName, artifactVersion);
+
+    String propertiesFilePath = arguments.get(ArgumentName.LOCAL_FILE_PATH.toString());
+    File propertiesFile = resolver.resolvePathToFile(propertiesFilePath);
+    try (Reader reader = new FileReader(propertiesFile)) {
+      Map<String, String> properties;
+      try {
+        properties = GSON.fromJson(reader, MAP_TYPE);
+      } catch (Exception e) {
+        throw new RuntimeException("Error parsing file contents as a JSON Object. " +
+                                     "Please check that it is a valid JSON Object.", e);
+      }
+      artifactClient.writeProperties(artifactId, properties);
+    }
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("set artifact properties <%s> <%s> <%s> <%s>",
+                         ArgumentName.ARTIFACT_NAME, ArgumentName.ARTIFACT_VERSION,
+                         ArgumentName.SCOPE, ArgumentName.LOCAL_FILE_PATH);
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format(
+      "Sets properties of %s. " +
+        "If a file is specified, the file must contain a JSON Object of the properties for the artifact. " +
+        "If a directory is specified, every file in the directory is added as a property, with the filename " +
+        "as the property key and the file contents as the property value.",
+      Fragment.of(Article.A, ElementType.ARTIFACT.getName()));
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ArtifactCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ArtifactCommands.java
@@ -21,11 +21,13 @@ import co.cask.cdap.cli.CommandCategory;
 import co.cask.cdap.cli.command.artifact.DeleteArtifactCommand;
 import co.cask.cdap.cli.command.artifact.DescribeArtifactCommand;
 import co.cask.cdap.cli.command.artifact.DescribeArtifactPluginCommand;
+import co.cask.cdap.cli.command.artifact.GetArtifactPropertiesCommand;
 import co.cask.cdap.cli.command.artifact.ListArtifactPluginTypesCommand;
 import co.cask.cdap.cli.command.artifact.ListArtifactPluginsCommand;
 import co.cask.cdap.cli.command.artifact.ListArtifactVersionsCommand;
 import co.cask.cdap.cli.command.artifact.ListArtifactsCommand;
 import co.cask.cdap.cli.command.artifact.LoadArtifactCommand;
+import co.cask.cdap.cli.command.artifact.SetArtifactPropertiesCommand;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
 import com.google.common.collect.ImmutableList;
@@ -41,14 +43,16 @@ public class ArtifactCommands extends CommandSet<Command> implements Categorized
   public ArtifactCommands(Injector injector) {
     super(
       ImmutableList.<Command>builder()
-        .add(injector.getInstance(ListArtifactsCommand.class))
-        .add(injector.getInstance(ListArtifactVersionsCommand.class))
+        .add(injector.getInstance(DeleteArtifactCommand.class))
         .add(injector.getInstance(DescribeArtifactCommand.class))
+        .add(injector.getInstance(DescribeArtifactPluginCommand.class))
+        .add(injector.getInstance(GetArtifactPropertiesCommand.class))
+        .add(injector.getInstance(ListArtifactsCommand.class))
         .add(injector.getInstance(ListArtifactPluginTypesCommand.class))
         .add(injector.getInstance(ListArtifactPluginsCommand.class))
-        .add(injector.getInstance(DescribeArtifactPluginCommand.class))
-        .add(injector.getInstance(DeleteArtifactCommand.class))
+        .add(injector.getInstance(ListArtifactVersionsCommand.class))
         .add(injector.getInstance(LoadArtifactCommand.class))
+        .add(injector.getInstance(SetArtifactPropertiesCommand.class))
         .build());
   }
 

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -51,8 +51,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -538,4 +540,126 @@ public class ArtifactClient {
     }
   }
 
+  /**
+   * Write artifact properties. Any existing properties will be overwritten.
+   *
+   * @param artifactId the artifact to add properties to
+   * @param properties the properties to add
+   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
+   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws ArtifactNotFoundException if the artifact does not exist
+   * @throws IOException if a network error occurred
+   */
+  public void writeProperties(Id.Artifact artifactId, Map<String, String> properties)
+    throws IOException, UnauthorizedException, ArtifactNotFoundException, BadRequestException {
+    String path = String.format("artifacts/%s/versions/%s/properties",
+                                artifactId.getName(),
+                                artifactId.getVersion().getVersion());
+    URL url = config.resolveNamespacedURLV3(artifactId.getNamespace(), path);
+    HttpRequest.Builder requestBuilder = HttpRequest.put(url);
+    HttpRequest request = requestBuilder.withBody(GSON.toJson(properties)).build();
+
+    HttpResponse response = restClient.execute(request, config.getAccessToken(),
+                                               HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND);
+
+    int responseCode = response.getResponseCode();
+    if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new ArtifactNotFoundException(artifactId);
+    } else if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
+  }
+
+  /**
+   * Delete all properties of an artifact. If no properties exist, this will be a no-op.
+   *
+   * @param artifactId the artifact to delete properties from
+   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
+   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws ArtifactNotFoundException if the artifact does not exist
+   * @throws IOException if a network error occurred
+   */
+  public void deleteProperties(Id.Artifact artifactId)
+    throws IOException, UnauthorizedException, ArtifactNotFoundException, BadRequestException {
+    String path = String.format("artifacts/%s/versions/%s/properties",
+                                artifactId.getName(),
+                                artifactId.getVersion().getVersion());
+    URL url = config.resolveNamespacedURLV3(artifactId.getNamespace(), path);
+    HttpRequest.Builder requestBuilder = HttpRequest.delete(url);
+    HttpRequest request = requestBuilder.build();
+
+    HttpResponse response = restClient.execute(request, config.getAccessToken(),
+                                               HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND);
+
+    int responseCode = response.getResponseCode();
+    if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new ArtifactNotFoundException(artifactId);
+    } else if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
+  }
+
+  /**
+   * Write a property of an artifact. If the property already exists, it will be overwritten. If the property
+   * does not exist, it will be added.
+   *
+   * @param artifactId the artifact to write the property to
+   * @param key the property key to write
+   * @param value the property value to write
+   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
+   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws ArtifactNotFoundException if the artifact does not exist
+   * @throws IOException if a network error occurred
+   */
+  public void writeProperty(Id.Artifact artifactId, String key, String value)
+    throws IOException, UnauthorizedException, ArtifactNotFoundException, BadRequestException {
+    String path = String.format("artifacts/%s/versions/%s/properties/%s",
+                                artifactId.getName(),
+                                artifactId.getVersion().getVersion(),
+                                key);
+    URL url = config.resolveNamespacedURLV3(artifactId.getNamespace(), path);
+    HttpRequest.Builder requestBuilder = HttpRequest.put(url);
+    HttpRequest request = requestBuilder.withBody(value).build();
+
+    HttpResponse response = restClient.execute(request, config.getAccessToken(),
+                                               HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND);
+
+    int responseCode = response.getResponseCode();
+    if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new ArtifactNotFoundException(artifactId);
+    } else if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
+  }
+
+  /**
+   * Delete a property of an artifact. If the property does not exist, this will be a no-op.
+   *
+   * @param artifactId the artifact to delete a property from
+   * @param key the property to delete
+   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
+   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws ArtifactNotFoundException if the artifact does not exist
+   * @throws IOException if a network error occurred
+   */
+  public void deleteProperty(Id.Artifact artifactId, String key)
+    throws IOException, UnauthorizedException, ArtifactNotFoundException, BadRequestException {
+    String path = String.format("artifacts/%s/versions/%s/properties/%s",
+                                artifactId.getName(),
+                                artifactId.getVersion().getVersion(),
+                                key);
+    URL url = config.resolveNamespacedURLV3(artifactId.getNamespace(), path);
+    HttpRequest.Builder requestBuilder = HttpRequest.delete(url);
+    HttpRequest request = requestBuilder.build();
+
+    HttpResponse response = restClient.execute(request, config.getAccessToken(),
+                                               HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND);
+
+    int responseCode = response.getResponseCode();
+    if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new ArtifactNotFoundException(artifactId);
+    } else if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
+  }
 }

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -541,7 +541,7 @@ public class ArtifactClient {
   }
 
   /**
-   * Write artifact properties. Any existing properties will be overwritten.
+   * Write properties for an artifact. Any existing properties will be overwritten.
    *
    * @param artifactId the artifact to add properties to
    * @param properties the properties to add
@@ -571,7 +571,7 @@ public class ArtifactClient {
   }
 
   /**
-   * Delete all properties of an artifact. If no properties exist, this will be a no-op.
+   * Delete all properties for an artifact. If no properties exist, this will be a no-op.
    *
    * @param artifactId the artifact to delete properties from
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
@@ -600,7 +600,7 @@ public class ArtifactClient {
   }
 
   /**
-   * Write a property of an artifact. If the property already exists, it will be overwritten. If the property
+   * Write a property for an artifact. If the property already exists, it will be overwritten. If the property
    * does not exist, it will be added.
    *
    * @param artifactId the artifact to write the property to
@@ -633,7 +633,7 @@ public class ArtifactClient {
   }
 
   /**
-   * Delete a property of an artifact. If the property does not exist, this will be a no-op.
+   * Delete a property for an artifact. If the property does not exist, this will be a no-op.
    *
    * @param artifactId the artifact to delete a property from
    * @param key the property to delete

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/ArtifactConfig.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/ArtifactConfig.java
@@ -19,6 +19,7 @@ package co.cask.cdap.common.conf;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -28,6 +29,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -40,14 +42,16 @@ public class ArtifactConfig  {
     .create();
   private final Set<ArtifactRange> parents;
   private final Set<PluginClass> plugins;
+  private final Map<String, String> properties;
 
   public ArtifactConfig() {
-    this(ImmutableSet.<ArtifactRange>of(), ImmutableSet.<PluginClass>of());
+    this(ImmutableSet.<ArtifactRange>of(), ImmutableSet.<PluginClass>of(), ImmutableMap.<String, String>of());
   }
 
-  public ArtifactConfig(Set<ArtifactRange> parents, Set<PluginClass> plugins) {
+  public ArtifactConfig(Set<ArtifactRange> parents, Set<PluginClass> plugins, Map<String, String> properties) {
     this.parents = ImmutableSet.copyOf(parents);
     this.plugins = ImmutableSet.copyOf(plugins);
+    this.properties = ImmutableMap.copyOf(properties);
   }
 
   public Set<ArtifactRange> getParents() {
@@ -56,6 +60,10 @@ public class ArtifactConfig  {
 
   public Set<PluginClass> getPlugins() {
     return plugins;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
   }
 
   public boolean hasParent(Id.Artifact artifactId) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/ArtifactConfigReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/ArtifactConfigReader.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -134,6 +135,7 @@ public class ArtifactConfigReader {
   private static final class ArtifactConfigDeserializer implements JsonDeserializer<ArtifactConfig> {
     private static final Type PLUGINS_TYPE = new TypeToken<Set<PluginClass>>() { }.getType();
     private static final Type PARENTS_TYPE = new TypeToken<Set<ArtifactRange>>() { }.getType();
+    private static final Type PROPERTIES_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
     @Override
     public ArtifactConfig deserialize(JsonElement json, Type typeOfT,
@@ -148,8 +150,10 @@ public class ArtifactConfigReader {
       parents = parents == null ? Collections.<ArtifactRange>emptySet() : parents;
       Set<PluginClass> plugins = context.deserialize(obj.get("plugins"), PLUGINS_TYPE);
       plugins = plugins == null ? Collections.<PluginClass>emptySet() : plugins;
+      Map<String, String> properties = context.deserialize(obj.get("properties"), PROPERTIES_TYPE);
+      properties = properties == null ? Collections.<String, String>emptyMap() : properties;
 
-      return new ArtifactConfig(parents, plugins);
+      return new ArtifactConfig(parents, plugins, properties);
     }
   }
 }

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/ArtifactConfigReaderTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/ArtifactConfigReaderTest.java
@@ -54,6 +54,10 @@ public class ArtifactConfigReaderTest {
           "x", new PluginPropertyField("x", "some field", "int", true),
           "y", new PluginPropertyField("y", "some other field", "string", false)
         ))
+      ),
+      ImmutableMap.of(
+        "k1", "v1",
+        "k2", "v2"
       )
     );
     File configFile = new File(tmpFolder.newFolder(), "r1-1.0.0.json");
@@ -70,7 +74,8 @@ public class ArtifactConfigReaderTest {
       ImmutableSet.of(
         new ArtifactRange(Id.Namespace.DEFAULT, "b", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0"))
       ),
-      ImmutableSet.<PluginClass>of());
+      ImmutableSet.<PluginClass>of(),
+      ImmutableMap.<String, String>of());
     File configFile = new File(tmpFolder.newFolder(), "r1-1.0.0.json");
     try (BufferedWriter writer = Files.newWriter(configFile, Charsets.UTF_8)) {
       writer.write(badConfig.toString());

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactInfo.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.artifact.ArtifactScope;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -29,18 +30,25 @@ import java.util.Objects;
 @Beta
 public class ArtifactInfo extends ArtifactSummary {
   private final ArtifactClasses classes;
+  private final Map<String, String> properties;
 
-  public ArtifactInfo(ArtifactId id, ArtifactClasses classes) {
-    this(id.getName(), id.getVersion().getVersion(), id.getScope(), classes);
+  public ArtifactInfo(ArtifactId id, ArtifactClasses classes, Map<String, String> properties) {
+    this(id.getName(), id.getVersion().getVersion(), id.getScope(), classes, properties);
   }
 
-  public ArtifactInfo(String name, String version, ArtifactScope scope, ArtifactClasses classes) {
+  public ArtifactInfo(String name, String version, ArtifactScope scope,
+                      ArtifactClasses classes, Map<String, String> properties) {
     super(name, version, scope);
     this.classes = classes;
+    this.properties = properties;
   }
 
   public ArtifactClasses getClasses() {
     return classes;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
   }
 
   @Override
@@ -55,12 +63,13 @@ public class ArtifactInfo extends ArtifactSummary {
     ArtifactInfo that = (ArtifactInfo) o;
 
     return super.equals(that) &&
-      Objects.equals(classes, that.classes);
+      Objects.equals(classes, that.classes) &&
+      Objects.equals(properties, that.properties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), classes);
+    return Objects.hash(super.hashCode(), classes, properties);
   }
 
   @Override
@@ -70,6 +79,7 @@ public class ArtifactInfo extends ArtifactSummary {
       ", version='" + version + '\'' +
       ", scope=" + scope +
       ", classes=" + classes +
+      ", properties=" + properties +
       '}';
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -68,6 +68,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -231,7 +232,8 @@ public class UnitTestManager implements TestManager {
                                 @Nullable Set<PluginClass> additionalPlugins,
                                 Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
     File pluginJar = createPluginJar(artifactId, pluginClass, pluginClasses);
-    artifactRepository.addArtifact(artifactId, pluginJar, parents, additionalPlugins, null);
+    artifactRepository.addArtifact(artifactId, pluginJar, parents,
+                                   additionalPlugins, Collections.<String, String>emptyMap());
     pluginJar.delete();
   }
 

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -231,7 +231,7 @@ public class UnitTestManager implements TestManager {
                                 @Nullable Set<PluginClass> additionalPlugins,
                                 Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
     File pluginJar = createPluginJar(artifactId, pluginClass, pluginClasses);
-    artifactRepository.addArtifact(artifactId, pluginJar, parents, additionalPlugins);
+    artifactRepository.addArtifact(artifactId, pluginJar, parents, additionalPlugins, null);
     pluginJar.delete();
   }
 


### PR DESCRIPTION
Added properties to an artifact. Properties are stored along with
other data about an artifact. Properties can be added to or deleted
from using the RESTful API. Also adding corresponding methods
to the ArtifactClient and CLI.

https://issues.cask.co/browse/CDAP-4289