### PR TITLE
CDAP-4316: CDAP CLI should not connect successfully if given a wrong IP and port

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
@@ -179,7 +179,12 @@ public class CLIConfig implements TableRendererConfig {
       .setAccessToken(accessToken)
       .build();
     MetaClient metaClient = new MetaClient(clientConfig);
-    metaClient.ping();
+
+    try {
+      metaClient.ping();
+    } catch (IOException e) {
+      throw new IOException("Check hostname and/or port", e);
+    }
   }
 
   private boolean isAuthenticationEnabled(ConnectionConfig connectionInfo) throws IOException {

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetaClientAvailableTest.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetaClientAvailableTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.client;
+
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.config.ConnectionConfig;
+import co.cask.cdap.common.UnauthorizedException;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HttpResponder;
+import co.cask.http.NettyHttpService;
+import com.google.common.collect.ImmutableList;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Test for {@link MetaClient#ping()} when CDAP is unavailable.
+ */
+public class MetaClientAvailableTest {
+
+  private TestPingHandler handler;
+  private NettyHttpService service;
+  private MetaClient metaClient;
+  private MetaClient fakeMetaClient;
+
+  @Before
+  public void setUp() {
+    handler = new TestPingHandler();
+    service = NettyHttpService.builder()
+      .addHttpHandlers(ImmutableList.of(handler))
+      .build();
+    service.startAndWait();
+
+    metaClient = new MetaClient(
+      ClientConfig.builder()
+        .setConnectionConfig(
+          ConnectionConfig.builder()
+            .setHostname(service.getBindAddress().getHostName())
+            .setPort(service.getBindAddress().getPort())
+            .setSSLEnabled(false)
+            .build())
+        .build());
+
+    fakeMetaClient = new MetaClient(
+      ClientConfig.builder()
+        .setConnectionConfig(
+          ConnectionConfig.builder()
+            .setHostname(service.getBindAddress().getHostName())
+            .setPort(service.getBindAddress().getPort() + 1)
+            .setSSLEnabled(false)
+            .build())
+        .build());
+  }
+
+  @After
+  public void tearDown() {
+    service.stopAndWait();
+  }
+
+  @Test
+  public void testAvailable() throws IOException, UnauthorizedException {
+    handler.setResponse(HttpResponseStatus.OK, "OK.\n");
+    metaClient.ping();
+  }
+
+  @Test
+  public void testUnavailable() throws IOException, UnauthorizedException {
+    try {
+      fakeMetaClient.ping();
+      Assert.fail();
+    } catch (ConnectException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testWrongCode() throws UnauthorizedException {
+    try {
+      handler.setResponse(HttpResponseStatus.CONFLICT, "HI");
+      metaClient.ping();
+      Assert.fail();
+    } catch (IOException e) {
+      Assert.assertTrue(
+        "Expected IOException message to contain '409: HI', but got: " + e.getMessage(),
+        e.getMessage().contains("409: HI"));
+    }
+  }
+
+  @Test
+  public void testWrongBody() throws UnauthorizedException {
+    try {
+      handler.setResponse(HttpResponseStatus.OK, "???");
+      metaClient.ping();
+      Assert.fail();
+    } catch (IOException e) {
+      Assert.assertTrue(
+        "Expected IOException message to contain 'response body', but got: " + e.getMessage(),
+        e.getMessage().contains("response body"));
+    }
+  }
+
+  public final class TestPingHandler extends AbstractHttpHandler {
+
+    private HttpResponseStatus status;
+    private String body;
+
+    @GET
+    @Path("/ping")
+    public void ping(HttpRequest request, HttpResponder responder) throws Exception {
+      responder.sendString(status, body);
+    }
+
+    public void setResponse(HttpResponseStatus status, String body) {
+      this.status = status;
+      this.body = body;
+    }
+  }
+}

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetaClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetaClientTestRun.java
@@ -58,6 +58,5 @@ public class MetaClientTestRun extends ClientTestBase {
     Assert.assertNotNull(configEntry);
     Assert.assertEquals("hadoop.tmp.dir", configEntry.getName());
     Assert.assertNotNull(configEntry.getValue());
-
   }
 }

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetaClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetaClient.java
@@ -31,6 +31,7 @@ import com.google.common.reflect.TypeToken;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.inject.Inject;
 
 /**
@@ -53,7 +54,11 @@ public class MetaClient {
   }
 
   public void ping() throws IOException, UnauthorizedException {
-    restClient.execute(HttpMethod.GET, config.resolveURLNoVersion("ping"), config.getAccessToken());
+    HttpResponse response = restClient.execute(
+      HttpMethod.GET, config.resolveURLNoVersion("ping"), config.getAccessToken());
+    if (!Objects.equals(response.getResponseBodyAsString(), "OK.\n")) {
+      throw new IOException("Unexpected response body");
+    }
   }
 
   public Version getVersion() throws IOException, UnauthorizedException {


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-4316
http://builds.cask.co/browse/CDAP-DUT3212

New CLI behavior:

```
cdap-cli.sh
Successfully connected to CDAP instance at http://hostname:10000/default
cdap (http://hostname:10000/namespace:default)>

cdap-cli.sh -u localhost:9999
CDAP instance at 'http://localhost:9999/default' could not be reached: Unexpected response body.
```