### PR TITLE
[CDAP 4338] Do not expire datasets based on GC's weak references; introduce a new API dismissDataset()

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetContext.java
@@ -24,7 +24,10 @@ import java.util.Map;
  * This interface provides methods that instantiate a Dataset during the runtime
  * of a program. If the same arguments are provided for the same dataset, then the
  * returned instance is the same as returned by previous calls.
+ *
+ * @deprecated replaced by {@link DatasetProvider}
  */
+@Deprecated
 public interface DatasetContext {
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetProvider.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetProvider.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.data;
 
+import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.dataset.Dataset;
 
 import java.util.Map;
@@ -41,6 +42,7 @@ public interface DatasetProvider extends DatasetContext {
    *
    * @param dataset The dataset to be released.
    */
+  @Beta
   void releaseDataset(Dataset dataset);
 
   /**
@@ -62,5 +64,6 @@ public interface DatasetProvider extends DatasetContext {
    *
    * @param dataset The dataset to be dismissed.
    */
+  @Beta
   void discardDataset(Dataset dataset);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetProvider.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetProvider.java
@@ -33,6 +33,11 @@ public interface DatasetProvider extends DatasetContext {
    * or {@link #getDataset(String, Map)}. It is up to the implementation of the
    * provider whether this dataset is discarded, or whether it is reused as the
    * result for subsequent {@link #getDataset} calls with the same arguments.
+   * This may be influenced by resource constraints, expiration policy, or
+   * advanced configuration.
+   * <p>
+   * Note: In the current implementation, this is equivalent to {@link #discardDataset(Dataset)}.
+   * </p>
    *
    * @param dataset The dataset to be released.
    */
@@ -40,10 +45,20 @@ public interface DatasetProvider extends DatasetContext {
 
   /**
    * Calling this means that the dataset is not used by the caller any more,
-   * and the DatasetProvider must close and discard it. The dataset must
-   * have been acquired through this provider using {@link #getDataset(String)}
-   * or {@link #getDataset(String, Map)}. It is guaranteed that no subsequent
-   * invocation of {@link #getDataset} will return the same object.
+   * and the DatasetProvider must close and discard it as soon as possible.
+   * The dataset must have been acquired through this provider using
+   * {@link #getDataset(String)} or {@link #getDataset(String, Map)}.
+   * <p>
+   * It is guaranteed that no subsequent
+   * invocation of {@link #getDataset} will return the same object. The only
+   * exception is if getDataset() is called again before the dataset could be
+   * effectively discarded. For example, if the dataset participates in a
+   * transaction, then the system can only discard it after that transaction
+   * has completed. If getDataset() is called again during the same transaction,
+   * then the DatasetProvider will return the same object, and this effectively
+   * cancels the discardDataset(), because the dataset was reacquired before it
+   * could be discarded.
+   * </p>
    *
    * @param dataset The dataset to be dismissed.
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetProvider.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetProvider.java
@@ -47,5 +47,5 @@ public interface DatasetProvider extends DatasetContext {
    *
    * @param dataset The dataset to be dismissed.
    */
-  void dismissDataset(Dataset dataset);
+  void discardDataset(Dataset dataset);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -174,8 +174,8 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   }
 
   @Override
-  public void dismissDataset(Dataset dataset) {
-    datasetCache.dismissDataset(dataset);
+  public void discardDataset(Dataset dataset) {
+    datasetCache.discardDataset(dataset);
   }
 
   public String getNamespaceId() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -260,7 +260,7 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
   }
 
   @Override
-  public void dismissDataset(Dataset dataset) {
+  public void discardDataset(Dataset dataset) {
     // nop-op: all datasets have to participate until the transaction (that is, the program) finishes
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -105,8 +105,8 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   }
 
   @Override
-  public void dismissDataset(Dataset dataset) {
-    delegate.dismissDataset(dataset);
+  public void discardDataset(Dataset dataset) {
+    delegate.discardDataset(dataset);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
@@ -114,8 +114,8 @@ public final class ClientSparkContext extends AbstractSparkContext {
   }
 
   @Override
-  public void dismissDataset(Dataset dataset) {
-    datasetCache.dismissDataset(dataset);
+  public void discardDataset(Dataset dataset) {
+    datasetCache.discardDataset(dataset);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionSparkContext.java
@@ -289,7 +289,7 @@ public class ExecutionSparkContext extends AbstractSparkContext {
   }
 
   @Override
-  public void dismissDataset(Dataset dataset) {
+  public void discardDataset(Dataset dataset) {
     // nop-op: all datasets have to participate until the transaction (that is, the program) finishes
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -440,7 +440,7 @@ public class HttpHandlerGeneratorTest {
     }
 
     @Override
-    public void dismissDataset(Dataset dataset) {
+    public void discardDataset(Dataset dataset) {
       // nop-op
     }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetCache.java
@@ -126,7 +126,7 @@ public abstract class DynamicDatasetCache implements DatasetProvider, Supplier<T
 
   @Override
   public void releaseDataset(Dataset dataset) {
-    dismissDataset(dataset);
+    discardDataset(dataset);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/MultiThreadDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/MultiThreadDatasetCache.java
@@ -104,8 +104,8 @@ public class MultiThreadDatasetCache extends DynamicDatasetCache {
   }
 
   @Override
-  public void dismissDataset(Dataset dataset) {
-    entryForCurrentThread().dismissDataset(dataset);
+  public void discardDataset(Dataset dataset) {
+    entryForCurrentThread().discardDataset(dataset);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/DynamicDatasetCacheTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/DynamicDatasetCacheTest.java
@@ -167,9 +167,9 @@ public abstract class DynamicDatasetCacheTest {
     Assert.assertSame(b, txAwares.get(1));
     Assert.assertSame(c, txAwares.get(2));
 
-    // dismiss b and c, validate that they are not closed yet
-    cache.dismissDataset(b);
-    cache.dismissDataset(c);
+    // discard b and c, validate that they are not closed yet
+    cache.discardDataset(b);
+    cache.discardDataset(c);
     Assert.assertNull(System.getProperty(TestDataset.generateSystemProperty("b", "k", "b", "close")));
     Assert.assertNull(System.getProperty(TestDataset.generateSystemProperty("c", "c", "c", "close")));
 
@@ -192,9 +192,9 @@ public abstract class DynamicDatasetCacheTest {
     Assert.assertSame(b, txAwares.get(1));
     Assert.assertSame(c, txAwares.get(2));
 
-    // dismiss b and c, validate that they are not closed yet
-    cache.dismissDataset(b);
-    cache.dismissDataset(c);
+    // discard b and c, validate that they are not closed yet
+    cache.discardDataset(b);
+    cache.discardDataset(c);
     Assert.assertNull(System.getProperty(TestDataset.generateSystemProperty("b", "k", "b", "close")));
     Assert.assertNull(System.getProperty(TestDataset.generateSystemProperty("c", "c", "c", "close")));
 
@@ -226,18 +226,18 @@ public abstract class DynamicDatasetCacheTest {
     Assert.assertNotNull(System.getProperty(TestDataset.generateSystemProperty("b", "k", "b", "tx")));
     Assert.assertNull(System.getProperty(TestDataset.generateSystemProperty("c", "c", "c", "tx")));
 
-    // validate that dismissing a dataset that is not in the tx does not cause errors
-    cache.dismissDataset(c);
+    // validate that discarding a dataset that is not in the tx does not cause errors
+    cache.discardDataset(c);
 
-    // get a new instance of c, validate that it is not the same as before, that is, c was really dismissed
+    // get a new instance of c, validate that it is not the same as before, that is, c was really discarded
     c1 = cache.getDataset("c", C_ARGUMENTS);
     Assert.assertNotSame(c, c1);
 
-    // dismiss c and finish the tx
-    cache.dismissDataset(c1);
+    // discard c and finish the tx
+    cache.discardDataset(c1);
     txContext.finish();
 
-    // verify that after dismissing the tx context, tx-awares is empty
+    // verify that after discarding the tx context, tx-awares is empty
     cache.dismissTransactionContext();
     Assert.assertTrue(getTxAwares().isEmpty());
 
@@ -270,7 +270,7 @@ public abstract class DynamicDatasetCacheTest {
           hash.set(System.identityHashCode(ds));
           // this would close and discard ds, but the transaction is going on, so we should get the
           // identical instance of the dataset again
-          cache.dismissDataset(ds);
+          cache.discardDataset(ds);
           ds = cache.getDataset("a", ImmutableMap.of("value", "x"));
           Assert.assertEquals(hash.get(), System.identityHashCode(ds));
         } catch (Exception e) {
@@ -280,7 +280,7 @@ public abstract class DynamicDatasetCacheTest {
           // get the same dataset again. It should be the same object
           TestDataset ds = cache.getDataset("a", ImmutableMap.of("value", "x"));
           Assert.assertEquals(hash.get(), System.identityHashCode(ds));
-          cache.dismissDataset(ds);
+          cache.discardDataset(ds);
         } catch (Exception e) {
           throw Throwables.propagate(e);
         }
@@ -294,7 +294,7 @@ public abstract class DynamicDatasetCacheTest {
         try {
           TestDataset ds = cache.getDataset("a", ImmutableMap.of("value", "x"));
           Assert.assertEquals("x", ds.read());
-          // validate that we now have a different instance because the old one was dismissed
+          // validate that we now have a different instance because the old one was discarded
           Assert.assertNotEquals(hash.get(), System.identityHashCode(ds));
         } catch (Exception e) {
           throw Throwables.propagate(e);

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
@@ -125,7 +125,7 @@ There are two ways to use a dataset in a program:
   by the program.
 
   However, contrary to static datasets, dynamic datasets allow the release of the resources held by their Java classes
-  after you are done using them. You can do that by calling the ``dismissDataset()`` method of the program context:
+  after you are done using them. You can do that by calling the ``discardDataset()`` method of the program context:
   it marks the dataset to be closed and removed from all transactions as soon as the current transaction completes,
   thereby releasing its resources.
 

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -145,7 +145,7 @@ function download_includes() {
   test_an_include 92ee39ca2ae5940f2daa1fc31471aa8c ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
 
   test_an_include 8a7b4aacee88800cd82d96b07280cc64 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
-  test_an_include 61e27fb1d9a15079a296a9de93d1dc14 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
+  test_an_include dd725ac6503dc32d4b4cfd70b1d07473 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
   test_an_include 738f54aa72df27c8a7022bd25c92e27f ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
   
   test_an_include c2374d482454dc57c5944e557b544dba ../../cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java

--- a/cdap-docs/examples-manual/source/examples/fileset-example.rst
+++ b/cdap-docs/examples-manual/source/examples/fileset-example.rst
@@ -61,8 +61,8 @@ file, and it opens an input stream for that location. ``Location`` is a file sys
 `Apache Twill Javadocs <http://twill.incubator.apache.org/apidocs/org/apache/twill/filesystem/Location.html>`__.
 
 Note that after obtaining the location from the file set, the handler dismisses that dataset through its context |---|
-it is not needed any more and can therefore be returned to the system. This is not strictly necessary: All datasets
-are eventually reclaimed by the system. However, explicitly dismissing a dataset allows the system to reclaim it
+it is not needed any more and therefore can be returned to the system. This is not strictly necessary: all datasets
+are eventually reclaimed by the system. However, explicitly discarding a dataset allows the system to reclaim it
 as soon as the current transaction ends, possibly freeing valuable resources.
 
 The ``write`` method uses an ``HttpContentConsumer`` to stream the body of the request to the location specified

--- a/cdap-docs/examples-manual/source/examples/fileset-example.rst
+++ b/cdap-docs/examples-manual/source/examples/fileset-example.rst
@@ -55,12 +55,12 @@ It first instantiates the dataset specified by the first path parameter through 
 Note that, conceptually, this method is not limited to using only the two datasets of this application (*lines* and
 *counts*) |---| ``getDataset()`` can dynamically instantiate any existing dataset.
 
-The handler method then uses the ``getLocation()`` of the file set to obtain the location representing the requested
+The handler method then uses the ``getLocation()`` of the FileSet to obtain the location representing the requested
 file, and it opens an input stream for that location. ``Location`` is a file system abstraction from
 `Apache™ Twill® <http://twill.incubator.apache.org>`__; you can read more about its interface in the
 `Apache Twill Javadocs <http://twill.incubator.apache.org/apidocs/org/apache/twill/filesystem/Location.html>`__.
 
-Note that after obtaining the location from the file set, the handler discards that dataset through its context |---|
+Note that after obtaining the location from the FileSet, the handler discards that dataset through its context |---|
 it is not needed any more and therefore can be returned to the system. This is not strictly necessary: all datasets
 are eventually reclaimed by the system. However, explicitly discarding a dataset allows the system to reclaim it
 as soon as the current transaction ends, possibly freeing valuable resources.

--- a/cdap-docs/examples-manual/source/examples/fileset-example.rst
+++ b/cdap-docs/examples-manual/source/examples/fileset-example.rst
@@ -60,7 +60,7 @@ file, and it opens an input stream for that location. ``Location`` is a file sys
 `Apache™ Twill® <http://twill.incubator.apache.org>`__; you can read more about its interface in the
 `Apache Twill Javadocs <http://twill.incubator.apache.org/apidocs/org/apache/twill/filesystem/Location.html>`__.
 
-Note that after obtaining the location from the file set, the handler dismisses that dataset through its context |---|
+Note that after obtaining the location from the file set, the handler discards that dataset through its context |---|
 it is not needed any more and therefore can be returned to the system. This is not strictly necessary: all datasets
 are eventually reclaimed by the system. However, explicitly discarding a dataset allows the system to reclaim it
 as soon as the current transaction ends, possibly freeing valuable resources.

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
@@ -76,7 +76,7 @@ public class FileSetService extends AbstractService {
       }
 
       Location location = fileSet.getLocation(filePath);
-      getContext().dismissDataset(fileSet);
+      getContext().discardDataset(fileSet);
 
       ByteBuffer content;
       try {
@@ -104,7 +104,7 @@ public class FileSetService extends AbstractService {
       }
 
       final Location location = fileSet.getLocation(filePath);
-      getContext().dismissDataset(fileSet);
+      getContext().discardDataset(fileSet);
       try {
         final WritableByteChannel channel = Channels.newChannel(location.getOutputStream());
         return new HttpContentConsumer() {


### PR DESCRIPTION
Please read https://issues.cask.co/browse/CDAP-4338 before review (note: branch name incorrectly has 4388). 
- removes the weak values configuration from the dataset cache, along with all the code to support that
- adds a new API DatasetProvider. It will replace DatasetContext in the future and has additional methods to explicitly release/dismiss a dataset that is no longer used
- all program contexts now implement DatasetProvider
- modified one example (FileSetExample) that uses dynamic datasets, to dismiss its service's datasets after use, and extended the test case to make repeated calls to the service.
- still pending: documentation changes to document the new behavior and API method. I will do that in its own commit so that it can be reviewed on its own

Docs Build: http://builds.cask.co/browse/CDAP-DOB66-5 [Updated for Build 5].