### PR TITLE
CDAP-4228 add ability to select plugin artifact in etl apps

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ArtifactSelector.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ArtifactSelector.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginSelector;
+import com.google.common.base.Preconditions;
+
+import java.util.Map;
+import java.util.SortedMap;
+import javax.annotation.Nullable;
+
+/**
+ * Selects which plugin to use based on optional artifact scope, name, and version fields.
+ * Will select the first artifact that matches all non-null fields.
+ */
+public class ArtifactSelector extends PluginSelector {
+  private final ArtifactScope scope;
+  private final String name;
+  private final ArtifactVersion version;
+  private final String errMsg;
+
+  public ArtifactSelector(String pluginType,
+                          String pluginName,
+                          @Nullable ArtifactScope scope,
+                          @Nullable String name,
+                          @Nullable ArtifactVersion version) {
+    Preconditions.checkArgument(scope != null || name != null || version != null,
+                                "Must specify an artifact scope, name, or version.");
+    this.scope = scope;
+    this.name = name;
+    this.version = version;
+    StringBuilder msg = new StringBuilder("Could not find an artifact that matches");
+    if (scope != null) {
+      msg.append(" scope ");
+      msg.append(scope.name());
+    }
+    if (name != null) {
+      msg.append(" name ");
+      msg.append(name);
+    }
+    if (version != null) {
+      msg.append(" version ");
+      msg.append(version.getVersion());
+    }
+    msg.append(" for plugin of type ");
+    msg.append(pluginType);
+    msg.append(" and name ");
+    msg.append(pluginName);
+    errMsg = msg.toString();
+  }
+
+  @Override
+  public Map.Entry<ArtifactId, PluginClass> select(SortedMap<ArtifactId, PluginClass> plugins) {
+    for (Map.Entry<ArtifactId, PluginClass> entry : plugins.entrySet()) {
+      ArtifactId artifactId = entry.getKey();
+      if ((scope == null || artifactId.getScope().equals(scope)) &&
+        (name == null || artifactId.getName().equals(name)) &&
+        (version == null || artifactId.getVersion().equals(version))) {
+        return entry;
+      }
+    }
+
+    throw new IllegalArgumentException(errMsg);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ArtifactSelector.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ArtifactSelector.java
@@ -35,6 +35,8 @@ public class ArtifactSelector extends PluginSelector {
   private final ArtifactScope scope;
   private final String name;
   private final ArtifactVersion version;
+  private final String pluginType;
+  private final String pluginName;
   private final String errMsg;
 
   public ArtifactSelector(String pluginType,
@@ -47,6 +49,8 @@ public class ArtifactSelector extends PluginSelector {
     this.scope = scope;
     this.name = name;
     this.version = version;
+    this.pluginType = pluginType;
+    this.pluginName = pluginName;
     StringBuilder msg = new StringBuilder("Could not find an artifact that matches");
     if (scope != null) {
       msg.append(" scope ");
@@ -69,6 +73,10 @@ public class ArtifactSelector extends PluginSelector {
 
   @Override
   public Map.Entry<ArtifactId, PluginClass> select(SortedMap<ArtifactId, PluginClass> plugins) {
+    if (plugins.isEmpty()) {
+      throw new IllegalArgumentException(String.format("No plugins of type %s and name %s were found.",
+                                                       pluginType, pluginName));
+    }
     for (Map.Entry<ArtifactId, PluginClass> entry : plugins.entrySet()) {
       ArtifactId artifactId = entry.getKey();
       if ((scope == null || artifactId.getScope().equals(scope)) &&

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ArtifactSelectorConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ArtifactSelectorConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import com.google.common.base.CharMatcher;
+
+/**
+ * Part of the etl configuration, used to choose which artifact to use for a plugin. Normally created through
+ * deserialization by the CDAP framework. Programmatic creation is only used for unit tests.
+ */
+public class ArtifactSelectorConfig {
+  private static final CharMatcher nameMatcher =
+    CharMatcher.inRange('A', 'Z')
+      .or(CharMatcher.inRange('a', 'z'))
+      .or(CharMatcher.inRange('0', '9'))
+      .or(CharMatcher.is('_'))
+      .or(CharMatcher.is('-'));
+  private final String scope;
+  private final String name;
+  private final String version;
+
+  public ArtifactSelectorConfig() {
+    this.scope = null;
+    this.name = null;
+    this.version = null;
+  }
+
+  // for unit tests
+  public ArtifactSelectorConfig(String scope, String name, String version) {
+    this.scope = scope;
+    this.name = name;
+    this.version = version;
+  }
+
+  /**
+   * Gets the corresponding {@link ArtifactSelector} for this config.
+   * Validates that any given scope, name, and version are all valid or null. The scope must be an
+   * {@link ArtifactScope}, the version must be an {@link ArtifactVersion}, and the name only contains
+   * alphanumeric, '-', or '_'. Also checks that at least one field is non-null.
+   *
+   * @return an {@link ArtifactSelector} using these config settings
+   * @throws IllegalArgumentException if any one of the fields are invalid
+   */
+  public ArtifactSelector getArtifactSelector(String pluginType, String pluginName) {
+    if (name != null && !nameMatcher.matchesAllOf(name)) {
+      throw new IllegalArgumentException(String.format("'%s' is an invalid artifact name. " +
+                                                         "Must contain only alphanumeric, '-', or '_' characters.",
+                                                       name));
+    }
+
+    ArtifactVersion artifactVersion = null;
+    if (version != null) {
+      artifactVersion = new ArtifactVersion(version);
+      if (artifactVersion.getVersion() == null) {
+        throw new IllegalArgumentException(String.format("Could not parse '%s' as an artifact version.", version));
+      }
+    }
+
+    ArtifactScope artifactScope = scope == null ? null : ArtifactScope.valueOf(scope.toUpperCase());
+    return new ArtifactSelector(pluginType, pluginName, artifactScope, name, artifactVersion);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelineRegisterer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelineRegisterer.java
@@ -87,9 +87,12 @@ public class PipelineRegisterer {
     String sourcePluginId = sourceConfig.getName();
 
     // instantiate source
+    String pluginName = sourceConfig.getPlugin().getName();
     PipelineConfigurable source = configurer.usePlugin(sourcePluginType,
-                                                       sourceConfig.getPlugin().getName(),
-                                                       sourcePluginId, getPluginProperties(sourceConfig));
+                                                       pluginName,
+                                                       sourcePluginId, getPluginProperties(sourceConfig),
+                                                       sourceConfig.getPlugin()
+                                                         .getPluginSelector(sourcePluginType, pluginName));
     if (source == null) {
       throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found.",
                                                        Constants.Source.PLUGINTYPE,
@@ -106,9 +109,12 @@ public class PipelineRegisterer {
       String transformId = transformConfig.getName();
 
       PluginProperties transformProperties = getPluginProperties(transformConfig);
+      pluginName = transformConfig.getPlugin().getName();
       Transform transformObj = configurer.usePlugin(Constants.Transform.PLUGINTYPE,
-                                                    transformConfig.getPlugin().getName(),
-                                                    transformId, transformProperties);
+                                                    pluginName,
+                                                    transformId, transformProperties,
+                                                    transformConfig.getPlugin()
+                                                      .getPluginSelector(Constants.Transform.PLUGINTYPE, pluginName));
       if (transformObj == null) {
         throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found",
                                                          Constants.Transform.PLUGINTYPE,
@@ -138,8 +144,11 @@ public class PipelineRegisterer {
       sinksInfo.add(new SinkInfo(sinkPluginId, sinkConfig.getErrorDatasetName()));
 
       // try to instantiate the sink
-      PipelineConfigurable sink = configurer.usePlugin(sinkPluginType, sinkConfig.getPlugin().getName(),
-                                                       sinkPluginId, getPluginProperties(sinkConfig));
+      pluginName = sinkConfig.getPlugin().getName();
+      PipelineConfigurable sink = configurer.usePlugin(sinkPluginType, pluginName,
+                                                       sinkPluginId, getPluginProperties(sinkConfig),
+                                                       sinkConfig.getPlugin()
+                                                         .getPluginSelector(sinkPluginType, pluginName));
       if (sink == null) {
         throw new IllegalArgumentException(
           String.format(

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Plugin.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Plugin.java
@@ -49,8 +49,10 @@ public class Plugin {
   }
 
   /**
-   * @param pluginType the plugin type to get a selector for. Only used for error messages
-   * @param pluginName the plugin name to get a selector for. Only used for error messages
+   * @param pluginType the plugin type to get a selector for. Only used for error messages when no matching artifact
+   *                   for the plugin is found
+   * @param pluginName the plugin name to get a selector for. Only used for error messages when no matching artifact
+   *                   for the plugin is found
    * @return the plugin selector for this plugin. If artifact settings have been given, the selector will try to
    *         match the specified artifact settings using an {@link ArtifactSelector}.
    *         If not, the default {@link PluginSelector} is returned.

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Plugin.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Plugin.java
@@ -16,24 +16,24 @@
 
 package co.cask.cdap.etl.common;
 
-import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.plugin.PluginSelector;
 import com.google.common.base.Objects;
 
 import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * Plugin Configuration that is part of {@link ETLStage}
+ * Plugin Configuration that is part of {@link ETLStage}.
  */
 public class Plugin {
   private final String name;
   private final Map<String, String> properties;
-  private final ArtifactId artifactId;
+  private final ArtifactSelectorConfig artifact;
 
-  public Plugin(String name, Map<String, String> properties, @Nullable ArtifactId artifactId) {
+  public Plugin(String name, Map<String, String> properties, @Nullable ArtifactSelectorConfig artifact) {
     this.name = name;
     this.properties = properties;
-    this.artifactId = artifactId;
+    this.artifact = artifact;
   }
 
   public Plugin(String name, Map<String, String> properties) {
@@ -48,9 +48,15 @@ public class Plugin {
     return properties;
   }
 
-  @Nullable
-  public ArtifactId getArtifactId() {
-    return artifactId;
+  /**
+   * @param pluginType the plugin type to get a selector for. Only used for error messages
+   * @param pluginName the plugin name to get a selector for. Only used for error messages
+   * @return the plugin selector for this plugin. If artifact settings have been given, the selector will try to
+   *         match the specified artifact settings using an {@link ArtifactSelector}.
+   *         If not, the default {@link PluginSelector} is returned.
+   */
+  public PluginSelector getPluginSelector(String pluginType, String pluginName) {
+    return artifact == null ? new PluginSelector() : artifact.getArtifactSelector(pluginType, pluginName);
   }
 
   @Override
@@ -58,7 +64,7 @@ public class Plugin {
     return Objects.toStringHelper(this)
       .add("name", name)
       .add("properties", properties)
-      .add("artifact", artifactId)
+      .add("artifact", artifact)
       .toString();
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/ArtifactSelectorConfigTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/ArtifactSelectorConfigTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.api.artifact.ArtifactScope;
+import org.junit.Test;
+
+/**
+ */
+public class ArtifactSelectorConfigTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidName() {
+    ArtifactSelectorConfig config = new ArtifactSelectorConfig(ArtifactScope.USER.name(), "abc?d", "1.0.0");
+    config.getArtifactSelector(null, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidVersion() {
+    ArtifactSelectorConfig config = new ArtifactSelectorConfig(ArtifactScope.USER.name(), "abc", "abc");
+    config.getArtifactSelector(null, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidScope() {
+    ArtifactSelectorConfig config = new ArtifactSelectorConfig("usr", "abc", "1.0.0");
+    config.getArtifactSelector(null, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAllNullFieldsIsInvalid() {
+    ArtifactSelectorConfig config = new ArtifactSelectorConfig();
+    config.getArtifactSelector(null, null);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/ArtifactSelectorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/ArtifactSelectorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ */
+public class ArtifactSelectorTest {
+
+  @Test
+  public void testSelection() {
+    SortedMap<ArtifactId, PluginClass> plugins = new TreeMap<>();
+    // doesn't matter what this is, since we only select on artifact id.
+    PluginClass pluginClass = new PluginClass("type", "name", "desc", "com.company.class", "field",
+                                              ImmutableMap.<String, PluginPropertyField>of());
+
+    // put every combination of abc or def as name, 1.0.0 or 2.0.0 as version, and system or user as scope
+    plugins.put(new ArtifactId("abc", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM), pluginClass);
+    plugins.put(new ArtifactId("abc", new ArtifactVersion("2.0.0"), ArtifactScope.SYSTEM), pluginClass);
+    plugins.put(new ArtifactId("abc", new ArtifactVersion("1.0.0"), ArtifactScope.USER), pluginClass);
+    plugins.put(new ArtifactId("abc", new ArtifactVersion("2.0.0"), ArtifactScope.USER), pluginClass);
+    plugins.put(new ArtifactId("def", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM), pluginClass);
+    plugins.put(new ArtifactId("def", new ArtifactVersion("2.0.0"), ArtifactScope.SYSTEM), pluginClass);
+    plugins.put(new ArtifactId("def", new ArtifactVersion("1.0.0"), ArtifactScope.USER), pluginClass);
+    plugins.put(new ArtifactId("def", new ArtifactVersion("2.0.0"), ArtifactScope.USER), pluginClass);
+
+    // test scope only
+    ArtifactSelector selector = new ArtifactSelector("type", "name", ArtifactScope.SYSTEM, null, null);
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", ArtifactScope.USER, null, null);
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("1.0.0"), ArtifactScope.USER),
+                        selector.select(plugins).getKey());
+
+    // test name only
+    selector = new ArtifactSelector("type", "name", null, "abc", null);
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", null, "def", null);
+    Assert.assertEquals(new ArtifactId("def", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    try {
+      selector = new ArtifactSelector("type", "name", null, "xyz", null);
+      selector.select(plugins);
+    } catch (Exception e) {
+      // expected
+    }
+
+    // test version only
+    selector = new ArtifactSelector("type", "name", null, null, new ArtifactVersion("1.0.0"));
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", null, null, new ArtifactVersion("2.0.0"));
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("2.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    try {
+      selector = new ArtifactSelector("type", "name", null, null, new ArtifactVersion("3.0.0"));
+      selector.select(plugins);
+    } catch (Exception e) {
+      // expected
+    }
+
+    // test name + version
+    selector = new ArtifactSelector("type", "name", null, "abc", new ArtifactVersion("1.0.0"));
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", null, "abc", new ArtifactVersion("2.0.0"));
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("2.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", null, "def", new ArtifactVersion("1.0.0"));
+    Assert.assertEquals(new ArtifactId("def", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", null, "def", new ArtifactVersion("2.0.0"));
+    Assert.assertEquals(new ArtifactId("def", new ArtifactVersion("2.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    try {
+      selector = new ArtifactSelector("type", "name", null, "xyz", new ArtifactVersion("1.0.0"));
+      selector.select(plugins);
+    } catch (Exception e) {
+      // expected
+    }
+    try {
+      selector = new ArtifactSelector("type", "name", null, "abc", new ArtifactVersion("3.0.0"));
+      selector.select(plugins);
+    } catch (Exception e) {
+      // expected
+    }
+
+    // test name + scope
+    selector = new ArtifactSelector("type", "name", ArtifactScope.SYSTEM, "abc", null);
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", ArtifactScope.SYSTEM, "def", null);
+    Assert.assertEquals(new ArtifactId("def", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", ArtifactScope.USER, "abc", null);
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("1.0.0"), ArtifactScope.USER),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", ArtifactScope.USER, "def", null);
+    Assert.assertEquals(new ArtifactId("def", new ArtifactVersion("1.0.0"), ArtifactScope.USER),
+                        selector.select(plugins).getKey());
+    try {
+      selector = new ArtifactSelector("type", "name", ArtifactScope.SYSTEM, "xyz", null);
+      selector.select(plugins);
+    } catch (Exception e) {
+      // expected
+    }
+
+    // test version + scope
+    selector = new ArtifactSelector("type", "name", ArtifactScope.SYSTEM, null, new ArtifactVersion("1.0.0"));
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", ArtifactScope.SYSTEM, null, new ArtifactVersion("2.0.0"));
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("2.0.0"), ArtifactScope.SYSTEM),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", ArtifactScope.USER, null, new ArtifactVersion("1.0.0"));
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("1.0.0"), ArtifactScope.USER),
+                        selector.select(plugins).getKey());
+    selector = new ArtifactSelector("type", "name", ArtifactScope.USER, null, new ArtifactVersion("2.0.0"));
+    Assert.assertEquals(new ArtifactId("abc", new ArtifactVersion("2.0.0"), ArtifactScope.USER),
+                        selector.select(plugins).getKey());
+    try {
+      selector = new ArtifactSelector("type", "name", ArtifactScope.SYSTEM, "xyz", null);
+      selector.select(plugins);
+    } catch (Exception e) {
+      // expected
+    }
+
+    // test name + version + scope
+    selector = new ArtifactSelector("type", "name", ArtifactScope.USER, "def", new ArtifactVersion("2.0.0"));
+    Assert.assertEquals(new ArtifactId("def", new ArtifactVersion("2.0.0"), ArtifactScope.USER),
+                        selector.select(plugins).getKey());
+    try {
+      selector = new ArtifactSelector("type", "name", ArtifactScope.USER, "xyz", new ArtifactVersion("2.0.0"));
+      selector.select(plugins);
+    } catch (Exception e) {
+      // expected
+    }
+  }
+}


### PR DESCRIPTION
Adding configuration settings to the etl apps that will select
a plugin's artifact using scope, name, and/or version settings
provided by the user. The app will choose the first artifact
that matches all of the given artifact settings. If scope,
name, or version is not given, the app will not try to match
that field. If no match is found, an exception is thrown and the
app is not created.