### PR TITLE
CDAP 4263: Add metadata support to stream view

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/EntityValidator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/EntityValidator.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.ProgramNotFoundException;
 import co.cask.cdap.common.StreamNotFoundException;
+import co.cask.cdap.common.ViewNotFoundException;
 import co.cask.cdap.common.namespace.AbstractNamespaceClient;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
@@ -100,7 +101,7 @@ public class EntityValidator {
         }
       } catch (StreamNotFoundException streamEx) {
         throw streamEx;
-      } catch (Exception ex)  {
+      } catch (Exception ex) {
         throw new IllegalStateException(ex);
       }
     } else if (entityId instanceof Id.Artifact) {
@@ -109,6 +110,17 @@ public class EntityValidator {
         artifactStore.getArtifact(artifactId);
       } catch (IOException e) {
         throw new RuntimeException(e);
+      }
+    } else if (entityId instanceof Id.Stream.View) {
+      Id.Stream.View viewId = (Id.Stream.View) entityId;
+      try {
+        if (!streamAdmin.viewExists(viewId)) {
+          throw new ViewNotFoundException(viewId);
+        }
+      } catch (ViewNotFoundException | StreamNotFoundException viewEx) {
+        throw viewEx;
+      } catch (Exception ex) {
+        throw new IllegalStateException(ex);
       }
     } else {
       throw new IllegalArgumentException("Invalid entity" + entityId);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -124,6 +124,17 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   }
 
   @GET
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata")
+  public void getViewMetadata(HttpRequest request, HttpResponder responder,
+                                @PathParam("namespace-id") String namespaceId,
+                                @PathParam("stream-id") String streamId,
+                                @PathParam("view-id") String viewId) throws NotFoundException {
+    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getMetadata(Id.Stream.View.from(namespaceId, streamId,
+                                                                                            viewId)),
+                       SET_METADATA_RECORD_TYPE, GSON);
+  }
+
+  @GET
   @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata/properties")
   public void getAppProperties(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
@@ -168,6 +179,16 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("stream-id") String streamId) throws NotFoundException {
     responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getProperties(Id.Stream.from(namespaceId, streamId)));
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/properties")
+  public void getViewProperties(HttpRequest request, HttpResponder responder,
+                                  @PathParam("namespace-id") String namespaceId,
+                                  @PathParam("stream-id") String streamId,
+                                  @PathParam("view-id") String viewId) throws NotFoundException {
+    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getProperties(Id.Stream.View.from(namespaceId, streamId,
+                                                                                              viewId)));
   }
 
   @POST
@@ -228,6 +249,17 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + stream);
   }
 
+  @POST
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/properties")
+  public void addViewProperties(HttpRequest request, HttpResponder responder,
+                                  @PathParam("namespace-id") String namespaceId,
+                                  @PathParam("stream-id") String streamId,
+                                  @PathParam("view-id") String viewId) throws NotFoundException, BadRequestException {
+    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    metadataAdmin.addProperties(view, readMetadata(request));
+    responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + view);
+  }
+
   @DELETE
   @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata")
   public void removeAppMetadata(HttpRequest request, HttpResponder responder,
@@ -285,6 +317,18 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     metadataAdmin.removeMetadata(stream);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata for stream %s deleted successfully.", stream));
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata")
+  public void removeViewMetadata(HttpRequest request, HttpResponder responder,
+                                   @PathParam("namespace-id") String namespaceId,
+                                   @PathParam("stream-id") String streamId,
+                                   @PathParam("view-id") String viewId) throws NotFoundException {
+    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    metadataAdmin.removeMetadata(view);
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Metadata for view %s deleted successfully.", view));
   }
 
   @DELETE
@@ -402,6 +446,18 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   }
 
   @DELETE
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/properties")
+  public void removeViewProperties(HttpRequest request, HttpResponder responder,
+                                      @PathParam("namespace-id") String namespaceId,
+                                      @PathParam("stream-id") String streamId,
+                                      @PathParam("view-id") String viewId) throws NotFoundException {
+    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    metadataAdmin.removeProperties(view);
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Metadata properties for view %s deleted successfully.", view));
+  }
+
+  @DELETE
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/metadata/properties/{property}")
   public void removeStreamProperty(HttpRequest request, HttpResponder responder,
                                    @PathParam("namespace-id") String namespaceId,
@@ -411,6 +467,19 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     metadataAdmin.removeProperties(stream, property);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata property %s for stream %s deleted successfully.", property, stream));
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/properties/{property}")
+  public void removeViewProperty(HttpRequest request, HttpResponder responder,
+                                 @PathParam("namespace-id") String namespaceId,
+                                 @PathParam("stream-id") String streamId,
+                                 @PathParam("view-id") String viewId,
+                                 @PathParam("property") String property) throws NotFoundException {
+    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    metadataAdmin.removeProperties(view, property);
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Metadata property %s for view %s deleted successfully.", property, view));
   }
 
   @POST
@@ -473,6 +542,18 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                          String.format("Added tags to stream %s successfully.", stream));
   }
 
+  @POST
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/tags")
+  public void addViewTags(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId,
+                            @PathParam("stream-id") String streamId,
+                            @PathParam("view-id") String viewId) throws NotFoundException, BadRequestException {
+    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    metadataAdmin.addTags(view, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Added tags to view %s successfully", view));
+  }
+
   @GET
   @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata/tags")
   public void getAppTags(HttpRequest request, HttpResponder responder,
@@ -521,6 +602,16 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                             @PathParam("stream-id") String streamId) throws NotFoundException {
     Id.Stream stream = Id.Stream.from(namespaceId, streamId);
     responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(stream));
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/tags")
+  public void getViewTags(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId,
+                            @PathParam("stream-id") String streamId,
+                            @PathParam("view-id") String viewId) throws NotFoundException {
+    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(view));
   }
 
   @DELETE
