### PR TITLE
CDAP-4226 enhance build to optionally copy additional artifacts

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -52,6 +52,12 @@ Standalone and Distributed CDAP
 
     MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -pl cdap-standalone,cdap-app-templates/cdap-etl,cdap-app-templates/cdap-data-quality,cdap-examples -am -amd -DskipTests -P examples,templates,dist,release,unit-tests
 
+- Build Standalone distribution ZIP with additional system artifacts::
+
+    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -pl cdap-standalone,cdap-app-templates/cdap-etl,cdap-app-templates/cdap-data-quality,cdap-examples -am -amd -DskipTests -P examples,templates,dist,release,unit-tests -Dadditional.artifacts.dir=</path/to/additional/artifacts>
+
+This will copy any .jar and .json files in any 'target' directories under the specified path to the artifacts directory.
+
 - Build the limited set of Javadocs used in distribution ZIP::
 
     mvn clean package javadoc:javadoc -pl cdap-api -am -DskipTests -P release

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -173,59 +173,22 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>2.5.4</version>
         <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>co.cask.cdap.etl.batch.*;co.cask.cdap.etl.transform.*;
+              co.cask.cdap.etl.validator.*;
+              co.cask.cdap.etl.common;org.apache.avro.mapreduce;parquet.avro.*;parquet.hadoop.*;
+              co.cask.cdap.etl.realtime.*;co.cask.cdap.etl.transform.*;
+              co.cask.cdap.etl.validator.*;co.cask.cdap.etl.common</_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
         <executions>
           <execution>
-            <id>batch-source-bundle</id>
-            <phase>prepare-package</phase>
-            <configuration>
-              <classifier>batch-source</classifier>
-              <instructions>
-                <!-- build bundle jar for batch sources for data quality artifact -->
-                <_exportcontents>co.cask.cdap.etl.batch.source.*;co.cask.cdap.etl.common;
-                  org.apache.avro.mapreduce;parquet.avro</_exportcontents>
-                <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
-                <Embed-Transitive>true</Embed-Transitive>
-                <Embed-Directory>lib</Embed-Directory>
-              </instructions>
-            </configuration>
+            <phase>package</phase>
             <goals>
-              <goal>bundle</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>batch-bundle</id>
-            <phase>prepare-package</phase>
-            <configuration>
-              <classifier>batch</classifier>
-              <instructions>
-                <!-- build bundle jar for batch. excluding realtime-->
-                <_exportcontents>co.cask.cdap.etl.batch.*;co.cask.cdap.etl.transform.*;
-                  co.cask.cdap.etl.validator.*;
-                  co.cask.cdap.etl.common;org.apache.avro.mapreduce;parquet.avro.*;parquet.hadoop.*</_exportcontents>
-                <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
-                <Embed-Transitive>true</Embed-Transitive>
-                <Embed-Directory>lib</Embed-Directory>
-              </instructions>
-            </configuration>
-            <goals>
-              <goal>bundle</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>realtime-bundle</id>
-            <phase>prepare-package</phase>
-            <configuration>
-              <classifier>realtime</classifier>
-              <instructions>
-                <!-- build bundle jar for realtime. excluding batch-->
-                <_exportcontents>co.cask.cdap.etl.realtime.*;co.cask.cdap.etl.transform.*;
-                  co.cask.cdap.etl.validator.*;co.cask.cdap.etl.common</_exportcontents>
-                <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
-                <Embed-Transitive>true</Embed-Transitive>
-                <Embed-Directory>lib</Embed-Directory>
-              </instructions>
-            </configuration>
-           <goals>
               <goal>bundle</goal>
             </goals>
           </execution>

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/resources/cdap-etl-lib-batch-source.json
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/resources/cdap-etl-lib-batch-source.json
@@ -1,3 +1,0 @@
-{
-  "parents": [ "cdap-data-quality[${project.version},${project.version}]" ]
-}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/resources/cdap-etl-lib-batch.json
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/resources/cdap-etl-lib-batch.json
@@ -1,3 +1,0 @@
-{
-  "parents": [ "cdap-etl-batch[${project.version},${project.version}]" ]
-}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/resources/cdap-etl-lib-realtime.json
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/resources/cdap-etl-lib-realtime.json
@@ -1,3 +1,0 @@
-{
-  "parents": [ "cdap-etl-realtime[${project.version},${project.version}]" ]
-}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/resources/cdap-etl-lib.json
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/resources/cdap-etl-lib.json
@@ -1,0 +1,7 @@
+{
+  "parents": [
+    "cdap-etl-batch[${project.version},${project.version}]",
+    "cdap-etl-realtime[${project.version},${project.version}]",
+    "cdap-data-quality[${project.version},${project.version}]"
+  ]
+}

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -165,6 +165,9 @@
         <package.depends>--depends cdap --depends cdap-hbase-compat-0.96 --depends cdap-hbase-compat-0.98
         --depends cdap-hbase-compat-1.0 --depends cdap-hbase-compat-1.0-cdh
         --depends cdap-hbase-compat-1.1</package.depends>
