### PR TITLE
Fix broken Documentation Build

### DIFF
--- a/cdap-docs/cdap-apps/build.sh
+++ b/cdap-docs/cdap-apps/build.sh
@@ -48,7 +48,7 @@ function download_includes() {
   test_an_include 329b73ee4e2bba510f006f1b80ef0089 "${cdap_etl}/batch/source/S3BatchSource.java"
   test_an_include 2af8f3fbf95a9d5f7becd9a7cbfaf6f9 "${cdap_etl}/batch/source/SnapshotFileBatchAvroSource.java"
   test_an_include cef2765da51af1eac905d920b7b92522 "${cdap_etl}/batch/source/SnapshotFileBatchParquetSource.java"
-  test_an_include 1ad8f9d4d9a27f10cdc0304bddf84c2b "${cdap_etl}/batch/source/StreamBatchSource.java"
+  test_an_include e7137b4c3e38ada2e10409d2b946bac6 "${cdap_etl}/batch/source/StreamBatchSource.java"
   test_an_include f8c07741ac3b09da7554b91351e7973b "${cdap_etl}/batch/source/TableSource.java"
   test_an_include 8835caf7e8c6c100904e88fc10b41ba2 "${cdap_etl}/batch/source/TimePartitionedFileSetDatasetAvroSource.java"
   test_an_include 03a4aa20385b9fb084938dc3df18b4c7 "${cdap_etl}/batch/source/TimePartitionedFileSetDatasetParquetSource.java"
@@ -60,7 +60,7 @@ function download_includes() {
   test_an_include ff03b40c1dfdc25d75dc6d3547d7293b "${cdap_etl}/realtime/sink/StreamSink.java"
 
   # Realtimesources
-  test_an_include 4c156d69fcc4d7b9145caab2dbed26ff "${cdap_etl}/realtime/source/DataGeneratorSource.java"
+  test_an_include ea55a0dfc9f6e085fba25b47435ff064 "${cdap_etl}/realtime/source/DataGeneratorSource.java"
   test_an_include c1d134466622468c36eaaf6a55677bb1 "${cdap_etl}/realtime/source/JmsSource.java"
   test_an_include c0605df8382ea941966785e5ad589c4a "${cdap_etl}/realtime/source/KafkaSource.java"
   test_an_include 62c19ecd2d694d3291b104645ad529a1 "${cdap_etl}/realtime/source/SqsSource.java"

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -142,7 +142,7 @@ function download_includes() {
   test_an_include 9f963a17090976d2c15a4d092bd9e8de ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
   
   test_an_include 16fabc25230c648f6aa157121145734f ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
-  test_an_include 92ee39ca2ae5940f2daa1fc31471aa8c ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+  test_an_include 7f665f50faa05e0141dc7b82d50179f5 ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
 
   test_an_include 8a7b4aacee88800cd82d96b07280cc64 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
   test_an_include 2c5094ecef8ca4fa8cadce5a70c88ee4 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java

--- a/cdap-docs/examples-manual/source/examples/data-cleansing.rst
+++ b/cdap-docs/examples-manual/source/examples/data-cleansing.rst
@@ -109,7 +109,7 @@ Otherwise, this is the default schema that is matched against the records:
 
 .. literalinclude:: /../../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
     :language: java
-    :lines: 139-143
+    :lines: 122-126
     :dedent: 2
 
 Querying the Results


### PR DESCRIPTION
Fix inclusion from example source code; update MD5 hashes after checking files.

Successful [Quick Build](http://builds.cask.co/browse/CDAP-DOB67-1).

You can see that the file inclusion is correct by looking at the [example schema](http://builds.cask.co/artifact/CDAP-DOB67/shared/build-1/Docs-HTML/3.3.0-SNAPSHOT/en/examples-manual/examples/data-cleansing.html#running-the-example).