@@ -635,6 +726,18 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   }
 
   @DELETE
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/tags")
+  public void removeViewTags(HttpRequest request, HttpResponder responder,
+                               @PathParam("namespace-id") String namespaceId,
+                               @PathParam("stream-id") String streamId,
+                               @PathParam("view-id") String viewId) throws NotFoundException {
+    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    metadataAdmin.removeTags(view);
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Tags for view %s deleted successfully.", view));
+  }
+
+  @DELETE
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/metadata/tags/{tag}")
   public void removeStreamTag(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId,
@@ -644,6 +747,19 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     metadataAdmin.removeTags(stream, tag);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tag %s for stream %s deleted successfully.", tag, stream));
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/tags/{tag}")
+  public void removeViewTag(HttpRequest request, HttpResponder responder,
+                              @PathParam("namespace-id") String namespaceId,
+                              @PathParam("stream-id") String streamId,
+                              @PathParam("view-id") String viewId,
+                              @PathParam("tag") String tag) throws NotFoundException {
+    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    metadataAdmin.removeTags(view, tag);
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Tag %s for view %s deleted successfully.", tag, view));
   }
 
   private Map<String, String> readMetadata(HttpRequest request) throws BadRequestException {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -39,6 +39,7 @@ import co.cask.cdap.metrics.query.MetricsQueryService;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.RunRecord;
+import co.cask.cdap.proto.ViewSpecification;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.tephra.TransactionManager;
@@ -745,6 +746,10 @@ public abstract class AppFabricTestBase {
 
   protected boolean streamExists(Id.Stream streamID) throws Exception {
     return streamAdmin.exists(streamID);
+  }
+
+  protected boolean createOrUpdateView(Id.Stream.View viewId, ViewSpecification spec) throws Exception {
+    return streamAdmin.createOrUpdateView(viewId, spec);
   }
 
   protected HttpResponse createNamespace(String id) throws Exception {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -135,6 +135,14 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     );
     Assert.assertEquals(expected, searchProperties);
 
+    // test search for artifact
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT,
+                                      "rKey:rValue", MetadataSearchTargetType.ARTIFACT);
+    expected = ImmutableSet.of(
+      new MetadataSearchResultRecord(artifactId)
+    );
+    Assert.assertEquals(expected, searchProperties);
+
     // test prefix search for service
     searchProperties = searchMetadata(Id.Namespace.DEFAULT, "sKey:s*", MetadataSearchTargetType.ALL);
     expected = ImmutableSet.of(

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -20,11 +20,13 @@ import co.cask.cdap.AppWithDataset;
 import co.cask.cdap.WordCountApp;
 import co.cask.cdap.WordCountMinusFlowApp;
 import co.cask.cdap.api.Config;
+import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.ViewSpecification;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.metadata.MetadataRecord;
@@ -53,10 +55,12 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
   private final Id.Program pingService = Id.Program.from(application, ProgramType.SERVICE, "PingService");
   private final Id.DatasetInstance myds = Id.DatasetInstance.from(Id.Namespace.DEFAULT, "myds");
   private final Id.Stream mystream = Id.Stream.from(Id.Namespace.DEFAULT, "mystream");
+  private final Id.Stream.View myview = Id.Stream.View.from(mystream, "myview");
   private final Id.Application nonExistingApp = Id.Application.from("blah", AppWithDataset.class.getSimpleName());
   private final Id.Service nonExistingService = Id.Service.from(nonExistingApp, "PingService");
   private final Id.DatasetInstance nonExistingDataset = Id.DatasetInstance.from("blah", "myds");
   private final Id.Stream nonExistingStream = Id.Stream.from("blah", "mystream");
+  private final Id.Stream.View nonExistingView = Id.Stream.View.from(nonExistingStream, "myView");
   private final Id.Artifact nonExistingArtifact = Id.Artifact.from(Id.Namespace.from("blah"), "art", "1.0.0");
 
   @Before
@@ -65,6 +69,9 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     AppRequest<Config> appRequest = new AppRequest<>(
       new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()));
     Assert.assertEquals(200, deploy(application, appRequest).getStatusLine().getStatusCode());
+    FormatSpecification format = new FormatSpecification("csv", null, null);
+    ViewSpecification viewSpec = new ViewSpecification(format, null);
+    createOrUpdateView(myview, viewSpec);
   }
 
   @After
@@ -91,6 +98,9 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     addProperties(mystream, null, BadRequestException.class);
     Map<String, String> streamProperties = ImmutableMap.of("stKey", "stValue", "stK", "stV");
     addProperties(mystream, streamProperties);
+    addProperties(myview, null, BadRequestException.class);
+    Map<String, String> viewProperties = ImmutableMap.of("viewKey", "viewValue", "viewK", "viewV");
+    addProperties(myview, viewProperties);
     // should fail because we haven't provided any metadata in the request
     addProperties(artifactId, null, BadRequestException.class);
     Map<String, String> artifactProperties = ImmutableMap.of("rKey", "rValue", "rK", "rV");
@@ -104,6 +114,8 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(datasetProperties, properties);
     properties = getProperties(mystream);
     Assert.assertEquals(streamProperties, properties);
+    properties = getProperties(myview);
+    Assert.assertEquals(viewProperties, properties);
     properties = getProperties(artifactId);
     Assert.assertEquals(artifactProperties, properties);
 
@@ -112,6 +124,14 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
                                                                       "stKey:stValue", MetadataSearchTargetType.STREAM);
     Set<MetadataSearchResultRecord> expected = ImmutableSet.of(
       new MetadataSearchResultRecord(mystream)
+    );
+    Assert.assertEquals(expected, searchProperties);
+
+    // test search for view
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT,
+                                      "viewKey:viewValue", MetadataSearchTargetType.VIEW);
+    expected = ImmutableSet.of(
+      new MetadataSearchResultRecord(myview)
     );
     Assert.assertEquals(expected, searchProperties);
 
