### PR TITLE
CDAP-4292 Documentation to clearly specify the difference between system and user artifacts

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/artifacts.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/artifacts.rst
@@ -11,34 +11,35 @@ Artifacts
 .. highlight:: java
 
 An *Artifact* is a JAR file that contains Java classes and resources required to create and run an *Application*.
+*Artifacts* are identified by a *name*, *version*, and *scope*.
 
-*Artifacts* are identified by a name, version, and scope.
-The artifact name must consist of only alphanumeric, '-', and '_' characters. For example,
-'my-application' is a valid artifact name, but 'my:application' is not.
+The **artifact name** must consist only of alphanumeric, ``'-'`` (hyphen), and ``'_'`` (underscore) characters.
+For example, ``'my-application'`` is a valid artifact name, but ``'my:application'`` is not.
 
-The artifact version is of the format '[major].[minor].[fix](-\|.)[suffix]'. Minor, fix, and suffix
+The **artifact version** is of the format ``'[major].[minor].[fix](-\|.)[suffix]'``. Minor, fix, and suffix
 portions of the version are optional, though it is suggested that you have them conform to
 standard versioning schemes. The major, minor, and fix portions of the version must be numeric.
-The suffix can be any of the acceptable characters. For example, '3.2.0-SNAPSHOT' is a valid artifact version,
-with a major version of 3, minor version of 2, fix version of 0, and suffix of SNAPSHOT. 
+The suffix can be any of the acceptable characters. For example, ``'3.2.0-SNAPSHOT'`` is a valid artifact version,
+with a major version of 3, minor version of 2, fix version of 0, and suffix of ``SNAPSHOT``. 
 
-The artifact scope is either 'user' or 'system'. An artifact in the 'user' scope was added by users
-through the CLI or RESTful API. A 'user' artifact belongs in a namespace and cannot be accessed in
-another namespace. A 'system' artifact is an artifact that is available across all namespaces. It
-is added by placing the artifact in a special directory on either the CDAP master node(s) or the
-CDAP Standalone. 
+The **artifact scope** is either ``'user'`` or ``'system'``. An artifact in the *'user'* scope is added by users
+through the CLI or RESTful API. A *'user'* artifact belongs in a namespace and cannot be accessed in
+another namespace. A *'system'* artifact is an artifact that is available across all namespaces. It
+is added by placing the artifact in a special directory on either the CDAP Master node(s) or the
+CDAP Standalone SDK. 
 
-Once added to CDAP, an *Artifact* cannot be modified unless it is a snapshot artifact.
-An *Artifact* is a snapshot artifact if the version suffix begins with SNAPSHOT. For example,
-'1.2.3.SNAPSHOT-test' is a snapshot version because it has a suffix of 'SNAPSHOT-test', which
-begins with SNAPSHOT. '1.2.3' is not a snapshot version because there is no suffix. '1.2.3-hadoop2'
-is also not a snapshot version because the suffix does not begin with SNAPSHOT.
+Once added to CDAP, an *Artifact* cannot be modified unless it is a **snapshot artifact.**
+An *Artifact* is a snapshot artifact if the version suffix begins with ``SNAPSHOT``. For example,
+``'1.2.3.SNAPSHOT-test'`` is a snapshot version because it has a suffix of ``'SNAPSHOT-test'``, which
+begins with ``SNAPSHOT``. ``'1.2.3'`` is not a snapshot version because there is no suffix. ``'1.2.3-hadoop2'``
+is also not a snapshot version because the suffix does not begin with ``SNAPSHOT``.
 
 Artifacts are managed using the :ref:`Artifact HTTP RESTful APIs <http-restful-api-artifact>`.
 
 Deploying an Artifact
 =====================
-An artifact is deployed through the RESTful API. If it contains an Application class, the artifact
+An artifact is deployed through the :ref:`RESTful API <http-restful-api-artifact-add>`. 
+If it contains an Application class, the artifact
 can then be used to create applications. Once an artifact is deployed, it cannot be changed, with
 the exception of snapshot versions of artifacts. Snapshot artifacts can be deployed multiple times,
 with each deployment overwriting the previous artifact. If a program is using a snapshot artifact,
@@ -64,22 +65,32 @@ If a program is already running, it will be unaffected. If that running program 
 be able to start again until the artifact is replaced, or the application is updated to use another
 artifact.
 
