### PR TITLE
fixes table layout issue affecting bg-color in safari

### DIFF
--- a/cdap-ui/app/features/admin/admin.less
+++ b/cdap-ui/app/features/admin/admin.less
@@ -144,6 +144,16 @@ body.theme-cdap {
       }
     }
   }
+  &.state-admin-system-configuration {
+    main.container {
+      .table {
+        table-layout: fixed;
+        td {
+          word-wrap: break-word;
+        }
+      }
+    }
+  }
   &.state-admin-namespace-detail-data-streammetadata {
     .form-horizontal {
 

--- a/cdap-ui/app/features/admin/templates/system/configuration.html
+++ b/cdap-ui/app/features/admin/templates/system/configuration.html
@@ -1,18 +1,18 @@
 <!--
   Copyright © 2015 Cask Data, Inc.
- 
+
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
   the License at
- 
+
   http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
   License for the specific language governing permissions and limitations under
   the License.
---> 
+-->
 
 <div class="row">
   <div class="col-xs-6">
@@ -29,24 +29,21 @@
 </div>
 <div class="row">
   <div class="col-xs-12">
-    <div class="table-responsive">
-      <table class="table table-curved" cask-sortable>
-        <thead>
-          <tr ng-class="{'sort-enabled': config.length>0}">
-            <th data-predicate="name">Name</th>
-            <th data-predicate="value">Value</th>
-            <th data-predicate="source">Source</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr ng-repeat="row in config | filter: searchText | orderBy:sortable.predicate:sortable.reverse | limitTo: 50">
-            <td>{{::row.name}}</td>
-            <td>{{::row.value}}</td>
-            <td>{{::row.source}}</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table class="table table-curved" cask-sortable>
+      <thead>
+        <tr ng-class="{'sort-enabled': config.length>0}">
+          <th data-predicate="name">Name</th>
+          <th data-predicate="value">Value</th>
+          <th data-predicate="source">Source</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-repeat="row in config | filter: searchText | orderBy:sortable.predicate:sortable.reverse | limitTo: 50">
+          <td>{{::row.name}}</td>
+          <td>{{::row.value}}</td>
+          <td>{{::row.source}}</td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
-


### PR DESCRIPTION
*  Removes unnecessary .div-responsive class from around table
*  Adds a fixed table layout and word-breaking to prevent table columns from becoming unevenly distributed
*  Tested in Safari, Chrome, and Firefox

![safari](https://cloud.githubusercontent.com/assets/5335210/11728213/6ed88470-9f3d-11e5-8a9b-c24c9d361218.gif)
