### PR TITLE
Feature/cdap 3944 multiple partition consumers part 1

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -143,11 +143,21 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
     return framework.getDatasetSpec(datasetInstanceId);
   }
 
+  /**
+   * @param tables the TransactionAwares over which the returned TransactionExecutor operates on.
+   * @return a TransactionExecutor that uses a dummy implementation of a TransactionSystemClient. Note that this
+   *         TransactionExecutor returns the same transaction ID across transactions, since it is using a dummy
+   *         implementation of TransactionSystemClient.
+   */
   public TransactionExecutor newTransactionExecutor(TransactionAware...tables) {
     Preconditions.checkArgument(tables != null);
     return new DefaultTransactionExecutor(new MinimalTxSystemClient(), tables);
   }
 
+  /**
+   * @param tables the TransactionAwares over which the returned TransactionExecutor operates on.
+   * @return a TransactionExecutor that uses an in-memory implementation of a TransactionSystemClient.
+   */
   public TransactionExecutor newInMemoryTransactionExecutor(TransactionAware...tables) {
     Preconditions.checkArgument(tables != null);
     return new DefaultTransactionExecutor(new InMemoryTxSystemClient(txManager), tables);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
@@ -80,7 +80,8 @@ public class TimePartitionedFileSetTest {
   @Test
   public void testPartitionMetadata() throws Exception {
     final TimePartitionedFileSet tpfs = dsFrameworkUtil.getInstance(TPFS_INSTANCE);
-    dsFrameworkUtil.newTransactionExecutor((TransactionAware) tpfs).execute(new TransactionExecutor.Subroutine() {
+    TransactionAware txAware = (TransactionAware) tpfs;
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAware).execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
         // make sure the dataset has no partitions
@@ -126,8 +127,8 @@ public class TimePartitionedFileSetTest {
   @Test
   public void testAddGetPartitions() throws Exception {
     final TimePartitionedFileSet fileSet = dsFrameworkUtil.getInstance(TPFS_INSTANCE);
-
-    dsFrameworkUtil.newTransactionExecutor((TransactionAware) fileSet).execute(new TransactionExecutor.Subroutine() {
+    TransactionAware txAwareDataset = (TransactionAware) fileSet;
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
         // this is an arbitrary data to use as the test time
@@ -253,11 +254,12 @@ public class TimePartitionedFileSetTest {
   public void testInputPartitionPaths() throws Exception {
     // make sure the dataset has no partitions
     final TimePartitionedFileSet tpfs = dsFrameworkUtil.getInstance(TPFS_INSTANCE);
+    TransactionAware txAwareDataset = (TransactionAware) tpfs;
     validateTimePartitions(tpfs, 0L, MAX, Collections.<Long, String>emptyMap());
 
     Date date = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).parse("6/4/12 10:00 am");
     final long time = date.getTime();
-    dsFrameworkUtil.newTransactionExecutor((TransactionAware) tpfs).execute(new TransactionExecutor.Subroutine() {
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
         tpfs.addPartition(time, "file");
@@ -284,7 +286,8 @@ public class TimePartitionedFileSetTest {
     TimePartitionedFileSetArguments.setInputStartTime(arguments, time + start * MINUTE);
     TimePartitionedFileSetArguments.setInputEndTime(arguments, time + end * MINUTE);
     final TimePartitionedFileSet tpfs = dsFrameworkUtil.getInstance(TPFS_INSTANCE, arguments);
-    dsFrameworkUtil.newTransactionExecutor((TransactionAware) tpfs).execute(new TransactionExecutor.Subroutine() {
+    TransactionAware txAwareDataset = (TransactionAware) tpfs;
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
         Map<String, String> inputConfig = tpfs.getInputFormatConfiguration();
@@ -486,7 +489,8 @@ public class TimePartitionedFileSetTest {
     // add a few partitions
     {
       final TimePartitionedFileSet dataset = dsFrameworkUtil.getInstance(TPFS_INSTANCE);
-      dsFrameworkUtil.newTransactionExecutor((TransactionAware) dataset).execute(new TransactionExecutor.Subroutine() {
+      final TransactionAware txAwareDataset = (TransactionAware) dataset;
+      dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
         @Override
         public void apply() throws Exception {
           dataset.addPartition(time8, path8);
@@ -521,7 +525,8 @@ public class TimePartitionedFileSetTest {
 
   private void testInputConfiguration(Map<String, String> arguments, final String expectedPath) throws Exception {
     final TimePartitionedFileSet dataset = dsFrameworkUtil.getInstance(TPFS_INSTANCE, arguments);
-    dsFrameworkUtil.newTransactionExecutor((TransactionAware) dataset).execute(new TransactionExecutor.Subroutine() {
+    TransactionAware txAwareDataset = (TransactionAware) dataset;
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
         Map<String, String> inputConf = dataset.getInputFormatConfiguration();
@@ -530,12 +535,14 @@ public class TimePartitionedFileSetTest {
         String[] inputs = input.split(",");
         Assert.assertEquals(1, inputs.length);
         Assert.assertTrue(inputs[0].endsWith(expectedPath));
-      }});
+      }
+    });
   }
 
   private void testInputConfigurationFailure(Map<String, String> arguments, final String why) throws Exception {
     final TimePartitionedFileSet dataset = dsFrameworkUtil.getInstance(TPFS_INSTANCE, arguments);
-    dsFrameworkUtil.newTransactionExecutor((TransactionAware) dataset).execute(new TransactionExecutor.Subroutine() {
+    TransactionAware txAwareDataset = (TransactionAware) dataset;
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
         try {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/PartitionKeyCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/PartitionKeyCodec.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import com.google.common.base.Throwables;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Codec used to serialize and deserialize {@link PartitionKey}s.
+ */
+public class PartitionKeyCodec implements JsonSerializer<PartitionKey>, JsonDeserializer<PartitionKey> {
+
+  @Override
+  public PartitionKey deserialize(JsonElement jsonElement, Type type,
+                                  JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+    JsonObject jsonObject = jsonElement.getAsJsonObject();
+    PartitionKey.Builder builder = PartitionKey.builder();
+    for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+      JsonArray jsonArray = entry.getValue().getAsJsonArray();
+      // the classname is serialized as the first element, the value is serialized as the second
+      Class<? extends Comparable> comparableClass = forName(jsonArray.get(0).getAsString());
+      Comparable value = jsonDeserializationContext.deserialize(jsonArray.get(1), comparableClass);
+      builder.addField(entry.getKey(), value);
+    }
+    return builder.build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Class<? extends Comparable> forName(String className) {
+    try {
+      // we know that the class is a Comparable because all partition keys are of type Comparable
+      return (Class<? extends Comparable>) Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public JsonElement serialize(PartitionKey partitionKey, Type type,
+                               JsonSerializationContext jsonSerializationContext) {
+    JsonObject jsonObj = new JsonObject();
+    for (Map.Entry<String, Comparable> entry : partitionKey.getFields().entrySet()) {
+      JsonArray jsonArray = new JsonArray();
+      jsonArray.add(jsonSerializationContext.serialize(entry.getValue().getClass().getName()));
+      jsonArray.add(jsonSerializationContext.serialize(entry.getValue()));
+      jsonObj.add(entry.getKey(), jsonArray);
+    }
+    return jsonObj;
+  }
+}

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/codec/PartitionKeyCodecTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/codec/PartitionKeyCodecTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link PartitionKeyCodec}.
+ */
+public class PartitionKeyCodecTest {
+
+  @Test
+  public void testSerDe() {
+    PartitionKey key = PartitionKey.builder()
+      .addField("a", "value,")
+      .addField("b", 1L)
+      .addField("c", -17)
+      .addField("d", true)
+      .addIntField("e", 42)
+      .addLongField("f", 15)
+      .addStringField("g", "value]}")
+      .build();
+
+    Gson gson = new GsonBuilder().registerTypeAdapter(PartitionKey.class, new PartitionKeyCodec()).create();
+    String serialized = gson.toJson(key);
+    Assert.assertEquals(key, gson.fromJson(serialized, PartitionKey.class));
+  }
+}


### PR DESCRIPTION
Update TimePartitionedFileSetTest to use in-memory txExecutor, because otherwise the transaction ID isn't incremented in each new transaction.

Implement a PartitionKeyCodec that is used for serialization/deserialization of PartitionKeys (needed for implementation of: https://issues.cask.co/browse/CDAP-3944

http://builds.cask.co/browse/CDAP-DUT3248-1