### PR TITLE
adds show more/less functionality to metadata tags

### DIFF
--- a/cdap-ui/app/directives/metadata-tags/metadata-tags.html
+++ b/cdap-ui/app/directives/metadata-tags/metadata-tags.html
@@ -38,7 +38,7 @@
   <a ng-if="MetadataController.metadataTags.length > 5 && MetadataController.limit === 5"
      class="tag-toggle"
      ng-click="MetadataController.showMoreTags()">show more</a>
-  <a ng-if="MetadataController.limit > 5"
+  <a ng-if="MetadataController.metadataTags.length > 5 && MetadataController.limit > 5"
      class="tag-toggle"
      ng-click="MetadataController.hideTags()">show less</a>
 </div>

--- a/cdap-ui/app/directives/metadata-tags/metadata-tags.html
+++ b/cdap-ui/app/directives/metadata-tags/metadata-tags.html
@@ -35,10 +35,10 @@
     </span>
   </div>
 
-  <a ng-if="MetadataController.limit === MetadataController.tagLimit"
+  <a ng-if="MetadataController.metadataTags.length > MetadataController.tagLimit && MetadataController.limit === MetadataController.tagLimit"
      class="tag-toggle"
      ng-click="MetadataController.limit = null">show more</a>
-  <a ng-if="MetadataController.limit === null"
+  <a ng-if="MetadataController.metadataTags.length > MetadataController.tagLimit && MetadataController.limit === null"
      class="tag-toggle"
      ng-click="MetadataController.limit = MetadataController.tagLimit">show less</a>
 </div>

--- a/cdap-ui/app/directives/metadata-tags/metadata-tags.html
+++ b/cdap-ui/app/directives/metadata-tags/metadata-tags.html
@@ -35,10 +35,10 @@
     </span>
   </div>
 
-  <a ng-if="MetadataController.metadataTags.length > 5 && MetadataController.limit === 5"
+  <a ng-if="MetadataController.limit === MetadataController.tagLimit"
      class="tag-toggle"
-     ng-click="MetadataController.showMoreTags()">show more</a>
-  <a ng-if="MetadataController.metadataTags.length > 5 && MetadataController.limit > 5"
+     ng-click="MetadataController.limit = null">show more</a>
+  <a ng-if="MetadataController.limit === null"
      class="tag-toggle"
-     ng-click="MetadataController.hideTags()">show less</a>
+     ng-click="MetadataController.limit = MetadataController.tagLimit">show less</a>
 </div>

--- a/cdap-ui/app/directives/metadata-tags/metadata-tags.html
+++ b/cdap-ui/app/directives/metadata-tags/metadata-tags.html
@@ -22,15 +22,23 @@
   </div>
   <div class="tag-input" ng-if="MetadataController.metadataAddOpen">
     <div my-escape-close="MetadataController.escapeMetadata()" ng-keypress="$event.keyCode === 13 && MetadataController.addMetadata()">
-      <input placeholder="new tag" type="text" class="form-control" ng-model="MetadataController.tag" cask-focus="metadataInput">
+      <input placeholder="new tag" type="text" class="form-control" ng-model="MetadataController.tag" cask-focus="metadataInput" ng-blur="MetadataController.escapeMetadata()">
     </div>
   </div>
-  <div class="tag" ng-repeat="tag in MetadataController.metadataTags">
-    <a class="btn">
+
+  <div class="tag" ng-repeat="tag in MetadataController.metadataTags | orderBy: tag | limitTo: MetadataController.limit">
+    <span class="btn"
+       ng-click="MetadataController.goToTag($event, tag)">
       {{tag}}
       <span class="fa fa-times"
-        ng-click="MetadataController.deleteMetadata(tag)"
-      ></span>
-    </a>
+            ng-click="MetadataController.deleteMetadata($event, tag)"></span>
+    </span>
   </div>
