### PR TITLE
CDAP-4006 Fail gracefully on Hive error

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -232,6 +232,11 @@ set_hive_classpath() {
 
       if [[ $(which hive 2>/dev/null) ]]; then
         HIVE_VAR_OUT=$(hive -e 'set -v' 2>/dev/null)
+        __ret=$?
+        if [ ${__ret} -ne 0 ]; then
+          echo "ERROR - Problem running: hive -e 'set -v'"
+          return 1
+        fi
         HIVE_VARS=$(echo ${HIVE_VAR_OUT} | tr ' ' '\n')
         # Quotes preserve whitespace
         HIVE_HOME=${HIVE_HOME:-$(echo -e "${HIVE_VARS}" | grep '^env:HIVE_HOME=' | cut -d= -f2)}


### PR DESCRIPTION
This causes the script to fail on a Hive error, informing the user of the failed command.

https://issues.cask.co/browse/CDAP-4006