-System Artifacts
-================
-Normally an artifact is added to a specific namespace. Users in one namespace cannot see or use
-artifacts in another namespace. Sometimes there is a need to provide an artifact that can be used
-across namespaces. One example of this are the etl artifacts shipped with CDAP. In such scenarios,
-a system artifact can be used. System artifacts cannot be added through the RESTful API, but must be
-added by placing the artifact in a special directory. For distributed CDAP, this directory is defined
-by the ``app.artifact.dir`` setting in cdap-site.xml. It defaults to ``/opt/cdap/master/artifacts``.
-For CDAP standalone, the directory is set to the ``artifacts`` directory.
+User and System Artifacts
+=========================
+Normally, an artifact is added to a specific namespace. Users in one namespace cannot see or use
+artifacts in another namespace. These are referred to as :ref:`user artifacts <plugins-deployment-user>`.
 
-Any artifact in the directory will be added to CDAP when it starts up. In addition, a RESTful API
+Sometimes there is a need to provide an artifact that can be used across namespaces. One
+example of this are the :ref:`ETL artifacts <included-apps-etl-plugins>` shipped with 
+CDAP. In such scenarios, a :ref:`system artifact <plugins-deployment-system>` can be used. 
+
+System artifacts cannot be added through the RESTful API, but must be added by placing the
+artifact in a special directory. For Distributed CDAP, this directory is defined by the
+``app.artifact.dir`` setting in :ref:`cdap-site.xml <appendix-cdap-site.xml>`. It defaults to
+``/opt/cdap/master/artifacts``. For the CDAP Standalone SDK, the directory is set to the
+``artifacts`` directory.
+
+Any artifact in the directory will be added to CDAP when it starts up. In addition, a 
+:ref:`RESTful API <http-restful-api-artifact-system-load>`
 call can be made to scan the directory for any new artifacts that may have been added since CDAP
-started. If a system artifact contains plugins that extend another system artifact, a matching
+started. 
+
+If a system artifact contains plugins that extend another system artifact, a matching
 JSON config file must be provided to specify which artifacts it extends. In addition, if a system
 artifact is a third-party JAR, the plugins in the artifact can be explicitly listed in that same config
-file. For example, suppose you want to add ``mysql-connector-java-5.1.3.jar`` as a system artifact. The
+file. 
+
+For example, suppose you want to add ``mysql-connector-java-5.1.3.jar`` as a system artifact. The
 artifact is the MySQL JDBC driver, and is a third-party JAR that we want to use as a JDBC plugin for
 the ``cdap-etl-batch`` artifact. You would place the JAR file in the artifacts directory along with a
 matching config file named ``mysql-connector-java-5.1.3.json``. The config file would contain::

--- a/cdap-docs/developers-manual/source/building-blocks/plugins.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/plugins.rst
@@ -169,11 +169,11 @@ packages, you would edit the bundler plugin in your pom.xml:
   </plugin>
 
 
-.. _plugins-deployment-system:
+.. _plugins-deployment-artifact:
 
 Deploying Artifacts
 -------------------
-A plugins can be deployed as either a :ref:`system <plugins-deployment-system>` or 
+A plugin can be deployed as either a :ref:`system <plugins-deployment-system>` or 
 :ref:`user <plugins-deployment-user>` artifact. System artifacts are available 
 across all namespaces, while user artifacts are local to one namespace.
 

--- a/cdap-docs/developers-manual/source/building-blocks/plugins.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/plugins.rst
@@ -131,11 +131,19 @@ the plugins when deploying the artifact. For example, if you are using the RESTf
 
 Plugin Deployment
 =================
+
+.. _plugins-deployment-artifact:
+
 To make plugins available to another artifact (and thus available to any application
 created from one of the artifacts), the plugins must first be packaged in a JAR file.
-After that, the JAR file must be deployed either as a system artifact or a user artifact.
+After that, the JAR file must be deployed either as a :ref:`system artifact 
+<plugins-deployment-system>` or a :ref:`user artifact <plugins-deployment-user>`.
+
 A system artifact is available to users across any namespace. A user artifact is available
