### PR TITLE
Update pom for hbase-0.94 dependency

### DIFF
--- a/cdap-data-fabric-tests/pom.xml
+++ b/cdap-data-fabric-tests/pom.xml
@@ -38,7 +38,7 @@
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.hbase</groupId>
+          <groupId>co.cask.hbase</groupId>
           <artifactId>hbase</artifactId>
         </exclusion>
       </exclusions>

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -85,7 +85,7 @@
       <artifactId>hadoop-mapreduce-client-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
     </dependency>
     <dependency>
@@ -107,7 +107,7 @@
       <artifactId>hadoop-minicluster</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
       <classifier>tests</classifier>
     </dependency>

--- a/cdap-hbase-compat-0.94/pom.xml
+++ b/cdap-hbase-compat-0.94/pom.xml
@@ -51,7 +51,7 @@
       <artifactId>hadoop-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
     </dependency>
 
@@ -77,7 +77,7 @@
       <artifactId>hadoop-minicluster</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
       <classifier>tests</classifier>
     </dependency>

--- a/cdap-hbase-compat-0.96/pom.xml
+++ b/cdap-hbase-compat-0.96/pom.xml
@@ -46,6 +46,10 @@
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>co.cask.hbase</groupId>
+          <artifactId>hbase</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/cdap-hbase-compat-0.98/pom.xml
+++ b/cdap-hbase-compat-0.98/pom.xml
@@ -46,6 +46,10 @@
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>co.cask.hbase</groupId>
+          <artifactId>hbase</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -106,7 +106,7 @@
       <artifactId>hadoop-minicluster</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
       <scope>test</scope>
     </dependency>
@@ -116,7 +116,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
       <classifier>tests</classifier>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,6 @@
       <id>sonatype</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
-    <repository>
-      <id>continuuity-public</id>
-      <url>https://repository.continuuity.com/content/repositories/public</url>
-    </repository>
   </repositories>
 
 
@@ -103,7 +99,7 @@
     <guava.version>13.0.1</guava.version>
     <guice.version>3.0</guice.version>
     <hadoop.version>2.3.0</hadoop.version>
-    <hbase94.version>0.94.6.1.continuuity</hbase94.version>
+    <hbase94.version>0.94.6.1.cask</hbase94.version>
     <hbase96.version>0.96.2-hadoop2</hbase96.version>
     <hbase98.version>0.98.6.1-hadoop2</hbase98.version>
     <hive.version>0.13.0</hive.version>
@@ -716,7 +712,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.hbase</groupId>
+        <groupId>co.cask.hbase</groupId>
         <artifactId>hbase</artifactId>
         <version>${hbase94.version}</version>
         <exclusions>
@@ -1111,7 +1107,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.hbase</groupId>
+        <groupId>co.cask.hbase</groupId>
         <artifactId>hbase</artifactId>
         <classifier>tests</classifier>
         <version>${hbase94.version}</version>


### PR DESCRIPTION
Cherry-picking a commit that was merged against release/3.0:
https://github.com/caskdata/cdap/pull/4559

https://issues.cask.co/browse/CDAP-4368
http://builds.cask.co/browse/CDAP-RBTKEY281-1