### PR TITLE
(CDAP-3696) Fix WorkflowHttpHandlerTest.testMultipleWorkflowInstances…

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/ConcurrentWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/ConcurrentWorkflowApp.java
@@ -17,67 +17,69 @@
 package co.cask.cdap;
 
 import co.cask.cdap.api.app.AbstractApplication;
-import co.cask.cdap.api.schedule.Schedules;
 import co.cask.cdap.api.workflow.AbstractWorkflow;
 import co.cask.cdap.api.workflow.AbstractWorkflowAction;
-import com.google.common.collect.Maps;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- *
+ * App to test multiple concurrent runs of a single workflow.
  */
 public class ConcurrentWorkflowApp extends AbstractApplication {
+  private static final Logger LOG = LoggerFactory.getLogger(ConcurrentWorkflowApp.class);
+  public static final String FILE_TO_CREATE_ARG = "file.to.create";
+  public static final String DONE_FILE_ARG = "done.file";
 
   @Override
   public void configure() {
-    setName("ConcurrentWorkflowApp");
     setDescription("Application with concurrently running Workflow instances");
     addWorkflow(new ConcurrentWorkflow());
-
-    // Schedule Workflow
-    Map<String, String> schedule1Properties = Maps.newHashMap();
-    schedule1Properties.put("schedule.name", "concurrentWorkflowSchedule1");
-    scheduleWorkflow(Schedules.builder("concurrentWorkflowSchedule1").createTimeSchedule("* * * * *"),
-                     "ConcurrentWorkflow", schedule1Properties);
-
-    Map<String, String> schedule2Properties = Maps.newHashMap();
-    schedule2Properties.put("schedule.name", "concurrentWorkflowSchedule2");
-    scheduleWorkflow(Schedules.builder("concurrentWorkflowSchedule2").createTimeSchedule("* * * * *"),
-                     "ConcurrentWorkflow", schedule2Properties);
   }
 
   /**
-   *
+   * Workflow with a single action to test concurrent runs.
    */
-  private static class ConcurrentWorkflow extends AbstractWorkflow {
+  public static class ConcurrentWorkflow extends AbstractWorkflow {
 
     @Override
     public void configure() {
-      setName("ConcurrentWorkflow");
       setDescription("Workflow configured to run concurrently.");
       addAction(new SimpleAction());
     }
   }
 
-  static final class SimpleAction extends AbstractWorkflowAction {
+  /**
+   * Custom action that creates a file passed as a runtime argument and then waits for a done file to be created
+   * externally.
+   */
+  public static final class SimpleAction extends AbstractWorkflowAction {
     @Override
     public void run() {
+      Map<String, String> runtimeArguments = getContext().getRuntimeArguments();
+      File file = new File(runtimeArguments.get(FILE_TO_CREATE_ARG));
+      LOG.info("Creating file - " + file);
       try {
-        String scheduleName = getContext().getRuntimeArguments().get("schedule.name");
+        Preconditions.checkArgument(file.createNewFile());
+      } catch (IOException e) {
+        LOG.error("Exception while creating file {}", file, e);
+        throw Throwables.propagate(e);
+      }
+      File doneFile = new File(runtimeArguments.get(DONE_FILE_ARG));
 
-        File file = new File(getContext().getRuntimeArguments().get(scheduleName + ".file"));
-        System.out.println("Creating file - " + getContext().getRuntimeArguments().get(scheduleName + ".file"));
-        file.createNewFile();
-        File doneFile = new File(getContext().getRuntimeArguments().get("done.file"));
-
-        while (!doneFile.exists()) {
+      while (!doneFile.exists()) {
+        try {
           TimeUnit.MILLISECONDS.sleep(50);
+        } catch (InterruptedException e) {
+          LOG.warn("Interrupted while waiting for done file.");
+          Thread.currentThread().interrupt();
         }
-      } catch (Exception e) {
-        // no-op
       }
     }
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -716,7 +716,16 @@ public abstract class AppFabricTestBase {
     return GSON.fromJson(json, new TypeToken<List<ScheduleSpecification>>() { }.getType());
   }
 
-  protected void verifyProgramRuns(final Id.Program program, final String status) throws Exception {
+  protected void verifyNoRunWithStatus(final Id.Program program, final String status) throws Exception {
+    Tasks.waitFor(0, new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return getProgramRuns(program, status).size();
+      }
+    }, 60, TimeUnit.SECONDS);
+  }
+
+  protected void verifyProgramRuns(Id.Program program, String status) throws Exception {
     verifyProgramRuns(program, status, 0);
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -33,7 +33,6 @@ import co.cask.cdap.api.workflow.WorkflowActionSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Tasks;
-import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.gateway.handlers.WorkflowHttpHandler;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.proto.Id;
@@ -228,7 +227,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     // Get runid for the running Workflow
     List<RunRecord> historyRuns = getProgramRuns(programId, "running");
-    Assert.assertTrue(historyRuns.size() == 1);
+    Assert.assertEquals(1, historyRuns.size());
     String runId = historyRuns.get(0).getPid();
 
     while (!firstSimpleActionFile.exists()) {
@@ -324,15 +323,14 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
   @Category(XSlowTests.class)
   @Test
   public void testMultipleWorkflowInstances() throws Exception {
-    String appWithConcurrentWorkflow = "ConcurrentWorkflowApp";
-    String appWithConcurrentWorkflowSchedule1 = "concurrentWorkflowSchedule1";
-    String appWithConcurrentWorkflowSchedule2 = "concurrentWorkflowSchedule2";
-    String concurrentWorkflowName = "ConcurrentWorkflow";
+    String appWithConcurrentWorkflow = ConcurrentWorkflowApp.class.getSimpleName();
 
     // Files used to synchronize between this test and workflow execution
-    File schedule1File = new File(tmpFolder.newFolder() + "/concurrentWorkflowSchedule1.file");
-    File schedule2File = new File(tmpFolder.newFolder() + "/concurrentWorkflowSchedule2.file");
-    File simpleActionDoneFile = new File(tmpFolder.newFolder() + "/simpleaction.file.done");
+    File tempDir = tmpFolder.newFolder(appWithConcurrentWorkflow);
+    File run1File = new File(tempDir, "concurrentRun1.file");
+    File run2File = new File(tempDir, "concurrentRun2.file");
+    File run1DoneFile = new File(tempDir, "concurrentRun1.done");
+    File run2DoneFile = new File(tempDir, "concurrentRun2.done");
 
     // create app in default namespace so that v2 and v3 api can be tested in the same test
     String defaultNamespace = Id.Namespace.DEFAULT.getId();
@@ -341,55 +339,50 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
 
     Id.Program programId = Id.Program.from(Id.Namespace.DEFAULT, appWithConcurrentWorkflow, ProgramType.WORKFLOW,
-                                           concurrentWorkflowName);
+                                           ConcurrentWorkflowApp.ConcurrentWorkflow.class.getSimpleName());
 
-    Map<String, String> propMap = ImmutableMap.of("concurrentWorkflowSchedule1.file", schedule1File.getAbsolutePath(),
-                                                  "concurrentWorkflowSchedule2.file", schedule2File.getAbsolutePath(),
-                                                  "done.file", simpleActionDoneFile.getAbsolutePath());
+    // start run 1
+    startProgram(programId, ImmutableMap.of(ConcurrentWorkflowApp.FILE_TO_CREATE_ARG, run1File.getAbsolutePath(),
+                                            ConcurrentWorkflowApp.DONE_FILE_ARG, run1DoneFile.getAbsolutePath()),
+                 200);
+    // start run 2
+    startProgram(programId, ImmutableMap.of(ConcurrentWorkflowApp.FILE_TO_CREATE_ARG, run2File.getAbsolutePath(),
+                                            ConcurrentWorkflowApp.DONE_FILE_ARG, run2DoneFile.getAbsolutePath()),
+                 200);
 
-    PreferencesStore store = getInjector().getInstance(PreferencesStore.class);
-    store.setProperties(defaultNamespace, appWithConcurrentWorkflow, ProgramType.WORKFLOW.getCategoryName(),
-                        concurrentWorkflowName, propMap);
-
-    Assert.assertEquals(200, resumeSchedule(defaultNamespace, appWithConcurrentWorkflow,
-                                            appWithConcurrentWorkflowSchedule1));
-    Assert.assertEquals(200, resumeSchedule(defaultNamespace, appWithConcurrentWorkflow,
-                                            appWithConcurrentWorkflowSchedule2));
-
-    while (!(schedule1File.exists() && schedule2File.exists())) {
+    while (!(run1File.exists() && run2File.exists())) {
       TimeUnit.MILLISECONDS.sleep(50);
     }
 
-    List<RunRecord> historyRuns = getProgramRuns(programId, "running");
-    Assert.assertTrue(historyRuns.size() >= 2);
+    verifyMultipleConcurrentRuns(programId);
 
-    // Suspend ConcurrentWorkflow schedules
-    List<ScheduleSpecification> schedules = getSchedules(defaultNamespace, appWithConcurrentWorkflow,
-                                                         concurrentWorkflowName);
+    Assert.assertTrue(run1DoneFile.createNewFile());
+    Assert.assertTrue(run2DoneFile.createNewFile());
 
-    for (ScheduleSpecification spec : schedules) {
-      Assert.assertEquals(200, suspendSchedule(defaultNamespace, appWithConcurrentWorkflow,
-                                               spec.getSchedule().getName()));
-    }
+    waitState(programId, "STOPPED");
+    // delete the application
+    deleteApp(programId.getApplication(), 200, 60, TimeUnit.SECONDS);
+  }
 
-    response = getWorkflowCurrentStatus(programId, historyRuns.get(0).getPid());
+  private void verifyMultipleConcurrentRuns(Id.Program workflowId) throws Exception {
+    List<RunRecord> historyRuns = getProgramRuns(workflowId, "running");
+    Assert.assertEquals(2, historyRuns.size());
+
+    HttpResponse response = getWorkflowCurrentStatus(workflowId, historyRuns.get(0).getPid());
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     String json = EntityUtils.toString(response.getEntity());
     List<WorkflowActionNode> nodes = GSON.fromJson(json, LIST_WORKFLOWACTIONNODE_TYPE);
     Assert.assertEquals(1, nodes.size());
-    Assert.assertEquals("SimpleAction", nodes.get(0).getProgram().getProgramName());
+    Assert.assertEquals(ConcurrentWorkflowApp.SimpleAction.class.getSimpleName(),
+                        nodes.get(0).getProgram().getProgramName());
 
-    response = getWorkflowCurrentStatus(programId, historyRuns.get(1).getPid());
+    response = getWorkflowCurrentStatus(workflowId, historyRuns.get(1).getPid());
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     json = EntityUtils.toString(response.getEntity());
     nodes = GSON.fromJson(json, LIST_WORKFLOWACTIONNODE_TYPE);
     Assert.assertEquals(1, nodes.size());
-    Assert.assertEquals("SimpleAction", nodes.get(0).getProgram().getProgramName());
-
-    Assert.assertTrue(simpleActionDoneFile.createNewFile());
-
-    // delete the application
-    deleteApp(programId.getApplication(), 200, 60, TimeUnit.SECONDS);
+    Assert.assertEquals(ConcurrentWorkflowApp.SimpleAction.class.getSimpleName(),
+                        nodes.get(0).getProgram().getProgramName());
   }
 
   private void verifyFileExists(final List<File> fileList)
@@ -446,7 +439,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     // Get the currently running RunRecord for the Workflow
     List<RunRecord> historyRuns = getProgramRuns(programId, "running");
-    Assert.assertTrue(historyRuns.size() == 1);
+    Assert.assertEquals(1, historyRuns.size());
     RunRecord record = historyRuns.get(0);
     String runId = record.getPid();
 
@@ -472,7 +465,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     // Get the currently running RunRecord for the Workflow
     historyRuns = getProgramRuns(programId, "running");
-    Assert.assertTrue(historyRuns.size() == 1);
+    Assert.assertEquals(1, historyRuns.size());
     record = historyRuns.get(0);
     Assert.assertTrue(!runId.equals(record.getPid()));
 
@@ -520,7 +513,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     // Store the new RunRecord for the currently running run
     historyRuns = getProgramRuns(programId, "running");
-    Assert.assertTrue(historyRuns.size() == 1);
+    Assert.assertEquals(1, historyRuns.size());
     runId = historyRuns.get(0).getPid();
 
     // Wait till first action in the Workflow starts executing
@@ -691,15 +684,17 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // List<ScheduledRuntime> previousRuntimes = getScheduledRunTime(programId, scheduleName, "previousruntime");
     // Assert.assertTrue(previousRuntimes.size() == 0);
 
-    Assert.assertEquals(200, resumeSchedule(TEST_NAMESPACE2, appName, sampleSchedule));
-
     long current = System.currentTimeMillis();
+    Assert.assertEquals(200, resumeSchedule(TEST_NAMESPACE2, appName, sampleSchedule));
 
     List<ScheduledRuntime> runtimes = getScheduledRunTime(programId, true);
     String id = runtimes.get(0).getId();
-    Assert.assertTrue(id.contains(scheduleName));
+    Assert.assertTrue(String.format("Expected schedule id '%s' to contain schedule name '%s'", id, scheduleName),
+                      id.contains(scheduleName));
     Long nextRunTime = runtimes.get(0).getTime();
-    Assert.assertTrue(nextRunTime > current);
+    Assert.assertTrue(String.format("Expected nextRuntime '%s' to be greater than current runtime '%s'",
+                                    nextRunTime, current),
+                      nextRunTime > current);
 
     verifyProgramRuns(programId, "completed");
 
@@ -713,12 +708,12 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     //check paused state
     assertSchedule(programId, scheduleName, false, 30, TimeUnit.SECONDS);
 
-    TimeUnit.SECONDS.sleep(2); //wait till any running jobs just before suspend call completes.
+    verifyNoRunWithStatus(programId, "running");
 
     int workflowRuns = getProgramRuns(programId, "completed").size();
 
     //Sleep for some time and verify there are no more scheduled jobs after the suspend.
-    TimeUnit.SECONDS.sleep(10);
+    TimeUnit.SECONDS.sleep(5);
 
     int workflowRunsAfterSuspend = getProgramRuns(programId, "completed").size();
     Assert.assertEquals(workflowRuns, workflowRunsAfterSuspend);
@@ -910,7 +905,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     // Verify that there are two runs of the Workflow currently running.
     List<RunRecord> historyRuns = getProgramRuns(programId, "running");
-    Assert.assertTrue(historyRuns.size() == 2);
+    Assert.assertEquals(2, historyRuns.size());
 
     // Stop both Workflow runs.
     String runId = historyRuns.get(0).getPid();
@@ -931,7 +926,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     }
     // Verify that currently only one run of the Workflow should be running.
     historyRuns = getProgramRuns(programId, "running");
-    Assert.assertTrue(historyRuns.size() == 1);
+    Assert.assertEquals(1, historyRuns.size());
 
     Assert.assertTrue(doneFile.createNewFile());
 
@@ -1027,7 +1022,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     // Get running program run
     List<RunRecord> historyRuns = getProgramRuns(programId, "running");
-    Assert.assertTrue(historyRuns.size() == 1);
+    Assert.assertEquals(1, historyRuns.size());
     String runId = historyRuns.get(0).getPid();
 
     // Since the fork on the else branch of condition has 3 parallel branches
@@ -1078,7 +1073,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     // Get running program run
     historyRuns = getProgramRuns(programId, "running");
-    Assert.assertTrue(historyRuns.size() == 1);
+    Assert.assertEquals(1, historyRuns.size());
     runId = historyRuns.get(0).getPid();
 
     // Since the fork on the if branch of the condition has 2 parallel branches


### PR DESCRIPTION
… to not use schedules, in an attempt to make the behavior less flaky. Having a schedule that runs every min may lead to more runs than expected, causing flaky behavior.

Jira: [CDAP-3696](https://issues.cask.co/browse/CDAP-3696)