+
+  <a ng-if="MetadataController.metadataTags.length > 5 && MetadataController.limit === 5"
+     class="tag-toggle"
+     ng-click="MetadataController.showMoreTags()">show more</a>
+  <a ng-if="MetadataController.limit > 5"
+     class="tag-toggle"
+     ng-click="MetadataController.hideTags()">show less</a>
 </div>

--- a/cdap-ui/app/directives/metadata-tags/metadata-tags.js
+++ b/cdap-ui/app/directives/metadata-tags/metadata-tags.js
@@ -23,7 +23,8 @@ angular.module(PKG.name + '.commons')
       controllerAs: 'MetadataController',
       scope: {
         params: '=',
-        type: '@'
+        type: '@',
+        tagLimit: '='
       },
       templateUrl: 'metadata-tags/metadata-tags.html',
     };
@@ -32,7 +33,7 @@ angular.module(PKG.name + '.commons')
     this.metadataAddOpen = false;
     this.metadataTags = [];
 
-    var tagLimit = 5;
+    var tagLimit = $scope.tagLimit;
     this.limit = tagLimit;
     this.showMoreTags = function() {
       this.limit = this.metadataTags.length;

--- a/cdap-ui/app/directives/metadata-tags/metadata-tags.js
+++ b/cdap-ui/app/directives/metadata-tags/metadata-tags.js
@@ -28,9 +28,19 @@ angular.module(PKG.name + '.commons')
       templateUrl: 'metadata-tags/metadata-tags.html',
     };
   })
