### PR TITLE
Use in-memory NamespaceStore implementation for test cases.

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
@@ -39,7 +39,6 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.store.DefaultNamespaceStore;
 import co.cask.cdap.store.NamespaceStore;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -111,7 +110,7 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
         protected void configure() {
           // We don't need notification in this test, hence inject an no-op one
           bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
-          bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
+          bind(NamespaceStore.class).to(InMemoryNamespaceStore.class);
         }
       }
     );

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryNamespaceStore.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryNamespaceStore.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.stream;
+
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.store.NamespaceStore;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * In-memory implementation of {@link NamespaceStore} used in test cases.
+ */
+public class InMemoryNamespaceStore implements NamespaceStore {
+
+  private final Map<Id.Namespace, NamespaceMeta> namespaces = new HashMap<>();
+
+  @Nullable
+  @Override
+  public NamespaceMeta create(NamespaceMeta metadata) {
+    return namespaces.put(Id.Namespace.from(metadata.getName()), metadata);
+  }
+
+  @Override
+  public void update(NamespaceMeta metadata) {
+    Id.Namespace namespaceId = Id.Namespace.from(metadata.getName());
+    if (namespaces.containsKey(namespaceId)) {
+      namespaces.put(namespaceId, metadata);
+    }
+  }
+
+  @Nullable
+  @Override
+  public NamespaceMeta get(Id.Namespace id) {
+    return namespaces.get(id);
+  }
+
+  @Nullable
+  @Override
+  public NamespaceMeta delete(Id.Namespace id) {
+    return namespaces.remove(id);
+  }
+
+  @Override
+  public List<NamespaceMeta> list() {
+    return new ArrayList<>(namespaces.values());
+  }
+}

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
@@ -37,7 +37,6 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.store.DefaultNamespaceStore;
 import co.cask.cdap.store.NamespaceStore;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -86,7 +85,7 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
         protected void configure() {
           // We don't need notification in this test, hence inject an no-op one
           bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
-          bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
+          bind(NamespaceStore.class).to(InMemoryNamespaceStore.class);
         }
       }
     );


### PR DESCRIPTION
Example of failing test case: http://builds.cask.co/browse/CDAP-DUT3185-7

https://issues.cask.co/browse/CDAP-4346
http://builds.cask.co/browse/CDAP-DUT3262-2