### PR TITLE
Fix doc build; add md support to Sphinx build

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -146,6 +146,12 @@ templates_path = ['_templates', '../../_common/_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
+try:
+    from recommonmark.parser import CommonMarkParser
+    source_parsers = {'.md': CommonMarkParser}
+    source_suffix = ['.rst', '.md']
+except ImportError:
+    print "Unable to import CommonMarkParser from recommonmark; can't process Markdown files."
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -150,6 +150,7 @@ try:
     from recommonmark.parser import CommonMarkParser
     source_parsers = {'.md': CommonMarkParser}
     source_suffix = ['.rst', '.md']
+    print "Imported CommonMarkParser from recommonmark; can process Markdown files."
 except ImportError:
     print "Unable to import CommonMarkParser from recommonmark; can't process Markdown files."
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,6 +19,8 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
+DEFAULT_XML_MD5_HASH="e8cc6ab35e17a8c28adafb02d65027b5"
+
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"
 CHECK_INCLUDES=${TRUE}
@@ -36,7 +38,7 @@ function download_includes() {
   local target_includes_dir=${1}
 
   echo_red_bold "Check guarded files for changes."
-  test_an_include d8f4664279c72b4c9d51a07a0a1fc573 "${DEFAULT_XML}"
+  test_an_include "${DEFAULT_XML_MD5_HASH}" "${DEFAULT_XML}"
 
   echo "Building rst file from cdap-default.xml..." 
   python "${DEFAULT_TOOL}" -g -t "${target_includes_dir}/${DEFAULT_RST}"

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -320,6 +320,7 @@ function build_docs_outer_level() {
   cp ${SCRIPT_PATH}/${COMMON_HIGHLEVEL_PY}  ${TARGET_PATH}/${SOURCE}/conf.py
   cp -R ${SCRIPT_PATH}/${COMMON_IMAGES}     ${TARGET_PATH}/${SOURCE}/
   cp ${SCRIPT_PATH}/${COMMON_SOURCE}/*.rst  ${TARGET_PATH}/${SOURCE}/
+  cp ${SCRIPT_PATH}/${COMMON_SOURCE}/*.md   ${TARGET_PATH}/${SOURCE}/
   
   local google_options
   if [ "x${google_code}" != "x" ]; then

--- a/cdap-docs/included-applications/build.sh
+++ b/cdap-docs/included-applications/build.sh
@@ -63,12 +63,12 @@ function download_includes() {
   test_an_include 4c156d69fcc4d7b9145caab2dbed26ff "${cdap_etl}/realtime/source/DataGeneratorSource.java"
   test_an_include c1d134466622468c36eaaf6a55677bb1 "${cdap_etl}/realtime/source/JmsSource.java"
   test_an_include c0605df8382ea941966785e5ad589c4a "${cdap_etl}/realtime/source/KafkaSource.java"
-  test_an_include 496fb353aa835ef2a60f2a76b56fdc01 "${cdap_etl}/realtime/source/SqsSource.java"
+  test_an_include 62c19ecd2d694d3291b104645ad529a1 "${cdap_etl}/realtime/source/SqsSource.java"
   test_an_include e8b987b6f648211ed183e18c68b41873 "${cdap_etl}/realtime/source/TwitterSource.java"
 
   # Transforms
   test_an_include 06ddd340ba65bbc068ab3e3cf2f346c1 "${cdap_etl}/transform/LogParserTransform.java"
-  test_an_include 7b5386499cc1a646e5be38ab5269d076 "${cdap_etl}/transform/ProjectionTransform.java"
+  test_an_include e2aa3c8d77b8f229e2642f5e1f0975bc "${cdap_etl}/transform/ProjectionTransform.java"
   test_an_include 480bc77f42c8c155a54deb6377ef05a2 "${cdap_etl}/transform/ScriptFilterTransform.java"
   test_an_include 0e09daa8c8e7b008f1b19ca1da224884 "${cdap_etl}/transform/ScriptTransform.java"
   test_an_include c3eb291d7b7d4ca0934d151bed882dd3 "${cdap_etl}/transform/StructuredRecordToGenericRecordTransform.java"


### PR DESCRIPTION
Fixes the Doc build in develop: passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB64-1)

Adds support for processing Markdown files if ``recommonmark`` has been installed.