-  .controller('MetadataTagsController', function ($scope, myMetadataFactory, caskFocusManager) {
+  .controller('MetadataTagsController', function ($scope, myMetadataFactory, caskFocusManager, $state) {
     this.metadataAddOpen = false;
     this.metadataTags = [];
+
+    var tagLimit = 5;
+    this.limit = tagLimit;
+    this.showMoreTags = function() {
+      this.limit = this.metadataTags.length;
+    };
+    this.hideTags = function() {
+      this.limit = 5;
+    };
+
     var prom;
     switch($scope.type) {
       case 'datasets':
@@ -73,7 +83,8 @@ angular.module(PKG.name + '.commons')
       }.bind(this));
     };
 
-    this.deleteMetadata = function (tag) {
+    this.deleteMetadata = function (event, tag) {
+      event.stopPropagation();
       var prom;
       switch($scope.type) {
         case 'datasets':
@@ -97,6 +108,11 @@ angular.module(PKG.name + '.commons')
     this.escapeMetadata = function () {
       this.tag = '';
       this.metadataAddOpen = false;
+    };
+
+    this.goToTag = function(event, tag) {
+      event.stopPropagation();
+      $state.go('search.objectswithtags', {tag: tag});
     };
 
     caskFocusManager.focus('metadataInput');

--- a/cdap-ui/app/directives/metadata-tags/metadata-tags.js
+++ b/cdap-ui/app/directives/metadata-tags/metadata-tags.js
@@ -33,14 +33,8 @@ angular.module(PKG.name + '.commons')
     this.metadataAddOpen = false;
     this.metadataTags = [];
 
-    var tagLimit = $scope.tagLimit;
-    this.limit = tagLimit;
-    this.showMoreTags = function() {
-      this.limit = this.metadataTags.length;
-    };
-    this.hideTags = function() {
-      this.limit = tagLimit;
-    };
+    this.tagLimit = $scope.tagLimit;
+    this.limit = $scope.tagLimit;
 
     var prom;
     switch($scope.type) {

--- a/cdap-ui/app/directives/metadata-tags/metadata-tags.js
+++ b/cdap-ui/app/directives/metadata-tags/metadata-tags.js
@@ -38,7 +38,7 @@ angular.module(PKG.name + '.commons')
       this.limit = this.metadataTags.length;
     };
     this.hideTags = function() {
-      this.limit = 5;
+      this.limit = tagLimit;
     };
 
     var prom;

--- a/cdap-ui/app/directives/metadata-tags/metadata-tags.less
+++ b/cdap-ui/app/directives/metadata-tags/metadata-tags.less
@@ -41,6 +41,15 @@ my-metadata-tags {
         }
       }
     }
+    a.tag-toggle {
+      font-size: 11px;
+      font-weight: 500;
+      margin-left: 5px;
+      &:hover, &:focus {
+        cursor: pointer;
+        text-decoration: none;
+      }
+    }
     div.add-tag {
       a.btn {
         .cask-btn(@background: transparent, @border: 1px solid @brand-primary, @border-radius: 0, @color: @brand-primary, @font-size: 11px, @padding: 6px 8px);
@@ -48,15 +57,13 @@ my-metadata-tags {
           background-color: lighten(@brand-primary, 30%);
         }
       }
-      span.fa-plus {
-        vertical-align: middle;
-      }
     }
     div.tag {
-      a.btn {
-        .cask-btn(@background: transparent, @border: 1px solid @program-text, @border-radius: 0, @color: gray, @font-size: 11px, @padding: 6px 8px);
+      span.btn {
+        .cask-btn(@background: transparent, @border: 1px solid lightgray, @border-radius: 0, @color: gray, @font-size: 11px, @padding: 6px 8px);
         &:hover {
-          background-color: rgba(150,150,150, 0.2);
+          background-color: @cdap-header;
+          color: white;
         }
         span.fa {
           font-size: 9px;
@@ -64,9 +71,8 @@ my-metadata-tags {
           bottom: 1px;
         }
       }
-
     }
-    a.btn {
+    .btn {
       font-weight: 500;
       margin-right: 3px;
       margin-bottom: 5px;

--- a/cdap-ui/app/directives/metadata-tags/metadata-tags.less
+++ b/cdap-ui/app/directives/metadata-tags/metadata-tags.less
@@ -44,7 +44,9 @@ my-metadata-tags {
     a.tag-toggle {
       font-size: 11px;
       font-weight: 500;
-      margin-left: 5px;
+      padding-left: 5px;
+      white-space: nowrap;
+      overflow: hidden;
       &:hover, &:focus {
         cursor: pointer;
         text-decoration: none;

--- a/cdap-ui/app/directives/metadata-tags/metadata-tags.less
+++ b/cdap-ui/app/directives/metadata-tags/metadata-tags.less
@@ -21,6 +21,7 @@
 my-metadata-tags {
   div.program-tags {
     margin-top: 10px;
+    margin-bottom: 20px;
     .add-tag, .tag {
       display: inline;
       margin-bottom: 2px;

--- a/cdap-ui/app/features/apps/templates/detail.html
+++ b/cdap-ui/app/features/apps/templates/detail.html
@@ -36,7 +36,7 @@
           </span>
         </span>
       </div>
-      <my-metadata-tags params="DetailController.metadataParams" type="apps"></my-metadata-tags>
+      <my-metadata-tags tag-limit="5" params="DetailController.metadataParams" type="apps"></my-metadata-tags>
     </div>
     <div class="col-sm-6 text-right">
 

--- a/cdap-ui/app/features/datasets/templates/detail.html
+++ b/cdap-ui/app/features/datasets/templates/detail.html
@@ -24,7 +24,7 @@
       <span class="icon-datasets"></span>
       <small> Type: Dataset </small>
     </div>
-    <my-metadata-tags params="DetailController.metadataParams" type="datasets"></my-metadata-tags>
+    <my-metadata-tags tag-limit="5" params="DetailController.metadataParams" type="datasets"></my-metadata-tags>
   </div>
   <div class="col-sm-6 text-right">
 

--- a/cdap-ui/app/features/flows/templates/detail.html
+++ b/cdap-ui/app/features/flows/templates/detail.html
@@ -27,7 +27,7 @@
             <small> Type: Tigon </small>
           </div>
           <p ng-bind="RunsController.description | myEllipsis: 144"></p>
-          <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>
+          <my-metadata-tags tag-limit="5" params="RunsController.metadataParams" type="programs"></my-metadata-tags>
         </div>
         <div class="col-sm-8 col-md-6">
           <div class="button-bar text-right">

--- a/cdap-ui/app/features/mapreduce/templates/detail.html
+++ b/cdap-ui/app/features/mapreduce/templates/detail.html
@@ -27,7 +27,7 @@
             <small> Type: Mapreduce </small>
           </div>
           <p ng-bind="RunsController.description | myEllipsis: 144"></p>
-          <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>
+          <my-metadata-tags tag-limit="5" params="RunsController.metadataParams" type="programs"></my-metadata-tags>
         </div>
         <div class="col-sm-8 col-md-6">
           <div class="button-bar text-right">

--- a/cdap-ui/app/features/services/templates/detail.html
+++ b/cdap-ui/app/features/services/templates/detail.html
@@ -27,7 +27,7 @@
             <small> Type: Service </small>
           </div>
           <p ng-bind="RunsController.description | myEllipsis: 144"></p>
-          <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>
+          <my-metadata-tags tag-limit="5" params="RunsController.metadataParams" type="programs"></my-metadata-tags>
         </div>
         <div class="col-sm-8 col-md-6">
           <div class="button-bar text-right">

--- a/cdap-ui/app/features/spark/templates/detail.html
+++ b/cdap-ui/app/features/spark/templates/detail.html
@@ -27,7 +27,7 @@
             <small> Type: Spark </small>
           </div>
           <p ng-bind="RunsController.description | myEllipsis: 144"></p>
-          <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>
+          <my-metadata-tags tag-limit="5" params="RunsController.metadataParams" type="programs"></my-metadata-tags>
         </div>
         <div class="col-sm-8 col-md-6">
           <div class="button-bar text-right">

--- a/cdap-ui/app/features/streams/templates/detail.html
+++ b/cdap-ui/app/features/streams/templates/detail.html
@@ -24,7 +24,7 @@
       <span class="icon-streams"></span>
       <small> Type: Stream </small>
     </div>
-    <my-metadata-tags params="DetailController.metadataParams" type="streams"></my-metadata-tags>
+    <my-metadata-tags tag-limit="5" params="DetailController.metadataParams" type="streams"></my-metadata-tags>
   </div>
   <div class="col-sm-6 text-right">
 

--- a/cdap-ui/app/features/workers/templates/detail.html
+++ b/cdap-ui/app/features/workers/templates/detail.html
@@ -26,7 +26,7 @@
             <small> Type: Worker </small>
           </div>
           <p ng-bind="RunsController.description | myEllipsis: 144"></p>
-          <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>
+          <my-metadata-tags tag-limit="5" params="RunsController.metadataParams" type="programs"></my-metadata-tags>
         </div>
         <div class="col-sm-8 col-md-6">
           <div class="button-bar text-right">

--- a/cdap-ui/app/features/workflows/templates/detail.html
+++ b/cdap-ui/app/features/workflows/templates/detail.html
@@ -27,7 +27,7 @@
             <small> Type: Workflow </small>
           </div>
           <p ng-bind="RunsController.description| myEllipsis: 144"></p>
-          <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>
+          <my-metadata-tags tag-limit="5" params="RunsController.metadataParams" type="programs"></my-metadata-tags>
         </div>
         <div class="col-sm-8 col-md-6">
           <div class="button-bar text-right">


### PR DESCRIPTION
*  Adds show more/show less functionality to metadata tags (5 displayed by default, show more displays all tags and show less limits display to 5)
*  Adds ng-blur event to add metadata input (input is now removed from display on blur)
*  Adds link to filtered results view

![tags](https://cloud.githubusercontent.com/assets/5335210/11548413/dd941376-9910-11e5-9a4d-4f2c3de333ca.gif)