@@ -151,7 +171,10 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(ImmutableMap.of("dK", "dV"), getProperties(myds));
     removeProperty(mystream, "stK");
     Assert.assertEquals(ImmutableMap.of("stKey", "stValue"), getProperties(mystream));
+    removeProperty(myview, "viewK");
+    Assert.assertEquals(ImmutableMap.of("viewKey", "viewValue"), getProperties(myview));
     // cleanup
+    removeProperties(myview);
     removeProperties(application);
     removeProperties(pingService);
     removeProperties(myds);
@@ -161,6 +184,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertTrue(getProperties(pingService).isEmpty());
     Assert.assertTrue(getProperties(myds).isEmpty());
     Assert.assertTrue(getProperties(mystream).isEmpty());
+    Assert.assertTrue(getProperties(myview).isEmpty());
     Assert.assertTrue(getProperties(artifactId).isEmpty());
 
     // non-existing namespace
@@ -168,6 +192,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     addProperties(nonExistingService, serviceProperties, NotFoundException.class);
     addProperties(nonExistingDataset, datasetProperties, NotFoundException.class);
     addProperties(nonExistingStream, streamProperties, NotFoundException.class);
+    addProperties(nonExistingView, streamProperties, NotFoundException.class);
     addProperties(nonExistingArtifact, artifactProperties, NotFoundException.class);
   }
 
@@ -187,6 +212,9 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     addTags(mystream, null, BadRequestException.class);
     Set<String> streamTags = ImmutableSet.of("stTag", "stT");
     addTags(mystream, streamTags);
+    addTags(myview, null, BadRequestException.class);
+    Set<String> viewTags = ImmutableSet.of("viewTag", "viewT");
+    addTags(myview, viewTags);
     Set<String> artifactTags = ImmutableSet.of("rTag", "rT");
     addTags(artifactId, artifactTags);
     // retrieve tags and verify
@@ -202,6 +230,9 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     tags = getTags(mystream);
     Assert.assertTrue(tags.containsAll(streamTags));
     Assert.assertTrue(streamTags.containsAll(tags));
+    tags = getTags(myview);
+    Assert.assertTrue(tags.containsAll(viewTags));
+    Assert.assertTrue(viewTags.containsAll(tags));
     tags = getTags(artifactId);
     Assert.assertTrue(tags.containsAll(artifactTags));
     Assert.assertTrue(artifactTags.containsAll(tags));
@@ -210,6 +241,13 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
       searchMetadata(Id.Namespace.DEFAULT, "stT*", MetadataSearchTargetType.STREAM);
     Set<MetadataSearchResultRecord> expected = ImmutableSet.of(
       new MetadataSearchResultRecord(mystream)
+    );
+    Assert.assertEquals(expected, searchTags);
+    // test search for view
+    searchTags =
+      searchMetadata(Id.Namespace.DEFAULT, "viewT*", MetadataSearchTargetType.VIEW);
+    expected = ImmutableSet.of(
+      new MetadataSearchResultRecord(myview)
     );
     Assert.assertEquals(expected, searchTags);
     // test prefix search, should match stream and service programs
@@ -239,6 +277,8 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(ImmutableSet.of("dTag"), getTags(myds));
     removeTag(mystream, "stT");
     removeTag(mystream, "stTag");
+    removeTag(myview, "viewT");
+    removeTag(myview, "viewTag");
     Assert.assertTrue(getTags(mystream).isEmpty());
     removeTag(artifactId, "rTag");
     removeTag(artifactId, "rT");
@@ -248,6 +288,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     removeTags(pingService);
     removeTags(myds);
     removeTags(mystream);
+    removeTags(myview);
     removeTags(artifactId);
     Assert.assertTrue(getTags(application).isEmpty());
     Assert.assertTrue(getTags(pingService).isEmpty());
@@ -259,6 +300,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     addTags(nonExistingService, serviceTags, NotFoundException.class);
     addTags(nonExistingDataset, datasetTags, NotFoundException.class);
     addTags(nonExistingStream, streamTags, NotFoundException.class);
+    addTags(nonExistingView, streamTags, NotFoundException.class);
     addTags(nonExistingArtifact, artifactTags, NotFoundException.class);
   }
 
@@ -273,21 +315,25 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Map<String, String> serviceProperties = ImmutableMap.of("sKey", "sValue");
     Map<String, String> datasetProperties = ImmutableMap.of("dKey", "dValue");
     Map<String, String> streamProperties = ImmutableMap.of("stKey", "stValue");
+    Map<String, String> viewProperties = ImmutableMap.of("viewKey", "viewValue");
     Map<String, String> artifactProperties = ImmutableMap.of("rKey", "rValue");
     Set<String> appTags = ImmutableSet.of("aTag");
     Set<String> serviceTags = ImmutableSet.of("sTag");
     Set<String> datasetTags = ImmutableSet.of("dTag");
     Set<String> streamTags = ImmutableSet.of("stTag");
