### PR TITLE
CDAP-4277: Id should not serialize toString and hashCode fields

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -67,8 +67,8 @@ public abstract class Id implements EntityIdCompatible {
     return namespaceMatcher.matchesAllOf(name);
   }
 
-  private String toString;
-  private int hashCode = -1;
+  private transient String toString;
+  private transient Integer hashCode;
 
   private static boolean isValidId(String name) {
     return idMatcher.matchesAllOf(name);
@@ -109,7 +109,7 @@ public abstract class Id implements EntityIdCompatible {
 
   @Override
   public final int hashCode() {
-    if (hashCode == -1) {
+    if (hashCode == null) {
       hashCode = toEntityId().hashCode();
     }
     return hashCode;

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/IdTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/IdTest.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.proto;
 
+import com.google.gson.Gson;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,6 +24,8 @@ import org.junit.Test;
  *
  */
 public class IdTest {
+
+  private static final Gson GSON = new Gson();
 
   @Test
   public void testFlow() {
@@ -38,6 +41,22 @@ public class IdTest {
     Id.Program notSame = Id.Program.from("ns1", "app1", ProgramType.MAPREDUCE, "flow1");
     Assert.assertNotEquals(flow, notSame);
     Assert.assertNotEquals(flow.toString(), notSame.toString());
+  }
+
+  @Test
+  public void testJsonHashCode() {
+    Id.Flow flow = Id.Flow.from("ns1", "app1", "flow1");
+    int hashCode = flow.hashCode();
+    String toString = flow.toString();
+
+    String json = GSON.toJson(flow);
+    Assert.assertFalse(json.contains(Integer.toString(hashCode)));
+    Assert.assertFalse(json.contains(toString));
+
+    Id.Flow sameFlow = GSON.fromJson(json, Id.Flow.class);
+    Assert.assertEquals(hashCode, sameFlow.hashCode());
+    Assert.assertEquals(toString, sameFlow.toString());
+    Assert.assertEquals(flow, sameFlow);
   }
 
 }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-4277
http://builds.cask.co/browse/CDAP-RBT528