### PR TITLE
CDAP-4225 added an upgrade tool for Hydrator

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/Resources.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Resources.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.api;
 
+import java.util.Objects;
+
 /**
  * Carries system resources requirements.
  */
@@ -66,5 +68,24 @@ public final class Resources {
    */
   public int getMemoryMB() {
     return memoryMB;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Resources that = (Resources) o;
+
+    return virtualCores == that.virtualCores && memoryMB == that.memoryMB;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(virtualCores, memoryMB);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/config/ETLBatchConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/config/ETLBatchConfig.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -68,5 +69,28 @@ public final class ETLBatchConfig extends ETLConfig {
 
   public List<ETLStage> getActions() {
     return actions;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    ETLBatchConfig that = (ETLBatchConfig) o;
+
+    return Objects.equals(schedule, that.schedule) &&
+      Objects.equals(actions, that.actions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), schedule, actions);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Connection.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Connection.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.etl.common;
 
+import java.util.Objects;
+
 /**
  *  Represents a connection between two {@link ETLStage}
  */
@@ -34,5 +36,24 @@ public class Connection {
 
   public String getTo() {
     return to;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Connection that = (Connection) o;
+
+    return Objects.equals(from, that.from) && Objects.equals(to, that.to);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(from, to);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLConfig.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Common ETL Config.
@@ -119,5 +120,41 @@ public class ETLConfig extends Config {
 
   public Boolean isStageLoggingEnabled() {
     return stageLoggingEnabled == null ? true : stageLoggingEnabled;
+  }
+
+  @Override
+  public String toString() {
+    return "ETLConfig{" +
+      "stageLoggingEnabled=" + stageLoggingEnabled +
+      ", source=" + source +
+      ", sinks=" + sinks +
+      ", transforms=" + transforms +
+      ", connections=" + connections +
+      ", resources=" + resources +
+      "} " + super.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ETLConfig that = (ETLConfig) o;
+
+    return Objects.equals(source, that.source) &&
+      Objects.equals(sinks, that.sinks) &&
+      Objects.equals(transforms, that.transforms) &&
+      Objects.equals(connections, that.connections) &&
+      Objects.equals(resources, that.resources) &&
+      isStageLoggingEnabled() == that.isStageLoggingEnabled();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(source, sinks, transforms, connections, resources, isStageLoggingEnabled());
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLStage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLStage.java
@@ -16,11 +16,8 @@
 
 package co.cask.cdap.etl.common;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
-
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -67,10 +64,31 @@ public final class ETLStage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("name", name)
-      .add("plugin", plugin.toString())
-      .toString();
+    return "ETLStage{" +
+      "name='" + name + '\'' +
+      ", plugin=" + plugin +
+      ", errorDatasetName='" + errorDatasetName + '\'' +
+      '}';
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ETLStage that = (ETLStage) o;
+
+    return Objects.equals(name, that.name) &&
+      Objects.equals(plugin, that.plugin) &&
+      Objects.equals(errorDatasetName, that.errorDatasetName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, plugin, errorDatasetName);
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Plugin.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Plugin.java
@@ -17,9 +17,9 @@
 package co.cask.cdap.etl.common;
 
 import co.cask.cdap.api.plugin.PluginSelector;
-import com.google.common.base.Objects;
 
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -63,11 +63,31 @@ public class Plugin {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("name", name)
-      .add("properties", properties)
-      .add("artifact", artifact)
-      .toString();
+    return "Plugin{" +
+      "name='" + name + '\'' +
+      ", properties=" + properties +
+      ", artifact=" + artifact +
+      '}';
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Plugin that = (Plugin) o;
+
+    return Objects.equals(name, that.name) &&
+      Objects.equals(properties, that.properties) &&
+      Objects.equals(artifact, that.artifact);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, properties, artifact);
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/config/ETLRealtimeConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/config/ETLRealtimeConfig.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * ETL Realtime Configuration.
@@ -69,5 +70,27 @@ public final class ETLRealtimeConfig extends ETLConfig {
 
   public Integer getInstances() {
     return instances;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    ETLRealtimeConfig that = (ETLRealtimeConfig) o;
+
+    return Objects.equals(instances, that.instances);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), instances);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2015 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap-etl</artifactId>
+    <version>3.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cdap-etl-tools</artifactId>
+  <name>CDAP ETL Tools</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <!-- to set the version property in src/main/resources/etl.properties -->
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>etl-tools-fat-jar</id>
+            <phase>package</phase>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <minimizeJar>true</minimizeJar>
+            </configuration>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
@@ -46,6 +46,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/UpgradeTool.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/UpgradeTool.java
@@ -145,10 +145,14 @@ public class UpgradeTool {
 
     CommandLineParser parser = new BasicParser();
     CommandLine commandLine = parser.parse(options, args);
+    String[] commandArgs = commandLine.getArgs();
 
-    if (commandLine.hasOption("h")) {
+    // if help is an option, or if there isn't a single 'upgrade' command, print usage and exit.
+    if (commandLine.hasOption("h") || commandArgs.length != 1 || !"upgrade".equalsIgnoreCase(commandArgs[0])) {
       HelpFormatter helpFormatter = new HelpFormatter();
-      helpFormatter.printHelp(UpgradeTool.class.getName(), "Upgrades Hydrator pipelines created for 3.2.x versions" +
+      helpFormatter.printHelp(
+        UpgradeTool.class.getName() + " upgrade",
+        "Upgrades Hydrator pipelines created for 3.2.x versions" +
         "of the cdap-etl-batch and cdap-etl-realtime artifacts into pipelines compatible with 3.3.x versions of " +
         "cdap-etl-batch and cdap-etl-realtime. Connects to an instance of CDAP to find any 3.2.x pipelines, then " +
         "upgrades those pipelines.", options, "");

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/UpgradeTool.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/UpgradeTool.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.tool;
+
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.client.ApplicationClient;
+import co.cask.cdap.client.NamespaceClient;
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.config.ConnectionConfig;
+import co.cask.cdap.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.etl.realtime.config.ETLRealtimeConfig;
+import co.cask.cdap.etl.tool.config.OldETLBatchConfig;
+import co.cask.cdap.etl.tool.config.OldETLRealtimeConfig;
+import co.cask.cdap.proto.ApplicationDetail;
+import co.cask.cdap.proto.ApplicationRecord;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.security.authentication.client.AccessToken;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import org.apache.commons.cli.BasicParser;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Used to upgrade pipelines from older pipelines to current pipelines.
+ */
+public class UpgradeTool {
+  private static final String BATCH_NAME = "cdap-etl-batch";
+  private static final String REALTIME_NAME = "cdap-etl-realtime";
+  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+  private static final int DEFAULT_READ_TIMEOUT = 90 * 1000;
+  private final NamespaceClient namespaceClient;
+  private final ApplicationClient appClient;
+  private final ArtifactSummary batchArtifact;
+  private final ArtifactSummary realtimeArtifact;
+
+  private UpgradeTool(ClientConfig clientConfig) {
+    String version = getVersion();
+    this.batchArtifact = new ArtifactSummary(BATCH_NAME, version, ArtifactScope.SYSTEM);
+    this.realtimeArtifact = new ArtifactSummary(REALTIME_NAME, version, ArtifactScope.SYSTEM);
+    this.appClient = new ApplicationClient(clientConfig);
+    this.namespaceClient = new NamespaceClient(clientConfig);
+  }
+
+  private void upgrade() throws Exception {
+    for (NamespaceMeta namespaceMeta : namespaceClient.list()) {
+      Id.Namespace namespace = Id.Namespace.from(namespaceMeta.getName());
+      upgrade(namespace);
+    }
+  }
+
+  private void upgrade(Id.Namespace namespace) throws Exception {
+    Set<String> artifactNames = ImmutableSet.of(BATCH_NAME, REALTIME_NAME);
+    for (ApplicationRecord appRecord : appClient.list(namespace, artifactNames, null)) {
+      Id.Application appId = Id.Application.from(namespace, appRecord.getName());
+      upgrade(appId);
+    }
+  }
+
+  private void upgrade(Id.Application appId) throws Exception {
+    ApplicationDetail appDetail = appClient.get(appId);
+
+    if (!shouldUpgrade(appDetail.getArtifact())) {
+      return;
+    }
+
+    if (BATCH_NAME.equals(appDetail.getArtifact().getName())) {
+      OldETLBatchConfig oldConfig = GSON.fromJson(appDetail.getConfiguration(), OldETLBatchConfig.class);
+      ETLBatchConfig newConfig = oldConfig.getNewConfig();
+      AppRequest<ETLBatchConfig> updateRequest = new AppRequest<>(batchArtifact, newConfig);
+      appClient.update(appId, updateRequest);
+    } else {
+      OldETLRealtimeConfig oldConfig = GSON.fromJson(appDetail.getConfiguration(), OldETLRealtimeConfig.class);
+      ETLRealtimeConfig newConfig = oldConfig.getNewConfig();
+      AppRequest<ETLRealtimeConfig> updateRequest = new AppRequest<>(realtimeArtifact, newConfig);
+      appClient.update(appId, updateRequest);
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+
+    Options options = new Options()
+      .addOption(new Option("h", "help", false, "Print this usage message."))
+      .addOption(new Option("u", "uri", true, "CDAP instance URI to interact with in the format " +
+        "[http[s]://]<hostname>:<port>. Defaults to localhost:10000."))
+      .addOption(new Option("a", "accesstoken", true, "File containing the access token to use when interacting " +
+        "with a secure CDAP instance."))
+      .addOption(new Option("t", "timeout", true, "Timeout in milliseconds to use when interacting with the " +
+        "CDAP RESTful APIs. Defaults to " + DEFAULT_READ_TIMEOUT + "."))
+      .addOption(new Option("n", "namespace", true, "Namespace to perform the upgrade in. If none is given, " +
+        "pipelines in all namespaces will be upgraded."))
+      .addOption(new Option("p", "pipeline", true, "Name of the pipeline to upgrade. If specified, a namespace " +
+        "must also be given."))
+      .addOption(new Option("f", "configfile", true, "File containing old application details to update. " +
+        "The file contents are expected to be in the same format as the request body for creating an " +
+        "ETL application from one of the etl artifacts. " +
+        "It is expected to be a JSON Object containing 'artifact' and 'config' fields." +
+        "The value for 'artifact' must be a JSON Object that specifies the artifact scope, name, and version. " +
+        "The value for 'config' must be a JSON Object specifies the source, transforms, and sinks of the pipeline, " +
+        "as expected by older versions of the etl artifacts."));
+
+    CommandLineParser parser = new BasicParser();
+    CommandLine commandLine = parser.parse(options, args);
+
+    if (commandLine.hasOption("h")) {
+      HelpFormatter helpFormatter = new HelpFormatter();
+      helpFormatter.printHelp(UpgradeTool.class.getName(), "Upgrades Hydrator pipelines created for 3.2.x versions" +
+        "of the cdap-etl-batch and cdap-etl-realtime artifacts into pipelines compatible with 3.3.x versions of " +
+        "cdap-etl-batch and cdap-etl-realtime. Connects to an instance of CDAP to find any 3.2.x pipelines, then " +
+        "upgrades those pipelines.", options, "");
+      System.exit(0);
+    }
+
+    if (commandLine.hasOption("f")) {
+      convertFile(commandLine.getOptionValue("f"));
+      System.exit(0);
+    }
+
+    UpgradeTool upgradeTool = new UpgradeTool(getClientConfig(commandLine));
+
+    String namespace = commandLine.getOptionValue("n");
+    String pipelineName = commandLine.getOptionValue("p");
+
+    if (pipelineName != null) {
+      if (namespace == null) {
+        throw new IllegalArgumentException("Must specify a namespace when specifying a pipeline.");
+      }
+      Id.Application appId = Id.Application.from(namespace, pipelineName);
+      upgradeTool.upgrade(appId);
+      System.out.println("Successfully upgraded pipeline " + appId);
+      System.exit(0);
+    }
+
+    if (namespace != null) {
+      upgradeTool.upgrade(Id.Namespace.from(namespace));
+      System.out.println("Successfully upgraded all pipelines in namespace " + namespace);
+      System.exit(0);
+    }
+
+    upgradeTool.upgrade();
+    System.out.println("Successfully upgraded all pipelines.");
+  }
+
+  private static ClientConfig getClientConfig(CommandLine commandLine) throws IOException {
+    String uriStr = commandLine.hasOption("u") ? commandLine.getOptionValue("u") : "localhost:10000";
+    if (!uriStr.contains("://")) {
+      uriStr = "http://" + uriStr;
+    }
+    URI uri = URI.create(uriStr);
+    String hostname = uri.getHost();
+    int port = uri.getPort();
+    boolean sslEnabled = "https".equals(uri.getScheme());
+    ConnectionConfig connectionConfig = ConnectionConfig.builder()
+      .setHostname(hostname)
+      .setPort(port)
+      .setSSLEnabled(sslEnabled)
+      .build();
+
+    int readTimeout = commandLine.hasOption("t") ?
+      Integer.parseInt(commandLine.getOptionValue("t")) : DEFAULT_READ_TIMEOUT;
+    ClientConfig.Builder clientConfigBuilder = ClientConfig.builder()
+      .setDefaultReadTimeout(readTimeout)
+      .setConnectionConfig(connectionConfig);
+
+    if (commandLine.hasOption("a")) {
+      String tokenFilePath = commandLine.getOptionValue("a");
+      File tokenFile = new File(tokenFilePath);
+      if (!tokenFile.exists()) {
+        throw new IllegalArgumentException("Access token file " + tokenFilePath + " does not exist.");
+      }
+      if (!tokenFile.isFile()) {
+        throw new IllegalArgumentException("Access token file " + tokenFilePath + " is not a file.");
+      }
+      String tokenValue = new String(Files.readAllBytes(tokenFile.toPath()), StandardCharsets.UTF_8).trim();
+      AccessToken accessToken = new AccessToken(tokenValue, 82000L, "Bearer");
+      clientConfigBuilder.setAccessToken(accessToken);
+    }
+
+    return clientConfigBuilder.build();
+  }
+
+  private static void convertFile(String configFilePath) throws IOException {
+    File configFile = new File(configFilePath);
+    if (!configFile.exists()) {
+      throw new IllegalArgumentException(configFilePath + " does not exist.");
+    }
+    if (!configFile.isFile()) {
+      throw new IllegalArgumentException(configFilePath + " is not a file.");
+    }
+    String fileContents = new String(Files.readAllBytes(configFile.toPath()), StandardCharsets.UTF_8);
+
+    ETLAppRequest artifactFile = GSON.fromJson(fileContents, ETLAppRequest.class);
+    if (!shouldUpgrade(artifactFile.artifact)) {
+      throw new IllegalArgumentException(
+        "Cannot update for artifact " + artifactFile.artifact + ". " +
+          "Please check the artifact is cdap-etl-batch or cdap-etl-realtime in the system scope of version 3.2.x.");
+    }
+
+    String version = getVersion();
+
+    if (BATCH_NAME.equals(artifactFile.artifact.getName())) {
+      ArtifactSummary artifact = new ArtifactSummary(BATCH_NAME, version, ArtifactScope.SYSTEM);
+      OldETLBatchConfig oldConfig = GSON.fromJson(artifactFile.config, OldETLBatchConfig.class);
+      AppRequest<ETLBatchConfig> updated = new AppRequest<>(artifact, oldConfig.getNewConfig());
+      System.out.println(GSON.toJson(updated));
+    } else {
+      ArtifactSummary artifact = new ArtifactSummary(REALTIME_NAME, version, ArtifactScope.SYSTEM);
+      OldETLRealtimeConfig oldConfig = GSON.fromJson(artifactFile.config, OldETLRealtimeConfig.class);
+      AppRequest<ETLRealtimeConfig> updated = new AppRequest<>(artifact, oldConfig.getNewConfig());
+      System.out.println(GSON.toJson(updated));
+    }
+  }
+
+  // reads current version from the etl.properties file contained in resources.
+  private static String getVersion() {
+    Properties prop = new Properties();
+    try {
+      URL resource = UpgradeTool.class.getResource("/etl.properties");
+      try (InputStream in = UpgradeTool.class.getResourceAsStream("/etl.properties")) {
+        prop.load(in);
+      }
+      return prop.getProperty("version");
+    } catch (Exception e) {
+      throw new RuntimeException("Error determining version. Please check that the jar was built correctly.", e);
+    }
+  }
+
+  // class used to deserialize the old pipeline requests
+  @SuppressWarnings("unused")
+  private static class ETLAppRequest {
+    private ArtifactSummary artifact;
+    private JsonObject config;
+  }
+
+  private static boolean shouldUpgrade(ArtifactSummary artifactSummary) {
+    // check its the system etl artifacts
+    if (artifactSummary.getScope() != ArtifactScope.SYSTEM) {
+      return false;
+    }
+
+    if (!BATCH_NAME.equals(artifactSummary.getName()) && !REALTIME_NAME.equals(artifactSummary.getName())) {
+      return false;
+    }
+
+    // check its 3.2.x versions of etl
+    ArtifactVersion artifactVersion = new ArtifactVersion(artifactSummary.getVersion());
+    return !(artifactVersion.getMajor() == null || artifactVersion.getMinor() == null) &&
+      artifactVersion.getMajor() == 3 && artifactVersion.getMinor() == 2;
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/OldETLBatchConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/OldETLBatchConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.tool.config;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.etl.common.ETLConfig;
+import co.cask.cdap.etl.common.ETLStage;
+import co.cask.cdap.etl.common.Plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * ETL Batch Configuration.
+ */
+public final class OldETLBatchConfig extends OldETLConfig {
+  private final String schedule;
+  private final List<OldETLStage> actions;
+
+  public OldETLBatchConfig(String schedule, OldETLStage source, List<OldETLStage> sinks, List<OldETLStage> transforms,
+                           Resources resources, List<OldETLStage> actions) {
+    super(source, sinks, transforms, resources);
+    this.schedule = schedule;
+    this.actions = actions;
+  }
+
+  public ETLBatchConfig getNewConfig() {
+    ETLConfig newConfig = super.getNewConfig();
+    int actionId = 1;
+    List<ETLStage> newActions = new ArrayList<>();
+    if (actions != null) {
+      for (OldETLStage oldAction : actions) {
+        newActions.add(new ETLStage(
+          oldAction.getName() + "." + actionId,
+          new Plugin(oldAction.getName(), oldAction.getProperties()),
+          oldAction.getErrorDatasetName()));
+        actionId++;
+      }
+    }
+    return new ETLBatchConfig(
+      schedule,
+      newConfig.getSource(),
+      newConfig.getSinks(),
+      newConfig.getTransforms(),
+      newConfig.getConnections(),
+      newConfig.getResources(),
+      newActions);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/OldETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/OldETLConfig.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.tool.config;
+
+import co.cask.cdap.api.Config;
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.etl.common.Connection;
+import co.cask.cdap.etl.common.ETLConfig;
+import co.cask.cdap.etl.common.ETLStage;
+import co.cask.cdap.etl.common.Plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Common ETL Config.
+ */
+public class OldETLConfig extends Config {
+  private final OldETLStage source;
+  private final List<OldETLStage> sinks;
+  private final List<OldETLStage> transforms;
+  private final Resources resources;
+
+  public OldETLConfig(OldETLStage source, List<OldETLStage> sinks, List<OldETLStage> transforms, Resources resources) {
+    this.source = source;
+    this.sinks = sinks;
+    this.transforms = transforms;
+    this.resources = resources;
+  }
+
+  // creates 3.3.x config from the old config.
+  public ETLConfig getNewConfig() {
+    int pluginNum = 1;
+    ETLStage sourceStage = new ETLStage(source.getName() +  "." + pluginNum,
+                                        new Plugin(source.getName(), source.getProperties()),
+                                        source.getErrorDatasetName());
+    List<ETLStage> transformStages = new ArrayList<>();
+    if (transforms != null) {
+      for (OldETLStage transform : transforms) {
+        pluginNum++;
+        transformStages.add(new ETLStage(
+          transform.getName() + "." + pluginNum,
+          new Plugin(transform.getName(), transform.getProperties()),
+          transform.getErrorDatasetName()));
+      }
+    }
+    List<ETLStage> sinkStages = new ArrayList<>();
+    for (OldETLStage sink : sinks) {
+      pluginNum++;
+      sinkStages.add(new ETLStage(
+        sink.getName() + "." + pluginNum,
+        new Plugin(sink.getName(), sink.getProperties()),
+        sink.getErrorDatasetName()));
+    }
+
+    List<Connection> connections = new ArrayList<>();
+    String prevStage = sourceStage.getName();
+    for (ETLStage transformStage : transformStages) {
+      connections.add(new Connection(prevStage, transformStage.getName()));
+      prevStage = transformStage.getName();
+    }
+    for (ETLStage sinkStage : sinkStages) {
+      connections.add(new Connection(prevStage, sinkStage.getName()));
+    }
+
+    return new ETLConfig(sourceStage, sinkStages, transformStages, connections, resources);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/OldETLRealtimeConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/OldETLRealtimeConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.tool.config;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.etl.common.ETLConfig;
+import co.cask.cdap.etl.realtime.config.ETLRealtimeConfig;
+
+import java.util.List;
+
+/**
+ * ETL Realtime Configuration.
+ */
+public final class OldETLRealtimeConfig extends OldETLConfig {
+  private final Integer instances;
+
+  public OldETLRealtimeConfig(Integer instances, OldETLStage source, List<OldETLStage> sinks,
+                              List<OldETLStage> transforms, Resources resources) {
+    super(source, sinks, transforms, resources);
+    this.instances = instances;
+  }
+
+  public ETLRealtimeConfig getNewConfig() {
+    ETLConfig newConfig = super.getNewConfig();
+    return new ETLRealtimeConfig(
+      instances,
+      newConfig.getSource(),
+      newConfig.getSinks(),
+      newConfig.getTransforms(),
+      newConfig.getConnections(),
+      newConfig.getResources());
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/OldETLStage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/OldETLStage.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.tool.config;
+
+import co.cask.cdap.etl.common.ETLStage;
+import co.cask.cdap.etl.common.Plugin;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * {@link ETLStage} as it existed in 3.2.x. The name and properties in this object were moved to the
+ * {@link Plugin} class.
+ */
+public class OldETLStage {
+  private final String name;
+  private final Map<String, String> properties;
+  private final String errorDatasetName;
+
+  public OldETLStage(String name, Map<String, String> properties, @Nullable String errorDatasetName) {
+    this.name = name;
+    this.properties = properties;
+    this.errorDatasetName = errorDatasetName;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getErrorDatasetName() {
+    return errorDatasetName;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/resources/etl.properties
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/resources/etl.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/test/java/co/cask/cdap/etl/tool/config/OldETLBatchConfigTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/test/java/co/cask/cdap/etl/tool/config/OldETLBatchConfigTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.tool.config;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.etl.common.Connection;
+import co.cask.cdap.etl.common.ETLStage;
+import co.cask.cdap.etl.common.Plugin;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ */
+public class OldETLBatchConfigTest {
+
+  @Test
+  public void testGetNewConfig() {
+    OldETLStage source = new OldETLStage("DataGenerator", ImmutableMap.of("p1", "v1"), null);
+    ETLStage sourceNew = new ETLStage("DataGenerator.1",
+                                      new Plugin(source.getName(), source.getProperties()),
+                                      source.getErrorDatasetName());
+
+    OldETLStage transform1 = new OldETLStage("Script", ImmutableMap.of("script", "something"), null);
+    ETLStage transform1New = new ETLStage("Script.2",
+                                          new Plugin(transform1.getName(), transform1.getProperties()),
+                                          transform1.getErrorDatasetName());
+
+    OldETLStage transform2 = new OldETLStage("Script", null, null);
+    ETLStage transform2New = new ETLStage("Script.3",
+                                          new Plugin(transform2.getName(), transform2.getProperties()),
+                                          transform2.getErrorDatasetName());
+
+    OldETLStage transform3 = new OldETLStage("Validator", ImmutableMap.of("p1", "v1", "p2", "v2"), "errorDS");
+    ETLStage transform3New = new ETLStage("Validator.4",
+                                          new Plugin(transform3.getName(), transform3.getProperties()),
+                                          transform3.getErrorDatasetName());
+
+    OldETLStage sink1 = new OldETLStage("Table", ImmutableMap.of("rowkey", "xyz"), null);
+    ETLStage sink1New = new ETLStage("Table.5",
+                                     new Plugin(sink1.getName(), sink1.getProperties()),
+                                     sink1.getErrorDatasetName());
+
+    OldETLStage sink2 = new OldETLStage("HDFS", ImmutableMap.of("name", "abc"), null);
+    ETLStage sink2New = new ETLStage("HDFS.6",
+                                     new Plugin(sink2.getName(), sink2.getProperties()),
+                                     sink2.getErrorDatasetName());
+
+    OldETLStage action = new OldETLStage("Email", ImmutableMap.of("email", "slj@example.com"), null);
+    ETLStage actionNew = new ETLStage("Email.1",
+                                      new Plugin(action.getName(), action.getProperties()),
+                                      action.getErrorDatasetName());
+
+    List<Connection> connections = new ArrayList<>();
+    connections.add(new Connection(sourceNew.getName(), transform1New.getName()));
+    connections.add(new Connection(transform1New.getName(), transform2New.getName()));
+    connections.add(new Connection(transform2New.getName(), transform3New.getName()));
+    connections.add(new Connection(transform3New.getName(), sink1New.getName()));
+    connections.add(new Connection(transform3New.getName(), sink2New.getName()));
+
+    String schedule = "*/5 * * * *";
+    Resources resources = new Resources(1024, 1);
+    OldETLBatchConfig config = new OldETLBatchConfig(schedule,
+                                                     source,
+                                                     ImmutableList.of(sink1, sink2),
+                                                     ImmutableList.of(transform1, transform2, transform3),
+                                                     resources,
+                                                     ImmutableList.of(action));
+    ETLBatchConfig configNew = new ETLBatchConfig(schedule,
+                                                  sourceNew,
+                                                  ImmutableList.of(sink1New, sink2New),
+                                                  ImmutableList.of(transform1New, transform2New, transform3New),
+                                                  connections,
+                                                  resources,
+                                                  ImmutableList.of(actionNew));
+    Assert.assertEquals(configNew, config.getNewConfig());
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/test/java/co/cask/cdap/etl/tool/config/OldETLRealtimeConfigTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/test/java/co/cask/cdap/etl/tool/config/OldETLRealtimeConfigTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.tool.config;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.etl.common.Connection;
+import co.cask.cdap.etl.common.ETLStage;
+import co.cask.cdap.etl.common.Plugin;
+import co.cask.cdap.etl.realtime.config.ETLRealtimeConfig;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ */
+public class OldETLRealtimeConfigTest {
+
+  @Test
+  public void testGetNewConfig() {
+    OldETLStage source = new OldETLStage("DataGenerator", ImmutableMap.of("p1", "v1"), null);
+    ETLStage sourceNew = new ETLStage("DataGenerator.1",
+                                      new Plugin(source.getName(), source.getProperties()),
+                                      source.getErrorDatasetName());
+
+    OldETLStage transform1 = new OldETLStage("Script", ImmutableMap.of("script", "something"), null);
+    ETLStage transform1New = new ETLStage("Script.2",
+                                          new Plugin(transform1.getName(), transform1.getProperties()),
+                                          transform1.getErrorDatasetName());
+
+    OldETLStage transform2 = new OldETLStage("Script", null, null);
+    ETLStage transform2New = new ETLStage("Script.3",
+                                          new Plugin(transform2.getName(), transform2.getProperties()),
+                                          transform2.getErrorDatasetName());
+
+    OldETLStage transform3 = new OldETLStage("Validator", ImmutableMap.of("p1", "v1", "p2", "v2"), "errorDS");
+    ETLStage transform3New = new ETLStage("Validator.4",
+                                          new Plugin(transform3.getName(), transform3.getProperties()),
+                                          transform3.getErrorDatasetName());
+
+    OldETLStage sink1 = new OldETLStage("Table", ImmutableMap.of("rowkey", "xyz"), null);
+    ETLStage sink1New = new ETLStage("Table.5",
+                                     new Plugin(sink1.getName(), sink1.getProperties()),
+                                     sink1.getErrorDatasetName());
+
+    OldETLStage sink2 = new OldETLStage("HDFS", ImmutableMap.of("name", "abc"), null);
+    ETLStage sink2New = new ETLStage("HDFS.6",
+                                     new Plugin(sink2.getName(), sink2.getProperties()),
+                                     sink2.getErrorDatasetName());
+
+    List<Connection> connections = new ArrayList<>();
+    connections.add(new Connection(sourceNew.getName(), transform1New.getName()));
+    connections.add(new Connection(transform1New.getName(), transform2New.getName()));
+    connections.add(new Connection(transform2New.getName(), transform3New.getName()));
+    connections.add(new Connection(transform3New.getName(), sink1New.getName()));
+    connections.add(new Connection(transform3New.getName(), sink2New.getName()));
+
+    Resources resources = new Resources(1024, 1);
+    OldETLRealtimeConfig config = new OldETLRealtimeConfig(1,
+                                                           source,
+                                                           ImmutableList.of(sink1, sink2),
+                                                           ImmutableList.of(transform1, transform2, transform3),
+                                                           resources);
+    ETLRealtimeConfig configNew = new ETLRealtimeConfig(1,
+                                                        sourceNew,
+                                                        ImmutableList.of(sink1New, sink2New),
+                                                        ImmutableList.of(transform1New, transform2New, transform3New),
+                                                        connections,
+                                                        resources);
+    Assert.assertEquals(configNew, config.getNewConfig());
+  }
+}

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -37,6 +37,7 @@
     <module>cdap-etl-realtime</module>
     <module>cdap-etl-archetypes</module>
     <module>cdap-etl-common</module>
+    <module>cdap-etl-tools</module>
   </modules>
 
   <properties>

--- a/cdap-docs/cdap-apps/source/hydrator/overview.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/overview.rst
@@ -166,19 +166,19 @@ The tool will connect to an instance of CDAP, look for any applications that use
 CDAP must be running when you run the command:
 
 .. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port>
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> upgrade
 
 You can also upgrade just the ETL applications within a specific namespace:
 
 .. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -n <namespace>
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -n <namespace> upgrade
 
 Or just one application:
 
 .. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -n <namespace> -p <app-name>
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -n <namespace> -p <app-name> upgrade
 
 If you have authentication turned on, you also need to store an authentication token in a file and pass the file to the tool:
 
 .. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -a <tokenfile>
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -a <tokenfile> upgrade

--- a/cdap-docs/cdap-apps/source/hydrator/overview.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/overview.rst
@@ -156,4 +156,29 @@ Application and Plugin Details
 
 - |etl-plugins|_ Details on ETL plugins and exploring available plugins using RESTful APIs.
 
+Upgrade Procedure
+=================
 
+If you wish to upgrade ETL applications created using the 3.2.x versions of ``cdap-etl-batch`` or ``cdap-etl-realtime``,
+you can use the ETL upgrade tool packaged with the distributed version of CDAP.
+The tool will connect to an instance of CDAP, look for any applications that use 3.2.x versions of the
+``cdap-etl-batch`` or ``cdap-etl-realtime`` artifacts, and then update application to use the |version| version of those artifacts.
+CDAP must be running when you run the command:
+
+.. parsed-literal::
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port>
+
+You can also upgrade just the ETL applications within a specific namespace:
+
+.. parsed-literal::
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -n <namespace>
+
+Or just one application:
+
+.. parsed-literal::
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -n <namespace> -p <app-name>
+
+If you have authentication turned on, you also need to store an authentication token in a file and pass the file to the tool:
+
+.. parsed-literal::
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -a <tokenfile>

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -176,6 +176,8 @@
         <stage.artifacts.dir>${stage.opt.dir}/artifacts</stage.artifacts.dir>
         <additional.artifacts.jar.pattern>**/target/*.jar</additional.artifacts.jar.pattern>
         <additional.artifacts.config.pattern>**/target/*.json</additional.artifacts.config.pattern>
+        <!-- contains hydrator upgrade tool. Should be moved out when Hydrator is moved out of CDAP -->
+        <stage.libexec.dir>${stage.opt.dir}/libexec</stage.libexec.dir>
       </properties>
       <build>
         <plugins>
@@ -226,6 +228,26 @@
                       <includes>
                         <include>cdap-etl-lib-${project.version}.jar</include>
                         <include>cdal-etl-lib-${project.version}.json</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+              <execution>
+                <id>copy-etl-tools</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${stage.libexec.dir}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>
+                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-tools/target
+                      </directory>
+                      <includes>
+                        <include>cdap-etl-tools-${project.version}.jar</include>
                       </includes>
                     </resource>
                   </resources>

--- a/pom.xml
+++ b/pom.xml
@@ -1389,6 +1389,7 @@
                   <!-- Excludes app-templates by default, include it in the templates profile -->
                   <exclude>cdap-app-templates/**</exclude>
                   <exclude>**/*.json</exclude>
+                  <exclude>**/resources/**/*.properties</exclude>
                   <exclude>**/*.json.template</exclude>
                   <exclude>**/MANIFEST.MF</exclude>
                 </excludes>


### PR DESCRIPTION
The 3.3.x versions of the etl applications are backwards
incompatible with the 3.2.x versions. The upgrade tool offers
a way to upgrade all pipelines, all pipelines in a namespace,
or a specific pipeline. Also offers a way to take a request that
could have been used to create a 3.2.x pipeline and convert it
into a request to create a 3.3.x pipeline.