### PR TITLE
System Metadata

### DIFF
--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/FormatSpecification.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/FormatSpecification.java
@@ -34,6 +34,7 @@ public final class FormatSpecification {
   private final Map<String, String> settings;
 
   // for Gson deserialization, to make sure settings is an empty map and not null.
+  @SuppressWarnings("unused")
   private FormatSpecification() {
     this(null, null, Collections.<String, String>emptyMap());
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
@@ -36,6 +36,7 @@ import co.cask.cdap.internal.app.deploy.pipeline.DeletedProgramHandlerStage;
 import co.cask.cdap.internal.app.deploy.pipeline.DeployDatasetModulesStage;
 import co.cask.cdap.internal.app.deploy.pipeline.LocalArtifactLoaderStage;
 import co.cask.cdap.internal.app.deploy.pipeline.ProgramGenerationStage;
+import co.cask.cdap.internal.app.deploy.pipeline.SystemMetadataWriterStage;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.pipeline.Pipeline;
@@ -72,15 +73,15 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
   private final MetadataStore metadataStore;
 
   @Inject
-  public LocalApplicationManager(CConfiguration configuration, PipelineFactory pipelineFactory,
-                                 NamespacedLocationFactory namespacedLocationFactory,
-                                 Store store, StreamConsumerFactory streamConsumerFactory,
-                                 QueueAdmin queueAdmin, DatasetFramework datasetFramework,
-                                 @Named("datasetMDS") DatasetFramework inMemoryDatasetFramework,
-                                 StreamAdmin streamAdmin, Scheduler scheduler,
-                                 @Assisted ProgramTerminator programTerminator, MetricStore metricStore,
-                                 UsageRegistry usageRegistry, ArtifactRepository artifactRepository,
-                                 MetadataStore metadataStore) {
+  LocalApplicationManager(CConfiguration configuration, PipelineFactory pipelineFactory,
+                          NamespacedLocationFactory namespacedLocationFactory,
+                          Store store, StreamConsumerFactory streamConsumerFactory,
+                          QueueAdmin queueAdmin, DatasetFramework datasetFramework,
+                          @Named("datasetMDS") DatasetFramework inMemoryDatasetFramework,
+                          StreamAdmin streamAdmin, Scheduler scheduler,
+                          @Assisted ProgramTerminator programTerminator, MetricStore metricStore,
+                          UsageRegistry usageRegistry, ArtifactRepository artifactRepository,
+                          MetadataStore metadataStore) {
     this.configuration = configuration;
     this.namespacedLocationFactory = namespacedLocationFactory;
     this.pipelineFactory = pipelineFactory;
@@ -112,6 +113,7 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
     pipeline.addLast(new ProgramGenerationStage(configuration, namespacedLocationFactory));
     pipeline.addLast(new ApplicationRegistrationStage(store, usageRegistry));
     pipeline.addLast(new CreateSchedulesStage(scheduler));
+    pipeline.addLast(new SystemMetadataWriterStage(metadataStore));
     return pipeline.execute(input);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStage.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.deploy.pipeline;
+
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.service.ServiceSpecification;
+import co.cask.cdap.api.spark.SparkSpecification;
+import co.cask.cdap.api.worker.WorkerSpecification;
+import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
+import co.cask.cdap.data2.metadata.system.AppSystemMetadataWriter;
+import co.cask.cdap.data2.metadata.system.ProgramSystemMetadataWriter;
+import co.cask.cdap.pipeline.AbstractStage;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.reflect.TypeToken;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Stage to write system metadata for the application.
+ */
+public class SystemMetadataWriterStage extends AbstractStage<ApplicationWithPrograms> {
+
+  private final MetadataStore metadataStore;
+
+  public SystemMetadataWriterStage(MetadataStore metadataStore) {
+    super(TypeToken.of(ApplicationWithPrograms.class));
+    this.metadataStore = metadataStore;
+  }
+
+  @Override
+  public void process(ApplicationWithPrograms input) throws Exception {
+    // add system metadata for apps
+    ApplicationSpecification appSpec = input.getSpecification();
+    AbstractSystemMetadataWriter appSystemMetadataWriter = new AppSystemMetadataWriter(metadataStore, input.getId(),
+                                                                                       appSpec);
+    appSystemMetadataWriter.write();
+
+    // add system metadata for programs
+    Id.Program programId;
+    List<AbstractSystemMetadataWriter> programSystemMetadataWriters = new ArrayList<>();
+    for (MapReduceSpecification mrSpec : appSpec.getMapReduce().values()) {
+      programId = Id.Program.from(input.getId(), ProgramType.MAPREDUCE, mrSpec.getName());
+      programSystemMetadataWriters.add(new ProgramSystemMetadataWriter(metadataStore, programId, mrSpec));
+    }
+    for (FlowSpecification flowSpec : appSpec.getFlows().values()) {
+      programId = Id.Program.from(input.getId(), ProgramType.FLOW, flowSpec.getName());
+      programSystemMetadataWriters.add(new ProgramSystemMetadataWriter(metadataStore, programId, flowSpec));
+    }
+    for (WorkflowSpecification workflowSpec : appSpec.getWorkflows().values()) {
+      programId = Id.Program.from(input.getId(), ProgramType.WORKFLOW, workflowSpec.getName());
+      programSystemMetadataWriters.add(new ProgramSystemMetadataWriter(metadataStore, programId, workflowSpec));
+    }
+    for (ServiceSpecification serviceSpec : appSpec.getServices().values()) {
+      programId = Id.Program.from(input.getId(), ProgramType.SERVICE, serviceSpec.getName());
+      programSystemMetadataWriters.add(new ProgramSystemMetadataWriter(metadataStore, programId, serviceSpec));
+    }
+    for (SparkSpecification sparkSpec : appSpec.getSpark().values()) {
+      programId = Id.Program.from(input.getId(), ProgramType.SPARK, sparkSpec.getName());
+      programSystemMetadataWriters.add(new ProgramSystemMetadataWriter(metadataStore, programId, sparkSpec));
+    }
+    for (WorkerSpecification workerSpec : appSpec.getWorkers().values()) {
+      programId = Id.Program.from(input.getId(), ProgramType.WORKER, workerSpec.getName());
+      programSystemMetadataWriters.add(new ProgramSystemMetadataWriter(metadataStore, programId, workerSpec));
+    }
+
+    for (AbstractSystemMetadataWriter programSystemMetadataWriter : programSystemMetadataWriters) {
+      programSystemMetadataWriter.write();
+    }
+
+    // Emit input to the next stage
+    emit(input);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -45,6 +45,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -75,24 +76,24 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   @GET
   @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata")
   public void getAppMetadata(HttpRequest request, HttpResponder responder,
-                                @PathParam("namespace-id") String namespaceId,
-                                @PathParam("app-id") String appId) throws NotFoundException {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getMetadata(MetadataScope.USER, Id.Application.from(namespaceId, appId)),
-                       SET_METADATA_RECORD_TYPE, GSON);
+                             @PathParam("namespace-id") String namespaceId,
+                             @PathParam("app-id") String appId,
+                             @QueryParam("scope") MetadataScope scope) throws NotFoundException {
+    Id.Application app = Id.Application.from(namespaceId, appId);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(app, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/metadata")
   public void getProgramMetadata(HttpRequest request, HttpResponder responder,
-                                    @PathParam("namespace-id") String namespaceId,
-                                    @PathParam("app-id") String appId,
-                                    @PathParam("program-type") String programType,
-                                    @PathParam("program-id") String programId) throws NotFoundException {
+                                 @PathParam("namespace-id") String namespaceId,
+                                 @PathParam("app-id") String appId,
+                                 @PathParam("program-type") String programType,
+                                 @PathParam("program-id") String programId,
+                                 @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
                                          ProgramType.valueOfCategoryName(programType), programId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getMetadata(MetadataScope.USER, program),
-                       SET_METADATA_RECORD_TYPE, GSON);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(program, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
@@ -100,50 +101,51 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void getArtifactMetadata(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("artifact-name") String artifactName,
-                                  @PathParam("artifact-version") String artifactVersionStr) throws NotFoundException {
+                                  @PathParam("artifact-version") String artifactVersionStr,
+                                  @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getMetadata(MetadataScope.USER, artifactId),
-                       SET_METADATA_RECORD_TYPE, GSON);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(artifactId, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/metadata")
   public void getDatasetMetadata(HttpRequest request, HttpResponder responder,
                                  @PathParam("namespace-id") String namespaceId,
-                                 @PathParam("dataset-id") String datasetId) throws NotFoundException {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getMetadata(MetadataScope.USER, Id.DatasetInstance.from(namespaceId, datasetId)),
-                       SET_METADATA_RECORD_TYPE, GSON);
+                                 @PathParam("dataset-id") String datasetId,
+                                 @QueryParam("scope") MetadataScope scope) throws NotFoundException {
+    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(namespaceId, datasetId);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(datasetInstance, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/metadata")
   public void getStreamMetadata(HttpRequest request, HttpResponder responder,
                                 @PathParam("namespace-id") String namespaceId,
-                                @PathParam("stream-id") String streamId) throws Exception {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getMetadata(MetadataScope.USER, Id.Stream.from(namespaceId, streamId)),
-                       SET_METADATA_RECORD_TYPE, GSON);
+                                @PathParam("stream-id") String streamId,
+                                @QueryParam("scope") MetadataScope scope) throws Exception {
+    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(stream, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata")
   public void getViewMetadata(HttpRequest request, HttpResponder responder,
-                                @PathParam("namespace-id") String namespaceId,
-                                @PathParam("stream-id") String streamId,
-                                @PathParam("view-id") String viewId) throws NotFoundException {
+                              @PathParam("namespace-id") String namespaceId,
+                              @PathParam("stream-id") String streamId,
+                              @PathParam("view-id") String viewId,
+                              @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getMetadata(MetadataScope.USER, view),
-                       SET_METADATA_RECORD_TYPE, GSON);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(view, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata/properties")
   public void getAppProperties(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
-                               @PathParam("app-id") String appId) throws NotFoundException {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getProperties(MetadataScope.USER, Id.Application.from(namespaceId, appId)));
+                               @PathParam("app-id") String appId,
+                               @QueryParam("scope") MetadataScope scope) throws NotFoundException {
+    Id.Application app = Id.Application.from(namespaceId, appId);
+    responder.sendJson(HttpResponseStatus.OK, getProperties(app, scope));
   }
 
   @GET
@@ -151,9 +153,10 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void getArtifactProperties(HttpRequest request, HttpResponder responder,
                                     @PathParam("namespace-id") String namespaceId,
                                     @PathParam("artifact-name") String artifactName,
-                                    @PathParam("artifact-version") String artifactVersionStr) throws NotFoundException {
+                                    @PathParam("artifact-version") String artifactVersionStr,
+                                    @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getProperties(MetadataScope.USER, artifactId));
+    responder.sendJson(HttpResponseStatus.OK, getProperties(artifactId, scope));
   }
 
   @GET
@@ -162,39 +165,42 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                    @PathParam("namespace-id") String namespaceId,
                                    @PathParam("app-id") String appId,
                                    @PathParam("program-type") String programType,
-                                   @PathParam("program-id") String programId) throws NotFoundException {
+                                   @PathParam("program-id") String programId,
+                                   @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
                                          ProgramType.valueOfCategoryName(programType), programId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getProperties(MetadataScope.USER, program));
+    responder.sendJson(HttpResponseStatus.OK, getProperties(program, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/metadata/properties")
   public void getDatasetProperties(HttpRequest request, HttpResponder responder,
                                    @PathParam("namespace-id") String namespaceId,
-                                   @PathParam("dataset-id") String datasetId) throws NotFoundException {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getProperties(MetadataScope.USER,
-                                                   Id.DatasetInstance.from(namespaceId, datasetId)));
+                                   @PathParam("dataset-id") String datasetId,
+                                   @QueryParam("scope") MetadataScope scope) throws NotFoundException {
+    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(namespaceId, datasetId);
+    responder.sendJson(HttpResponseStatus.OK, getProperties(datasetInstance, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/metadata/properties")
   public void getStreamProperties(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
-                                  @PathParam("stream-id") String streamId) throws NotFoundException {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getProperties(MetadataScope.USER, Id.Stream.from(namespaceId, streamId)));
+                                  @PathParam("stream-id") String streamId,
+                                  @QueryParam("scope") MetadataScope scope) throws NotFoundException {
+    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    responder.sendJson(HttpResponseStatus.OK, getProperties(stream, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/properties")
   public void getViewProperties(HttpRequest request, HttpResponder responder,
-                                  @PathParam("namespace-id") String namespaceId,
-                                  @PathParam("stream-id") String streamId,
-                                  @PathParam("view-id") String viewId) throws NotFoundException {
+                                @PathParam("namespace-id") String namespaceId,
+                                @PathParam("stream-id") String streamId,
+                                @PathParam("view-id") String viewId,
+                                @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getProperties(MetadataScope.USER, view));
+    responder.sendJson(HttpResponseStatus.OK, getProperties(view, scope));
   }
 
   @POST
@@ -564,9 +570,10 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata/tags")
   public void getAppTags(HttpRequest request, HttpResponder responder,
                          @PathParam("namespace-id") String namespaceId,
-                         @PathParam("app-id") String appId) throws NotFoundException {
+                         @PathParam("app-id") String appId,
+                         @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Application app = Id.Application.from(namespaceId, appId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, app));
+    responder.sendJson(HttpResponseStatus.OK, getTags(app, scope));
   }
 
   @GET
@@ -574,10 +581,11 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void getArtifactTags(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId,
                               @PathParam("artifact-name") String artifactName,
-                              @PathParam("artifact-version") String artifactVersionStr)
+                              @PathParam("artifact-version") String artifactVersionStr,
+                              @QueryParam("scope") MetadataScope scope)
     throws BadRequestException, NotFoundException {
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, artifactId));
+    responder.sendJson(HttpResponseStatus.OK, getTags(artifactId, scope));
   }
 
   @GET
@@ -586,38 +594,42 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                              @PathParam("namespace-id") String namespaceId,
                              @PathParam("app-id") String appId,
                              @PathParam("program-type") String programType,
-                             @PathParam("program-id") String programId) throws NotFoundException {
+                             @PathParam("program-id") String programId,
+                             @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
                                          ProgramType.valueOfCategoryName(programType), programId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, program));
+    responder.sendJson(HttpResponseStatus.OK, getTags(program, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/metadata/tags")
   public void getDatasetTags(HttpRequest request, HttpResponder responder,
                              @PathParam("namespace-id") String namespaceId,
-                             @PathParam("dataset-id") String datasetId) throws NotFoundException {
+                             @PathParam("dataset-id") String datasetId,
+                             @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, dataset));
+    responder.sendJson(HttpResponseStatus.OK, getTags(dataset, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/metadata/tags")
   public void getStreamTags(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId,
-                            @PathParam("stream-id") String streamId) throws NotFoundException {
+                            @PathParam("stream-id") String streamId,
+                            @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Stream stream = Id.Stream.from(namespaceId, streamId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, stream));
+    responder.sendJson(HttpResponseStatus.OK, getTags(stream, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/tags")
   public void getViewTags(HttpRequest request, HttpResponder responder,
-                            @PathParam("namespace-id") String namespaceId,
-                            @PathParam("stream-id") String streamId,
-                            @PathParam("view-id") String viewId) throws NotFoundException {
+                          @PathParam("namespace-id") String namespaceId,
+                          @PathParam("stream-id") String streamId,
+                          @PathParam("view-id") String viewId,
+                          @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, view));
+    responder.sendJson(HttpResponseStatus.OK, getTags(view, scope));
   }
 
   @DELETE
@@ -824,5 +836,20 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                                                            metadataSearchTargetType);
 
     responder.sendJson(HttpResponseStatus.OK, results, SET_METADATA_SEARCH_RESULT_TYPE, GSON);
+  }
+
+  private Set<MetadataRecord> getMetadata(Id.NamespacedId entityId,
+                                          @Nullable MetadataScope scope) throws NotFoundException {
+    return  (scope == null) ? metadataAdmin.getMetadata(entityId) : metadataAdmin.getMetadata(scope, entityId);
+  }
+
+  private Map<String, String> getProperties(Id.NamespacedId entityId,
+                                            @Nullable MetadataScope scope) throws NotFoundException {
+    return  (scope == null) ? metadataAdmin.getProperties(entityId) : metadataAdmin.getProperties(scope, entityId);
+  }
+
+  private Set<String> getTags(Id.NamespacedId entityId,
+                              @Nullable MetadataScope scope) throws NotFoundException {
+    return  (scope == null) ? metadataAdmin.getTags(entityId) : metadataAdmin.getTags(scope, entityId);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Type;
+import java.net.URLDecoder;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -832,7 +833,8 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     } else {
       metadataSearchTargetType = null;
     }
-    Set<MetadataSearchResultRecord> results = metadataAdmin.searchMetadata(namespaceId, searchQuery,
+    Set<MetadataSearchResultRecord> results = metadataAdmin.searchMetadata(namespaceId,
+                                                                           URLDecoder.decode(searchQuery, "UTF-8"),
                                                                            metadataSearchTargetType);
 
     responder.sendJson(HttpResponseStatus.OK, results, SET_METADATA_SEARCH_RESULT_TYPE, GSON);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
@@ -32,6 +32,7 @@ import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.base.Predicate;
@@ -78,34 +79,34 @@ public class LineageTest extends MetadataTestBase {
       // Add metadata to applicaton
       ImmutableMap<String, String> appProperties = ImmutableMap.of("app-key1", "app-value1");
       addProperties(app, appProperties);
-      Assert.assertEquals(appProperties, getProperties(app));
+      Assert.assertEquals(appProperties, getProperties(app, MetadataScope.USER));
       ImmutableSet<String> appTags = ImmutableSet.of("app-tag1");
       addTags(app, appTags);
-      Assert.assertEquals(appTags, getTags(app));
+      Assert.assertEquals(appTags, getTags(app, MetadataScope.USER));
 
       // Add metadata to flow
       ImmutableMap<String, String> flowProperties = ImmutableMap.of("flow-key1", "flow-value1");
       addProperties(flow, flowProperties);
-      Assert.assertEquals(flowProperties, getProperties(flow));
+      Assert.assertEquals(flowProperties, getProperties(flow, MetadataScope.USER));
       ImmutableSet<String> flowTags = ImmutableSet.of("flow-tag1", "flow-tag2");
       addTags(flow, flowTags);
-      Assert.assertEquals(flowTags, getTags(flow));
+      Assert.assertEquals(flowTags, getTags(flow, MetadataScope.USER));
 
       // Add metadata to dataset
       ImmutableMap<String, String> dataProperties = ImmutableMap.of("data-key1", "data-value1");
       addProperties(dataset, dataProperties);
-      Assert.assertEquals(dataProperties, getProperties(dataset));
+      Assert.assertEquals(dataProperties, getProperties(dataset, MetadataScope.USER));
       ImmutableSet<String> dataTags = ImmutableSet.of("data-tag1", "data-tag2");
       addTags(dataset, dataTags);
-      Assert.assertEquals(dataTags, getTags(dataset));
+      Assert.assertEquals(dataTags, getTags(dataset, MetadataScope.USER));
 
       // Add metadata to stream
       ImmutableMap<String, String> streamProperties = ImmutableMap.of("stream-key1", "stream-value1");
       addProperties(stream, streamProperties);
-      Assert.assertEquals(streamProperties, getProperties(stream));
+      Assert.assertEquals(streamProperties, getProperties(stream, MetadataScope.USER));
       ImmutableSet<String> streamTags = ImmutableSet.of("stream-tag1", "stream-tag2");
       addTags(stream, streamTags);
-      Assert.assertEquals(streamTags, getTags(stream));
+      Assert.assertEquals(streamTags, getTags(stream, MetadataScope.USER));
 
       long startTime = TimeMathParser.nowInSeconds();
       RunId flowRunId = runAndWait(flow);
@@ -210,15 +211,15 @@ public class LineageTest extends MetadataTestBase {
       // Add metadata
       ImmutableSet<String> sparkTags = ImmutableSet.of("spark-tag1", "spark-tag2");
       addTags(spark, sparkTags);
-      Assert.assertEquals(sparkTags, getTags(spark));
+      Assert.assertEquals(sparkTags, getTags(spark, MetadataScope.USER));
 
       ImmutableSet<String> workerTags = ImmutableSet.of("worker-tag1");
       addTags(worker, workerTags);
-      Assert.assertEquals(workerTags, getTags(worker));
+      Assert.assertEquals(workerTags, getTags(worker, MetadataScope.USER));
 
       ImmutableMap<String, String> datasetProperties = ImmutableMap.of("data-key1", "data-value1");
       addProperties(dataset, datasetProperties);
-      Assert.assertEquals(datasetProperties, getProperties(dataset));
+      Assert.assertEquals(datasetProperties, getProperties(dataset, MetadataScope.USER));
 
       // Start all programs
       RunId flowRunId = runAndWait(flow);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -48,6 +48,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -515,7 +517,8 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, AllProgramsApp.STREAM_NAME);
     Assert.assertTrue(getTags(streamId, MetadataScope.SYSTEM).isEmpty());
     Map<String, String> streamSystemProperties = getProperties(streamId, MetadataScope.SYSTEM);
-    Assert.assertEquals(Schema.Type.STRING.toString(), streamSystemProperties.get("field\u0001body"));
+    Assert.assertEquals("field\u0001body",
+                        streamSystemProperties.get("field\u0001body\u0001" + Schema.Type.STRING.toString()));
     Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DATASET_NAME);
     Set<String> dsSystemTags = getTags(datasetInstance, MetadataScope.SYSTEM);
     Assert.assertEquals(4, dsSystemTags.size());
@@ -536,6 +539,9 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     assertProgramSystemMetadata(Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR.NAME), "Batch");
     assertProgramSystemMetadata(Id.Program.from(app, ProgramType.SPARK, AllProgramsApp.NoOpSpark.NAME), "Batch");
     assertProgramSystemMetadata(Id.Program.from(app, ProgramType.WORKFLOW, AllProgramsApp.NoOpWorkflow.NAME), "Batch");
+    String encoded = URLEncoder.encode("field\u0001body", "UTF-8");
+    Set<MetadataSearchResultRecord> metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT,
+                                                                                 encoded, null);
   }
 
   private void assertProgramSystemMetadata(Id.Program programId, String mode) throws Exception {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -16,11 +16,18 @@
 
 package co.cask.cdap.metadata;
 
+import co.cask.cdap.AllProgramsApp;
 import co.cask.cdap.AppWithDataset;
 import co.cask.cdap.WordCountApp;
 import co.cask.cdap.WordCountMinusFlowApp;
 import co.cask.cdap.api.Config;
+import co.cask.cdap.api.data.batch.BatchReadable;
+import co.cask.cdap.api.data.batch.BatchWritable;
+import co.cask.cdap.api.data.batch.RecordScannable;
+import co.cask.cdap.api.data.batch.RecordWritable;
 import co.cask.cdap.api.data.format.FormatSpecification;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
@@ -43,6 +50,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Tests for {@link MetadataHttpHandler}
@@ -106,17 +114,17 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Map<String, String> artifactProperties = ImmutableMap.of("rKey", "rValue", "rK", "rV");
     addProperties(artifactId, artifactProperties);
     // retrieve properties and verify
-    Map<String, String> properties = getProperties(application);
+    Map<String, String> properties = getProperties(application, MetadataScope.USER);
     Assert.assertEquals(appProperties, properties);
-    properties = getProperties(pingService);
+    properties = getProperties(pingService, MetadataScope.USER);
     Assert.assertEquals(serviceProperties, properties);
-    properties = getProperties(myds);
+    properties = getProperties(myds, MetadataScope.USER);
     Assert.assertEquals(datasetProperties, properties);
-    properties = getProperties(mystream);
+    properties = getProperties(mystream, MetadataScope.USER);
     Assert.assertEquals(streamProperties, properties);
-    properties = getProperties(myview);
+    properties = getProperties(myview, MetadataScope.USER);
     Assert.assertEquals(viewProperties, properties);
-    properties = getProperties(artifactId);
+    properties = getProperties(artifactId, MetadataScope.USER);
     Assert.assertEquals(artifactProperties, properties);
 
     // test search for stream
@@ -171,16 +179,16 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
 
     // test removal
     removeProperties(application);
-    Assert.assertTrue(getProperties(application).isEmpty());
+    Assert.assertTrue(getProperties(application, MetadataScope.USER).isEmpty());
     removeProperty(pingService, "sKey");
     removeProperty(pingService, "sK");
-    Assert.assertTrue(getProperties(pingService).isEmpty());
+    Assert.assertTrue(getProperties(pingService, MetadataScope.USER).isEmpty());
     removeProperty(myds, "dKey");
-    Assert.assertEquals(ImmutableMap.of("dK", "dV"), getProperties(myds));
+    Assert.assertEquals(ImmutableMap.of("dK", "dV"), getProperties(myds, MetadataScope.USER));
     removeProperty(mystream, "stK");
-    Assert.assertEquals(ImmutableMap.of("stKey", "stValue"), getProperties(mystream));
+    Assert.assertEquals(ImmutableMap.of("stKey", "stValue"), getProperties(mystream, MetadataScope.USER));
     removeProperty(myview, "viewK");
-    Assert.assertEquals(ImmutableMap.of("viewKey", "viewValue"), getProperties(myview));
+    Assert.assertEquals(ImmutableMap.of("viewKey", "viewValue"), getProperties(myview, MetadataScope.USER));
     // cleanup
     removeProperties(myview);
     removeProperties(application);
@@ -188,12 +196,12 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     removeProperties(myds);
     removeProperties(mystream);
     removeProperties(artifactId);
-    Assert.assertTrue(getProperties(application).isEmpty());
-    Assert.assertTrue(getProperties(pingService).isEmpty());
-    Assert.assertTrue(getProperties(myds).isEmpty());
-    Assert.assertTrue(getProperties(mystream).isEmpty());
-    Assert.assertTrue(getProperties(myview).isEmpty());
-    Assert.assertTrue(getProperties(artifactId).isEmpty());
+    Assert.assertTrue(getProperties(application, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getProperties(pingService, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getProperties(myds, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getProperties(mystream, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getProperties(myview, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getProperties(artifactId, MetadataScope.USER).isEmpty());
 
     // non-existing namespace
     addProperties(nonExistingApp, appProperties, NotFoundException.class);
@@ -226,22 +234,22 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Set<String> artifactTags = ImmutableSet.of("rTag", "rT");
     addTags(artifactId, artifactTags);
     // retrieve tags and verify
-    Set<String> tags = getTags(application);
+    Set<String> tags = getTags(application, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(appTags));
     Assert.assertTrue(appTags.containsAll(tags));
-    tags = getTags(pingService);
+    tags = getTags(pingService, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(serviceTags));
     Assert.assertTrue(serviceTags.containsAll(tags));
-    tags = getTags(myds);
+    tags = getTags(myds, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(datasetTags));
     Assert.assertTrue(datasetTags.containsAll(tags));
-    tags = getTags(mystream);
+    tags = getTags(mystream, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(streamTags));
     Assert.assertTrue(streamTags.containsAll(tags));
-    tags = getTags(myview);
+    tags = getTags(myview, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(viewTags));
     Assert.assertTrue(viewTags.containsAll(tags));
-    tags = getTags(artifactId);
+    tags = getTags(artifactId, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(artifactTags));
     Assert.assertTrue(artifactTags.containsAll(tags));
     // test search for stream
@@ -276,21 +284,21 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
 
     // test removal
     removeTag(application, "aTag");
-    Assert.assertEquals(ImmutableSet.of("aT"), getTags(application));
+    Assert.assertEquals(ImmutableSet.of("aT"), getTags(application, MetadataScope.USER));
     removeTags(pingService);
-    Assert.assertTrue(getTags(pingService).isEmpty());
+    Assert.assertTrue(getTags(pingService, MetadataScope.USER).isEmpty());
     removeTags(pingService);
-    Assert.assertTrue(getTags(pingService).isEmpty());
+    Assert.assertTrue(getTags(pingService, MetadataScope.USER).isEmpty());
     removeTag(myds, "dT");
-    Assert.assertEquals(ImmutableSet.of("dTag"), getTags(myds));
+    Assert.assertEquals(ImmutableSet.of("dTag"), getTags(myds, MetadataScope.USER));
     removeTag(mystream, "stT");
     removeTag(mystream, "stTag");
     removeTag(myview, "viewT");
     removeTag(myview, "viewTag");
-    Assert.assertTrue(getTags(mystream).isEmpty());
+    Assert.assertTrue(getTags(mystream, MetadataScope.USER).isEmpty());
     removeTag(artifactId, "rTag");
     removeTag(artifactId, "rT");
-    Assert.assertTrue(getTags(artifactId).isEmpty());
+    Assert.assertTrue(getTags(artifactId, MetadataScope.USER).isEmpty());
     // cleanup
     removeTags(application);
     removeTags(pingService);
@@ -298,11 +306,11 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     removeTags(mystream);
     removeTags(myview);
     removeTags(artifactId);
-    Assert.assertTrue(getTags(application).isEmpty());
-    Assert.assertTrue(getTags(pingService).isEmpty());
-    Assert.assertTrue(getTags(myds).isEmpty());
-    Assert.assertTrue(getTags(mystream).isEmpty());
-    Assert.assertTrue(getTags(artifactId).isEmpty());
+    Assert.assertTrue(getTags(application, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getTags(pingService, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getTags(myds, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getTags(mystream, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getTags(artifactId, MetadataScope.USER).isEmpty());
     // non-existing namespace
     addTags(nonExistingApp, appTags, NotFoundException.class);
     addTags(nonExistingService, serviceTags, NotFoundException.class);
@@ -314,10 +322,10 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
 
   @Test
   public void testMetadata() throws Exception {
-    assertCleanState();
+    assertCleanState(MetadataScope.USER);
     // Remove when nothing exists
     removeAllMetadata();
-    assertCleanState();
+    assertCleanState(MetadataScope.USER);
     // Add some properties and tags
     Map<String, String> appProperties = ImmutableMap.of("aKey", "aValue");
     Map<String, String> serviceProperties = ImmutableMap.of("sKey", "sValue");
@@ -344,7 +352,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     addTags(myview, viewTags);
     addTags(artifactId, artifactTags);
     // verify app
-    Set<MetadataRecord> metadataRecords = getMetadata(application);
+    Set<MetadataRecord> metadataRecords = getMetadata(application, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     MetadataRecord metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -352,7 +360,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(appProperties, metadata.getProperties());
     Assert.assertEquals(appTags, metadata.getTags());
     // verify service
-    metadataRecords = getMetadata(pingService);
+    metadataRecords = getMetadata(pingService, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -360,7 +368,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(serviceProperties, metadata.getProperties());
     Assert.assertEquals(serviceTags, metadata.getTags());
     // verify dataset
-    metadataRecords = getMetadata(myds);
+    metadataRecords = getMetadata(myds, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -368,7 +376,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(datasetProperties, metadata.getProperties());
     Assert.assertEquals(datasetTags, metadata.getTags());
     // verify stream
-    metadataRecords = getMetadata(mystream);
+    metadataRecords = getMetadata(mystream, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -376,7 +384,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(streamProperties, metadata.getProperties());
     Assert.assertEquals(streamTags, metadata.getTags());
     // verify view
-    metadataRecords = getMetadata(myview);
+    metadataRecords = getMetadata(myview, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -384,7 +392,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(viewProperties, metadata.getProperties());
     Assert.assertEquals(viewTags, metadata.getTags());
     // verify artifact
-    metadataRecords = getMetadata(artifactId);
+    metadataRecords = getMetadata(artifactId, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -393,7 +401,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(artifactTags, metadata.getTags());
     // cleanup
     removeAllMetadata();
-    assertCleanState();
+    assertCleanState(MetadataScope.USER);
   }
 
   @Test
@@ -406,7 +414,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     addProperties(program, flowProperties);
 
     // Get properties
-    Map<String, String> properties = getProperties(program);
+    Map<String, String> properties = getProperties(program, MetadataScope.USER);
     Assert.assertEquals(2, properties.size());
 
     //Delete the App after stopping the flow
@@ -487,7 +495,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     addProperties(program, flowProperties);
 
     // Get properties
-    Map<String, String> properties = getProperties(program);
+    Map<String, String> properties = getProperties(program, MetadataScope.USER);
     Assert.assertEquals(2, properties.size());
 
     // Deploy WordCount App without Flow program. No need to start/stop the flow.
@@ -501,6 +509,43 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     deleteApp(wordCountApp, 200);
   }
 
+  @Test
+  public void testSystemMetadata() throws Exception {
+    deploy(AllProgramsApp.class);
+    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, AllProgramsApp.STREAM_NAME);
+    Assert.assertTrue(getTags(streamId, MetadataScope.SYSTEM).isEmpty());
+    Map<String, String> streamSystemProperties = getProperties(streamId, MetadataScope.SYSTEM);
+    Assert.assertEquals(Schema.Type.STRING.toString(), streamSystemProperties.get("field\u0001body"));
+    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DATASET_NAME);
+    Set<String> dsSystemTags = getTags(datasetInstance, MetadataScope.SYSTEM);
+    Assert.assertEquals(4, dsSystemTags.size());
+    Assert.assertTrue(dsSystemTags.contains(BatchReadable.class.getSimpleName()));
+    Assert.assertTrue(dsSystemTags.contains(BatchWritable.class.getSimpleName()));
+    Assert.assertTrue(dsSystemTags.contains(RecordScannable.class.getSimpleName()));
+    Assert.assertTrue(dsSystemTags.contains(RecordWritable.class.getSimpleName()));
+    Map<String, String> dsSystemProperties = getProperties(datasetInstance, MetadataScope.SYSTEM);
+    Assert.assertEquals(KeyValueTable.class.getName(), dsSystemProperties.get("type"));
+    Id.Application app = Id.Application.from(Id.Namespace.DEFAULT, AllProgramsApp.NAME);
+    Set<String> appSystemTags = getTags(app, MetadataScope.SYSTEM);
+    Assert.assertEquals(AllProgramsApp.class.getSimpleName(), appSystemTags.iterator().next());
+    Assert.assertTrue(getProperties(app, MetadataScope.SYSTEM).isEmpty());
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.FLOW, AllProgramsApp.NoOpFlow.NAME), "Real-time");
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.WORKER, AllProgramsApp.NoOpWorker.NAME), "Real-time");
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.SERVICE, AllProgramsApp.NoOpService.NAME),
+                                "Real-time");
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR.NAME), "Batch");
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.SPARK, AllProgramsApp.NoOpSpark.NAME), "Batch");
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.WORKFLOW, AllProgramsApp.NoOpWorkflow.NAME), "Batch");
+  }
+
+  private void assertProgramSystemMetadata(Id.Program programId, String mode) throws Exception {
+    Assert.assertTrue(getProperties(programId, MetadataScope.SYSTEM).isEmpty());
+    Set<String> programSystemTags = getTags(programId, MetadataScope.SYSTEM);
+    Assert.assertEquals(2, programSystemTags.size());
+    Assert.assertTrue(programSystemTags.contains(programId.getType().getPrettyName()));
+    Assert.assertTrue(programSystemTags.contains(mode));
+  }
+
   private void removeAllMetadata() throws Exception {
     removeMetadata(application);
     removeMetadata(pingService);
@@ -510,43 +555,22 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     removeMetadata(artifactId);
   }
 
-  private void assertCleanState() throws Exception {
-    // Assert clean state
-    Set<MetadataRecord> appMetadatas = getMetadata(application);
-    // only user metadata right now.
-    Assert.assertEquals(1, appMetadatas.size());
-    MetadataRecord appMetadata = appMetadatas.iterator().next();
-    Assert.assertTrue(appMetadata.getProperties().isEmpty());
-    Assert.assertTrue(appMetadata.getTags().isEmpty());
-    Set<MetadataRecord> serviceMetadatas = getMetadata(pingService);
-    // only user metadata right now.
-    Assert.assertEquals(1, serviceMetadatas.size());
-    MetadataRecord serviceMetadata = serviceMetadatas.iterator().next();
-    Assert.assertTrue(serviceMetadata.getProperties().isEmpty());
-    Assert.assertTrue(serviceMetadata.getTags().isEmpty());
-    Set<MetadataRecord> datasetMetadatas = getMetadata(myds);
-    // only user metadata right now.
-    Assert.assertEquals(1, datasetMetadatas.size());
-    MetadataRecord datasetMetadata = datasetMetadatas.iterator().next();
-    Assert.assertTrue(datasetMetadata.getProperties().isEmpty());
-    Assert.assertTrue(datasetMetadata.getTags().isEmpty());
-    Set<MetadataRecord> streamMetadatas = getMetadata(mystream);
-    // only user metadata right now.
-    Assert.assertEquals(1, streamMetadatas.size());
-    MetadataRecord streamMetadata = streamMetadatas.iterator().next();
-    Assert.assertTrue(streamMetadata.getProperties().isEmpty());
-    Assert.assertTrue(streamMetadata.getTags().isEmpty());
-    Set<MetadataRecord> viewMetadatas = getMetadata(myview);
-    // only user metadata right now.
-    Assert.assertEquals(1, viewMetadatas.size());
-    MetadataRecord viewMetadata = viewMetadatas.iterator().next();
-    Assert.assertTrue(viewMetadata.getProperties().isEmpty());
-    Assert.assertTrue(viewMetadata.getTags().isEmpty());
-    Set<MetadataRecord> artifactMetadatas = getMetadata(artifactId);
-    // only user metadata right now.
-    Assert.assertEquals(1, artifactMetadatas.size());
-    MetadataRecord artifactMetadata = artifactMetadatas.iterator().next();
-    Assert.assertTrue(artifactMetadata.getProperties().isEmpty());
-    Assert.assertTrue(artifactMetadata.getTags().isEmpty());
+  private void assertCleanState(@Nullable MetadataScope scope) throws Exception {
+    assertEmptyMetadata(getMetadata(application, scope), scope);
+    assertEmptyMetadata(getMetadata(pingService, scope), scope);
+    assertEmptyMetadata(getMetadata(myds, scope), scope);
+    assertEmptyMetadata(getMetadata(mystream, scope), scope);
+    assertEmptyMetadata(getMetadata(myview, scope), scope);
+    assertEmptyMetadata(getMetadata(artifactId, scope), scope);
+  }
+
+  private void assertEmptyMetadata(Set<MetadataRecord> entityMetadata, @Nullable MetadataScope scope) {
+    // should have two metadata records - one for each scope, both should have empty properties and tags
+    int expectedRecords = (scope == null) ? 2 : 1;
+    Assert.assertEquals(expectedRecords, entityMetadata.size());
+    for (MetadataRecord metadataRecord : entityMetadata) {
+      Assert.assertTrue(metadataRecord.getProperties().isEmpty());
+      Assert.assertTrue(metadataRecord.getTags().isEmpty());
+    }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
@@ -160,57 +161,81 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
   }
 
   protected Set<MetadataRecord> getMetadata(Id.Application app) throws Exception {
-    return metadataClient.getMetadata(app);
+    return getMetadata(app, null);
   }
 
   protected Set<MetadataRecord> getMetadata(Id.Artifact artifact) throws Exception {
-    return metadataClient.getMetadata(artifact);
+    return getMetadata(artifact, null);
   }
 
   protected Set<MetadataRecord> getMetadata(Id.Program program) throws Exception {
-    return metadataClient.getMetadata(program);
+    return getMetadata(program, null);
   }
 
   protected Set<MetadataRecord> getMetadata(Id.DatasetInstance dataset) throws Exception {
-    return metadataClient.getMetadata(dataset);
+    return getMetadata(dataset, null);
   }
 
   protected Set<MetadataRecord> getMetadata(Id.Stream stream) throws Exception {
-    return metadataClient.getMetadata(stream);
+    return getMetadata(stream, null);
   }
 
   protected Set<MetadataRecord> getMetadata(Id.Stream.View view) throws Exception {
-    return metadataClient.getMetadata(view);
+    return getMetadata(view, null);
   }
 
-  // Currently, getMetadata(entity) returns a single-element set, so we can get the properties from there
-  protected Map<String, String> getProperties(Id.Application app) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(app).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.Application app, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(app, scope);
   }
 
-  protected Map<String, String> getProperties(Id.Artifact artifact) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(artifact).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.Artifact artifact, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(artifact, scope);
   }
 
-  protected Map<String, String> getProperties(Id.Program program) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(program).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.Program program, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(program, scope);
   }
 
-  protected Map<String, String> getProperties(Id.DatasetInstance dataset) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(dataset).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.DatasetInstance dataset,
+                                            @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(dataset, scope);
   }
 
-  protected Map<String, String> getProperties(Id.Stream stream) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(stream).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.Stream stream, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(stream, scope);
   }
 
-  protected Map<String, String> getProperties(Id.Stream.View view) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(view).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.Stream.View view, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(view, scope);
+  }
+
+  protected Map<String, String> getProperties(Id.Application app, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(app, scope).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.Artifact artifact, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(artifact, scope).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.Program program, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(program, scope).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.DatasetInstance dataset, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(dataset, scope).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.Stream stream, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(stream, scope).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.Stream.View view, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(view, scope).iterator()).getProperties();
   }
 
   protected void getPropertiesFromInvalidEntity(Id.Application app) throws Exception {
     try {
-      getProperties(app);
+      getProperties(app, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + app);
     } catch (NotFoundException expected) {
       // expected
@@ -219,7 +244,7 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
 
   protected void getPropertiesFromInvalidEntity(Id.Program program) throws Exception {
     try {
-      getProperties(program);
+      getProperties(program, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + program);
     } catch (NotFoundException expected) {
       // expected
@@ -228,7 +253,7 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
 
   protected void getPropertiesFromInvalidEntity(Id.DatasetInstance dataset) throws Exception {
     try {
-      getProperties(dataset);
+      getProperties(dataset, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + dataset);
     } catch (NotFoundException expected) {
       // expected
@@ -237,7 +262,7 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
 
   protected void getPropertiesFromInvalidEntity(Id.Stream stream) throws Exception {
     try {
-      getProperties(stream);
+      getProperties(stream, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + stream);
     } catch (NotFoundException expected) {
       // expected
@@ -245,7 +270,7 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
   }
   protected void getPropertiesFromInvalidEntity(Id.Stream.View view) throws Exception {
     try {
-      getProperties(view);
+      getProperties(view, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + view);
     } catch (NotFoundException expected) {
       // expected
@@ -416,33 +441,32 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
   }
 
   protected Set<MetadataSearchResultRecord> searchMetadata(Id.Namespace namespaceId, String query,
-                                                           MetadataSearchTargetType target) throws Exception {
+                                                           @Nullable MetadataSearchTargetType target) throws Exception {
     return metadataClient.searchMetadata(namespaceId, query, target);
   }
 
-  // Currently, getMetadata(entity) returns a single-element set, so we can get the tags from there
-  protected Set<String> getTags(Id.Application app) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(app).iterator()).getTags();
+  protected Set<String> getTags(Id.Application app, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(app, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Artifact artifact) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(artifact).iterator()).getTags();
+  protected Set<String> getTags(Id.Artifact artifact, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(artifact, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Program program) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(program).iterator()).getTags();
+  protected Set<String> getTags(Id.Program program, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(program, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.DatasetInstance dataset) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(dataset).iterator()).getTags();
+  protected Set<String> getTags(Id.DatasetInstance dataset, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(dataset, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Stream stream) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(stream).iterator()).getTags();
+  protected Set<String> getTags(Id.Stream stream, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(stream, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Stream.View view) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(view).iterator()).getTags();
+  protected Set<String> getTags(Id.Stream.View view, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(view, scope).iterator()).getTags();
   }
 
   protected void removeTags(Id.Application app) throws Exception {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
@@ -72,13 +72,13 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * tests that flowlets and batch jobs close their data sets.
+ * Tests that flowlets and batch jobs close their data sets.
  */
 @Category(XSlowTests.class)
 public class OpenCloseDataSetTest {
 
   @ClassRule
-  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
   private static Location namespaceHomeLocation;
 
   private static final Supplier<File> TEMP_FOLDER_SUPPLIER = new Supplier<File>() {
@@ -86,7 +86,7 @@ public class OpenCloseDataSetTest {
     @Override
     public File get() {
       try {
-        return tmpFolder.newFolder();
+        return TEMP_FOLDER.newFolder();
       } catch (IOException e) {
         throw Throwables.propagate(e);
       }
@@ -153,8 +153,11 @@ public class OpenCloseDataSetTest {
 
     // get the number of writes to the foo table
     Assert.assertEquals(4, TrackingTable.getTracker(tableName, "write"));
-    // only the flow has started with s single flowlet (service is loaded lazily on 1st request)
-    Assert.assertEquals(1, TrackingTable.getTracker(tableName, "open"));
+    // only 2 "open" calls should be tracked:
+    // 1. the flow has started with single flowlet (service is loaded lazily on 1st request)
+    // 2. DatasetSystemMetadataWriter also instantiates the dataset because it needs to add some system tags
+    // for the dataset
+    Assert.assertEquals(2, TrackingTable.getTracker(tableName, "open"));
 
     // now send a request to the service
     Gson gson = new Gson();
@@ -181,8 +184,9 @@ public class OpenCloseDataSetTest {
 
     // now the dataset must have a read and another open operation
     Assert.assertEquals(1, TrackingTable.getTracker(tableName, "read"));
-    Assert.assertEquals(2, TrackingTable.getTracker(tableName, "open"));
-    Assert.assertEquals(0, TrackingTable.getTracker(tableName, "close"));
+    Assert.assertEquals(3, TrackingTable.getTracker(tableName, "open"));
+    // The dataset that was instantiated by the DatasetSystemMetadataWriter should have been closed
+    Assert.assertEquals(1, TrackingTable.getTracker(tableName, "close"));
 
     // stop all programs, they should both close the data set foo
     for (ProgramController controller : controllers) {

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
 import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.common.http.HttpMethod;
@@ -95,7 +96,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Application appId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(appId, constructPath(appId));
+    return getMetadata(appId, null);
   }
 
   /**
@@ -104,7 +105,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Artifact artifactId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(artifactId, constructPath(artifactId));
+    return getMetadata(artifactId, null);
   }
 
   /**
@@ -113,7 +114,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.DatasetInstance datasetInstance)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(datasetInstance, constructPath(datasetInstance));
+    return getMetadata(datasetInstance, null);
   }
 
   /**
@@ -122,7 +123,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Stream streamId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(streamId, constructPath(streamId));
+    return getMetadata(streamId, null);
   }
 
   /**
@@ -131,7 +132,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Stream.View viewId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(viewId, constructPath(viewId));
+    return getMetadata(viewId, null);
   }
 
   /**
@@ -140,7 +141,61 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Program programId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(programId, constructPath(programId));
+    return getMetadata(programId, null);
+  }
+
+  /**
+   * @param appId the app for which to retrieve metadata
+   * @return The metadata for the application.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Application appId, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(appId, constructPath(appId), scope);
+  }
+
+  /**
+   * @param artifactId the artifact for which to retrieve metadata
+   * @return The metadata for the artifact.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Artifact artifactId, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(artifactId, constructPath(artifactId), scope);
+  }
+
+  /**
+   * @param datasetInstance the dataset for which to retrieve metadata
+   * @return The metadata for the dataset.
+   */
+  public Set<MetadataRecord> getMetadata(Id.DatasetInstance datasetInstance, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(datasetInstance, constructPath(datasetInstance), scope);
+  }
+
+  /**
+   * @param streamId the stream for which to retrieve metadata
+   * @return The metadata for the stream.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Stream streamId, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(streamId, constructPath(streamId), scope);
+  }
+
+  /**
+   * @param viewId the view for which to retrieve metadata
+   * @return The metadata for the view.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Stream.View viewId, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(viewId, constructPath(viewId), scope);
+  }
+
+  /**
+   * @param programId the program for which to retrieve metadata
+   * @return The metadata for the program.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Program programId, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(programId, constructPath(programId), scope);
   }
 
   /**
@@ -149,12 +204,19 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Run runId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(runId, constructPath(runId));
+    return doGetMetadata(runId, constructPath(runId));
   }
 
-  private Set<MetadataRecord> getMetadata(Id.NamespacedId namespacedId, String entityPath)
+  private Set<MetadataRecord> doGetMetadata(Id.NamespacedId namespacedId, String entityPath)
+    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    return doGetMetadata(namespacedId, entityPath, null);
+  }
+
+  private Set<MetadataRecord> doGetMetadata(Id.NamespacedId namespacedId, String entityPath,
+                                            @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata", entityPath);
+    path = scope == null ? path : String.format("%s?scope=%s", path, scope);
     HttpResponse response = makeRequest(namespacedId, path, HttpMethod.GET);
     return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_RECORD_TYPE);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -237,13 +237,11 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
 
   private DatasetInstanceConfiguration getInstanceConfiguration(HttpRequest request) {
     Reader reader = new InputStreamReader(new ChannelBufferInputStream(request.getContent()), Charsets.UTF_8);
-    DatasetInstanceConfiguration creationProperties = GSON.fromJson(reader, DatasetInstanceConfiguration.class);
-    return creationProperties;
+    return GSON.fromJson(reader, DatasetInstanceConfiguration.class);
   }
 
   private Map<String, String> getProperties(HttpRequest request) {
     Reader reader = new InputStreamReader(new ChannelBufferInputStream(request.getContent()), Charsets.UTF_8);
-    Map<String, String> properties = GSON.fromJson(reader, new TypeToken<Map<String, String>>() { }.getType());
-    return properties;
+    return GSON.fromJson(reader, new TypeToken<Map<String, String>>() { }.getType());
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
@@ -27,8 +27,8 @@ import java.util.Map;
  */
 public abstract class AbstractSystemMetadataWriter {
 
-  protected static final char CTRL_A = '\001';
-  protected static final String SCHEMA_FIELD_PROPERTY_PREFIX = "field";
+  public static final char CTRL_A = '\001';
+  public static final String SCHEMA_FIELD_PROPERTY_PREFIX = "schema";
 
   private final MetadataStore metadataStore;
   private final Id.NamespacedId entityId;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.metadata.MetadataScope;
+
+import java.util.Map;
+
+/**
+ * A class to write {@link MetadataScope#SYSTEM} metadata for an {@link Id.NamespacedId entity}.
+ */
+public abstract class AbstractSystemMetadataWriter {
+
+  protected static final char CTRL_A = '\001';
+  protected static final String SCHEMA_FIELD_PROPERTY_PREFIX = "field";
+
+  private final MetadataStore metadataStore;
+  private final Id.NamespacedId entityId;
+
+  public AbstractSystemMetadataWriter(MetadataStore metadataStore, Id.NamespacedId entityId) {
+    this.metadataStore = metadataStore;
+    this.entityId = entityId;
+  }
+
+  /**
+   * Define the {@link MetadataScope#SYSTEM system} metadata properties to add for this entity.
+   *
+   * @return A {@link Map} of properties to add to this {@link Id.NamespacedId entity} in {@link MetadataScope#SYSTEM}
+   */
+  abstract Map<String, String> getSystemPropertiesToAdd();
+
+  /**
+   * Define the {@link MetadataScope#SYSTEM system} tags to add for this entity.
+   *
+   * @return an array of tags to add to this {@link Id.NamespacedId entity} in {@link MetadataScope#SYSTEM}
+   */
+  abstract String[] getSystemTagsToAdd();
+
+  /**
+   * Updates the {@link MetadataScope#SYSTEM} metadata for this {@link Id.NamespacedId entity}.
+   */
+  public void write() {
+    Map<String, String> properties = getSystemPropertiesToAdd();
+    if (properties.size() > 0) {
+      metadataStore.setProperties(MetadataScope.SYSTEM, entityId, properties);
+    }
+    String[] tags = getSystemTagsToAdd();
+    if (tags.length > 0) {
+      metadataStore.addTags(MetadataScope.SYSTEM, entityId, tags);
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AppSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AppSystemMetadataWriter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * A {@link AbstractSystemMetadataWriter} for an {@link Id.Application application}.
+ */
+public class AppSystemMetadataWriter extends AbstractSystemMetadataWriter {
+
+  private ApplicationSpecification appSpec;
+
+  public AppSystemMetadataWriter(MetadataStore metadataStore, Id.Application entityId,
+                                 ApplicationSpecification appSpec) {
+    super(metadataStore, entityId);
+    this.appSpec = appSpec;
+  }
+
+  @Override
+  Map<String, String> getSystemPropertiesToAdd() {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    for (Map.Entry<String, Plugin> pluginEntry : appSpec.getPlugins().entrySet()) {
+      String pluginId = pluginEntry.getKey();
+      PluginClass pluginClass = pluginEntry.getValue().getPluginClass();
+      properties.put("plugin" + CTRL_A + pluginId + CTRL_A + "type", pluginClass.getType());
+      properties.put("plugin" + CTRL_A + pluginId + CTRL_A + "name", pluginClass.getName());
+    }
+    return properties.build();
+  }
+
+  @Override
+  String[] getSystemTagsToAdd() {
+    return new String[]{appSpec.getArtifactId().getName()};
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriter.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.api.data.batch.BatchReadable;
+import co.cask.cdap.api.data.batch.BatchWritable;
+import co.cask.cdap.api.data.batch.RecordScannable;
+import co.cask.cdap.api.data.batch.RecordWritable;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link AbstractSystemMetadataWriter} for a {@link Id.DatasetInstance dataset}.
+ */
+public class DatasetSystemMetadataWriter extends AbstractSystemMetadataWriter {
+  private final Id.DatasetInstance dsInstance;
+  private final String dsType;
+  private final DatasetProperties dsProperties;
+  private final SystemDatasetInstantiatorFactory dsInstantiatorFactory;
+
+  public DatasetSystemMetadataWriter(MetadataStore metadataStore,
+                                     SystemDatasetInstantiatorFactory dsInstantiatorFactory,
+                                     Id.DatasetInstance dsInstance, DatasetProperties dsProperties,
+                                     @Nullable String dsType) {
+    super(metadataStore, dsInstance);
+    this.dsInstance = dsInstance;
+    this.dsType = dsType;
+    this.dsProperties = dsProperties;
+    this.dsInstantiatorFactory = dsInstantiatorFactory;
+  }
+
+  @Override
+  Map<String, String> getSystemPropertiesToAdd() {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    if (dsProperties.getProperties().containsKey("schema")) {
+      addSchema(properties, dsProperties.getProperties().get("schema"));
+    }
+    if (dsType != null) {
+      properties.put("type", dsType);
+    }
+    return properties.build();
+  }
+
+  @Override
+  String[] getSystemTagsToAdd() {
+    List<String> tags = new ArrayList<>();
+    try (SystemDatasetInstantiator dsInstantiator = dsInstantiatorFactory.create();
+         Dataset dataset = dsInstantiator.getDataset(dsInstance);) {
+      if (dataset instanceof RecordScannable) {
+        tags.add(RecordScannable.class.getSimpleName());
+      }
+      if (dataset instanceof RecordWritable) {
+        tags.add(RecordWritable.class.getSimpleName());
+      }
+      if (dataset instanceof BatchReadable) {
+        tags.add(BatchReadable.class.getSimpleName());
+      }
+      if (dataset instanceof BatchWritable) {
+        tags.add(BatchWritable.class.getSimpleName());
+      }
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    return tags.toArray(new String[tags.size()]);
+  }
+
+  private void addSchema(ImmutableMap.Builder<String, String> propertiesToUpdate, String schemaStr) {
+    Schema schema = getSchema(schemaStr);
+    if (schema.isSimpleOrNullableSimple()) {
+      Schema.Type type;
+      if (schema.isNullable()) {
+        type = schema.getNonNullable().getType();
+      } else {
+        type = schema.getType();
+      }
+      propertiesToUpdate.put(SCHEMA_FIELD_PROPERTY_PREFIX, type.toString());
+    } else {
+      for (Schema.Field field : schema.getFields()) {
+        propertiesToUpdate.put(SCHEMA_FIELD_PROPERTY_PREFIX + CTRL_A + field.getName(), field.getSchema().toString());
+      }
+    }
+  }
+
+  private Schema getSchema(String schemaStr) {
+    if (schemaStr.startsWith("\"") && schemaStr.endsWith("\"")) {
+      // simple type in lower case
+      schemaStr = schemaStr.substring(1, schemaStr.length() - 1);
+      return Schema.of(Schema.Type.valueOf(schemaStr.toUpperCase()));
+    }
+    // otherwise its a json
+    try {
+      return Schema.parseJson(schemaStr);
+    } catch (IOException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ProgramSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ProgramSystemMetadataWriter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * A {@link AbstractSystemMetadataWriter} for a {@link Id.Program program}.
+ */
+public class ProgramSystemMetadataWriter extends AbstractSystemMetadataWriter {
+  private final Id.Program programId;
+  private final ProgramSpecification programSpec;
+
+  public ProgramSystemMetadataWriter(MetadataStore metadataStore, Id.Program programId,
+                                     ProgramSpecification programSpec) {
+    super(metadataStore, programId);
+    this.programId = programId;
+    this.programSpec = programSpec;
+  }
+
+  @Override
+  Map<String, String> getSystemPropertiesToAdd() {
+    return ImmutableMap.of();
+  }
+
+  @Override
+  String[] getSystemTagsToAdd() {
+    return new String[]{programId.getType().getPrettyName(), getMode()};
+  }
+
+  public String getMode() {
+    String mode;
+    switch (programId.getType()) {
+      case MAPREDUCE:
+      case SPARK:
+      case WORKFLOW:
+      case CUSTOM_ACTION:
+        mode = "Batch";
+        break;
+      case FLOW:
+      case WORKER:
+      case SERVICE:
+        mode = "Real-time";
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown program type " + programId.getType());
+    }
+    return mode;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.data2.transaction.stream.StreamConfig;
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * A {@link AbstractSystemMetadataWriter} for a {@link Id.Stream stream}.
+ */
+public class StreamSystemMetadataWriter extends AbstractSystemMetadataWriter {
+
+  private final StreamConfig config;
+
+  public StreamSystemMetadataWriter(MetadataStore metadataStore, Id.Stream streamId, StreamConfig config) {
+    super(metadataStore, streamId);
+    this.config = config;
+  }
+
+  @Override
+  Map<String, String> getSystemPropertiesToAdd() {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    Schema schema = config.getFormat().getSchema();
+    if (schema != null) {
+      for (Schema.Field field : schema.getFields()) {
+        properties.put(SCHEMA_FIELD_PROPERTY_PREFIX + CTRL_A + field.getName(), field.getSchema().getType().toString());
+      }
+    }
+    return properties.build();
+  }
+
+  @Override
+  String[] getSystemTagsToAdd() {
+    return new String[0];
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
@@ -42,7 +42,10 @@ public class StreamSystemMetadataWriter extends AbstractSystemMetadataWriter {
     Schema schema = config.getFormat().getSchema();
     if (schema != null) {
       for (Schema.Field field : schema.getFields()) {
-        properties.put(SCHEMA_FIELD_PROPERTY_PREFIX + CTRL_A + field.getName(), field.getSchema().getType().toString());
+        String fieldName = field.getName();
+        String fieldType = field.getSchema().getType().toString();
+        properties.put(SCHEMA_FIELD_PROPERTY_PREFIX + CTRL_A + fieldName + CTRL_A + fieldType,
+                       SCHEMA_FIELD_PROPERTY_PREFIX + CTRL_A + fieldName);
       }
     }
     return properties.build();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
@@ -22,7 +22,6 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ViewSpecification;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ViewSpecification;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@link AbstractSystemMetadataWriter} for an {@link Id.Stream.View view}.
+ */
+public class ViewSystemMetadataWriter extends AbstractSystemMetadataWriter {
+
+  private final ViewSpecification viewSpec;
+
+  public ViewSystemMetadataWriter(MetadataStore metadataStore, Id.Stream.View viewId, ViewSpecification viewSpec) {
+    super(metadataStore, viewId);
+    this.viewSpec = viewSpec;
+  }
+
+  @Override
+  Map<String, String> getSystemPropertiesToAdd() {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    Schema schema = viewSpec.getFormat().getSchema();
+    if (schema != null) {
+      for (Schema.Field field : schema.getFields()) {
+        properties.put(SCHEMA_FIELD_PROPERTY_PREFIX + CTRL_A + field.getName(), field.getSchema().toString());
+      }
+    }
+    return properties.build();
+  }
+
+  @Override
+  String[] getSystemTagsToAdd() {
+    return new String[0];
+  }
+}


### PR DESCRIPTION
System Metadata Support
Issue: https://issues.cask.co/browse/CDAP-4264
Doc: https://wiki.cask.co/display/CE/Metadata+and+Data+Discovery+3.3
Build: http://builds.cask.co/browse/CDAP-DUT3284-1

This PR has 3 commits:
1. The first commit in this branch adds the ability to manage system metadata. It is added/updated/deleted automatically when an app/dataset/stream/view is added/updated/deleted. For datasets/streams/views, also adds schema as metadata. Also includes REST APIs to retrieve system metadata for an entity.
2. The second commit changes the order (key becomes value, value becomes key) of how schema fields are stored as system metadata. This is to make it easier to implement search the following types:
  a. Entity that contains a field.
  b. Entity that contains a field with a specified type.
It currently does this only for streams, but if this is the right approach, we should make this switch for datasets and views too.
3. Add capability to allow user to query for schema with fieldname and/or type with ":" which we replace with CTRL+A character with which we store and adds tests for schema search. 

Few open question which I will like to get answered
1. Currently, we do not add any system metadata for an artifact. 
What will be the needed system metadata for an artifact ?
2. Please provide your feedback on schema storage and search as soon as possible so that if it's okay for this release then I will add it to dataset and views too.