-only to users in the namespace to which it is deployed.
+only to users in the namespace to which it is deployed. By design, deploying as a user
+artifact just requires acess to the :ref:`RESTful API <http-restful-api-artifact-add>`,
+while deploying as a system artifact requires access to the filesystem of the CDAP Master.
+This then requires administrator access and permission.
 
 .. _plugins-deployment-packaging:
 
@@ -169,22 +177,10 @@ packages, you would edit the bundler plugin in your pom.xml:
   </plugin>
 
 
-.. _plugins-deployment-artifact:
-
-Deploying Artifacts
--------------------
-A plugin can be deployed as either a :ref:`system <plugins-deployment-system>` or 
-:ref:`user <plugins-deployment-user>` artifact. System artifacts are available 
-across all namespaces, while user artifacts are local to one namespace.
-
-By design, deploying as a user artifact just requires acess to the :ref:`RESTful API 
-<http-restful-api-artifact-add>`, while deploying as a system artifact requires access to
-the filesystem of the CDAP Master. This then requires administrator access and permission.
-
 .. _plugins-deployment-system:
 
-Deploying a System Artifact
----------------------------
+Deploying as a System Artifact
+------------------------------
 To deploy the artifact as a system artifact, both the JAR file and a matching configuration file
 must be placed in the appropriate directory.
 
@@ -254,8 +250,8 @@ mode, and ``cdap-master`` services should be restarted in the Distributed mode.
 
 .. _plugins-deployment-user:
 
-Deploying a User Artifact
--------------------------
+Deploying as a User Artifact
+----------------------------
 To deploy the artifact as a user artifact, use the :ref:`RESTful Add Artifact API <http-restful-api-artifact-add>`
 or the CLI. When using the RESTful API, you will need to specify the ``Artifact-Extends`` header. When using
 the CLI, a configuration file exactly like the one described in the

--- a/cdap-docs/developers-manual/source/building-blocks/plugins.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/plugins.rst
@@ -171,6 +171,18 @@ packages, you would edit the bundler plugin in your pom.xml:
 
 .. _plugins-deployment-system:
 
+Deploying Artifacts
+-------------------
+A plugins can be deployed as either a :ref:`system <plugins-deployment-system>` or 
+:ref:`user <plugins-deployment-user>` artifact. System artifacts are available 
+across all namespaces, while user artifacts are local to one namespace.
+
+By design, deploying as a user artifact just requires acess to the :ref:`RESTful API 
+<http-restful-api-artifact-add>`, while deploying as a system artifact requires access to
+the filesystem of the CDAP Master. This then requires administrator access and permission.
+
+.. _plugins-deployment-system:
+
 Deploying a System Artifact
 ---------------------------
 To deploy the artifact as a system artifact, both the JAR file and a matching configuration file

--- a/cdap-docs/included-applications/source/etl/custom.rst
+++ b/cdap-docs/included-applications/source/etl/custom.rst
@@ -443,6 +443,9 @@ of those classes to the "Export-Package" as well. This is to ensure those classe
 visible to the Hadoop MapReduce framework during the plugin execution. Otherwise, the
 execution will typically fail with a ``ClassNotFoundException``.
 
+Plugin Deployment
+-----------------
+
 .. include:: ../../../developers-manual/source/building-blocks/plugins.rst 
-   :start-after: .. _plugins-deployment-packaging:
+   :start-after: .. _plugins-deployment-artifact:
    :end-before:  .. _plugins-use-case:


### PR DESCRIPTION
Fix for issue https://issues.cask.co/browse/CDAP-4292

Documentation should clearly specify the difference between system and user artifacts for Hydrator plugins.

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB49-2)

- [Developers' Manual: Building Blocks… Plugins](http://builds.cask.co/artifact/CDAP-DOB49/shared/build-2/Docs-HTML/3.2.1/en/developers-manual/building-blocks/plugins.html#plugin-deployment)
- [Developers' Manual: Building Blocks… Artifacts](http://builds.cask.co/artifact/CDAP-DOB49/shared/build-2/Docs-HTML/3.2.1/en/developers-manual/building-blocks/artifacts.html)
- [Included Applications: Creating Custom ETL Plugins…](http://builds.cask.co/artifact/CDAP-DOB49/shared/build-2/Docs-HTML/3.2.1/en/included-applications/etl/custom.html#plugin-packaging-and-deployment)


