### PR TITLE
removing unwanted constructor as the fields can be inferred during deserialization

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduceTestRun.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduceTestRun.java
@@ -151,40 +151,6 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
     }
   }
 
-  // TODO : remove this test after UI changes for unique name support in ETLStage is implemented.
-  @Test
-  public void testKVToKVMetaWithoutStageNames() throws Exception {
-    ETLBatchConfig etlConfig =
-      new ETLBatchConfig("* * * * *",
-                         new ETLStage("MetaKVTable",
-                                      ImmutableMap.of(Properties.BatchReadableWritable.NAME, "mtable1"), null),
-                         new ETLStage("MetaKVTable",
-                                      ImmutableMap.of(Properties.BatchReadableWritable.NAME, "mtable2"), null));
-
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "KVToKVMeta");
-    ApplicationManager appManager = deployApplication(appId, appRequest);
-
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
-
-    DataSetManager<KeyValueTable> sourceMetaTable = getDataset(MetaKVTableSource.META_TABLE);
-    KeyValueTable sourceTable = sourceMetaTable.get();
-    Assert.assertEquals(MetaKVTableSource.PREPARE_RUN_KEY,
-                        Bytes.toString(sourceTable.read(MetaKVTableSource.PREPARE_RUN_KEY)));
-    Assert.assertEquals(MetaKVTableSource.FINISH_RUN_KEY,
-                        Bytes.toString(sourceTable.read(MetaKVTableSource.FINISH_RUN_KEY)));
-
-    DataSetManager<KeyValueTable> sinkMetaTable = getDataset(MetaKVTableSink.META_TABLE);
-    try (KeyValueTable sinkTable = sinkMetaTable.get()) {
-      Assert.assertEquals(MetaKVTableSink.PREPARE_RUN_KEY,
-                          Bytes.toString(sinkTable.read(MetaKVTableSink.PREPARE_RUN_KEY)));
-      Assert.assertEquals(MetaKVTableSink.FINISH_RUN_KEY,
-                          Bytes.toString(sinkTable.read(MetaKVTableSink.FINISH_RUN_KEY)));
-    }
-  }
-
   @SuppressWarnings("ConstantConditions")
   @Test
   public void testTableToTableWithValidations() throws Exception {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLStage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLStage.java
@@ -41,17 +41,6 @@ public final class ETLStage {
     this.errorDatasetName = errorDatasetName;
   }
 
-  public ETLStage(String name, Map<String, String> properties, @Nullable String errorDatasetName) {
-    this.name = name;
-    this.properties = properties;
-    this.plugin = null;
-    this.errorDatasetName = errorDatasetName;
-  }
-
-  public ETLStage(String name, Map<String, String> properties) {
-    this(name, properties, null);
-  }
-
   public ETLStage(String name, Plugin plugin) {
     this(name, plugin, null);
   }


### PR DESCRIPTION
https://github.com/caskdata/cdap/pull/4573 - kept the old constructors as we had to keep few old fields for backward compatibility, since they can be inferred during deserialization without constructor, removing them as they are not needed.