### PR TITLE
CDAP-4233 add a way to get a logger specific to an etl stage

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/TransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/TransformContext.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.plugin.PluginProperties;
+import org.slf4j.Logger;
 
 /**
  * Context passed to ETL stages.
@@ -44,9 +45,17 @@ public interface TransformContext extends PluginContext, LookupProvider {
   StageMetrics getMetrics();
 
   /**
-   * Gets the unique stage name of the transform, useful for setting the context of logging in transforms.
+   * Gets the unique stage name of the transform.
    *
    * @return stage name
    */
   String getStageName();
+
+  /**
+   * Get a logger that will prefix all log messages with the name of the stage it was logged from.
+   *
+   * @param clazz class of the stage
+   * @return logger that will prefix all log messages with the name of the stage it was logged from
+   */
+  Logger getStageLogger(Class clazz);
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchContext.java
@@ -19,6 +19,7 @@ package co.cask.cdap.etl.api.batch;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.etl.api.TransformContext;
+import org.slf4j.Logger;
 
 import java.util.Map;
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractTransformContext.java
@@ -23,6 +23,8 @@ import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.api.TransformContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -83,5 +85,10 @@ public abstract class AbstractTransformContext implements TransformContext {
   @Override
   public <T> Lookup<T> provide(String table, Map<String, String> arguments) {
     return lookup.provide(table, arguments);
+  }
+
+  @Override
+  public Logger getStageLogger(Class clazz) {
+    return new StageLogger(LoggerFactory.getLogger(clazz), stageName);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/StageLogger.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/StageLogger.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+/**
+ * A Logger that prefixes every message with the name of the stage it was logged from.
+ *
+ * This is used instead of including the stage name in the Logger name in order to prevent certain stage names from
+ * being shortened by the Logger.
+ * For example, if we just do LoggerFactory.getLogger(this.getClass().getName() + ":" + stageName),
+ * if the stageName contains a '.', everything to the left of the dot will get shortened.
+ */
+public class StageLogger implements Logger {
+  private final Logger logger;
+  private final String prefix;
+
+  public StageLogger(Logger logger, String stageName) {
+    this.logger = logger;
+    this.prefix = stageName + " - ";
+  }
+
+  @Override
+  public String getName() {
+    return logger.getName();
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return logger.isTraceEnabled();
+  }
+
+  @Override
+  public void trace(String msg) {
+    logger.trace(prefix + msg);
+  }
+
+  @Override
+  public void trace(String format, Object arg) {
+    logger.trace(prefix + format, arg);
+  }
+
+  @Override
+  public void trace(String format, Object arg1, Object arg2) {
+    logger.trace(prefix + format, arg1, arg2);
+  }
+
+  @Override
+  public void trace(String format, Object... arguments) {
+    logger.trace(prefix + format, arguments);
+  }
+
+  @Override
+  public void trace(String msg, Throwable t) {
+    logger.trace(prefix + msg, t);
+  }
+
+  @Override
+  public boolean isTraceEnabled(Marker marker) {
+    return logger.isTraceEnabled(marker);
+  }
+
+  @Override
+  public void trace(Marker marker, String msg) {
+    logger.trace(marker, prefix + msg);
+  }
+
+  @Override
+  public void trace(Marker marker, String format, Object arg) {
+    logger.trace(marker, prefix + format, arg);
+  }
+
+  @Override
+  public void trace(Marker marker, String format, Object arg1, Object arg2) {
+    logger.trace(marker, prefix + format, arg1, arg2);
+  }
+
+  @Override
+  public void trace(Marker marker, String format, Object... argArray) {
+    logger.trace(marker, prefix + format, argArray);
+  }
+
+  @Override
+  public void trace(Marker marker, String msg, Throwable t) {
+    logger.trace(marker, prefix + msg, t);
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return logger.isDebugEnabled();
+  }
+
+  @Override
+  public void debug(String msg) {
+    logger.debug(prefix + msg);
+  }
+
+  @Override
+  public void debug(String format, Object arg) {
+    logger.debug(prefix + format, arg);
+  }
+
+  @Override
+  public void debug(String format, Object arg1, Object arg2) {
+    logger.debug(prefix + format, arg1, arg2);
+  }
+
+  @Override
+  public void debug(String format, Object... arguments) {
+    logger.debug(prefix + format, arguments);
+  }
+
+  @Override
+  public void debug(String msg, Throwable t) {
+    logger.debug(prefix + msg, t);
+  }
+
+  @Override
+  public boolean isDebugEnabled(Marker marker) {
+    return logger.isDebugEnabled(marker);
+  }
+
+  @Override
+  public void debug(Marker marker, String msg) {
+    logger.debug(marker, prefix + msg);
+  }
+
+  @Override
+  public void debug(Marker marker, String format, Object arg) {
+    logger.debug(marker, prefix + format, arg);
+  }
+
+  @Override
+  public void debug(Marker marker, String format, Object arg1, Object arg2) {
+    logger.debug(marker, prefix + format, arg1, arg2);
+  }
+
+  @Override
+  public void debug(Marker marker, String format, Object... arguments) {
+    logger.debug(marker, prefix + format, arguments);
+  }
+
+  @Override
+  public void debug(Marker marker, String msg, Throwable t) {
+    logger.debug(marker, prefix + msg, t);
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return logger.isInfoEnabled();
+  }
+
+  @Override
+  public void info(String msg) {
+    logger.info(prefix + msg);
+  }
+
+  @Override
+  public void info(String format, Object arg) {
+    logger.info(prefix + format, arg);
+  }
+
+  @Override
+  public void info(String format, Object arg1, Object arg2) {
+    logger.info(prefix + format, arg1, arg2);
+  }
+
+  @Override
+  public void info(String format, Object... arguments) {
+    logger.info(prefix + format, arguments);
+  }
+
+  @Override
+  public void info(String msg, Throwable t) {
+    logger.info(prefix + msg, t);
+  }
+
+  @Override
+  public boolean isInfoEnabled(Marker marker) {
+    return logger.isInfoEnabled(marker);
+  }
+
+  @Override
+  public void info(Marker marker, String msg) {
+    logger.info(marker, prefix + msg);
+  }
+
+  @Override
+  public void info(Marker marker, String format, Object arg) {
+    logger.info(marker, prefix + format, arg);
+  }
+
+  @Override
+  public void info(Marker marker, String format, Object arg1, Object arg2) {
+    logger.info(marker, prefix + format, arg1, arg2);
+  }
+
+  @Override
+  public void info(Marker marker, String format, Object... arguments) {
+    logger.info(marker, prefix + format, arguments);
+  }
+
+  @Override
+  public void info(Marker marker, String msg, Throwable t) {
+    logger.info(marker, prefix + msg, t);
+  }
+
+  @Override
+  public boolean isWarnEnabled() {
+    return logger.isWarnEnabled();
+  }
+
+  @Override
+  public void warn(String msg) {
+    logger.warn(prefix + msg);
+  }
+
+  @Override
+  public void warn(String format, Object arg) {
+    logger.warn(prefix + format, arg);
+  }
+
+  @Override
+  public void warn(String format, Object... arguments) {
+    logger.warn(prefix + format, arguments);
+  }
+
+  @Override
+  public void warn(String format, Object arg1, Object arg2) {
+    logger.warn(prefix + format, arg1, arg2);
+  }
+
+  @Override
+  public void warn(String msg, Throwable t) {
+    logger.warn(prefix + msg, t);
+  }
+
+  @Override
+  public boolean isWarnEnabled(Marker marker) {
+    return logger.isWarnEnabled(marker);
+  }
+
+  @Override
+  public void warn(Marker marker, String msg) {
+    logger.warn(marker, prefix + msg);
+  }
+
+  @Override
+  public void warn(Marker marker, String format, Object arg) {
+    logger.warn(marker, prefix + format, arg);
+  }
+
+  @Override
+  public void warn(Marker marker, String format, Object arg1, Object arg2) {
+    logger.warn(marker, prefix + format, arg1, arg2);
+  }
+
+  @Override
+  public void warn(Marker marker, String format, Object... arguments) {
+    logger.warn(marker, prefix + format, arguments);
+  }
+
+  @Override
+  public void warn(Marker marker, String msg, Throwable t) {
+    logger.warn(marker, prefix + msg, t);
+  }
+
+  @Override
+  public boolean isErrorEnabled() {
+    return logger.isErrorEnabled();
+  }
+
+  @Override
+  public void error(String msg) {
+    logger.error(prefix + msg);
+  }
+
+  @Override
+  public void error(String format, Object arg) {
+    logger.error(prefix + format, arg);
+  }
+
+  @Override
+  public void error(String format, Object arg1, Object arg2) {
+    logger.error(prefix + format, arg1, arg2);
+  }
+
+  @Override
+  public void error(String format, Object... arguments) {
+    logger.error(prefix + format, arguments);
+  }
+
+  @Override
+  public void error(String msg, Throwable t) {
+    logger.error(prefix + msg, t);
+  }
+
+  @Override
+  public boolean isErrorEnabled(Marker marker) {
+    return logger.isErrorEnabled(marker);
+  }
+
+  @Override
+  public void error(Marker marker, String msg) {
+    logger.error(marker, prefix + msg);
+  }
+
+  @Override
+  public void error(Marker marker, String format, Object arg) {
+    logger.error(marker, prefix + format, arg);
+  }
+
+  @Override
+  public void error(Marker marker, String format, Object arg1, Object arg2) {
+    logger.error(marker, prefix + format, arg1, arg2);
+  }
+
+  @Override
+  public void error(Marker marker, String format, Object... arguments) {
+    logger.error(marker, prefix + format, arguments);
+  }
+
+  @Override
+  public void error(Marker marker, String msg, Throwable t) {
+    logger.error(marker, prefix + msg, t);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/DBSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/DBSink.java
@@ -41,8 +41,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.lib.db.DBConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.Driver;
@@ -62,8 +60,6 @@ import java.util.Map;
 @Name("Database")
 @Description("Writes records to a database table. Each record will be written to a row in the table.")
 public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> {
-  private static final Logger LOG = LoggerFactory.getLogger(DBSink.class);
-
   private final DBSinkConfig dbSinkConfig;
   private final DBManager dbManager;
   private Class<? extends Driver> driverClass;
@@ -86,9 +82,10 @@ public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> 
 
   @Override
   public void prepareRun(BatchSinkContext context) {
-    LOG.debug("tableName = {}; pluginType = {}; pluginName = {}; connectionString = {}; columns = {}",
-              dbSinkConfig.tableName, dbSinkConfig.jdbcPluginType, dbSinkConfig.jdbcPluginName,
-              dbSinkConfig.connectionString, dbSinkConfig.columns);
+    context.getStageLogger(this.getClass())
+      .debug("tableName = {}; pluginType = {}; pluginName = {}; connectionString = {}; columns = {}",
+             dbSinkConfig.tableName, dbSinkConfig.jdbcPluginType, dbSinkConfig.jdbcPluginName,
+             dbSinkConfig.connectionString, dbSinkConfig.columns);
 
     // Load the plugin class to make sure it is available.
     Class<? extends Driver> driverClass = context.loadPluginClass(getJDBCPluginId());

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/SnapshotFileBatchSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/SnapshotFileBatchSink.java
@@ -26,8 +26,6 @@ import co.cask.cdap.etl.common.SnapshotFileSetConfig;
 import co.cask.cdap.etl.dataset.SnapshotFileSet;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -40,7 +38,6 @@ import java.util.Map;
  * @param <VAL_OUT> the type of value the sink outputs
  */
 public abstract class SnapshotFileBatchSink<KEY_OUT, VAL_OUT> extends BatchSink<StructuredRecord, KEY_OUT, VAL_OUT> {
-  private static final Logger LOG = LoggerFactory.getLogger(SnapshotFileBatchSink.class);
   private static final Gson GSON = new Gson();
   private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
@@ -78,7 +75,8 @@ public abstract class SnapshotFileBatchSink<KEY_OUT, VAL_OUT> extends BatchSink<
       try {
         snapshotFileSet.onSuccess(context.getLogicalStartTime());
       } catch (Exception e) {
-        LOG.error("Exception updating state file with value of latest snapshot, ", e);
+        context.getStageLogger(this.getClass())
+          .error("Exception updating state file with value of latest snapshot, ", e);
       }
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/DBSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/DBSource.java
@@ -34,15 +34,11 @@ import co.cask.cdap.etl.common.db.DBManager;
 import co.cask.cdap.etl.common.db.DBRecord;
 import co.cask.cdap.etl.common.db.DBUtils;
 import co.cask.cdap.etl.common.db.ETLDBInputFormat;
-import com.google.common.base.Throwables;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.lib.db.DBConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.sql.Driver;
 
 /**
@@ -53,8 +49,6 @@ import java.sql.Driver;
 @Description("Reads from a database using a configurable SQL query." +
   " Outputs one record for each row returned by the query.")
 public class DBSource extends BatchSource<LongWritable, DBRecord, StructuredRecord> {
-  private static final Logger LOG = LoggerFactory.getLogger(DBSource.class);
-
   private static final String IMPORT_QUERY_DESCRIPTION = "The SELECT query to use to import data from the specified " +
     "table. You can specify an arbitrary number of columns to import, or import all columns using *. " +
     "You can also specify a number of WHERE clauses or ORDER BY clauses. However, LIMIT and OFFSET clauses " +
@@ -80,10 +74,11 @@ public class DBSource extends BatchSource<LongWritable, DBRecord, StructuredReco
 
   @Override
   public void prepareRun(BatchSourceContext context) throws Exception {
-    LOG.debug("pluginType = {}; pluginName = {}; connectionString = {}; importQuery = {}; " +
-                "countQuery = {}",
-              dbSourceConfig.jdbcPluginType, dbSourceConfig.jdbcPluginName,
-              dbSourceConfig.connectionString, dbSourceConfig.importQuery, dbSourceConfig.countQuery);
+    context.getStageLogger(this.getClass())
+      .debug("pluginType = {}; pluginName = {}; connectionString = {}; importQuery = {}; " +
+               "countQuery = {}",
+             dbSourceConfig.jdbcPluginType, dbSourceConfig.jdbcPluginName,
+             dbSourceConfig.connectionString, dbSourceConfig.importQuery, dbSourceConfig.countQuery);
 
     Job job = Job.getInstance();
     Configuration hConf = job.getConfiguration();

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/StreamBatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/StreamBatchSource.java
@@ -56,8 +56,6 @@ import javax.annotation.Nullable;
 @Name("Stream")
 @Description("Batch source for a stream.")
 public class StreamBatchSource extends BatchSource<LongWritable, Object, StructuredRecord> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(StreamBatchSource.class);
   private static final String FORMAT_SETTING_PREFIX = "format.setting.";
   private static final Schema DEFAULT_SCHEMA = Schema.recordOf(
     "event",
@@ -103,7 +101,7 @@ public class StreamBatchSource extends BatchSource<LongWritable, Object, Structu
     long endTime = context.getLogicalStartTime() - delay;
     long startTime = endTime - duration;
 
-    LOG.info("Setting input to Stream : {}", streamBatchConfig.name);
+    context.getStageLogger(this.getClass()).info("Setting input to Stream : {}", streamBatchConfig.name);
 
     FormatSpecification formatSpec = streamBatchConfig.getFormatSpec();
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/realtime/source/SqsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/realtime/source/SqsSource.java
@@ -31,7 +31,6 @@ import com.amazon.sqs.javamessaging.SQSConnectionFactory;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.jms.Message;
@@ -47,7 +46,6 @@ import javax.jms.TextMessage;
 @Name("AmazonSQS")
 @Description("Amazon Simple Queue Service real-time source: emits a record with a field 'body' of type String.")
 public class SqsSource extends RealtimeSource<StructuredRecord> {
-  private static final Logger LOG = LoggerFactory.getLogger(SqsSource.class);
   private static final String REGION_DESCRIPTION = "Region where the queue is located.";
   private static final String ACCESSKEY_DESCRIPTION = "Access Key of the AWS (Amazon Web Services) account to use.";
   private static final String ACCESSID_DESCRIPTION = "Access ID of the AWS (Amazon Web Services) account to use.";
@@ -65,6 +63,7 @@ public class SqsSource extends RealtimeSource<StructuredRecord> {
   private MessageConsumer consumer;
   private Session session;
   private SQSConnection connection;
+  private Logger logger;
 
   public SqsSource(SqsConfig config) {
     this.config = config;
@@ -72,6 +71,7 @@ public class SqsSource extends RealtimeSource<StructuredRecord> {
 
   @Override
   public void initialize(RealtimeContext context) {
+    logger = context.getStageLogger(this.getClass());
     try {
       super.initialize(context);
       SQSConnectionFactory.Builder sqsBuild = SQSConnectionFactory.builder()
@@ -86,24 +86,24 @@ public class SqsSource extends RealtimeSource<StructuredRecord> {
         try {
           session.close();
         } catch (Exception ex1) {
-          LOG.warn("Exception when closing session", ex1);
+          logger.warn("Exception when closing session", ex1);
         }
       }
       if (connection != null) {
         try {
           connection.close();
         } catch (Exception ex2) {
-          LOG.warn("Exception when closing connection", ex2);
+          logger.warn("Exception when closing connection", ex2);
         }
       }
       if (consumer != null) {
         try {
           consumer.close();
         } catch (Exception ex3) {
-          LOG.warn("Exception when closing consumer", ex3);
+          logger.warn("Exception when closing consumer", ex3);
         }
       }
-      LOG.error("Failed to connect to SQS");
+      logger.error("Failed to connect to SQS");
       throw new IllegalStateException("Could not connect to SQS.");
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/realtime/source/TwitterSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/realtime/source/TwitterSource.java
@@ -27,8 +27,6 @@ import co.cask.cdap.etl.api.realtime.RealtimeContext;
 import co.cask.cdap.etl.api.realtime.RealtimeSource;
 import co.cask.cdap.etl.api.realtime.SourceState;
 import com.google.common.collect.Queues;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import twitter4j.StallWarning;
 import twitter4j.Status;
 import twitter4j.StatusDeletionNotice;
@@ -53,7 +51,6 @@ import javax.annotation.Nullable;
   "rtCount (int), source (nullable string), geoLat (nullable double), geoLong (nullable double), " +
   "and isRetweet (boolean).")
 public class TwitterSource extends RealtimeSource<StructuredRecord> {
-  private static final Logger LOG = LoggerFactory.getLogger(TwitterSource.class);
   private static final String CONSUMER_KEY = "ConsumerKey";
   private static final String CONSUMER_SECRET = "ConsumerSecret";
   private static final String ACCESS_TOKEN = "AccessToken";

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptFilterTransform.java
@@ -36,7 +36,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.script.Invocable;
@@ -95,7 +94,7 @@ public class ScriptFilterTransform extends Transform<StructuredRecord, Structure
   public void initialize(TransformContext context) throws Exception {
     super.initialize(context);
     metrics = context.getMetrics();
-    logger = LoggerFactory.getLogger(ScriptFilterTransform.class.getName() + " - Stage:" + context.getStageName());
+    logger = context.getStageLogger(this.getClass());
     init(context);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ScriptTransform.java
@@ -37,7 +37,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -126,7 +125,7 @@ public class ScriptTransform extends Transform<StructuredRecord, StructuredRecor
   public void initialize(TransformContext context) throws Exception {
     super.initialize(context);
     metrics = context.getMetrics();
-    logger = LoggerFactory.getLogger(ScriptTransform.class.getName() + " - Stage:" + context.getStageName());
+    logger = context.getStageLogger(context.getClass());
 
     // for Nashorn (Java 8+) support -- get method to convert ScriptObjectMirror to List
     try {

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ValidatorTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/transform/ValidatorTransform.java
@@ -40,7 +40,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -95,7 +94,6 @@ public class ValidatorTransform extends Transform<StructuredRecord, StructuredRe
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(StructuredRecord.class, new StructuredRecordSerializer())
     .create();
-  private static final Logger LOG = LoggerFactory.getLogger(ValidatorTransform.class);
   private static final String VARIABLE_NAME = "dont_name_your_variable_this";
   private static final String FUNCTION_NAME = "dont_name_your_function_this";
   private static final String CONTEXT_NAME = "dont_name_your_context_this";
@@ -134,6 +132,7 @@ public class ValidatorTransform extends Transform<StructuredRecord, StructuredRe
   @Override
   public void initialize(TransformContext context) throws Exception {
     super.initialize(context);
+    logger = context.getStageLogger(this.getClass());
     List<Validator> validators = new ArrayList<>();
     for (String pluginId : config.validators.split("\\s*,\\s*")) {
       validators.add((Validator) context.newPluginInstance(pluginId));
@@ -144,7 +143,6 @@ public class ValidatorTransform extends Transform<StructuredRecord, StructuredRe
   @VisibleForTesting
   void setUpInitialScript(TransformContext context, List<Validator> validators) throws ScriptException {
     metrics = context.getMetrics();
-    logger = LoggerFactory.getLogger(ValidatorTransform.class.getName() + " - Stage:" + context.getStageName());
     init(validators, context);
   }
 
@@ -164,7 +162,7 @@ public class ValidatorTransform extends Transform<StructuredRecord, StructuredRe
         emitter.emitError(getErrorObject(result, input));
         metrics.count("invalid", 1);
         metrics.pipelineCount("invalid", 1);
-        LOG.trace("Error code : {} , Error Message {}", result.get("errorCode"), result.get("errorMsg"));
+        logger.trace("Error code : {} , Error Message {}", result.get("errorCode"), result.get("errorMsg"));
       }
     } catch (Exception e) {
       throw new IllegalArgumentException("Invalid filter condition.", e);

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/common/MockRealtimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/common/MockRealtimeContext.java
@@ -21,6 +21,8 @@ import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.api.realtime.RealtimeContext;
 import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -51,6 +53,11 @@ public class MockRealtimeContext implements RealtimeContext {
   @Override
   public String getStageName() {
     return "singleStage";
+  }
+
+  @Override
+  public Logger getStageLogger(Class clazz) {
+    return LoggerFactory.getLogger(clazz);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/MockTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/etl/transform/MockTransformContext.java
@@ -24,6 +24,8 @@ import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.api.TransformContext;
 import co.cask.cdap.etl.common.MockLookupProvider;
 import co.cask.cdap.etl.common.NoopMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -94,6 +96,11 @@ public class MockTransformContext implements TransformContext {
   @Override
   public String getStageName() {
     return "singleStage";
+  }
+
+  @Override
+  public Logger getStageLogger(Class clazz) {
+    return LoggerFactory.getLogger(clazz);
   }
 
   @Override


### PR DESCRIPTION
The logger returned will prefix all messages with the name of
the stage it was logged from. This is useful when different stages
use the same plugin class, as it would otherwise be difficult to
tell which stage is emitting which message.