### PR TITLE
Release 3.2.2 Documentation changes

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -322,23 +322,20 @@ function set_version() {
     GIT_BRANCH_TYPE=${GIT_BRANCH}
   elif [ "${full_branch:0:4}" == "docs" ]; then
     GIT_BRANCH="${full_branch}"
-    GIT_BRANCH_TYPE="release-feature"
+    if [ "x${GIT_BRANCH_TYPE}" == "x" ]; then
+      GIT_BRANCH_TYPE="release-feature"
+    fi
   elif [ "${GIT_BRANCH:0:7}" == "release" ]; then
     GIT_BRANCH_TYPE="release"
   else
     # We are on a feature branch: but from develop or release?
     # This is not easy to determine. This can fail very easily.
-    local git_branch_listing=$(git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1)
-    if [ "x${git_branch_listing}" == "x" ]; then 
-      echo_red_bold "Unable to determine parent branch as git_branch_listing empty"
-      echo_red_bold "Using default GIT_BRANCH_PARENT: ${GIT_BRANCH_PARENT}"
-    else
-      GIT_BRANCH_PARENT=$(echo ${git_branch_listing} | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')
-    fi
-    if [ "${GIT_BRANCH_PARENT:0:7}" == "release" ]; then
-      GIT_BRANCH_TYPE="release-feature"
-    else
-      GIT_BRANCH_TYPE="develop-feature"
+    if [ "x${GIT_BRANCH_TYPE}" == "x" ]; then
+      if [ "${GIT_BRANCH_PARENT:0:7}" == "release" ]; then
+        GIT_BRANCH_TYPE="release-feature"
+      else
+        GIT_BRANCH_TYPE="develop-feature"
+      fi
     fi
   fi
   cd ${current_directory}

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -165,7 +165,7 @@ function download_includes() {
   test_an_include 45b100e826b51372fd7783b3465e87e9 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
   
   test_an_include a33ca6df16ab5443d1d446f13d16348d ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
-  test_an_include 8db18c84a0ee405d85014ebbcf2d383e ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
+  test_an_include 6da2a4b6ad176388e6c2080be1b039c4 ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
   
   test_an_include 2260781c7cef2938aa36c946f3a34341 ../../cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfiles.java
 

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -23,6 +23,52 @@ Cask Data Application Platform Release Notes
    :backlinks: none
    :depth: 2
 
+`Release 3.2.2 <http://docs.cask.co/cdap/3.2.2/index.html>`__
+=============================================================
+
+Improvement
+-----------
+
+- `CDAP-4133 <https://issues.cask.co/browse/CDAP-4133>`__ -
+  Added ability to get the live-info for the CDAP AppFabric system service.
+
+Bug Fixes
+---------
+
+- `CDAP-3644 <https://issues.cask.co/browse/CDAP-3644>`__ -
+  Fixed a problem with upgrading the metadata system datasets.
+
+- `CDAP-4067 <https://issues.cask.co/browse/CDAP-4067>`__ -
+  Fixed an issue where socket connections to the TransactionManager were not being closed.
+
+- `CDAP-4092 <https://issues.cask.co/browse/CDAP-4092>`__ -
+  Fixes an issue that causes worker threads to go into an infinite recursion while
+  exceptions are being thrown in channel handlers.
+
+- `CDAP-4093 <https://issues.cask.co/browse/CDAP-4093>`__ -
+  Fixed a problem with installation documentation for Cloudera Manager and Apache Ambari.
+
+- `CDAP-4097 <https://issues.cask.co/browse/CDAP-4097>`__ -
+  Fixed a problem with the AbstractDatasetProvider throwing exceptions and polluting the logs.
+
+- `CDAP-4119 <https://issues.cask.co/browse/CDAP-4119>`__ -
+  Fixed a problem where, when the CDAP Master switched from active to standby, that 
+  any programs that were running were marked as failed.
+
+- `CDAP-4275 <https://issues.cask.co/browse/CDAP-4275>`__ -
+  Fixed a problem with searching CDAP entities based on tags where the entity has multiple tags.
+
+- `CDAP-4278 <https://issues.cask.co/browse/CDAP-4278>`__ -
+  Fixed a problem that caused a Workflow to fail if datasets were used in custom actions.
+
+- `CDAP-4373 <https://issues.cask.co/browse/CDAP-4373>`__ -
+  Fixed a problem that prevented MapReduce jobs from being run when the Resource Manager
+  switches from active to standby in a Kerberos-enabled HA cluster.
+
+- `CDAP-4384 <https://issues.cask.co/browse/CDAP-4384>`__ -
+  Fixed a problem that prevented streams from being read in HA HDFS mode.
+
+
 `Release 3.2.1 <http://docs.cask.co/cdap/3.2.1/index.html>`__
 =============================================================
 

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -63,7 +63,7 @@ Bug Fixes
   Fixed a problem that prevented streams from being read in HA HDFS mode.
 
 
-.. _known-issues-321:
+.. _known-issues-322:
 
 Known Issues
 ------------

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -29,14 +29,17 @@ Cask Data Application Platform Release Notes
 Improvement
 -----------
 
+- `CDAP-3644 <https://issues.cask.co/browse/CDAP-3644>`__ -
+  Made the metadata system datasets upgradable.
+
+- `CDAP-4093 <https://issues.cask.co/browse/CDAP-4093>`__ -
+  Revised the installation documentation for Cloudera Manager and Apache Ambari.
+
 - `CDAP-4133 <https://issues.cask.co/browse/CDAP-4133>`__ -
   Added ability to get the live-info for the CDAP AppFabric system service.
 
 Bug Fixes
 ---------
-
-- `CDAP-3644 <https://issues.cask.co/browse/CDAP-3644>`__ -
-  Fixed a problem with upgrading the metadata system datasets.
 
 - `CDAP-4067 <https://issues.cask.co/browse/CDAP-4067>`__ -
   Fixed an issue where socket connections to the TransactionManager were not being closed.
@@ -45,18 +48,9 @@ Bug Fixes
   Fixes an issue that causes worker threads to go into an infinite recursion while
   exceptions are being thrown in channel handlers.
 
-- `CDAP-4093 <https://issues.cask.co/browse/CDAP-4093>`__ -
-  Fixed a problem with installation documentation for Cloudera Manager and Apache Ambari.
-
-- `CDAP-4097 <https://issues.cask.co/browse/CDAP-4097>`__ -
-  Fixed a problem with the AbstractDatasetProvider throwing exceptions and polluting the logs.
-
 - `CDAP-4119 <https://issues.cask.co/browse/CDAP-4119>`__ -
   Fixed a problem where, when the CDAP Master switched from active to standby, that 
   any programs that were running were marked as failed.
-
-- `CDAP-4275 <https://issues.cask.co/browse/CDAP-4275>`__ -
-  Fixed a problem with searching CDAP entities based on tags where the entity has multiple tags.
 
 - `CDAP-4278 <https://issues.cask.co/browse/CDAP-4278>`__ -
   Fixed a problem that caused a Workflow to fail if datasets were used in custom actions.
@@ -67,6 +61,17 @@ Bug Fixes
 
 - `CDAP-4384 <https://issues.cask.co/browse/CDAP-4384>`__ -
   Fixed a problem that prevented streams from being read in HA HDFS mode.
+
+
+.. _known-issues-321:
+
+Known Issues
+------------
+
+- `CDAP-4393 <https://issues.cask.co/browse/CDAP-4393>`__ -
+  Metadata search for tags does not work if the search key is not the first tag in the list.
+
+- See also the *Known Issues* of `version 3.2.0 <#known-issues-320>`_\ .
 
 
 `Release 3.2.1 <http://docs.cask.co/cdap/3.2.1/index.html>`__


### PR DESCRIPTION
- Ports a change from 3.3.0 to help with determination of the correct branch when building the docs.
- Fixes documentation build (update MD5 hash after checking file).
- Adds release notes for 3.2.2.

Passes [Quick Build #2](http://builds.cask.co/browse/CDAP-DOB68-2). 

[Release Notes](http://builds.cask.co/artifact/CDAP-DOB68/shared/build-2/Docs-HTML/3.2.2/en/reference-manual/release-notes.html#release-3-2-2)