+    Set<String> viewTags = ImmutableSet.of("viewTag");
     Set<String> artifactTags = ImmutableSet.of("rTag");
     addProperties(application, appProperties);
     addProperties(pingService, serviceProperties);
     addProperties(myds, datasetProperties);
     addProperties(mystream, streamProperties);
+    addProperties(myview, viewProperties);
     addProperties(artifactId, artifactProperties);
     addTags(application, appTags);
     addTags(pingService, serviceTags);
     addTags(myds, datasetTags);
     addTags(mystream, streamTags);
+    addTags(myview, viewTags);
     addTags(artifactId, artifactTags);
     // verify app
     Set<MetadataRecord> metadataRecords = getMetadata(application);
@@ -313,7 +359,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(myds, metadata.getEntityId());
     Assert.assertEquals(datasetProperties, metadata.getProperties());
     Assert.assertEquals(datasetTags, metadata.getTags());
-    // verify service
+    // verify stream
     metadataRecords = getMetadata(mystream);
     Assert.assertEquals(1, metadataRecords.size());
     metadata = metadataRecords.iterator().next();
@@ -321,6 +367,14 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(mystream, metadata.getEntityId());
     Assert.assertEquals(streamProperties, metadata.getProperties());
     Assert.assertEquals(streamTags, metadata.getTags());
+    // verify view
+    metadataRecords = getMetadata(myview);
+    Assert.assertEquals(1, metadataRecords.size());
+    metadata = metadataRecords.iterator().next();
+    Assert.assertEquals(MetadataScope.USER, metadata.getScope());
+    Assert.assertEquals(myview, metadata.getEntityId());
+    Assert.assertEquals(viewProperties, metadata.getProperties());
+    Assert.assertEquals(viewTags, metadata.getTags());
     // verify artifact
     metadataRecords = getMetadata(artifactId);
     Assert.assertEquals(1, metadataRecords.size());
@@ -365,12 +419,14 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Id.Program nonExistingProgram = Id.Program.from(application, ProgramType.SERVICE, "NonExistingService");
     Id.DatasetInstance nonExistingDataset = Id.DatasetInstance.from(Id.Namespace.DEFAULT, "NonExistingDataset");
     Id.Stream nonExistingStream = Id.Stream.from(Id.Namespace.DEFAULT, "NonExistingStream");
-    Id.Application nonExistingApp = Id.Application.from(Id.Namespace.DEFAULT, "NonExistingStream");
+    Id.Stream.View nonExistingView = Id.Stream.View.from(mystream, "NonExistingView");
+    Id.Application nonExistingApp = Id.Application.from(Id.Namespace.DEFAULT, "NonExistingApp");
 
     Map<String, String> properties = ImmutableMap.of("aKey", "aValue", "aK", "aV");
     addProperties(nonExistingApp, properties, NotFoundException.class);
     addProperties(nonExistingProgram, properties, NotFoundException.class);
     addProperties(nonExistingDataset, properties, NotFoundException.class);
+    addProperties(nonExistingView, properties, NotFoundException.class);
     addProperties(nonExistingStream, properties, NotFoundException.class);
   }
 
@@ -442,6 +498,8 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     removeMetadata(pingService);
     removeMetadata(myds);
     removeMetadata(mystream);
+    removeMetadata(myview);
+    removeMetadata(artifactId);
   }
 
   private void assertCleanState() throws Exception {
@@ -470,5 +528,17 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     MetadataRecord streamMetadata = streamMetadatas.iterator().next();
     Assert.assertTrue(streamMetadata.getProperties().isEmpty());
     Assert.assertTrue(streamMetadata.getTags().isEmpty());
+    Set<MetadataRecord> viewMetadatas = getMetadata(myview);
+    // only user metadata right now.
+    Assert.assertEquals(1, viewMetadatas.size());
+    MetadataRecord viewMetadata = viewMetadatas.iterator().next();
+    Assert.assertTrue(viewMetadata.getProperties().isEmpty());
+    Assert.assertTrue(viewMetadata.getTags().isEmpty());
+    Set<MetadataRecord> artifactMetadatas = getMetadata(artifactId);
+    // only user metadata right now.
+    Assert.assertEquals(1, artifactMetadatas.size());
+    MetadataRecord artifactMetadata = artifactMetadatas.iterator().next();
+    Assert.assertTrue(artifactMetadata.getProperties().isEmpty());
+    Assert.assertTrue(artifactMetadata.getTags().isEmpty());
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
@@ -132,12 +132,28 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
     metadataClient.addProperties(stream, properties);
   }
 
+  protected void addProperties(Id.Stream.View view, @Nullable Map<String, String> properties)
+    throws Exception {
+    metadataClient.addProperties(view, properties);
+  }
+
   protected void addProperties(final Id.Stream stream, @Nullable final Map<String, String> properties,
                                Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
       public Void call() throws Exception {
         addProperties(stream, properties);
+        return null;
+      }
+    }, expectedExceptionClass);
+  }
+
+  protected void addProperties(final Id.Stream.View view, @Nullable final Map<String, String> properties,
+                               Class<? extends Exception> expectedExceptionClass) throws IOException {
+    expectException(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        addProperties(view, properties);
         return null;
       }
     }, expectedExceptionClass);
@@ -163,6 +179,10 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
     return metadataClient.getMetadata(stream);
   }
 
