### PR TITLE
(CDAP-4307) Adding some missing null checks in the Workflow stats cod…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -315,9 +315,13 @@ public class DefaultStore implements Store {
         ProgramType programType = ProgramType.valueOfSchedulableType(workflowNode.getProgram().getProgramType());
         Id.Program innerProgram = Id.Program.from(app.getNamespaceId(), app.getId(), programType, entry.getKey());
         RunRecordMeta innerProgramRun = getRun(innerProgram, entry.getValue());
-        if (innerProgramRun.getStatus().equals(ProgramRunStatus.COMPLETED)) {
+        if (innerProgramRun != null && innerProgramRun.getStatus().equals(ProgramRunStatus.COMPLETED)) {
+          Long stopTs = innerProgramRun.getStopTs();
+          // since the program is completed, the stop ts cannot be null
+          Preconditions.checkState(stopTs != null, "Since the program has completed, expected its stop time to not " +
+            "be null. Program = %s, Workflow = %s, Run = %s, Stop Ts = %s", innerProgram, id, run, stopTs);
           programRunsList.add(new WorkflowDataset.ProgramRun(
-            entry.getKey(), entry.getValue(), programType, innerProgramRun.getStopTs() - innerProgramRun.getStartTs()));
+            entry.getKey(), entry.getValue(), programType, stopTs - innerProgramRun.getStartTs()));
         } else {
           workFlowNodeFailed = true;
           break;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithSchedule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithSchedule.java
@@ -80,16 +80,11 @@ public class AppWithSchedule extends AbstractApplication {
     private static final Logger LOG = LoggerFactory.getLogger(DummyAction.class);
     @Override
     public void run() {
+      Preconditions.checkArgument(getContext().getRuntimeArguments().get("oneKey").equals("oneValue"));
+      Preconditions.checkArgument(getContext().getRuntimeArguments().get("anotherKey").equals("anotherValue"));
+      Preconditions.checkArgument(getContext().getRuntimeArguments().get("someKey").equals("someWorkflowValue"));
+      Preconditions.checkArgument(getContext().getRuntimeArguments().get("workflowKey").equals("workflowValue"));
       LOG.info("Ran dummy action");
-      try {
-        TimeUnit.MILLISECONDS.sleep(500);
-        Preconditions.checkArgument(getContext().getRuntimeArguments().get("oneKey").equals("oneValue"));
-        Preconditions.checkArgument(getContext().getRuntimeArguments().get("anotherKey").equals("anotherValue"));
-        Preconditions.checkArgument(getContext().getRuntimeArguments().get("someKey").equals("someWorkflowValue"));
-        Preconditions.checkArgument(getContext().getRuntimeArguments().get("workflowKey").equals("workflowValue"));
-      } catch (InterruptedException e) {
-        LOG.info("Interrupted");
-      }
     }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/ConcurrentWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/ConcurrentWorkflowApp.java
@@ -81,6 +81,7 @@ public class ConcurrentWorkflowApp extends AbstractApplication {
           Thread.currentThread().interrupt();
         }
       }
+      LOG.info("Found done file {}. Workflow completed.", doneFile);
     }
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/Tasks.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/Tasks.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
 
 /**
  * General task utils.
@@ -27,6 +28,47 @@ import java.util.concurrent.TimeoutException;
 public final class Tasks {
 
   private Tasks() { }
+
+  /**
+   * Calls callable, waiting sleepDelay between each call,
+   * until it returns the desiredValue or the timeout has passed.
+   *
+   * @param desiredValue the desired value to get from callable
+   * @param callable the callable to check
+   * @param timeout time until we timeout
+   * @param timeoutUnit unit of time for timeout
+   * @param sleepDelay time to wait between calls to callable
+   * @param sleepDelayUnit unit of time for sleepDelay
+   * @param message an optional message for the {@link TimeoutException}
+   * @param <T> type of desiredValue
+   * @throws TimeoutException if timeout has passed, but didn't get the desiredValue
+   * @throws InterruptedException if something interrupted this waiting operation
+   * @throws ExecutionException if there was an exception in calling the callable
+   */
+  public static <T> void waitFor(T desiredValue, Callable<T> callable, long timeout, TimeUnit timeoutUnit,
+                                 long sleepDelay, TimeUnit sleepDelayUnit, @Nullable String message)
+    throws TimeoutException, InterruptedException, ExecutionException {
+
+    long sleepDelayMs = sleepDelayUnit.toMillis(sleepDelay);
+    long startTime = System.currentTimeMillis();
+    long timeoutMs = timeoutUnit.toMillis(timeout);
+    T actualValue = null;
+    while (System.currentTimeMillis() - startTime < timeoutMs) {
+      try {
+        actualValue = callable.call();
+        if (desiredValue.equals(actualValue)) {
+          return;
+        }
+      } catch (Exception e) {
+        throw new ExecutionException(e);
+      }
+      Thread.sleep(sleepDelayMs);
+    }
+    if (message == null) {
+      message = String.format("Timeout occurred. Expected %s but found %s.", desiredValue, actualValue);
+    }
+    throw new TimeoutException(message);
+  }
 
   /**
    * Calls callable, waiting sleepDelay between each call,
@@ -46,23 +88,29 @@ public final class Tasks {
   public static <T> void waitFor(T desiredValue, Callable<T> callable, long timeout, TimeUnit timeoutUnit,
                                  long sleepDelay, TimeUnit sleepDelayUnit)
     throws TimeoutException, InterruptedException, ExecutionException {
-
-    long sleepDelayMs = sleepDelayUnit.toMillis(sleepDelay);
-    long startTime = System.currentTimeMillis();
-    long timeoutMs = timeoutUnit.toMillis(timeout);
-    while (System.currentTimeMillis() - startTime < timeoutMs) {
-      try {
-        if (desiredValue.equals(callable.call())) {
-          return;
-        }
-      } catch (Exception e) {
-        throw new ExecutionException(e);
-      }
-      Thread.sleep(sleepDelayMs);
-    }
-    throw new TimeoutException();
+    waitFor(desiredValue, callable, timeout, timeoutUnit, sleepDelay, sleepDelayUnit, null);
   }
 
+
+  /**
+   * Calls callable, waiting 50 milliseconds between each call,
+   * until it returns the desiredValue or the timeout has passed.
+   *
+   * @param desiredValue the desired value to get from callable
+   * @param callable the callable to check
+   * @param timeout time until we timeout
+   * @param timeoutUnit unit of time for timeout
+   * @param <T> type of desiredValue
+   * @param message an optional message for the {@link TimeoutException}
+   * @throws TimeoutException if timeout has passed, but didn't get the desiredValue
+   * @throws InterruptedException if something interrupted this waiting operation
+   * @throws ExecutionException if there was an exception in calling the callable
+   */
+  public static <T> void waitFor(T desiredValue, Callable<T> callable, long timeout, TimeUnit timeoutUnit,
+                                 @Nullable String message)
+    throws TimeoutException, InterruptedException, ExecutionException {
+    waitFor(desiredValue, callable, timeout, timeoutUnit, 50, TimeUnit.MILLISECONDS, message);
+  }
 
   /**
    * Calls callable, waiting 50 milliseconds between each call,


### PR DESCRIPTION
…e. This PR still does not fix a possible race condition yet.

(CDAP-3696) Add a message to the TimeoutException thrown in Tasks.waitFor. Also add some more instrumentation/logging for WorkflowHttpHandlerTest.testMultipleWorkflowInstances.

Make testWorkflowSchedules more predictable


Jira: 
[CDAP-3696](https://issues.cask.co/browse/CDAP-3696)
[CDAP-4307](https://issues.cask.co/browse/CDAP-4307)

Build: http://builds.cask.co/browse/CDAP-DUT3201