### PR TITLE
Fixes hydrator detailed (batch) - Poll for next run time + fixes lastrun duration

### DIFF
--- a/cdap-ui/app/features/hydrator/controllers/detail/top-panel-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/detail/top-panel-ctrl.js
@@ -28,12 +28,12 @@ angular.module(PKG.name + '.feature.hydrator')
       this.runsCount = DetailRunsStore.getRunsCount();
       var runs = DetailRunsStore.getRuns();
       var status, i;
-      var lastRunDuration = (runs.length > 0 && runs[0].end) ? runs[0].end - runs[0].start : angular.noop();
+      var lastRunDuration;
       var nextRunTime = DetailRunsStore.getNextRunTime();
-      var averageRunTime = DetailRunsStore.getStatistics().avgRunTime;
       if (nextRunTime) {
         nextRunTime = nextRunTime[0].time? nextRunTime[0].time: null;
       }
+      this.nextRunTime = nextRunTime || 'N/A';
       for (i=0 ; i<runs.length; i++) {
         status = runs[i].status;
         if (['RUNNING', 'STARTING', 'STOPPING'].indexOf(status) === -1) {
@@ -41,13 +41,13 @@ angular.module(PKG.name + '.feature.hydrator')
           break;
         }
       }
-
-      this.nextRunTime = nextRunTime || 'N/A';
-      if (lastRunDuration) {
+      if (this.lastFinished) {
+        lastRunDuration = this.lastFinished.end - this.lastFinished.start;
         this.lastRunTime = moment.utc(lastRunDuration * 1000).format('HH:mm:ss');
       } else {
         this.lastRunTime = 'N/A';
       }
+      var averageRunTime = DetailRunsStore.getStatistics().avgRunTime;
       // We get time as seconds from backend. So multiplying it by 1000 to give moment.js in milliseconds.
       if (averageRunTime) {
         this.avgRunTime = moment.utc( averageRunTime * 1000 ).format('HH:mm:ss');
@@ -66,7 +66,7 @@ angular.module(PKG.name + '.feature.hydrator')
         DetailRunsStore.getApi(),
         params
       );
-      PipelineDetailActionFactory.getNextRunTime(
+      PipelineDetailActionFactory.pollNextRunTime(
         DetailRunsStore.getApi(),
         DetailRunsStore.getParams()
       );

--- a/cdap-ui/app/features/hydrator/services/detail/actions/pipeline-detail-actions.js
+++ b/cdap-ui/app/features/hydrator/services/detail/actions/pipeline-detail-actions.js
@@ -41,8 +41,8 @@ angular.module(PKG.name + '.feature.hydrator')
           dispatcher.dispatch('onRunsChange', runs);
         });
     };
-    this.getNextRunTime = function(api, params) {
-      api.nextRunTime(params)
+    this.pollNextRunTime = function(api, params) {
+      api.pollNextRunTime(params)
         .$promise
         .then(function (nextRuntime) {
           dispatcher.dispatch('onNextRunTime', nextRuntime);

--- a/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-runs-store.js
+++ b/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-runs-store.js
@@ -125,7 +125,8 @@ angular.module(PKG.name + '.feature.hydrator')
         list: runs,
         count: runs.length,
         latest: runs[0],
-        runsCount: runs.length
+        runsCount: runs.length,
+        nextRunTime: this.state.runs.nextRunTime || null
       };
       if (this.state.type === GLOBALS.etlBatch) {
         this.state.logsParams.runId = this.state.runs.latest.properties.ETLMapReduce;

--- a/cdap-ui/app/services/hydrator/my-pipeline-detailed-common-api.js
+++ b/cdap-ui/app/services/hydrator/my-pipeline-detailed-common-api.js
@@ -41,7 +41,8 @@ angular.module(PKG.name + '.services')
 
         getRuns: myHelpers.getConfig('GET', 'REQUEST', runsPath),
         pollRuns: myHelpers.getConfig('GET', 'POLL', basePath + '/runs', true),
-        nextRunTime: myHelpers.getConfig('GET', 'REQUEST', basePath + '/nextruntime', true)
+        nextRunTime: myHelpers.getConfig('GET', 'REQUEST', basePath + '/nextruntime', true),
+        pollNextRunTime: myHelpers.getConfig('GET', 'POLL', basePath + '/nextruntime', true)
       }
     );
   });


### PR DESCRIPTION
- Fixes last run duration & last run time
- Fixes next runtime from REQUEST to POLL to update as soon as new value comes in.

Right now there is a latency in updating the last run's time and duration but this is because /runs end point in the backend doesn't update the status immediately. Ideally this should only be few seconds.

![streamsourceoutput](https://cloud.githubusercontent.com/assets/1452845/11606814/763e5a68-9ae3-11e5-9290-897b9f0e442d.gif)
