### PR TITLE
CDAP-4154 Refactored status call response from the ProgramLifeCycleHt…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramController.java
@@ -18,6 +18,7 @@ package co.cask.cdap.app.runtime;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramStatus;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.twill.api.RunId;
 import org.apache.twill.common.Cancellable;
@@ -104,12 +105,19 @@ public interface ProgramController {
 
     private final ProgramRunStatus runStatus;
 
+    private final ProgramStatus programStatus;
+
     State(ProgramRunStatus runStatus) {
       this.runStatus = runStatus;
+      this.programStatus = ProgramRunStatus.RUNNING == runStatus ? ProgramStatus.RUNNING : ProgramStatus.STOPPED;
     }
 
     public ProgramRunStatus getRunStatus() {
       return runStatus;
+    }
+
+    public ProgramStatus getProgramStatus() {
+      return programStatus;
     }
 
     public boolean isDone() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -37,6 +37,7 @@ import co.cask.cdap.gateway.handlers.WorkflowHttpHandler;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.ScheduledRuntime;
@@ -224,7 +225,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     startProgram(programId, 200);
 
     // Workflow should be running
-    waitState(programId, ProgramRunStatus.RUNNING.name());
+    waitState(programId, ProgramStatus.RUNNING.name());
 
     // Get runid for the running Workflow
     String runId = getRunIdOfRunningProgram(programId);
@@ -240,7 +241,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     suspendWorkflow(programId, runId, 200);
 
     // Workflow status hould be SUSPENDED
-    waitState(programId, ProgramRunStatus.SUSPENDED.name());
+    waitState(programId, ProgramStatus.STOPPED.name());
 
     // Meta store information for this Workflow should reflect suspended run
     verifyProgramRuns(programId, "suspended");
@@ -262,7 +263,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     resumeWorkflow(programId, runId, 200);
 
     // Workflow should be running
-    waitState(programId, ProgramRunStatus.RUNNING.name());
+    waitState(programId, ProgramStatus.RUNNING.name());
 
     verifyProgramRuns(programId, "running");
 
@@ -281,7 +282,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     suspendWorkflow(programId, runId, 200);
 
     // Status of the Workflow should be suspended
-    waitState(programId, ProgramRunStatus.SUSPENDED.name());
+    waitState(programId, ProgramStatus.STOPPED.name());
 
     // Store should reflect the suspended status of the Workflow
     verifyProgramRuns(programId, "suspended");
@@ -299,7 +300,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     resumeWorkflow(programId, runId, 200);
 
-    waitState(programId, ProgramRunStatus.RUNNING.name());
+    waitState(programId, ProgramStatus.RUNNING.name());
 
     while (!lastSimpleActionFile.exists()) {
       TimeUnit.SECONDS.sleep(1);
@@ -311,7 +312,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     verifyProgramRuns(programId, "completed");
 
-    waitState(programId, "STOPPED");
+    waitState(programId, ProgramStatus.STOPPED.name());
 
     suspendWorkflow(programId, runId, 404);
 
@@ -358,7 +359,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     Assert.assertTrue(run1DoneFile.createNewFile());
     Assert.assertTrue(run2DoneFile.createNewFile());
 
-    waitState(programId, "STOPPED");
+    waitState(programId, ProgramStatus.STOPPED.name());
     // delete the application
     deleteApp(programId.getApplication(), 200, 60, TimeUnit.SECONDS);
   }
@@ -433,7 +434,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     startProgram(programId);
 
     // Workflow should be running
-    waitState(programId, ProgramRunStatus.RUNNING.name());
+    waitState(programId, ProgramStatus.RUNNING.name());
 
     // Get the runId for the currently running Workflow
     String runId = getRunIdOfRunningProgram(programId);
@@ -456,7 +457,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     startProgram(programId);
 
     // Workflow should be running
-    waitState(programId, ProgramRunStatus.RUNNING.name());
+    waitState(programId, ProgramStatus.RUNNING.name());
 
     // Get the runId for the currently running Workflow
     String newRunId = getRunIdOfRunningProgram(programId);
@@ -485,7 +486,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     stopProgram(programId, 200);
 
     // Wait till the program stop
-    waitState(programId, "STOPPED");
+    waitState(programId, ProgramStatus.STOPPED.name());
 
     // Current endpoint would return 404
     response = getWorkflowCurrentStatus(programId, runId);
@@ -504,7 +505,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     startProgram(programId);
 
     // Wait till the Workflow is running
-    waitState(programId, ProgramRunStatus.RUNNING.name());
+    waitState(programId, ProgramStatus.RUNNING.name());
 
     // Store the new RunRecord for the currently running run
     runId = getRunIdOfRunningProgram(programId);
@@ -580,13 +581,13 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     // Start the workflow
     startProgram(programId);
-    waitState(programId, "RUNNING");
+    waitState(programId, ProgramStatus.RUNNING.name());
     List<RunRecord> workflowHistoryRuns = getProgramRuns(programId, "running");
     String workflowRunId = workflowHistoryRuns.get(0).getPid();
 
     Id.Program mr1ProgramId = Id.Program.from(TEST_NAMESPACE2, workflowAppWithScopedParameters, ProgramType.MAPREDUCE,
                                               "OneMR");
-    waitState(mr1ProgramId, "RUNNING");
+    waitState(mr1ProgramId, ProgramStatus.RUNNING.name());
     List<RunRecord> oneMRHistoryRuns = getProgramRuns(mr1ProgramId, "running");
 
     String expectedMessage = String.format("Cannot stop the program '%s' started by the Workflow run '%s'. " +
@@ -1106,8 +1107,8 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     String outputPath = new File(tmpFolder.newFolder(), "output").getAbsolutePath();
     startProgram(workflowId, ImmutableMap.of("inputPath", createInput("input"),
                                              "outputPath", outputPath));
-    waitState(workflowId, ProgramRunStatus.RUNNING.name());
-    waitState(workflowId, "STOPPED");
+    waitState(workflowId, ProgramStatus.RUNNING.name());
+    waitState(workflowId, ProgramStatus.STOPPED.name());
 
     List<RunRecord> programRuns = getProgramRuns(workflowId, ProgramRunStatus.COMPLETED.name());
     Assert.assertEquals(1, programRuns.size());
@@ -1211,8 +1212,8 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     String outputPath = new File(tmpFolder.newFolder(), "output").getAbsolutePath();
     startProgram(workflowId, ImmutableMap.of("inputPath", createInputForRecordVerification("firstInput"),
                                              "outputPath", outputPath, "put.in.mapper.initialize", "true"));
-    waitState(workflowId, ProgramRunStatus.RUNNING.name());
-    waitState(workflowId, "STOPPED");
+    waitState(workflowId, ProgramStatus.RUNNING.name());
+    waitState(workflowId, ProgramStatus.STOPPED.name());
 
     verifyProgramRuns(workflowId, "failed");
 
@@ -1225,8 +1226,8 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     outputPath = new File(tmpFolder.newFolder(), "output").getAbsolutePath();
     startProgram(workflowId, ImmutableMap.of("inputPath", createInputForRecordVerification("secondInput"),
                                              "outputPath", outputPath, "put.in.map", "true"));
-    waitState(workflowId, ProgramRunStatus.RUNNING.name());
-    waitState(workflowId, "STOPPED");
+    waitState(workflowId, ProgramStatus.RUNNING.name());
+    waitState(workflowId, ProgramStatus.STOPPED.name());
 
     verifyProgramRuns(workflowId, "failed", 1);
 
@@ -1239,8 +1240,8 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     outputPath = new File(tmpFolder.newFolder(), "output").getAbsolutePath();
     startProgram(workflowId, ImmutableMap.of("inputPath", createInputForRecordVerification("thirdInput"),
                                              "outputPath", outputPath, "put.in.reducer.initialize", "true"));
-    waitState(workflowId, ProgramRunStatus.RUNNING.name());
-    waitState(workflowId, "STOPPED");
+    waitState(workflowId, ProgramStatus.RUNNING.name());
+    waitState(workflowId, ProgramStatus.STOPPED.name());
 
     verifyProgramRuns(workflowId, "failed", 2);
 
@@ -1253,8 +1254,8 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     outputPath = new File(tmpFolder.newFolder(), "output").getAbsolutePath();
     startProgram(workflowId, ImmutableMap.of("inputPath", createInputForRecordVerification("fourthInput"),
                                              "outputPath", outputPath, "put.in.reduce", "true"));
-    waitState(workflowId, ProgramRunStatus.RUNNING.name());
-    waitState(workflowId, "STOPPED");
+    waitState(workflowId, ProgramStatus.RUNNING.name());
+    waitState(workflowId, ProgramStatus.STOPPED.name());
 
     verifyProgramRuns(workflowId, "failed", 3);
 
@@ -1265,8 +1266,8 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     outputPath = new File(tmpFolder.newFolder(), "output").getAbsolutePath();
     startProgram(workflowId, ImmutableMap.of("inputPath", createInputForRecordVerification("fifthInput"),
                                              "outputPath", outputPath, "closurePutToken", "true"));
-    waitState(workflowId, ProgramRunStatus.RUNNING.name());
-    waitState(workflowId, "STOPPED");
+    waitState(workflowId, ProgramStatus.RUNNING.name());
+    waitState(workflowId, ProgramStatus.STOPPED.name());
 
     verifyProgramRuns(workflowId, "failed", 4);
 
@@ -1282,8 +1283,8 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     startProgram(workflowId, ImmutableMap.of("inputPath", createInputForRecordVerification("sixthInput"),
                                              "outputPath", outputPath));
 
-    waitState(workflowId, ProgramRunStatus.RUNNING.name());
-    waitState(workflowId, "STOPPED");
+    waitState(workflowId, ProgramStatus.RUNNING.name());
+    waitState(workflowId, ProgramStatus.STOPPED.name());
 
     verifyProgramRuns(workflowId, "completed");
 
@@ -1315,8 +1316,8 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
                                              "wait.file", fileToWait.getAbsolutePath(),
                                              "mapreduce." + WorkflowFailureInForkApp.SECOND_MAPREDUCE_NAME
                                                + ".throw.exception", "true"));