+  protected Set<MetadataRecord> getMetadata(Id.Stream.View view) throws Exception {
+    return metadataClient.getMetadata(view);
+  }
+
   // Currently, getMetadata(entity) returns a single-element set, so we can get the properties from there
   protected Map<String, String> getProperties(Id.Application app) throws Exception {
     return Iterators.getOnlyElement(getMetadata(app).iterator()).getProperties();
@@ -182,6 +202,10 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
 
   protected Map<String, String> getProperties(Id.Stream stream) throws Exception {
     return Iterators.getOnlyElement(getMetadata(stream).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.Stream.View view) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(view).iterator()).getProperties();
   }
 
   protected void getPropertiesFromInvalidEntity(Id.Application app) throws Exception {
@@ -219,9 +243,21 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
       // expected
     }
   }
+  protected void getPropertiesFromInvalidEntity(Id.Stream.View view) throws Exception {
+    try {
+      getProperties(view);
+      Assert.fail("Expected not to be able to get properties from invalid entity: " + view);
+    } catch (NotFoundException expected) {
+      // expected
+    }
+  }
 
   protected void removeMetadata(Id.Application app) throws Exception {
     metadataClient.removeMetadata(app);
+  }
+
+  protected void removeMetadata(Id.Artifact artifact) throws Exception {
+    metadataClient.removeMetadata(artifact);
   }
 
   protected void removeMetadata(Id.Program program) throws Exception {
@@ -234,6 +270,10 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
 
   protected void removeMetadata(Id.Stream stream) throws Exception {
     metadataClient.removeMetadata(stream);
+  }
+
+  protected void removeMetadata(Id.Stream.View view) throws Exception {
+    metadataClient.removeMetadata(view);
   }
 
   protected void removeProperties(Id.Application app) throws Exception {
@@ -272,8 +312,16 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
     metadataClient.removeProperties(stream);
   }
 
+  protected void removeProperties(Id.Stream.View view) throws Exception {
+    metadataClient.removeProperties(view);
+  }
+
   protected void removeProperty(Id.Stream stream, String propertyToRemove) throws Exception {
     metadataClient.removeProperty(stream, propertyToRemove);
+  }
+
+  protected void removeProperty(Id.Stream.View view, String propertyToRemove) throws Exception {
+    metadataClient.removeProperty(view, propertyToRemove);
   }
 
   protected void addTags(Id.Application app, @Nullable Set<String> tags) throws Exception {
@@ -341,12 +389,27 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
     metadataClient.addTags(stream, tags);
   }
 
+  protected void addTags(Id.Stream.View view, @Nullable Set<String> tags) throws Exception {
+    metadataClient.addTags(view, tags);
+  }
+
   protected void addTags(final Id.Stream stream, @Nullable final Set<String> tags,
                          Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
       public Void call() throws Exception {
         addTags(stream, tags);
+        return null;
+      }
+    }, expectedExceptionClass);
+  }
+
+  protected void addTags(final Id.Stream.View view, @Nullable final Set<String> tags,
+                         Class<? extends Exception> expectedExceptionClass) throws IOException {
+    expectException(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        addTags(view, tags);
         return null;
       }
     }, expectedExceptionClass);
@@ -376,6 +439,10 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
 
   protected Set<String> getTags(Id.Stream stream) throws Exception {
     return Iterators.getOnlyElement(getMetadata(stream).iterator()).getTags();
+  }
+
+  protected Set<String> getTags(Id.Stream.View view) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(view).iterator()).getTags();
   }
 
   protected void removeTags(Id.Application app) throws Exception {
@@ -414,8 +481,16 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
     metadataClient.removeTags(stream);
   }
 
+  protected void removeTags(Id.Stream.View view) throws Exception {
+    metadataClient.removeTags(view);
+  }
+
   protected void removeTag(Id.Stream stream, String tagToRemove) throws Exception {
     metadataClient.removeTag(stream, tagToRemove);
+  }
+
+  protected void removeTag(Id.Stream.View view, String tagToRemove) throws Exception {
+    metadataClient.removeTag(view, tagToRemove);
   }
 
   // expect an exception during fetching of lineage

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
@@ -126,6 +126,15 @@ public class MetadataClient {
   }
 
   /**
+   * @param viewId the view for which to retrieve metadata
+   * @return The metadata for the view.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Stream.View viewId)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return getMetadata(viewId, constructPath(viewId));
+  }
+
+  /**
    * @param programId the program for which to retrieve metadata
    * @return The metadata for the program.
    */
