### PR TITLE
Move SchemaConverter from etl-lib to etl-common

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-common/src/main/java/co/cask/cdap/etl/common/HiveSchemaConverter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-common/src/main/java/co/cask/cdap/etl/common/HiveSchemaConverter.java
@@ -25,9 +25,9 @@ import java.util.Map;
 /**
  * Helper class for converting a {@link Schema} into a hive schema.
  */
-public final class SchemaConverter {
+public final class HiveSchemaConverter {
 
-  private SchemaConverter() { }
+  private HiveSchemaConverter() { }
 
   /**
    * Translate the given schema into a hive schema. Assumes the input schema is not recursive.

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/SnapshotFileBatchParquetSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/SnapshotFileBatchParquetSink.java
@@ -26,7 +26,7 @@ import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
-import co.cask.cdap.etl.common.SchemaConverter;
+import co.cask.cdap.etl.common.HiveSchemaConverter;
 import co.cask.cdap.etl.common.SnapshotFileSetConfig;
 import co.cask.cdap.etl.common.StructuredToAvroTransformer;
 import org.apache.avro.generic.GenericRecord;
@@ -71,7 +71,7 @@ public class SnapshotFileBatchParquetSink extends SnapshotFileBatchSink<Void, Ge
     new org.apache.avro.Schema.Parser().parse(config.schema.toLowerCase());
     String hiveSchema;
     try {
-      hiveSchema = SchemaConverter.toHiveSchema(Schema.parseJson(config.schema.toLowerCase()));
+      hiveSchema = HiveSchemaConverter.toHiveSchema(Schema.parseJson(config.schema.toLowerCase()));
     } catch (UnsupportedTypeException | IOException e) {
       throw new RuntimeException("Error: Schema is not valid ", e);
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
@@ -29,7 +29,7 @@ import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSink;
-import co.cask.cdap.etl.common.SchemaConverter;
+import co.cask.cdap.etl.common.HiveSchemaConverter;
 import co.cask.cdap.etl.common.StructuredToAvroTransformer;
 import org.apache.avro.generic.GenericRecord;
 import parquet.avro.AvroParquetInputFormat;
@@ -68,7 +68,7 @@ public class TimePartitionedFileSetDatasetParquetSink extends
     new org.apache.avro.Schema.Parser().parse(config.schema.toLowerCase());
     String hiveSchema;
     try {
-      hiveSchema = SchemaConverter.toHiveSchema(Schema.parseJson(config.schema.toLowerCase()));
+      hiveSchema = HiveSchemaConverter.toHiveSchema(Schema.parseJson(config.schema.toLowerCase()));
     } catch (UnsupportedTypeException | IOException e) {
       throw new RuntimeException("Error: Schema is not valid ", e);
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/SnapshotFileBatchParquetSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/SnapshotFileBatchParquetSource.java
@@ -25,7 +25,7 @@ import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.common.AvroToStructuredTransformer;
-import co.cask.cdap.etl.common.SchemaConverter;
+import co.cask.cdap.etl.common.HiveSchemaConverter;
 import co.cask.cdap.etl.common.SnapshotFileSetConfig;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.io.NullWritable;
@@ -62,7 +62,7 @@ public class SnapshotFileBatchParquetSource extends SnapshotFileBatchSource<Null
       .setEnableExploreOnCreate(true)
       .setExploreFormat("parquet");
     try {
-      String hiveSchema = SchemaConverter.toHiveSchema(
+      String hiveSchema = HiveSchemaConverter.toHiveSchema(
         co.cask.cdap.api.data.schema.Schema.parseJson(config.schema.toLowerCase()));
       propertiesBuilder.setExploreSchema(hiveSchema.substring(1, hiveSchema.length() - 1));
     } catch (UnsupportedTypeException e) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/TimePartitionedFileSetDatasetParquetSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/TimePartitionedFileSetDatasetParquetSource.java
@@ -27,7 +27,7 @@ import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.common.AvroToStructuredTransformer;
-import co.cask.cdap.etl.common.SchemaConverter;
+import co.cask.cdap.etl.common.HiveSchemaConverter;
 import com.google.common.base.Throwables;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -83,7 +83,7 @@ public class TimePartitionedFileSetDatasetParquetSource extends
       .setEnableExploreOnCreate(true)
       .setExploreFormat("parquet");
     try {
-      String hiveSchema = SchemaConverter.toHiveSchema(
+      String hiveSchema = HiveSchemaConverter.toHiveSchema(
         co.cask.cdap.api.data.schema.Schema.parseJson(tpfsParquetConfig.schema.toLowerCase()));
       properties.setExploreSchema(hiveSchema.substring(1, hiveSchema.length() - 1));
     } catch (UnsupportedTypeException e) {


### PR DESCRIPTION
Also renamed.
Build : http://builds.cask.co/browse/CDAP-DUT3270-1