+        <stage.artifacts.dir>${stage.opt.dir}/artifacts</stage.artifacts.dir>
+        <additional.artifacts.jar.pattern>**/target/*.jar</additional.artifacts.jar.pattern>
+        <additional.artifacts.config.pattern>**/target/*.json</additional.artifacts.config.pattern>
       </properties>
       <build>
         <plugins>
@@ -173,7 +176,7 @@
             <artifactId>maven-jar-plugin</artifactId>
             <version>2.4</version>
           </plugin>
- 	        <plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
             <version>2.8</version>
@@ -184,13 +187,13 @@
             <version>2.6</version>
             <executions>
               <execution>
-                <id>copy-etl-batch</id>
+                <id>copy-etl</id>
                 <phase>process-resources</phase>
                 <goals>
                   <goal>copy-resources</goal>
                 </goals>
                 <configuration combine.self="override">
-                  <outputDirectory>${stage.opt.dir}/artifacts</outputDirectory>
+                  <outputDirectory>${stage.artifacts.dir}</outputDirectory>
                   <resources>
                     <resource>
                       <directory>
@@ -200,35 +203,6 @@
                         <include>cdap-etl-batch-${project.version}.jar</include>
                       </includes>
                     </resource>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-lib/target
-                      </directory>
-                      <includes>
-                        <include>cdap-etl-lib-${project.version}-batch.jar</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-lib/target/classes
-                      </directory>
-                      <filtering>true</filtering>
-                      <includes>
-                        <include>cdap-etl-lib-batch.json</include>
-                      </includes>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-              <execution>
-                <id>copy-etl-realtime</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration combine.self="override">
-                  <outputDirectory>${stage.opt.dir}/artifacts</outputDirectory>
-                  <resources>
                     <resource>
                       <directory>
                         ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-realtime/target
@@ -242,7 +216,7 @@
                         ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-lib/target
                       </directory>
                       <includes>
-                        <include>cdap-etl-lib-${project.version}-realtime.jar</include>
+                        <include>cdap-etl-lib-${project.version}.jar</include>
                       </includes>
                     </resource>
                     <resource>
@@ -251,7 +225,7 @@
                       </directory>
                       <filtering>true</filtering>
                       <includes>
-                        <include>cdap-etl-lib-realtime.json</include>
+                        <include>cdap-etl-lib.json</include>
                       </includes>
                     </resource>
                   </resources>
@@ -264,7 +238,7 @@
                   <goal>copy-resources</goal>
                 </goals>
                 <configuration combine.self="override">
-                  <outputDirectory>${stage.opt.dir}/artifacts</outputDirectory>
+                  <outputDirectory>${stage.artifacts.dir}</outputDirectory>
                   <resources>
                     <resource>
                       <directory>
@@ -272,23 +246,6 @@
                       </directory>
                       <includes>
                         <include>cdap-data-quality-${project.version}.jar</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-lib/target
-                      </directory>
-                      <includes>
-                        <include>cdap-etl-lib-${project.version}-batch-source.jar</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-lib/target/classes
-                      </directory>
-                      <filtering>true</filtering>
-                      <includes>
-                        <include>cdap-etl-lib-batch-source.json</include>
                       </includes>
                     </resource>
                   </resources>
@@ -309,11 +266,28 @@
                 </goals>
                 <configuration>
                   <target>
-                    <move file="${stage.opt.dir}/artifacts/cdap-etl-lib-batch.json" tofile="${stage.opt.dir}/artifacts/cdap-etl-lib-${project.version}-batch.json" />
-                    <move file="${stage.opt.dir}/artifacts/cdap-etl-lib-realtime.json" tofile="${stage.opt.dir}/artifacts/cdap-etl-lib-${project.version}-realtime.json" />
-                    <move file="${stage.opt.dir}/artifacts/cdap-etl-lib-batch-source.json" tofile="${stage.opt.dir}/artifacts/cdap-etl-lib-${project.version}-batch-source.json" />
+                    <move file="${stage.artifacts.dir}/cdap-etl-lib.json" tofile="${stage.artifacts.dir}/cdap-etl-lib-${project.version}.json" />
                   </target>
                 </configuration>
+              </execution>
+              <!-- Copy any additional system artifacts.
+                   For example, if you want to include plugins from hydrator-plugins. -->
+              <execution>
+                <id>copy-additional-system-artifacts</id>
+                <phase>prepare-package</phase>
+                <configuration>
+                  <target if="additional.artifacts.dir">
+                    <copy todir="${stage.artifacts.dir}" flatten="true">
+                      <fileset dir="${additional.artifacts.dir}">
+                        <include name="${additional.artifacts.jar.pattern}"/>
+                        <include name="${additional.artifacts.config.pattern}"/>
+                      </fileset>
+                    </copy>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -184,7 +184,9 @@
         <stage.opt.dir>${sdk.dir}/cdap-sdk-${project.version}</stage.opt.dir>
         <stage.lib.dir>${stage.opt.dir}/lib</stage.lib.dir>
         <stage.libexec.dir>${stage.opt.dir}/libexec</stage.libexec.dir>
-        <stage.plugins.dir>${stage.opt.dir}/plugins</stage.plugins.dir>
+        <stage.artifacts.dir>${stage.opt.dir}/artifacts</stage.artifacts.dir>
+        <additional.artifacts.jar.pattern>**/target/*.jar</additional.artifacts.jar.pattern>
+        <additional.artifacts.config.pattern>**/target/*.json</additional.artifacts.config.pattern>
       </properties>
       <build>
         <plugins>
@@ -373,13 +375,13 @@
                 </configuration>
               </execution>
               <execution>
-                <id>copy-etl-batch</id>
+                <id>copy-etl</id>
                 <phase>prepare-package</phase>
                 <goals>
                   <goal>copy-resources</goal>
                 </goals>
                 <configuration combine.self="override">
-                  <outputDirectory>${stage.opt.dir}/artifacts</outputDirectory>
+                  <outputDirectory>${stage.artifacts.dir}</outputDirectory>
                   <resources>
                     <resource>
                       <directory>
@@ -389,35 +391,6 @@
                         <include>cdap-etl-batch-${project.version}.jar</include>
                       </includes>
                     </resource>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-lib/target
-                      </directory>
-                      <includes>
-                        <include>cdap-etl-lib-${project.version}-batch.jar</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-lib/target/classes
-                      </directory>
-                      <filtering>true</filtering>
-                      <includes>
-                        <include>cdap-etl-lib-batch.json</include>
-                      </includes>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-              <execution>
-                <id>copy-etl-realtime</id>
-                <phase>prepare-package</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration combine.self="override">
-                  <outputDirectory>${stage.opt.dir}/artifacts</outputDirectory>
-                  <resources>
                     <resource>
                       <directory>
                         ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-realtime/target
@@ -431,7 +404,7 @@
                         ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-lib/target
                       </directory>
                       <includes>
-                        <include>cdap-etl-lib-${project.version}-realtime.jar</include>
+                        <include>cdap-etl-lib-${project.version}.jar</include>
                       </includes>
                     </resource>
                     <resource>
@@ -440,7 +413,7 @@
                       </directory>
                       <filtering>true</filtering>
                       <includes>
-                        <include>cdap-etl-lib-realtime.json</include>
+                        <include>cdap-etl-lib.json</include>
                       </includes>
                     </resource>
                   </resources>
@@ -453,7 +426,7 @@
                   <goal>copy-resources</goal>
                 </goals>
                 <configuration combine.self="override">
-                  <outputDirectory>${stage.opt.dir}/artifacts</outputDirectory>
+                  <outputDirectory>${stage.artifacts.dir}</outputDirectory>
                   <resources>
                     <resource>
                       <directory>
@@ -461,23 +434,6 @@
                       </directory>
                       <includes>
                         <include>cdap-data-quality-${project.version}.jar</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-lib/target
-                      </directory>
-                      <includes>
-                        <include>cdap-etl-lib-${project.version}-batch-source.jar</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-lib/target/classes
-                      </directory>
-                      <filtering>true</filtering>
-                      <includes>
-                        <include>cdap-etl-lib-batch-source.json</include>
                       </includes>
                     </resource>
                   </resources>
@@ -556,11 +512,28 @@
                 </goals>
                 <configuration>
                   <target>
-                    <move file="${stage.opt.dir}/artifacts/cdap-etl-lib-batch.json" tofile="${stage.opt.dir}/artifacts/cdap-etl-lib-${project.version}-batch.json" />
-                    <move file="${stage.opt.dir}/artifacts/cdap-etl-lib-realtime.json" tofile="${stage.opt.dir}/artifacts/cdap-etl-lib-${project.version}-realtime.json" />
-                    <move file="${stage.opt.dir}/artifacts/cdap-etl-lib-batch-source.json" tofile="${stage.opt.dir}/artifacts/cdap-etl-lib-${project.version}-batch-source.json" />
+                    <move file="${stage.artifacts.dir}/cdap-etl-lib.json" tofile="${stage.artifacts.dir}/cdap-etl-lib-${project.version}.json" />
                   </target>
                 </configuration>
+              </execution>
+              <!-- Copy any additional system artifacts.
+                   For example, if you want to include plugins from hydrator-plugins. -->
+              <execution>
+                <id>copy-additional-system-artifacts</id>
+                <phase>prepare-package</phase>
+                <configuration>
+                  <target if="additional.artifacts.dir">
+                    <copy todir="${stage.artifacts.dir}" flatten="true">
+                      <fileset dir="${additional.artifacts.dir}">
+                        <include name="${additional.artifacts.jar.pattern}"/>
+                        <include name="${additional.artifacts.config.pattern}"/>
+                      </fileset>
+                    </copy>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
               </execution>
               <!-- Rename CLI jar and make CLI scripts executable -->
               <execution>


### PR DESCRIPTION
Adding a property that will allow the build to copy additional
artifacts into the artifacts directory. This can be used to
include artifacts from other projects that we want to be included
as system artifacts. For example, we plan on including various
hydrator plugins that may come from different repositories.

Also simplifying etl lib build to only create a single jar, since
the three it was creating before were exactly the same except for
their manifests.