@@ -195,6 +204,17 @@ public class MetadataClient {
   }
 
   /**
+   * Adds tags to a view.
+   *
+   * @param viewId view to add tags to
+   * @param tags tags to be added
+   */
+  public void addTags(Id.Stream.View viewId, Set<String> tags)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    addTags(viewId, constructPath(viewId), tags);
+  }
+
+  /**
    * Adds tags to a program.
    *
    * @param programId program to add tags to
@@ -253,6 +273,17 @@ public class MetadataClient {
   public void addProperties(Id.Stream streamId, Map<String, String> properties)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
     addProperties(streamId, constructPath(streamId), properties);
+  }
+
+  /**
+   * Adds properties to a view.
+   *
+   * @param viewId view to add properties to
+   * @param properties properties to be added
+   */
+  public void addProperties(Id.Stream.View viewId, Map<String, String> properties)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    addProperties(viewId, constructPath(viewId), properties);
   }
 
   /**
@@ -317,6 +348,17 @@ public class MetadataClient {
   }
 
   /**
+   * Removes a property from a view.
+   *
+   * @param viewId view to remove property from
+   * @param propertyToRemove property to be removed
+   */
+  public void removeProperty(Id.Stream.View viewId, String propertyToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeProperty(viewId, constructPath(viewId), propertyToRemove);
+  }
+
+  /**
    * Removes a property from a program.
    *
    * @param programId program to remove property from
@@ -372,6 +414,16 @@ public class MetadataClient {
   public void removeProperties(Id.Stream streamId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
     removeProperties(streamId, constructPath(streamId));
+  }
+
+  /**
+   * Removes all properties from a view.
+   *
+   * @param viewId view to remove properties from
+   */
+  public void removeProperties(Id.Stream.View viewId)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeProperties(viewId, constructPath(viewId));
   }
 
   /**
@@ -436,6 +488,17 @@ public class MetadataClient {
   }
 
   /**
+   * Removes a tag from a view.
+   *
+   * @param viewId view to remove tag from
+   * @param tagToRemove tag to be removed
+   */
+  public void removeTag(Id.Stream.View viewId, String tagToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeTag(viewId, constructPath(viewId), tagToRemove);
+  }
+
+  /**
    * Removes a tag from a program.
    *
    * @param programId program to remove tag from
@@ -493,6 +556,16 @@ public class MetadataClient {
   }
 
   /**
+   * Removes all tags from a view.
+   *
+   * @param viewId view to remove tags from
+   */
+  public void removeTags(Id.Stream.View viewId)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeTags(viewId, constructPath(viewId));
+  }
+
+  /**
    * Removes all tags from a program.
    *
    * @param programId program to remove tags from
@@ -546,6 +619,16 @@ public class MetadataClient {
   public void removeMetadata(Id.Stream streamId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
     removeMetadata(streamId, constructPath(streamId));
+  }
+
+  /**
+   * Removes metadata from a view.
+   *
+   * @param viewId view to remove metadata from
+   */
+  public void removeMetadata(Id.Stream.View viewId)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeMetadata(viewId, constructPath(viewId));
   }
 
   /**
@@ -617,5 +700,9 @@ public class MetadataClient {
 
   private String constructPath(Id.Stream streamId) {
     return String.format("streams/%s", streamId.getId());
+  }
+
+  private String constructPath(Id.Stream.View viewId) {
+    return String.format("streams/%s/views/%s", viewId.getStreamId(), viewId.getId());
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/ViewNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ViewNotFoundException.java
@@ -13,26 +13,24 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package co.cask.cdap.proto.metadata;
+
+package co.cask.cdap.common;
+
+import co.cask.cdap.proto.Id;
 
 /**
- * Supported types for metadata search.
+ * Thrown when a view is not found
  */
