### PR TITLE
CDAP-3611 Documenting Queue Debugger Tool

### DIFF
--- a/cdap-docs/admin-manual/source/operations/tx-maintenance.rst
+++ b/cdap-docs/admin-manual/source/operations/tx-maintenance.rst
@@ -10,6 +10,8 @@ Transaction Service Maintenance
 
 .. highlight:: console
 
+Pruning Invalid Transactions
+============================
 The Transaction Service keeps track of all invalid transactions so as to exclude their writes from all future reads. 
 Over time, this *invalid* list can grow and lead to performance degradation. To avoid that, you can prune the *invalid*
 list after the data of invalid transactions has been removed |---| the removal of which happens during major HBase 
@@ -32,7 +34,8 @@ To prune the invalid list manually, follow these steps:
 
   Pick the minimum time across all region servers. In this case, ``1440202895873``.
 
-- Find the minimum prune time across all queues by running the tool ``SimpleHBaseQueueDebugger``. This should print lines such as::
+- Find the minimum prune time across all queues by running the tool ``SimpleHBaseQueueDebugger``. 
+  This should print lines such as::
 
     $ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.SimpleHBaseQueueDebugger
     Results for queue queue:///ns1/WordCount/WordCounter/counter/queue: min tx timestamp: 1440198510309
@@ -55,3 +58,42 @@ with the :ref:`Transaction Service HTTP RESTful API <http-restful-api-transactio
 The current length of the invalid transaction list can be obtained using 
 :ref:`a call <http-restful-api-transactions-number>` 
 with the :ref:`Transaction Service HTTP RESTful API <http-restful-api-transactions-number>`.
+
+
+Using the Queue Debugger Tool
+=============================
+The Queue Debugger Tool allows you to look at the entries in queues, and can be useful in
+solving problems with transactions. This is a debug tool for a queue, returning
+information such as how many entries are in a queue, how many have been processed, and how
+many are in progress. 
+
+Background
+----------
+Each flow has a queue table. Within each queue table are multiple queues. There is one
+queue for each connection between flowlets. As each flowlet may have multiple consuming
+flowlets, this results in there being multiple queues.
+
+The name of a queue is determined by the producer flowlet. The consumer flowlet (required
+for the command line parameters of the tool) is referred to as the consumer. 
+
+Running the Tool
+----------------
+It's important that the tool be run with the same classpath as CDAP Master to avoid
+problems with the ordering of classes and to ensure that the CDAP classes appear before
+the HBase classpath. This is to avoid the invocation of any older versions of the ASM
+library that are present in the HBase classpath.
+
+The easiest way to start the tool with the same classpath as CDAP Master is to use::
+
+  $ /etc/init.d/cdap-master run co.cask.cdap.data.tools.HBaseQueueDebugger
+  
+or::
+
+  $ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.HBaseQueueDebugger
+  
+Running the ``help`` option will give a summary of commands and required parameters.
+
+The tool ``SimpleHBaseQueueDebugger`` is a wrapper of the tool that uses common defaults. 
+
+
+

--- a/cdap-docs/admin-manual/source/operations/tx-maintenance.rst
+++ b/cdap-docs/admin-manual/source/operations/tx-maintenance.rst
@@ -62,10 +62,10 @@ with the :ref:`Transaction Service HTTP RESTful API <http-restful-api-transactio
 
 Using the Queue Debugger Tool
 =============================
-The Queue Debugger Tool allows you to look at the entries in queues, and can be useful in
-solving problems with transactions. This is a debug tool for a queue, returning
-information such as how many entries are in a queue, how many have been processed, and how
-many are in progress. 
+The Queue Debugger Tool allows you to calculate queue statistics, and can be useful in
+solving problems with queues. This is a debug tool for a queue, returning information such
+as how many entries are in a queue, how many have been processed, and how many are not yet
+processed. 
 
 Background
 ----------
@@ -93,7 +93,5 @@ or::
   
 Running the ``help`` option will give a summary of commands and required parameters.
 
-The tool ``SimpleHBaseQueueDebugger`` is a wrapper of the tool that uses common defaults. 
-
-
-
+The tool ``SimpleHBaseQueueDebugger`` is a wrapper of the tool that that uses a set of
+defaults useful for displaying the minimum transaction time for all events in all queues.


### PR DESCRIPTION
Adds documentation of the Queue Debugger Tool to the Transaction Maintenance page.

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB55-3. [Updated to Build 3]

Page Of Interest:

- [Operations: Transactions Maintenance](http://builds.cask.co/artifact/CDAP-DOB55/shared/build-3/Docs-HTML/3.3.0-SNAPSHOT/en/admin-manual/operations/tx-maintenance.html)