### PR TITLE
Increase VM memory earlier

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
@@ -28,8 +28,10 @@
         "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
         "initrd=/install/initrd.gz -- <enter>"
       ],
+      "vboxmanage": [
+        ["modifyvm", "{{ .Name }}", "--memory", "4096"]
+      ],
       "vboxmanage_post": [
-        ["modifyvm", "{{ .Name }}", "--memory", "4096"],
         ["modifyvm", "{{ .Name }}", "--clipboard", "bidirectional"],
         ["modifyvm", "{{ .Name }}", "--accelerate2dvideo", "on"],
         ["modifyvm", "{{ .Name }}", "--accelerate3d", "on"],


### PR DESCRIPTION
Otherwise, we run out of memory attempting to fill the Maven cache. This is for the old VM build, which uses artifacts from Maven Central, exclusively.