### PR TITLE
CDAP-4229 output schema propagation

### DIFF
--- a/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/MapReducePipelineConfigurer.java
+++ b/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/MapReducePipelineConfigurer.java
@@ -24,6 +24,8 @@ import co.cask.cdap.api.mapreduce.MapReduceConfigurer;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.plugin.PluginSelector;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
+import co.cask.cdap.etl.common.DefaultStageConfigurer;
 
 import javax.annotation.Nullable;
 
@@ -32,11 +34,13 @@ import javax.annotation.Nullable;
  */
 public class MapReducePipelineConfigurer implements PipelineConfigurer {
   private final MapReduceConfigurer mrConfigurer;
-  private final String prefixId;
+  private final String stageName;
+  private final StageConfigurer stageConfigurer;
 
-  public MapReducePipelineConfigurer(MapReduceConfigurer configurer, String prefixId) {
+  public MapReducePipelineConfigurer(MapReduceConfigurer configurer, String stageName) {
     this.mrConfigurer = configurer;
-    this.prefixId = prefixId;
+    this.stageName = stageName;
+    this.stageConfigurer = new DefaultStageConfigurer(stageName);
   }
 
   @Override
@@ -82,27 +86,32 @@ public class MapReducePipelineConfigurer implements PipelineConfigurer {
   @Nullable
   @Override
   public <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties properties) {
-    return mrConfigurer.usePlugin(pluginType, pluginName, prefixId + pluginId, properties);
+    return mrConfigurer.usePlugin(pluginType, pluginName, stageName + pluginId, properties);
   }
 
   @Nullable
   @Override
   public <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties properties,
                          PluginSelector selector) {
-    return mrConfigurer.usePlugin(pluginType, pluginName, prefixId + pluginId, properties, selector);
+    return mrConfigurer.usePlugin(pluginType, pluginName, stageName + pluginId, properties, selector);
   }
 
   @Nullable
   @Override
   public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId,
                                      PluginProperties properties) {
-    return mrConfigurer.usePluginClass(pluginType, pluginName, prefixId + pluginId, properties);
+    return mrConfigurer.usePluginClass(pluginType, pluginName, stageName + pluginId, properties);
   }
 
   @Nullable
   @Override
   public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId, PluginProperties properties,
                                      PluginSelector selector) {
-    return mrConfigurer.usePluginClass(pluginType, pluginName, prefixId + pluginId, properties, selector);
+    return mrConfigurer.usePluginClass(pluginType, pluginName, stageName + pluginId, properties, selector);
+  }
+
+  @Override
+  public StageConfigurer getStageConfigurer() {
+    return stageConfigurer;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageConfigurer.java
@@ -17,18 +17,28 @@
 package co.cask.cdap.etl.api;
 
 import co.cask.cdap.api.annotation.Beta;
-import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.api.data.schema.Schema;
+
+import javax.annotation.Nullable;
 
 /**
- * Configures an ETL Pipeline. Allows adding datasets and streams, which will be created when a pipeline is created.
- * Using this as a layer between plugins and CDAP's PluginConfigurer in case pipelines need etl specific methods.
+ * This stores the input schema that is passed to this stage from other stages in the pipeline and
+ * the output schema that could be sent to the next stages from this stage.
  */
 @Beta
-public interface PipelineConfigurer extends PluginConfigurer {
+public interface StageConfigurer {
 
   /**
-   * Get stage configurer for the pipeline stage
-   * @return stage configurer
+   * get the input schema for this stage, or null if its unknown
+   * @return input schema
    */
-  StageConfigurer getStageConfigurer();
+  @Nullable
+  Schema getInputSchema();
+
+  /**
+   * set output schema for this stage, or null if its unknown
+   * @param outputSchema output schema for this stage
+   */
+  void setOutputSchema(@Nullable Schema outputSchema);
+
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -359,7 +359,7 @@ public class ETLMapReduce extends AbstractMapReduce {
                                                 new ArrayList<String>()));
       }
 
-      transformExecutor = new TransformExecutor(transformations, ImmutableList.of(sourcePluginId));
+      transformExecutor = new TransformExecutor<>(transformations, ImmutableList.of(sourcePluginId));
 
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultPipelineConfigurer.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.plugin.PluginConfigurer;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.plugin.PluginSelector;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 
 import javax.annotation.Nullable;
 
@@ -34,11 +35,13 @@ import javax.annotation.Nullable;
  */
 public class DefaultPipelineConfigurer implements PipelineConfigurer {
   private final PluginConfigurer configurer;
-  private final String pluginPrefix;
+  private final String stageName;
+  private final DefaultStageConfigurer stageConfigurer;
 
-  public DefaultPipelineConfigurer(PluginConfigurer configurer, String pluginPrefix) {
+  public DefaultPipelineConfigurer(PluginConfigurer configurer, String stageName) {
     this.configurer = configurer;
-    this.pluginPrefix = pluginPrefix;
+    this.stageName = stageName;
+    this.stageConfigurer = new DefaultStageConfigurer(stageName);
   }
 
   @Override
@@ -109,6 +112,11 @@ public class DefaultPipelineConfigurer implements PipelineConfigurer {
   }
   
   private String getPluginId(String childPluginId) {
-    return String.format("%s%s%s", pluginPrefix, Constants.ID_SEPARATOR, childPluginId);
+    return String.format("%s%s%s", stageName, Constants.ID_SEPARATOR, childPluginId);
+  }
+
+  @Override
+  public StageConfigurer getStageConfigurer() {
+    return stageConfigurer;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultStageConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultStageConfigurer.java
@@ -1,0 +1,67 @@
+/**
+ *
+ */
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.etl.api.StageConfigurer;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+
+/**
+ * This stores the input schema that is passed to this stage from other stages in the pipeline and
+ * the output schema that could be sent to the next stages from this stage.
+ * Currently we only allow a sinlge input/output schema per stage
+ */
+public class DefaultStageConfigurer implements StageConfigurer {
+  private Schema outputSchema;
+  private Schema inputSchema;
+  private final String stageName;
+  boolean inputSchemaSet;
+
+  public DefaultStageConfigurer(String stageName) {
+    this.stageName = stageName;
+    this.inputSchemaSet = false;
+  }
+
+  public Schema getOutputSchema() {
+    return outputSchema;
+  }
+
+  @Override
+  @Nullable
+  public Schema getInputSchema() {
+    return inputSchema;
+  }
+
+  @Override
+  public void setOutputSchema(@Nullable Schema outputSchema) {
+    this.outputSchema = outputSchema;
+  }
+
+  public void setInputSchema(@Nullable Schema inputSchema) {
+    if (this.inputSchemaSet && !Objects.equals(this.inputSchema, inputSchema)) {
+      throw new IllegalArgumentException("Two different input schema were set for the stage " + stageName);
+    }
+    this.inputSchema = inputSchema;
+    this.inputSchemaSet = true;
+  }
+}
+


### PR DESCRIPTION
configuring pipeline with a sorted order and configuring the pipeline with appropriate input schemas for validating schema during configuring a pipeline. 

JIRA : https://issues.cask.co/browse/CDAP-4229
Build : http://builds.cask.co/browse/CDAP-DUT3287-1