-public enum MetadataSearchTargetType {
-  ALL("All"),
-  APP("Application"),
-  PROGRAM("Program"),
-  DATASET("DatasetInstance"),
-  STREAM("Stream"),
-  VIEW("View");
+public class ViewNotFoundException extends NotFoundException {
 
-  private final String internalName;
+  private final Id.Stream.View id;
 
-  private MetadataSearchTargetType(String internalName) {
-    this.internalName = internalName;
+  public ViewNotFoundException(Id.Stream.View id) {
+    super(id);
+    this.id = id;
   }
 
-  public String getInternalName() {
-    return internalName;
+  public Id.Stream.View getId() {
+    return id;
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/KeyHelper.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/KeyHelper.java
@@ -54,6 +54,14 @@ public class KeyHelper {
       String instanceId = stream.getId();
       builder.add(namespaceId);
       builder.add(instanceId);
+    } else if (type.equals(Id.Stream.View.class.getSimpleName())) {
+      Id.Stream.View view = (Id.Stream.View) namespacedId;
+      String namespaceId = view.getNamespaceId();
+      String streamId = view.getStreamId();
+      String viewId = view.getId();
+      builder.add(namespaceId);
+      builder.add(streamId);
+      builder.add(viewId);
     } else if (type.equals(Id.Artifact.class.getSimpleName())) {
       Id.Artifact artifactId = (Id.Artifact) namespacedId;
       String namespaceId = artifactId.getNamespace().getId();
@@ -86,6 +94,11 @@ public class KeyHelper {
       String namespaceId = keySplitter.getString();
       String instanceId  = keySplitter.getString();
       return Id.Stream.from(namespaceId, instanceId);
+    } else if (type.equals(Id.Stream.View.class.getSimpleName())) {
+      String namespaceId = keySplitter.getString();
+      String streamId  = keySplitter.getString();
+      String viewId = keySplitter.getString();
+      return Id.Stream.View.from(Id.Stream.from(namespaceId, streamId), viewId);
     }
     throw new IllegalArgumentException("Illegal Type " + type + " of metadata source.");
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/KeyHelper.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/KeyHelper.java
@@ -86,6 +86,11 @@ public class KeyHelper {
       String namespaceId = keySplitter.getString();
       String appId = keySplitter.getString();
       return Id.Application.from(namespaceId, appId);
+    } else if (type.equals(Id.Artifact.class.getSimpleName())) {
+      String namespaceId = keySplitter.getString();
+      String name = keySplitter.getString();
+      String version = keySplitter.getString();
+      return Id.Artifact.from(Id.Namespace.from(namespaceId), name, version);
     } else if (type.equals(Id.DatasetInstance.class.getSimpleName())) {
       String namespaceId = keySplitter.getString();
       String instanceId  = keySplitter.getString();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsValueKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsValueKey.java
@@ -52,6 +52,11 @@ public class MdsValueKey {
     } else if (type.equals(Id.Stream.class.getSimpleName())) {
       keySplitter.skipString();
       keySplitter.skipString();
+    } else if (type.equals(Id.Stream.View.class.getSimpleName())) {
+      // skip namespace, stream, view
+      keySplitter.skipString();
+      keySplitter.skipString();
+      keySplitter.skipString();
     } else if (type.equals(Id.Artifact.class.getSimpleName())) {
       // skip namespace, name, version
       keySplitter.skipString();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.transaction.queue.inmemory;
 
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.StreamNotFoundException;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data.stream.service.StreamMetaStore;
 import co.cask.cdap.data.view.ViewAdmin;
@@ -156,7 +157,7 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
   @Override
   public boolean viewExists(Id.Stream.View viewId) throws Exception {
     if (!exists(viewId.getStream())) {
-      throw new NotFoundException(viewId.getStreamId());
+      throw new StreamNotFoundException(viewId.getStream());
     }
     return viewAdmin.exists(viewId);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.transaction.stream;
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.StreamNotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
@@ -399,7 +400,7 @@ public class FileStreamAdmin implements StreamAdmin {
   @Override
   public boolean viewExists(Id.Stream.View viewId) throws Exception {
     if (!exists(viewId.getStream())) {
-      throw new NotFoundException(viewId.getStreamId());
+      throw new StreamNotFoundException(viewId.getStream());
     }
     return viewAdmin.exists(viewId);
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
@@ -55,6 +55,7 @@ public class BusinessMetadataDatasetTest {
   private final Id.Program flow1 = Id.Program.from("ns1", "app1", ProgramType.FLOW, "flow1");
   private final Id.DatasetInstance dataset1 = Id.DatasetInstance.from("ns1", "ds1");
   private final Id.Stream stream1 = Id.Stream.from("ns1", "s1");
+  private final Id.Stream.View view1 = Id.Stream.View.from(stream1, "v1");
   private final Id.Artifact artifact1 = Id.Artifact.from(Id.Namespace.from("ns1"), "a1", "1.0.0");
 
   @Before
@@ -73,6 +74,7 @@ public class BusinessMetadataDatasetTest {
     Assert.assertEquals(0, dataset.getProperties(flow1).size());
     Assert.assertEquals(0, dataset.getProperties(dataset1).size());
     Assert.assertEquals(0, dataset.getProperties(stream1).size());
+    Assert.assertEquals(0, dataset.getProperties(view1).size());
     Assert.assertEquals(0, dataset.getProperties(artifact1).size());
     // Set some properties
     dataset.setProperty(app1, "akey1", "avalue1");
@@ -81,6 +83,8 @@ public class BusinessMetadataDatasetTest {
     dataset.setProperty(dataset1, "dkey1", "dvalue1");
     dataset.setProperty(stream1, "skey1", "svalue1");
     dataset.setProperty(stream1, "skey2", "svalue2");
+    dataset.setProperty(view1, "vkey1", "vvalue1");
+    dataset.setProperty(view1, "vkey2", "vvalue2");
     dataset.setProperty(artifact1, "rkey1", "rvalue1");
     dataset.setProperty(artifact1, "rkey2", "rvalue2");
     // verify
@@ -106,6 +110,11 @@ public class BusinessMetadataDatasetTest {
     result = dataset.getProperty(artifact1, "rkey2");
     expected = new BusinessMetadataRecord(artifact1, "rkey2", "rvalue2");
     Assert.assertEquals(expected, result);
+    properties = dataset.getProperties(view1);
+    Assert.assertEquals(ImmutableMap.of("vkey1", "vvalue1", "vkey2", "vvalue2"), properties);
+    result = dataset.getProperty(view1, "vkey2");
+    expected = new BusinessMetadataRecord(view1, "vkey2", "vvalue2");
+    Assert.assertEquals(expected, result);
     // reset a property
     dataset.setProperty(stream1, "skey1", "sv1");
     Assert.assertEquals(ImmutableMap.of("skey1", "sv1", "skey2", "svalue2"), dataset.getProperties(stream1));
@@ -115,10 +124,12 @@ public class BusinessMetadataDatasetTest {
     dataset.removeProperties(dataset1);
     dataset.removeProperties(stream1);
     dataset.removeProperties(artifact1);
+    dataset.removeProperties(view1);
     Assert.assertEquals(0, dataset.getProperties(app1).size());
     Assert.assertEquals(0, dataset.getProperties(flow1).size());
     Assert.assertEquals(0, dataset.getProperties(dataset1).size());
     Assert.assertEquals(0, dataset.getProperties(stream1).size());
+    Assert.assertEquals(0, dataset.getProperties(view1).size());
     Assert.assertEquals(0, dataset.getProperties(artifact1).size());
   }
 
@@ -128,11 +139,13 @@ public class BusinessMetadataDatasetTest {
     Assert.assertEquals(0, dataset.getTags(flow1).size());
     Assert.assertEquals(0, dataset.getTags(dataset1).size());
     Assert.assertEquals(0, dataset.getTags(stream1).size());
+    Assert.assertEquals(0, dataset.getTags(view1).size());
     Assert.assertEquals(0, dataset.getTags(artifact1).size());
     dataset.addTags(app1, "tag1", "tag2", "tag3");
     dataset.addTags(flow1, "tag1");
     dataset.addTags(dataset1, "tag3", "tag2");
     dataset.addTags(stream1, "tag2");
+    dataset.addTags(view1, "tag4");
     dataset.addTags(artifact1, "tag3");
     Set<String> tags = dataset.getTags(app1);
     Assert.assertEquals(3, tags.size());
@@ -152,6 +165,9 @@ public class BusinessMetadataDatasetTest {
     tags = dataset.getTags(stream1);
     Assert.assertEquals(1, tags.size());
     Assert.assertTrue(tags.contains("tag2"));
+    tags = dataset.getTags(view1);
+    Assert.assertEquals(1, tags.size());
+    Assert.assertTrue(tags.contains("tag4"));
     dataset.removeTags(app1, "tag1", "tag2");
     tags = dataset.getTags(app1);
     Assert.assertEquals(1, tags.size());
@@ -168,11 +184,13 @@ public class BusinessMetadataDatasetTest {
     dataset.removeTags(flow1);
     dataset.removeTags(dataset1);
     dataset.removeTags(stream1);
+    dataset.removeTags(view1);
     dataset.removeTags(artifact1);
     Assert.assertEquals(0, dataset.getTags(app1).size());
     Assert.assertEquals(0, dataset.getTags(flow1).size());
     Assert.assertEquals(0, dataset.getTags(dataset1).size());
     Assert.assertEquals(0, dataset.getTags(stream1).size());
+    Assert.assertEquals(0, dataset.getTags(view1).size());
     Assert.assertEquals(0, dataset.getTags(artifact1).size());
   }
 

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -83,10 +83,12 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       matches(uriParts, "v3", "namespaces", null, "apps", null, null, null, "metadata", "properties") ||
       matches(uriParts, "v3", "namespaces", null, "datasets", null, "metadata", "properties") ||
       matches(uriParts, "v3", "namespaces", null, "streams", null, "metadata", "properties") ||
+      matches(uriParts, "v3", "namespaces", null, "views", null, "metadata", "properties") ||
       matches(uriParts, "v3", "namespaces", null, "apps", null, "metadata", "tags") ||
       matches(uriParts, "v3", "namespaces", null, "apps", null, null, null, "metadata", "tags") ||
       matches(uriParts, "v3", "namespaces", null, "datasets", null, "metadata", "tags") ||
       matches(uriParts, "v3", "namespaces", null, "streams", null, "metadata", "tags") ||
+      matches(uriParts, "v3", "namespaces", null, "views", null, "metadata", "tags") ||
       matches(uriParts, "v3", "namespaces", null, "metadata", "search") ||
       matches(uriParts, "v3", "namespaces", null, "datasets", null, "lineage") ||
       matches(uriParts, "v3", "namespaces", null, "streams", null, "lineage") ||

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/NamespacedIdCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/NamespacedIdCodec.java
@@ -30,7 +30,7 @@ import java.lang.reflect.Type;
 
 /**
  * Codec for {@link Id.NamespacedId}. Currently only supports {@link Id.Application}, {@link Id.Artifact},
- * {@link Id.Program}, {@link Id.DatasetInstance} and {@link Id.Stream}.
+ * {@link Id.Program}, {@link Id.DatasetInstance}, {@link Id.Stream} and {@link Id.Stream.View}.
  * Support for other {@link Id.NamespacedId} objects will be added later.
  */
 public class NamespacedIdCodec extends AbstractSpecificationCodec<Id.NamespacedId> {
@@ -70,12 +70,14 @@ public class NamespacedIdCodec extends AbstractSpecificationCodec<Id.NamespacedI
         return deserializeDatasetInstanceId(id);
       case "stream":
         return deserializeStreamId(id);
+      case "view":
+        return deserializeViewId(id);
       case "artifact":
         return deserializeArtifactId(id);
       default:
         throw new UnsupportedOperationException(
           String.format("Unsupported object of type %s found. Deserialization of only %s, %s, %s, %s, %s, %s, %s, " +
-                          "%s, %s, %s, %s is supported.",
+                          "%s, %s, %s, %s, %s is supported.",
                         type,
                         Id.Application.class.getSimpleName(),
                         Id.Program.class.getSimpleName(),
@@ -87,6 +89,7 @@ public class NamespacedIdCodec extends AbstractSpecificationCodec<Id.NamespacedI
                         Id.Workflow.class.getSimpleName(),
                         Id.DatasetInstance.class.getSimpleName(),
                         Id.Stream.class.getSimpleName(),
+                        Id.Stream.View.class.getSimpleName(),
                         Id.Artifact.class.getSimpleName()
           )
         );
@@ -161,5 +164,11 @@ public class NamespacedIdCodec extends AbstractSpecificationCodec<Id.NamespacedI
     Id.Namespace namespace = deserializeNamespace(id);
     String streamName = id.get("streamName").getAsString();
     return Id.Stream.from(namespace, streamName);
+  }
+
+  private Id.Stream.View deserializeViewId(JsonObject id) {
+    Id.Stream streamId = deserializeStreamId(id.getAsJsonObject("stream"));
+    String view = id.get("id").getAsString();
+    return Id.Stream.View.from(streamId, view);
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchTargetType.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchTargetType.java
@@ -20,6 +20,7 @@ package co.cask.cdap.proto.metadata;
  */
 public enum MetadataSearchTargetType {
   ALL("All"),
+  ARTIFACT("Artifact"),
   APP("Application"),
   PROGRAM("Program"),
   DATASET("DatasetInstance"),


### PR DESCRIPTION
- Adds support for metadata to stream view
- Adds createOrUpdateView in AppFabricTestBase since currently a view cannot be created in an app spec and can only be created through StreamAdmin or HTTP calls. 
- Fixes an issue in metadata for artifact to make search work and adds a test for it.

Build: http://builds.cask.co/browse/CDAP-DUT3190-1
