### PR TITLE
Correct formatting of Build.rst and adjusts MD5 hash.

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -56,7 +56,7 @@ Standalone and Distributed CDAP
 
     MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -pl cdap-standalone,cdap-app-templates/cdap-etl,cdap-app-templates/cdap-data-quality,cdap-examples -am -amd -DskipTests -P examples,templates,dist,release,unit-tests -Dadditional.artifacts.dir=</path/to/additional/artifacts>
 
-This will copy any .jar and .json files in any 'target' directories under the specified path to the artifacts directory.
+  This will copy any .jar and .json files in any 'target' directories under the specified path to the artifacts directory.
 
 - Build the limited set of Javadocs used in distribution ZIP::
 
@@ -107,7 +107,7 @@ This will copy any .jar and .json files in any 'target' directories under the sp
     cd cdap-ui
     bower install && npm install && gulp build
     
-  (Whenever there is a change in the UI packages)
+  (Whenever there is a change in the UI packages.)
     
   Then, run standalone from IDE.
     

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -109,7 +109,7 @@ GITHUB="github"
 
 # BUILD.rst
 BUILD_RST="BUILD.rst"
-BUILD_RST_HASH="126957968d95aa006b7f0c5a7f2ff1ef"
+BUILD_RST_HASH="d7bac2503dbc69785a7b85be139ac25c"
 
 
 function usage() {


### PR DESCRIPTION
Fix broken Doc Build.

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB56-1)