### PR TITLE
CDAP-3696 Ignore the flaky test case.

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -647,6 +647,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     Assert.assertEquals(workflowRunRecordProperties.get("AnotherSpark"), anotherSparkHistoryRuns.get(0).getPid());
   }
 
+  @Ignore
   @Test
   public void testWorkflowSchedules() throws Exception {
     // Steps for the test:


### PR DESCRIPTION
Plan is to - 
1. Disable the test case on the develop.
2. Refactor to use larger frequency (15-30 seconds) of the schedule instead of 1 second.
3. Have at least 10 successful builds on the branch.
4. Merge it to the develop again.