-    waitState(workflowId, ProgramRunStatus.RUNNING.name());
-    waitState(workflowId, "STOPPED");
+    waitState(workflowId, ProgramStatus.RUNNING.name());
+    waitState(workflowId, ProgramStatus.STOPPED.name());
 
     verifyProgramRuns(workflowId, "failed");
 

--- a/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
@@ -37,7 +37,6 @@ import co.cask.cdap.proto.Instances;
 import co.cask.cdap.proto.ProgramLiveInfo;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramRunStatus;
-import co.cask.cdap.proto.ProgramStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.codec.WorkflowActionSpecificationCodec;
@@ -76,6 +75,7 @@ public class ProgramClient {
     .create();
   private static final Type BATCH_STATUS_RESPONSE_TYPE = new TypeToken<List<BatchProgramStatus>>() { }.getType();
   private static final Type BATCH_RESULTS_TYPE = new TypeToken<List<BatchProgramResult>>() { }.getType();
+  private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
   private final RESTClient restClient;
   private final ClientConfig config;
@@ -266,7 +266,9 @@ public class ProgramClient {
       throw new ProgramNotFoundException(program);
     }
 
-    return ObjectResponse.fromJsonBody(response, ProgramStatus.class).getResponseObject().getStatus();
+    Map<String, String> responseObject
+      = ObjectResponse.<Map<String, String>>fromJsonBody(response, MAP_STRING_STRING_TYPE, GSON).getResponseObject();
+    return responseObject.get("status");
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
@@ -30,14 +30,17 @@ import co.cask.cdap.proto.codec.ScheduleSpecificationCodec;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpResponse;
 import co.cask.common.http.ObjectResponse;
+import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
+
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 import javax.inject.Inject;
 
 /**
@@ -49,6 +52,8 @@ public class ScheduleClient {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(ScheduleSpecification.class, new ScheduleSpecificationCodec())
     .create();
+
+  private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
   private final RESTClient restClient;
   private final ClientConfig config;
@@ -132,6 +137,9 @@ public class ScheduleClient {
     if (HttpURLConnection.HTTP_NOT_FOUND == response.getResponseCode()) {
       throw new NotFoundException(schedule);
     }
-    return ObjectResponse.fromJsonBody(response, ProgramStatus.class).getResponseObject().getStatus();
+
+    Map<String, String> responseObject
+      = ObjectResponse.<Map<String, String>>fromJsonBody(response, MAP_STRING_STRING_TYPE, GSON).getResponseObject();
+    return responseObject.get("status");
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramStatus.java
@@ -17,20 +17,9 @@
 package co.cask.cdap.proto;
 
 /**
- * Class containing a program status.
+ * Program level status types.
  */
-public class ProgramStatus {
-  private String applicationId;
-  private String programId;
-  private String status;
-
-  public ProgramStatus(String applicationId, String programId, String status) {
-    this.applicationId = applicationId;
-    this.programId = programId;
-    this.status = status;
-  }
-
-  public String getStatus() {
-    return this.status;
-  }
+public enum ProgramStatus {
+  RUNNING,
+  STOPPED
 }


### PR DESCRIPTION
…tpHandler.

JIRA: https://issues.cask.co/browse/CDAP-4154

Changes done in the PR:
1. Removed the `StatusMap` class.
2. Moved `ProgramStatus` from class with string value for the status to enum. `ProgramStatus` is only used for returning either `RUNNING` or `STOPPED` status for the status call made at the program level.