### PR TITLE
cleans up data/apps detail overview heading

### DIFF
--- a/cdap-ui/app/features/apps/applications.less
+++ b/cdap-ui/app/features/apps/applications.less
@@ -20,9 +20,6 @@
 body {
   &.state-apps-detail {
     &.theme-cdap {
-      div.type-heading {
-        margin-top: 20px;
-      }
       .table {
         tbody {
           a:hover, a:focus {

--- a/cdap-ui/app/features/apps/applications.less
+++ b/cdap-ui/app/features/apps/applications.less
@@ -20,7 +20,9 @@
 body {
   &.state-apps-detail {
     &.theme-cdap {
-
+      div.type-heading {
+        margin-top: 20px;
+      }
       .table {
         tbody {
           a:hover, a:focus {

--- a/cdap-ui/app/features/apps/templates/detail.html
+++ b/cdap-ui/app/features/apps/templates/detail.html
@@ -15,32 +15,36 @@
 -->
 
 <my-breadcrumbs></my-breadcrumbs>
-  <div class="row">
+  <div class="row type-heading">
     <div class="col-sm-6">
-      <h2>
-        <span ng-bind="$state.params.appId"></span>
-      </h2>
       <div class="type-block">
         <span ng-if="DetailController.myHydratorFactory.isCustomApp(DetailController.artifact.name)">
-          <span class="icon-app"></span>
-          <small> Type: App </small>
+          <span class="icon-app pull-left"
+                tooltip="Type: App"
+                tooltip-placement="top"
+                tooltip-append-to-body="true"></span>
         </span>
         <span ng-if="DetailController.myHydratorFactory.isETLApp(DetailController.artifact.name)">
           <span ng-if="DetailController.artifact.name === DetailController.GLOBALS.etlBatch">
-            <span class="icon-ETLBatch"></span>
-            <small> Type: ETL Batch </small>
+            <span class="icon-ETLBatch pull-left"
+                  tooltip="Type: ETL Batch"
+                  tooltip-placement="top"
+                  tooltip-append-to-body="true"></span>
           </span>
           <span ng-if="DetailController.artifact.name === DetailController.GLOBALS.etlRealtime">
-            <span class="icon-ETLRealtime"></span>
-            <small> Type: ETL Realtime </small>
+            <span class="icon-ETLRealtime pull-left"
+                  tooltip="Type: ETL Realtime"
+                  tooltip-placement="top"
+                  tooltip-append-to-body="true"></span>
           </span>
         </span>
+        <h2 ng-bind="$state.params.appId"></h2>
       </div>
       <my-metadata-tags params="DetailController.metadataParams" type="apps"></my-metadata-tags>
     </div>
     <div class="col-sm-6 text-right">
 
-      <div class="btn-group dropdown-right h3" dropdown>
+      <div class="btn-group dropdown-right" dropdown>
         <button type="button" class="btn btn-default dropdown-toggle" dropdown-toggle>
           Actions <span class="caret"></span>
         </button>

--- a/cdap-ui/app/features/apps/templates/detail.html
+++ b/cdap-ui/app/features/apps/templates/detail.html
@@ -15,7 +15,7 @@
 -->
 
 <my-breadcrumbs></my-breadcrumbs>
-  <div class="row type-heading">
+  <div class="row" cdap-object-heading>
     <div class="col-sm-6">
       <div class="type-block">
         <span ng-if="DetailController.myHydratorFactory.isCustomApp(DetailController.artifact.name)">

--- a/cdap-ui/app/features/datasets/datasets.less
+++ b/cdap-ui/app/features/datasets/datasets.less
@@ -17,6 +17,9 @@
 @import "../../styles/variables.less";
 
 body.state-datasets-detail {
+  div.type-heading {
+    margin-top: 20px;
+  }
 
   section.explore {
     padding: @grid-gutter-width 0;

--- a/cdap-ui/app/features/datasets/datasets.less
+++ b/cdap-ui/app/features/datasets/datasets.less
@@ -17,10 +17,6 @@
 @import "../../styles/variables.less";
 
 body.state-datasets-detail {
-  div.type-heading {
-    margin-top: 20px;
-  }
-
   section.explore {
     padding: @grid-gutter-width 0;
 

--- a/cdap-ui/app/features/datasets/templates/detail.html
+++ b/cdap-ui/app/features/datasets/templates/detail.html
@@ -15,7 +15,7 @@
 -->
 
 <my-breadcrumbs></my-breadcrumbs>
-<div class="row type-heading">
+<div class="row" cdap-object-heading>
   <div class="col-sm-6">
     <div class="type-block">
       <span class="icon-datasets pull-left"

--- a/cdap-ui/app/features/datasets/templates/detail.html
+++ b/cdap-ui/app/features/datasets/templates/detail.html
@@ -15,20 +15,20 @@
 -->
 
 <my-breadcrumbs></my-breadcrumbs>
-<div class="row">
+<div class="row type-heading">
   <div class="col-sm-6">
-    <h2>
-      <span ng-bind="$state.params.datasetId"></span>
-    </h2>
     <div class="type-block">
-      <span class="icon-datasets"></span>
-      <small> Type: Dataset </small>
+      <span class="icon-datasets pull-left"
+            tooltip="Type: Dataset"
+            tooltip-placement="top"
+            tooltip-append-to-body="true"></span>
+      <h2 ng-bind="$state.params.datasetId"></h2>
     </div>
     <my-metadata-tags params="DetailController.metadataParams" type="datasets"></my-metadata-tags>
   </div>
   <div class="col-sm-6 text-right">
 
-    <div class="btn-group dropdown-right h3" dropdown>
+    <div class="btn-group dropdown-right" dropdown>
       <button type="button" class="btn btn-default dropdown-toggle" dropdown-toggle>
         Actions <span class="caret"></span>
       </button>

--- a/cdap-ui/app/features/flows/flows.less
+++ b/cdap-ui/app/features/flows/flows.less
@@ -24,11 +24,6 @@ body.state-flows {
     padding-right: 0;
     padding-left: 0;
 
-    h2 {
-      font-weight: 500;
-      margin-top: 0;
-      margin-bottom: 5px;
-    }
     h3 {
       font-weight: 400;
     }

--- a/cdap-ui/app/features/flows/templates/detail.html
+++ b/cdap-ui/app/features/flows/templates/detail.html
@@ -19,7 +19,7 @@
 <div class="levels">
   <div class="program-level">
     <div class="container">
-      <div class="row" program-heading>
+      <div class="row" cdap-object-heading>
         <div class="col-sm-4 col-md-6">
           <div class="type-block">
             <span class="icon-tigon pull-left"

--- a/cdap-ui/app/features/flows/templates/detail.html
+++ b/cdap-ui/app/features/flows/templates/detail.html
@@ -21,10 +21,12 @@
     <div class="container">
       <div class="row" program-heading>
         <div class="col-sm-4 col-md-6">
-          <h2 ng-bind="$state.params.programId"></h2>
           <div class="type-block">
-            <span class="icon-tigon"></span>
-            <small> Type: Tigon </small>
+            <span class="icon-tigon pull-left"
+                  tooltip="Type: Tigon"
+                  tooltip-placement="top"
+                  tooltip-append-to-body="true"></span>
+            <h2 ng-bind="$state.params.programId"></h2>
           </div>
           <p ng-bind="RunsController.description | myEllipsis: 144"></p>
           <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>

--- a/cdap-ui/app/features/mapreduce/mapreduce.less
+++ b/cdap-ui/app/features/mapreduce/mapreduce.less
@@ -25,11 +25,6 @@ body.state-mapreduce {
     padding-right: 0;
     padding-left: 0;
 
-    h2 {
-      font-weight: 500;
-      margin-top: 0;
-      margin-bottom: 5px;
-    }
     h3 {
       font-weight: 400;
     }

--- a/cdap-ui/app/features/mapreduce/templates/detail.html
+++ b/cdap-ui/app/features/mapreduce/templates/detail.html
@@ -19,7 +19,7 @@
 <div class="levels">
   <div class="program-level">
     <div class="container">
-      <div class="row" program-heading>
+      <div class="row" cdap-object-heading>
         <div class="col-sm-4 col-md-6">
           <div class="type-block">
             <span class="icon-mapreduce pull-left"

--- a/cdap-ui/app/features/mapreduce/templates/detail.html
+++ b/cdap-ui/app/features/mapreduce/templates/detail.html
@@ -21,10 +21,12 @@
     <div class="container">
       <div class="row" program-heading>
         <div class="col-sm-4 col-md-6">
-          <h2 ng-bind="$state.params.programId"></h2>
           <div class="type-block">
-            <span class="icon-mapreduce"></span>
-            <small> Type: Mapreduce </small>
+            <span class="icon-mapreduce pull-left"
+                  tooltip="Type: Mapreduce"
+                  tooltip-placement="top"
+                  tooltip-append-to-body="true"></span>
+            <h2 ng-bind="$state.params.programId"></h2>
           </div>
           <p ng-bind="RunsController.description | myEllipsis: 144"></p>
           <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>

--- a/cdap-ui/app/features/services/services.less
+++ b/cdap-ui/app/features/services/services.less
@@ -26,11 +26,6 @@ body.state-services {
     padding-right: 0;
     padding-left: 0;
 
-    h2 {
-      font-weight: 500;
-      margin-top: 0;
-      margin-bottom: 5px;
-    }
     h3 {
       font-weight: 400;
     }

--- a/cdap-ui/app/features/services/templates/detail.html
+++ b/cdap-ui/app/features/services/templates/detail.html
@@ -21,11 +21,14 @@
     <div class="container">
       <div class="row" program-heading>
         <div class="col-sm-4 col-md-6">
-          <h2 ng-bind="$state.params.programId"></h2>
           <div class="type-block">
-            <span class="icon-service"></span>
-            <small> Type: Service </small>
+            <span class="icon-service pull-left"
+                  tooltip="Type: Service"
+                  tooltip-placement="top"
+                  tooltip-append-to-body="true"></span>
+            <h2 ng-bind="$state.params.programId"></h2>
           </div>
+
           <p ng-bind="RunsController.description | myEllipsis: 144"></p>
           <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>
         </div>

--- a/cdap-ui/app/features/services/templates/detail.html
+++ b/cdap-ui/app/features/services/templates/detail.html
@@ -19,7 +19,7 @@
 <div class="levels">
   <div class="program-level">
     <div class="container">
-      <div class="row" program-heading>
+      <div class="row" cdap-object-heading>
         <div class="col-sm-4 col-md-6">
           <div class="type-block">
             <span class="icon-service pull-left"

--- a/cdap-ui/app/features/spark/spark.less
+++ b/cdap-ui/app/features/spark/spark.less
@@ -24,11 +24,6 @@ body.state-spark {
     padding-right: 0;
     padding-left: 0;
 
-    h2 {
-      font-weight: 500;
-      margin-top: 0;
-      margin-bottom: 5px;
-    }
     h3 {
       font-weight: 400;
     }

--- a/cdap-ui/app/features/spark/templates/detail.html
+++ b/cdap-ui/app/features/spark/templates/detail.html
@@ -19,7 +19,7 @@
 <div class="levels">
   <div class="program-level">
     <div class="container">
-      <div class="row" program-heading>
+      <div class="row" cdap-object-heading>
         <div class="col-sm-4 col-md-6">
           <div class="type-block">
             <span class="icon-spark pull-left"

--- a/cdap-ui/app/features/spark/templates/detail.html
+++ b/cdap-ui/app/features/spark/templates/detail.html
@@ -21,10 +21,12 @@
     <div class="container">
       <div class="row" program-heading>
         <div class="col-sm-4 col-md-6">
-          <h2 ng-bind="$state.params.programId"></h2>
           <div class="type-block">
-            <span class="icon-spark"></span>
-            <small> Type: Spark </small>
+            <span class="icon-spark pull-left"
+                    tooltip="Type: Spark"
+                    tooltip-placement="top"
+                    tooltip-append-to-body="true"></span>
+            <h2 ng-bind="$state.params.programId"></h2>
           </div>
           <p ng-bind="RunsController.description | myEllipsis: 144"></p>
           <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>

--- a/cdap-ui/app/features/streams/streams.less
+++ b/cdap-ui/app/features/streams/streams.less
@@ -32,9 +32,6 @@ body.state-streams {
 }
 
 body.state-streams-detail {
-  div.type-heading {
-    margin-top: 20px;
-  }
   section.explore {
     padding: @grid-gutter-width 0;
 

--- a/cdap-ui/app/features/streams/streams.less
+++ b/cdap-ui/app/features/streams/streams.less
@@ -32,7 +32,9 @@ body.state-streams {
 }
 
 body.state-streams-detail {
-
+  div.type-heading {
+    margin-top: 20px;
+  }
   section.explore {
     padding: @grid-gutter-width 0;
 

--- a/cdap-ui/app/features/streams/templates/detail.html
+++ b/cdap-ui/app/features/streams/templates/detail.html
@@ -15,20 +15,20 @@
 -->
 
 <my-breadcrumbs></my-breadcrumbs>
-<div class="row">
+<div class="row type-heading">
   <div class="col-sm-6">
-    <h2>
-      <span ng-bind="$state.params.streamId"></span>
-    </h2>
     <div class="type-block">
-      <span class="icon-streams"></span>
-      <small> Type: Stream </small>
+      <span class="icon-streams pull-left"
+              tooltip="Type: Stream"
+              tooltip-placement="top"
+              tooltip-append-to-body="true"></span>
+      <h2 ng-bind="$state.params.streamId"></h2>
     </div>
     <my-metadata-tags params="DetailController.metadataParams" type="streams"></my-metadata-tags>
   </div>
   <div class="col-sm-6 text-right">
 
-    <div class="btn-group dropdown-right h3" dropdown>
+    <div class="btn-group dropdown-right" dropdown>
       <button type="button" class="btn btn-default dropdown-toggle" dropdown-toggle>
         Actions <span class="caret"></span>
       </button>

--- a/cdap-ui/app/features/streams/templates/detail.html
+++ b/cdap-ui/app/features/streams/templates/detail.html
@@ -15,7 +15,7 @@
 -->
 
 <my-breadcrumbs></my-breadcrumbs>
-<div class="row type-heading">
+<div class="row" cdap-object-heading>
   <div class="col-sm-6">
     <div class="type-block">
       <span class="icon-streams pull-left"

--- a/cdap-ui/app/features/workers/templates/detail.html
+++ b/cdap-ui/app/features/workers/templates/detail.html
@@ -21,9 +21,8 @@
     <div class="container">
       <div class="row" program-heading>
         <div class="col-sm-4 col-md-6">
-          <h2 ng-bind="$state.params.programId"></h2>
           <div class="type-block">
-            <small> Type: Worker </small>
+            <h2 ng-bind="$state.params.programId"></h2>
           </div>
           <p ng-bind="RunsController.description | myEllipsis: 144"></p>
           <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>

--- a/cdap-ui/app/features/workers/templates/detail.html
+++ b/cdap-ui/app/features/workers/templates/detail.html
@@ -19,7 +19,7 @@
 <div class="levels">
   <div class="program-level">
     <div class="container">
-      <div class="row" program-heading>
+      <div class="row" cdap-object-heading>
         <div class="col-sm-4 col-md-6">
           <div class="type-block">
             <h2 ng-bind="$state.params.programId"></h2>

--- a/cdap-ui/app/features/workers/workers.less
+++ b/cdap-ui/app/features/workers/workers.less
@@ -26,11 +26,6 @@ body.state-worker {
     padding-right: 0;
     padding-left: 0;
 
-    h2 {
-      font-weight: 500;
-      margin-top: 0;
-      margin-bottom: 5px;
-    }
     h3 {
       font-weight: 400;
     }

--- a/cdap-ui/app/features/workflows/templates/detail.html
+++ b/cdap-ui/app/features/workflows/templates/detail.html
@@ -19,7 +19,7 @@
 <div class="levels">
   <div class="program-level">
     <div class="container">
-      <div class="row" program-heading>
+      <div class="row" cdap-object-heading>
         <div class="col-sm-4 col-md-6">
           <div class="type-block">
             <span class="icon-workflow pull-left"

--- a/cdap-ui/app/features/workflows/templates/detail.html
+++ b/cdap-ui/app/features/workflows/templates/detail.html
@@ -21,10 +21,12 @@
     <div class="container">
       <div class="row" program-heading>
         <div class="col-sm-4 col-md-6">
-          <h2 ng-bind="$state.params.programId"></h2>
           <div class="type-block">
-            <span class="icon-workflow"></span>
-            <small> Type: Workflow </small>
+            <span class="icon-workflow pull-left"
+                  tooltip="Type: Workflow"
+                  tooltip-placement="top"
+                  tooltip-append-to-body="true"></span>
+            <h2 ng-bind="$state.params.programId"></h2>
           </div>
           <p ng-bind="RunsController.description| myEllipsis: 144"></p>
           <my-metadata-tags params="RunsController.metadataParams" type="programs"></my-metadata-tags>

--- a/cdap-ui/app/features/workflows/workflow.less
+++ b/cdap-ui/app/features/workflows/workflow.less
@@ -27,11 +27,6 @@ body.state-workflows {
     padding-right: 0;
     padding-left: 0;
 
-    h2 {
-      font-weight: 500;
-      margin-top: 0;
-      margin-bottom: 5px;
-    }
     h3 {
       font-weight: 400;
     }

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -193,15 +193,4 @@ footer {
 
 [program-heading] {
   margin-top: 20px;
-  margin-bottom: 5px;
-  .programTitle {
-    vertical-align: middle;
-    margin: 0;
-
-    span {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-  }
 }

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -191,6 +191,6 @@ footer {
   padding: 0;
 }
 
-[program-heading] {
+[cdap-object-heading] {
   margin-top: 20px;
 }

--- a/cdap-ui/app/styles/themes/cdap.less
+++ b/cdap-ui/app/styles/themes/cdap.less
@@ -89,12 +89,16 @@ body.theme-cdap {
     }
 
     .type-block {
-      padding: 5px 0 10px;
-      small, span {
-        display: inline-block;
-        font-size: 16px;
+      padding-bottom: 5px;
+      h2, [class*="icon-"] {
+        font-size: 21px;
+      }
+      h2 {
+        margin: 0;
+      }
+      [class*="icon-"] {
         color: @brand-primary;
-        line-height: 15px;
+        margin-right: 5px;
         vertical-align: middle;
       }
       + p {
@@ -102,14 +106,8 @@ body.theme-cdap {
         font-size: 14px;
         margin-bottom: 0;
       }
-      [class*="icon-"] {
-        font-size: 23px;
-      }
     }
-    .type-icon {
-      margin-right: 5px;
-    }
-    // All custom icons we added need to be a little bigger.
+    // Make all custom icons outside of class="type-block" a little bit bigger
     [class*="icon-"] {
       font-size: 15px;
     }
@@ -177,7 +175,6 @@ body.theme-cdap {
         border-top: 1px solid @table-border-color;
         border-bottom: 1px solid @table-border-color;
       }
-      margin-top: 20px;
       .run-level-inner {
         .flexbox();
         flex-direction: row;


### PR DESCRIPTION
*  Moves "Type: X" to icon tooltip
*  Consolidates styling of elements inside class="type-block"

data views:
![data](https://cloud.githubusercontent.com/assets/5335210/11551138/657902a0-992b-11e5-803f-46623da0f617.gif)

app views:
![programs](https://cloud.githubusercontent.com/assets/5335210/11551132/5832e106-992b-11e5-900f-c53efd785c1a.gif)
