### PR TITLE
router connection timeout

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -391,22 +391,12 @@ public final class Constants {
     public static final String SERVER_WORKER_THREADS = "router.server.worker.threads";
     public static final String CLIENT_BOSS_THREADS = "router.client.boss.threads";
     public static final String CLIENT_WORKER_THREADS = "router.client.worker.threads";
+    public static final String CONNECTION_TIMEOUT_SECS = "router.connection.timeout.secs";
 
     /**
      * Defaults.
      */
     public static final String DEFAULT_ROUTER_PORT = "10000";
-    public static final String DEFAULT_WEBAPP_PORT = "20000";
-    public static final String DEFAULT_ROUTER_SSL_PORT = "10443";
-    public static final String DEFAULT_WEBAPP_SSL_PORT = "20443";
-    public static final boolean DEFAULT_WEBAPP_ENABLED = false;
-
-
-    public static final int DEFAULT_BACKLOG = 20000;
-    public static final int DEFAULT_SERVER_BOSS_THREADS = 1;
-    public static final int DEFAULT_SERVER_WORKER_THREADS = 10;
-    public static final int DEFAULT_CLIENT_BOSS_THREADS = 1;
-    public static final int DEFAULT_CLIENT_WORKER_THREADS = 10;
 
     public static final String GATEWAY_DISCOVERY_NAME = Service.GATEWAY;
     public static final String WEBAPP_DISCOVERY_NAME = "webapp/$HOST";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1110,7 +1110,7 @@
     <name>notification.transport.system</name>
     <value>kafka</value>
     <description>
-      Transport system used by the Notification system - can be kafka/stream
+      Transport system used by the Notification system: can be kafka/stream
     </description>
   </property>
 
@@ -1163,11 +1163,49 @@
   </property>
 
   <property>
+    <name>router.client.boss.threads</name>
+    <value>1</value>
+    <description>The number of boss threads in the router client</description>
+  </property>
+
+  <property>
+    <name>router.client.worker.threads</name>
+    <value>10</value>
+    <description>The number of worker threads in the router client</description>
+  </property>
+
+  <property>
+    <name>router.connection.backlog</name>
+    <value>20000</value>
+    <description>The connection backlog in the router server</description>
+  </property>
+
+  <property>
+    <name>router.connection.timeout.secs</name>
+    <value>15</value>
+    <description>
+      The number of seconds after which idle router connections are closed
+    </description>
+  </property>
+
+  <property>
+    <name>router.server.boss.threads</name>
+    <value>1</value>
+    <description>The number of boss threads in the router server</description>
+  </property>
+
+  <property>
     <name>router.server.port</name>
     <value>${router.bind.port}</value>
     <description>
       Router port to which CDAP UI connects
     </description>
+  </property>
+
+  <property>
+    <name>router.server.worker.threads</name>
+    <value>10</value>
+    <description>The number of worker threads in the Router server</description>
   </property>
 
   <property>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1184,8 +1184,7 @@
     <name>router.connection.timeout.secs</name>
     <value>15</value>
     <description>
-      <!-- TODO: make it more clear that in-progress http requests aren't timed out-->
-      The number of seconds after which idle router connections are closed
+      The number of seconds after an http request completes that idle router connections are closed
     </description>
   </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1184,6 +1184,7 @@
     <name>router.connection.timeout.secs</name>
     <value>15</value>
     <description>
+      <!-- TODO: make it more clear that in-progress http requests aren't timed out-->
       The number of seconds after which idle router connections are closed
     </description>
   </property>

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,11 +27,11 @@ import co.cask.cdap.security.auth.TokenValidator;
 import co.cask.cdap.security.tools.SSLHandlerFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import org.apache.hadoop.hbase.util.Threads;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.jboss.netty.bootstrap.ClientBootstrap;
 import org.jboss.netty.bootstrap.ServerBootstrap;
@@ -53,12 +53,15 @@ import org.jboss.netty.channel.socket.nio.NioWorkerPool;
 import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
 import org.jboss.netty.handler.codec.http.HttpRequestEncoder;
 import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
+import org.jboss.netty.util.HashedWheelTimer;
+import org.jboss.netty.util.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -74,52 +77,38 @@ public class NettyRouter extends AbstractIdleService {
   private final int serverBossThreadPoolSize;
   private final int serverWorkerThreadPoolSize;
   private final int serverConnectionBacklog;
-
   private final int clientBossThreadPoolSize;
   private final int clientWorkerThreadPoolSize;
   private final InetAddress hostname;
   private final Map<String, Integer> serviceToPortMap;
-
   private final ChannelGroup channelGroup = new DefaultChannelGroup("server channels");
   private final RouterServiceLookup serviceLookup;
-
   private final boolean securityEnabled;
   private final TokenValidator tokenValidator;
   private final AccessTokenTransformer accessTokenTransformer;
   private final CConfiguration configuration;
-  private final SConfiguration sConfiguration;
   private final String realm;
+  private final boolean sslEnabled;
+  private final SSLHandlerFactory sslHandlerFactory;
+  private final int connectionTimeout;
+  private final Timer timer;
 
   private ServerBootstrap serverBootstrap;
   private ClientBootstrap clientBootstrap;
-
   private DiscoveryServiceClient discoveryServiceClient;
-
-  private final boolean sslEnabled;
-  private final boolean webAppEnabled;
-  private final SSLHandlerFactory sslHandlerFactory;
 
   @Inject
   public NettyRouter(CConfiguration cConf, SConfiguration sConf, @Named(Constants.Router.ADDRESS) InetAddress hostname,
                      RouterServiceLookup serviceLookup, TokenValidator tokenValidator,
                      AccessTokenTransformer accessTokenTransformer,
                      DiscoveryServiceClient discoveryServiceClient) {
-
-    this.serverBossThreadPoolSize = cConf.getInt(Constants.Router.SERVER_BOSS_THREADS,
-                                                 Constants.Router.DEFAULT_SERVER_BOSS_THREADS);
-    this.serverWorkerThreadPoolSize = cConf.getInt(Constants.Router.SERVER_WORKER_THREADS,
-                                                   Constants.Router.DEFAULT_SERVER_WORKER_THREADS);
-    this.serverConnectionBacklog = cConf.getInt(Constants.Router.BACKLOG_CONNECTIONS,
-                                                Constants.Router.DEFAULT_BACKLOG);
-
-    this.clientBossThreadPoolSize = cConf.getInt(Constants.Router.CLIENT_BOSS_THREADS,
-                                                 Constants.Router.DEFAULT_CLIENT_BOSS_THREADS);
-    this.clientWorkerThreadPoolSize = cConf.getInt(Constants.Router.CLIENT_WORKER_THREADS,
-                                                   Constants.Router.DEFAULT_CLIENT_WORKER_THREADS);
-
+    this.serverBossThreadPoolSize = cConf.getInt(Constants.Router.SERVER_BOSS_THREADS);
+    this.serverWorkerThreadPoolSize = cConf.getInt(Constants.Router.SERVER_WORKER_THREADS);
+    this.serverConnectionBacklog = cConf.getInt(Constants.Router.BACKLOG_CONNECTIONS);
+    this.clientBossThreadPoolSize = cConf.getInt(Constants.Router.CLIENT_BOSS_THREADS);
+    this.clientWorkerThreadPoolSize = cConf.getInt(Constants.Router.CLIENT_WORKER_THREADS);
     this.hostname = hostname;
-    this.serviceToPortMap = Maps.newHashMap();
-
+    this.serviceToPortMap = new HashMap<>();
     this.serviceLookup = serviceLookup;
     this.securityEnabled = cConf.getBoolean(Constants.Security.ENABLED, false);
     this.realm = cConf.get(Constants.Security.CFG_REALM);
@@ -127,18 +116,14 @@ public class NettyRouter extends AbstractIdleService {
     this.accessTokenTransformer = accessTokenTransformer;
     this.discoveryServiceClient = discoveryServiceClient;
     this.configuration = cConf;
-    this.sConfiguration = sConf;
-
     this.sslEnabled = cConf.getBoolean(Constants.Security.SSL_ENABLED);
-    this.webAppEnabled = cConf.getBoolean(Constants.Router.WEBAPP_ENABLED);
+    boolean webAppEnabled = cConf.getBoolean(Constants.Router.WEBAPP_ENABLED);
     if (isSSLEnabled()) {
       this.serviceToPortMap.put(Constants.Router.GATEWAY_DISCOVERY_NAME,
-                                Integer.parseInt(cConf.get(Constants.Router.ROUTER_SSL_PORT,
-                                                           Constants.Router.DEFAULT_ROUTER_SSL_PORT)));
+                                cConf.getInt(Constants.Router.ROUTER_SSL_PORT));
       if (webAppEnabled) {
         this.serviceToPortMap.put(Constants.Router.WEBAPP_DISCOVERY_NAME,
-                                  Integer.parseInt(cConf.get(Constants.Router.WEBAPP_SSL_PORT,
-                                                             Constants.Router.DEFAULT_WEBAPP_SSL_PORT)));
+                                  cConf.getInt(Constants.Router.WEBAPP_SSL_PORT));
       }
 
       File keystore;
@@ -154,22 +139,20 @@ public class NettyRouter extends AbstractIdleService {
                                                      sConf.get(Constants.Security.Router.SSL_KEYSTORE_PASSWORD),
                                                      sConf.get(Constants.Security.Router.SSL_KEYPASSWORD));
     } else {
-      this.serviceToPortMap.put(Constants.Router.GATEWAY_DISCOVERY_NAME,
-                        Integer.parseInt(cConf.get(Constants.Router.ROUTER_PORT,
-                                                   Constants.Router.DEFAULT_ROUTER_PORT)));
+      this.serviceToPortMap.put(Constants.Router.GATEWAY_DISCOVERY_NAME, cConf.getInt(Constants.Router.ROUTER_PORT));
       if (webAppEnabled) {
-        this.serviceToPortMap.put(Constants.Router.WEBAPP_DISCOVERY_NAME,
-                                  Integer.parseInt(cConf.get(Constants.Router.WEBAPP_PORT,
-                                                             Constants.Router.DEFAULT_WEBAPP_PORT)));
+        this.serviceToPortMap.put(Constants.Router.WEBAPP_DISCOVERY_NAME, cConf.getInt(Constants.Router.WEBAPP_PORT));
       }
       this.sslHandlerFactory = null;
     }
+    this.connectionTimeout = cConf.getInt(Constants.Router.CONNECTION_TIMEOUT_SECS);
+    this.timer = new HashedWheelTimer(Threads.newDaemonThreadFactory("idle-event-generator-timer"));
     LOG.info("Service to Port Mapping - {}", this.serviceToPortMap);
   }
 
   @Override
   protected void startUp() throws Exception {
-    ChannelUpstreamHandler connectionTracker =  new SimpleChannelUpstreamHandler() {
+    ChannelUpstreamHandler connectionTracker = new SimpleChannelUpstreamHandler() {
       @Override
       public void handleUpstream(ChannelHandlerContext ctx, ChannelEvent e)
         throws Exception {
@@ -198,6 +181,7 @@ public class NettyRouter extends AbstractIdleService {
       clientBootstrap.releaseExternalResources();
       serverBootstrap.releaseExternalResources();
       tokenValidator.stopAndWait();
+      timer.stop();
     }
 
     LOG.info("Stopped Netty Router.");

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
@@ -93,8 +93,8 @@ public class NettyRouter extends AbstractIdleService {
   private final boolean sslEnabled;
   private final SSLHandlerFactory sslHandlerFactory;
   private final int connectionTimeout;
-  private final Timer timer;
 
+  private Timer timer;
   private ServerBootstrap serverBootstrap;
   private ClientBootstrap clientBootstrap;
   private DiscoveryServiceClient discoveryServiceClient;
@@ -149,7 +149,6 @@ public class NettyRouter extends AbstractIdleService {
     }
     this.connectionTimeout = cConf.getInt(Constants.Router.CONNECTION_TIMEOUT_SECS);
     LOG.info("Using connection timeout: {}", connectionTimeout);
-    this.timer = new HashedWheelTimer(Threads.newDaemonThreadFactory("idle-event-generator-timer"));
     LOG.info("Service to Port Mapping - {}", this.serviceToPortMap);
   }
 
@@ -165,6 +164,7 @@ public class NettyRouter extends AbstractIdleService {
     };
 
     tokenValidator.startAndWait();
+    timer = new HashedWheelTimer(Threads.newDaemonThreadFactory("router-idle-event-generator-timer"));
     bootstrapClient(connectionTracker);
 
     bootstrapServer(connectionTracker);

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterModules.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -55,6 +55,7 @@ public class RouterModules extends RuntimeModule {
 
       @Provides
       @Named(Constants.Router.ADDRESS)
+      @SuppressWarnings("unused")
       public final InetAddress providesHostname(CConfiguration cConf) {
         return Networks.resolve(cConf.get(Constants.Router.ADDRESS),
                                 new InetSocketAddress("localhost", 0).getAddress());

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpIdleStateHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpIdleStateHandler.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.router.handlers;
+
+import org.jboss.netty.channel.ChannelHandler;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.LifeCycleAwareChannelHandler;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelHandler;
+import org.jboss.netty.handler.codec.http.HttpChunk;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.util.ExternalResourceReleasable;
+import org.jboss.netty.util.HashedWheelTimer;
+import org.jboss.netty.util.Timeout;
+import org.jboss.netty.util.Timer;
+import org.jboss.netty.util.TimerTask;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.jboss.netty.channel.Channels.fireExceptionCaught;
+
+/**
+ * Closes the channel when an HTTP request is not in session or has been in session for the configured timeout.
+ *
+ * The {@link Timer} which was specified when the {@link HttpIdleStateHandler} is
+ * created should be stopped manually by calling {@link #releaseExternalResources()}
+ * or {@link Timer#stop()} when your application shuts down.
+ *
+ */
+@ChannelHandler.Sharable
+public class HttpIdleStateHandler extends SimpleChannelHandler
+  implements LifeCycleAwareChannelHandler, ExternalResourceReleasable {
+
+  private final Timer timer;
+  private final long requestIdleTimeMillis;
+
+  /**
+   * Creates a new instance.
+   *
+   * @param timer the {@link Timer} that is used to trigger the scheduled channel close.
+   *        The recommended {@link Timer} implementation is {@link HashedWheelTimer}.
+   * @param requestIdleTimeSeconds the associated channel will be closed request was performed for the specified
+   *        period of time.  Specify {@code 0} to disable.
+   */
+  public HttpIdleStateHandler(Timer timer, int requestIdleTimeSeconds) {
+    this(timer, requestIdleTimeSeconds, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Creates a new instance.
+   *
+   * @param timer the {@link Timer} that is used to trigger the scheduled event.
+   *        The recommended {@link Timer} implementation is {@link HashedWheelTimer}.
+   * @param requestIdleTime the associated channel will be closed request was performed for the specified
+   *        period of time.  Specify {@code 0} to disable.
+   * @param unit the {@link TimeUnit} of {@code requestIdleTime}, {@code writeIdleTime}, and {@code allIdleTime}
+   */
+  public HttpIdleStateHandler(Timer timer, long requestIdleTime, TimeUnit unit) {
+    if (timer == null) {
+      throw new NullPointerException("timer");
+    }
+    if (unit == null) {
+      throw new NullPointerException("unit");
+    }
+
+    this.timer = timer;
+    if (requestIdleTime <= 0) {
+      requestIdleTimeMillis = 0;
+    } else {
+      requestIdleTimeMillis = Math.max(unit.toMillis(requestIdleTime), 1);
+    }
+  }
+
+  /**
+   * Return the configured requestIdleTime, in milliseconds.
+   *
+   */
+  public long getRequestIdleTimeInMillis() {
+    return requestIdleTimeMillis;
+  }
+
+  /**
+   * Stops the {@link Timer} which was specified in the constructor of this
+   * handler.  You should not call this method if the {@link Timer} is in use
+   * by other objects.
+   */
+  public void releaseExternalResources() {
+    timer.stop();
+  }
+
+  public void beforeAdd(ChannelHandlerContext ctx) throws Exception {
+    if (ctx.getPipeline().isAttached()) {
+      // channelOpen event has been fired already, which means
+      // this.channelOpen() will not be invoked.
+      // We have to initialize here instead.
+      initialize(ctx);
+    } else {
+      // channelOpen event has not been fired yet.
+      // this.channelOpen() will be invoked and initialization will occur there.
+    }
+  }
+
+  public void afterAdd(ChannelHandlerContext ctx) throws Exception {
+    // NOOP
+  }
+
+  public void beforeRemove(ChannelHandlerContext ctx) throws Exception {
+    destroy(ctx);
+  }
+
+  public void afterRemove(ChannelHandlerContext ctx) throws Exception {
+    // NOOP
+  }
+
+  @Override
+  public void channelOpen(ChannelHandlerContext ctx, ChannelStateEvent e)
+    throws Exception {
+    // This method will be invoked only if this handler was added
+    // before channelOpen event is fired.  If a user adds this handler
+    // after the channelOpen event, initialize() will be called by beforeAdd().
+    initialize(ctx);
+    ctx.sendUpstream(e);
+  }
+
+  @Override
+  public void channelClosed(ChannelHandlerContext ctx, ChannelStateEvent e)
+    throws Exception {
+    destroy(ctx);
+    ctx.sendUpstream(e);
+  }
+
+  @Override
+  public void messageReceived(ChannelHandlerContext ctx, MessageEvent e)
+    throws Exception {
+    Object message = e.getMessage();
+    if (message instanceof HttpResponse) {
+      HttpResponse response = (HttpResponse) message;
+      if (!response.isChunked()) {
+        markRequestEnd(ctx);
+      }
+    } else if (message instanceof HttpChunk) {
+      HttpChunk chunk = (HttpChunk) message;
+
+      if (chunk.isLast()) {
+        markRequestEnd(ctx);
+      }
+    }
+
+    ctx.sendUpstream(e);
+  }
+
+  private void markRequestEnd(ChannelHandlerContext ctx) {
+    State state = (State) ctx.getAttachment();
+    state.lastMessageTime = System.currentTimeMillis();
+    state.requestInProgress = false;
+  }
+
+  private void markRequestInProgress(ChannelHandlerContext ctx) {
+    // TODO: check if already in progress. if so, return.
+    // this helps avoid the call to System#currentTimeMillis,
+    // at the cost of `lastMessageTime` being inaccurate when requestInProgress is true
+
+    State state = (State) ctx.getAttachment();
+    state.lastMessageTime = System.currentTimeMillis();
+    state.requestInProgress = true;
+  }
+
+  @Override
+  public void writeRequested(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+    Object message = e.getMessage();
+    if (message instanceof HttpRequest || message instanceof HttpChunk) {
+      markRequestInProgress(ctx);
+    }
+    ctx.sendDownstream(e);
+  }
+
+  private void initialize(ChannelHandlerContext ctx) {
+    State state = state(ctx);
+
+    // Avoid the case where destroy() is called before scheduling timeouts.
+    // See: https://github.com/netty/netty/issues/143
+    synchronized (state) {
+      switch (state.state) {
+        case 1:
+        case 2:
+          return;
+      }
+      state.state = 1;
+    }
+
+    state.lastMessageTime = System.currentTimeMillis();
+    if (requestIdleTimeMillis > 0) {
+      state.requestIdleTimeout = timer.newTimeout(new RequestIdleTimeoutTask(ctx),
+                                                  requestIdleTimeMillis, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private static void destroy(ChannelHandlerContext ctx) {
+    State state = state(ctx);
+    synchronized (state) {
+      if (state.state != 1) {
+        return;
+      }
+      state.state = 2;
+    }
+
+    if (state.requestIdleTimeout != null) {
+      state.requestIdleTimeout.cancel();
+      state.requestIdleTimeout = null;
+    }
+  }
+
+  private static State state(ChannelHandlerContext ctx) {
+    synchronized (ctx) {
+      State state = (State) ctx.getAttachment();
+      if (state != null) {
+        return state;
+      }
+      state = new State();
+      ctx.setAttachment(state);
+      return state;
+    }
+  }
+
+  private void fireChannelIdle(final ChannelHandlerContext ctx) {
+    ctx.getPipeline().execute(new Runnable() {
+
+      public void run() {
+        try {
+          ctx.getChannel().close();
+        } catch (Throwable t) {
+          fireExceptionCaught(ctx, t);
+        }
+      }
+    });
+  }
+
+  private final class RequestIdleTimeoutTask implements TimerTask {
+
+    private final ChannelHandlerContext ctx;
+
+    RequestIdleTimeoutTask(ChannelHandlerContext ctx) {
+      this.ctx = ctx;
+    }
+
+    public void run(Timeout timeout) throws Exception {
+      if (timeout.isCancelled() || !ctx.getChannel().isOpen()) {
+        return;
+      }
+
+      State state = (State) ctx.getAttachment();
+
+      long nextDelay = computeNextDelay(state);
+      if (!state.requestInProgress && nextDelay <= 0) {
+        // request is idle - set a new timeout and notify the callback.
+        state.requestIdleTimeout = timer.newTimeout(this, requestIdleTimeMillis, TimeUnit.MILLISECONDS);
+        fireChannelIdle(ctx);
+      } else {
+        // either request is in progress or was in progress within the past requestIdleTimeMillis
+        state.requestIdleTimeout = timer.newTimeout(this, nextDelay, TimeUnit.MILLISECONDS);
+      }
+    }
+
+    private long computeNextDelay(State state) {
+      if (state.requestInProgress) {
+        return requestIdleTimeMillis;
+      } else {
+        long currentTime = System.currentTimeMillis();
+        long lastMessageTime = state.lastMessageTime;
+        return requestIdleTimeMillis - (currentTime - lastMessageTime);
+      }
+    }
+  }
+
+  private static final class State {
+    // 0 - none, 1 - initialized, 2 - destroyed
+    int state;
+
+    volatile Timeout requestIdleTimeout;
+    volatile long lastMessageTime;
+    volatile boolean requestInProgress;
+
+    State() {
+    }
+  }
+}

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpRequestHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,7 +20,6 @@ import co.cask.cdap.common.HandlerException;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.gateway.router.ProxyRule;
 import co.cask.cdap.gateway.router.RouterServiceLookup;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.io.Closeables;
 import org.apache.twill.discovery.Discoverable;
@@ -47,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -76,7 +76,7 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler {
                             List<ProxyRule> proxyRules) {
     this.clientBootstrap = clientBootstrap;
     this.serviceLookup = serviceLookup;
-    this.discoveryLookup = Maps.newHashMap();
+    this.discoveryLookup = new HashMap<>();
     this.proxyRules = proxyRules;
   }
 

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamViewHttpHandlerTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamViewHttpHandlerTest.java
@@ -65,9 +65,8 @@ public class StreamViewHttpHandlerTest extends GatewayTestBase {
 
     List<String> views = execute(
       200, HttpRequest.get(resolve("/v3/namespaces/default/streams/foo/views")).build(),
-      new TypeToken<List<String>>() {
-      }.getType());
-    Assert.assertEquals(ImmutableList.of(), views);
+      new TypeToken<List<String>>() { }.getType());
+    Assert.assertEquals(ImmutableList.<String>of(), views);
 
     Schema schema = Schema.recordOf("foo", Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
     FormatSpecification formatSpec = new FormatSpecification(
@@ -120,7 +119,7 @@ public class StreamViewHttpHandlerTest extends GatewayTestBase {
     views = execute(
       200, HttpRequest.get(resolve("/v3/namespaces/default/streams/foo/views")).build(),
       new TypeToken<List<String>>() { }.getType());
-    Assert.assertEquals(ImmutableList.of(), views);
+    Assert.assertEquals(ImmutableList.<String>of(), views);
 
     // Deleting a stream should also delete the associated views
     execute(200, HttpRequest.delete(resolve("/v3/namespaces/default/streams/foo")).build());

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -84,6 +84,7 @@ public class NettyRouterHttpTest extends NettyRouterTestBase {
       cConf.setInt(Constants.Router.ROUTER_PORT, 0);
       cConf.setBoolean(Constants.Router.WEBAPP_ENABLED, true);
       cConf.setInt(Constants.Router.WEBAPP_PORT, 0);
+      cConf.setInt(Constants.Router.CONNECTION_TIMEOUT_SECS, CONNECTION_IDLE_TIMEOUT_SECS);
       router =
         new NettyRouter(cConf, sConfiguration, InetAddresses.forString(hostname),
                         new RouterServiceLookup((DiscoveryServiceClient) discoveryService,

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpsTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -137,6 +137,7 @@ public class NettyRouterHttpsTest extends NettyRouterTestBase {
       cConf.setInt(Constants.Router.ROUTER_PORT, 0);
       cConf.setBoolean(Constants.Router.WEBAPP_ENABLED, true);
       cConf.setInt(Constants.Router.WEBAPP_PORT, 0);
+      cConf.setInt(Constants.Router.CONNECTION_TIMEOUT_SECS, CONNECTION_IDLE_TIMEOUT_SECS);
 
       sConf.set(Constants.Security.Router.SSL_KEYSTORE_PATH, certUrl.getPath());
 

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
@@ -97,7 +97,6 @@ public class NettyRouterPipelineTest {
   private static final DiscoveryService discoveryService = new InMemoryDiscoveryService();
   private static final String gatewayService = Constants.Service.APP_FABRIC_HTTP;
   private static final String GATEWAY_LOOKUP = Constants.Router.GATEWAY_DISCOVERY_NAME;
-  private static final String webappService = "$HOST";
   private static final int maxUploadBytes = 10 * 1024 * 1024;
   private static final int chunkSize = 1024 * 1024;      // NOTE: maxUploadBytes % chunkSize == 0
   private static byte[] applicationJarInBytes;

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
@@ -198,7 +198,7 @@ public class NettyRouterPipelineTest {
 
       ByteStreams.copy(Locations.newInputSupplier(programJar), urlConn.getOutputStream());
       Assert.assertEquals(200, urlConn.getResponseCode());
-      // TODO: close the InputStream
+      urlConn.getInputStream().close();
       urlConn.disconnect();
     }
   }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
@@ -76,16 +76,20 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 
 /**
  * Verify the ordering of events in the RouterPipeline.
@@ -177,8 +181,7 @@ public class NettyRouterPipelineTest {
   private void deploy(int num) throws Exception {
 
     String path = String.format("http://%s:%d/v1/deploy",
-                                hostname,
-                                ROUTER.getServiceMap().get(GATEWAY_LOOKUP));
+                                hostname, ROUTER.getServiceMap().get(GATEWAY_LOOKUP));
 
     LocationFactory lf = new LocalLocationFactory(TMP_FOLDER.newFolder());
     Location programJar = AppJarHelper.createDeploymentJar(lf, AllProgramsApp.class);
@@ -195,6 +198,7 @@ public class NettyRouterPipelineTest {
 
       ByteStreams.copy(Locations.newInputSupplier(programJar), urlConn.getOutputStream());
       Assert.assertEquals(200, urlConn.getResponseCode());
+      // TODO: close the InputStream
       urlConn.disconnect();
     }
   }
@@ -358,8 +362,8 @@ public class NettyRouterPipelineTest {
               responder.sendStatus(HttpResponseStatus.OK);
               return;
             }
-              responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-            }
+            responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+          }
 
           @Override
           public void handleError(Throwable cause) {
@@ -367,7 +371,6 @@ public class NettyRouterPipelineTest {
           }
         };
       }
-
     }
   }
 

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,6 +19,7 @@ package co.cask.cdap.gateway.router;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.ResolvingDiscoverable;
 import co.cask.cdap.common.utils.Networks;
+import co.cask.cdap.test.SlowTests;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.ChunkResponder;
 import co.cask.http.HttpResponder;
@@ -57,6 +58,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,11 +68,13 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -89,6 +93,7 @@ public abstract class NettyRouterTestBase {
   protected static final String WEBAPP_SERVICE = Constants.Router.WEBAPP_DISCOVERY_NAME;
   protected static final String APP_FABRIC_SERVICE = Constants.Service.APP_FABRIC_HTTP;
   protected static final String WEB_APP_SERVICE_PREFIX = "webapp/";
+  protected static final int CONNECTION_IDLE_TIMEOUT_SECS = 5;
 
   private static final Logger LOG = LoggerFactory.getLogger(NettyRouterTestBase.class);
   private static final int MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
@@ -388,6 +393,25 @@ public abstract class NettyRouterTestBase {
     Assert.assertEquals(times, defaultServer1.getNumRequests() + defaultServer2.getNumRequests());
   }
 
+  @Test
+  public void testConnectionNoIdleTimeout() throws Exception {
+    // 300ms under the configured idle timeout
+    testConnectionIdleTimeout(TimeUnit.SECONDS.toMillis(CONNECTION_IDLE_TIMEOUT_SECS) - 300);
+  }
+
+  // TODO: this exception shouldn't get thrown. the timeout is only once the http request is complete
+  @Test(expected = SocketException.class)
+  public void testConnectionIdleTimeout() throws Exception {
+    // 300ms over the configured idle timeout
+    testConnectionIdleTimeout(TimeUnit.SECONDS.toMillis(CONNECTION_IDLE_TIMEOUT_SECS) + 300);
+  }
+
+  private void testConnectionIdleTimeout(long timeoutMillis) throws Exception {
+    URL url = new URL(resolveURI(Constants.Router.GATEWAY_DISCOVERY_NAME, "/v1/timeout/" + timeoutMillis));
+    HttpURLConnection urlConnection = openURL(url);
+    urlConnection.getResponseCode();
+  }
+
   protected HttpURLConnection openURL(URL url) throws Exception {
     return (HttpURLConnection) url.openConnection();
   }
@@ -580,9 +604,18 @@ public abstract class NettyRouterTestBase {
         responder.sendStatus(HttpResponseStatus.OK);
       }
 
+      @GET
+      @Path("/v1/timeout/{timeout-millis}")
+      public void timeout(HttpRequest request, HttpResponder responder,
+                          @PathParam("timeout-millis") int timeoutMillis) throws InterruptedException {
+        numRequests.incrementAndGet();
+        TimeUnit.MILLISECONDS.sleep(timeoutMillis);
+        responder.sendStatus(HttpResponseStatus.OK);
+      }
+
       @POST
       @Path("/v1/upload")
-      public void upload(HttpRequest request, final HttpResponder responder) throws InterruptedException, IOException {
+      public void upload(HttpRequest request, HttpResponder responder) throws IOException {
         ChannelBuffer content = request.getContent();
 
         int readableBytes;

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterTestBase.java
@@ -394,7 +394,7 @@ public abstract class NettyRouterTestBase {
   public void testConnectionNoIdleTimeout() throws Exception {
     // even though the handler will sleep for 500ms over the configured idle timeout before responding, the connection
     // is not closed because the http request is in progress
-    long timeoutMillis = TimeUnit.SECONDS.toMillis(CONNECTION_IDLE_TIMEOUT_SECS) - 500;
+    long timeoutMillis = TimeUnit.SECONDS.toMillis(CONNECTION_IDLE_TIMEOUT_SECS) + 500;
     URL url = new URL(resolveURI(Constants.Router.GATEWAY_DISCOVERY_NAME, "/v1/timeout/" + timeoutMillis));
     HttpURLConnection urlConnection = openURL(url);
     urlConnection.getResponseCode();


### PR DESCRIPTION
NettyRouter now closes connections if there has been no HTTP request in flight for a given timeout.
The core of the implementation is in HttpIdleStateHandler.java.

The first commit is based off of Bhooshan's changes: https://github.com/caskdata/cdap/pull/4299
The second commit consists of changes that are new in this PR.

https://issues.cask.co/browse/CDAP-3887


Note: Opening this PR for review; once reviewed, these changes will be back-ported to previous releases (3.2.2 and 2.8.3).
TODO: additional unit testing and performance testing.