### PR TITLE
CDAP-4007: NamespaceAlreadyExists error when multiple unit tests are in a module

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryNamespaceStore.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryNamespaceStore.java
@@ -60,6 +60,11 @@ public class InMemoryNamespaceStore implements NamespaceStore {
   }
 
   @Override
+  public boolean exists(Id.Namespace id) {
+    return namespaces.containsKey(id);
+  }
+
+  @Override
   public List<NamespaceMeta> list() {
     return new ArrayList<>(namespaces.values());
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -44,6 +44,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.io.InputSupplier;
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
@@ -57,6 +58,7 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -224,6 +226,16 @@ class DatasetServiceClient {
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Failed to delete modules, details: %s", response));
     }
+  }
+
+  public boolean namespaceExists() throws DatasetManagementException {
+    HttpResponse response = doGet("admin/exists");
+    if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
+      throw new DatasetManagementException(String.format("Failed to check namespace existence, details: %s", response));
+    }
+
+    JsonObject jsonResponse = GSON.fromJson(response.getResponseBodyAsString(), JsonObject.class);
+    return jsonResponse.get("exists").getAsBoolean();
   }
 
   public void createNamespace() throws DatasetManagementException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -258,6 +258,11 @@ public class RemoteDatasetFramework implements DatasetFramework {
   }
 
   @Override
+  public boolean namespaceExists(Id.Namespace namespace) throws DatasetManagementException {
+    return clientCache.getUnchecked(namespace).namespaceExists();
+  }
+
+  @Override
   public void createNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
     clientCache.getUnchecked(namespaceId).createNamespace();
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/StorageProviderNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/StorageProviderNamespaceAdmin.java
@@ -46,6 +46,11 @@ public class StorageProviderNamespaceAdmin {
     this.exploreFacade = exploreFacade;
   }
 
+  protected boolean exists(Id.Namespace namespace) throws IOException {
+    Location namespaceHome = namespacedLocationFactory.get(namespace);
+    return namespaceHome.exists();
+  }
+
   /**
    * Create a namespace in the underlying system.
    * Can perform operations such as creating directories, creating namespaces, etc.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/StorageProviderNamespaceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/StorageProviderNamespaceHandler.java
@@ -22,6 +22,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -29,6 +30,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -44,6 +46,20 @@ public class StorageProviderNamespaceHandler extends AbstractHttpHandler {
   @Inject
   public StorageProviderNamespaceHandler(StorageProviderNamespaceAdmin storageProviderNamespaceAdmin) {
     this.storageProviderNamespaceAdmin = storageProviderNamespaceAdmin;
+  }
+
+  @GET
+  @Path("data/admin/exists")
+  public void namespaceExists(
+    HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId) {
+
+    try {
+      boolean exists = storageProviderNamespaceAdmin.exists(Id.Namespace.from(namespaceId));
+      responder.sendJson(HttpResponseStatus.OK, ImmutableMap.of("exists", exists));
+    } catch (IOException e) {
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                           "Error while checking namespace existence - " + e.getMessage());
+    }
   }
 
   @PUT

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -300,6 +300,11 @@ public interface DatasetFramework {
     throws DatasetManagementException, IOException;
 
   /**
+   * @return true if the namespace exists
+   */
+  boolean namespaceExists(Id.Namespace namespace) throws DatasetManagementException;
+
+  /**
    * Creates a namespace in the Storage Providers - HBase/LevelDB, Hive and HDFS/Local File System.
    *
    * @param namespaceId the {@link Id.Namespace} to create

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -420,6 +420,16 @@ public class InMemoryDatasetFramework implements DatasetFramework {
   }
 
   @Override
+  public boolean namespaceExists(Id.Namespace namespace) throws DatasetManagementException {
+    readLock.lock();
+    try {
+      return namespaces.contains(namespace);
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  @Override
   public void createNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
     writeLock.lock();
     try {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/StaticDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/StaticDatasetFramework.java
@@ -108,6 +108,12 @@ public class StaticDatasetFramework extends InMemoryDatasetFramework implements 
   }
 
   @Override
+  public boolean namespaceExists(Id.Namespace namespace) throws DatasetManagementException {
+    throw new UnsupportedOperationException("Cannot change modules of "
+                                              + StaticDatasetFramework.class.getSimpleName());
+  }
+
+  @Override
   public void createNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
     throw new UnsupportedOperationException("Cannot change modules of "
                                               + StaticDatasetFramework.class.getSimpleName());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
@@ -195,6 +195,11 @@ public class LineageWriterDatasetFramework implements DatasetFramework, ProgramC
   }
 
   @Override
+  public boolean namespaceExists(Id.Namespace namespace) throws DatasetManagementException {
+    return delegate.namespaceExists(namespace);
+  }
+
+  @Override
   public void createNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
     delegate.createNamespace(namespaceId);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/DefaultNamespaceStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/DefaultNamespaceStore.java
@@ -156,6 +156,17 @@ public class DefaultNamespaceStore implements NamespaceStore {
   }
 
   @Override
+  public boolean exists(final Id.Namespace id) {
+    return appsTx.get().executeUnchecked(
+      new TransactionExecutor.Function<NamespaceMDS, Boolean>() {
+        @Override
+        public Boolean apply(NamespaceMDS mds) throws Exception {
+          return mds.get(id) != null;
+        }
+      }, apps.get());
+  }
+
+  @Override
   public List<NamespaceMeta> list() {
     return appsTx.get().executeUnchecked(
       new TransactionExecutor.Function<NamespaceMDS, List<NamespaceMeta>>() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/NamespaceStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/NamespaceStore.java
@@ -66,6 +66,12 @@ public interface NamespaceStore {
   NamespaceMeta delete(Id.Namespace id);
 
   /**
+   * @param id the namespace
+   * @return true if the namespace exists
+   */
+  boolean exists(Id.Namespace id);
+
+  /**
    * Lists all registered namespaces.
    *
    * @return a list of all registered namespaces

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.InMemoryProgramRunnerModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
+import co.cask.cdap.common.NamespaceAlreadyExistsException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -251,7 +252,13 @@ public class TestBase {
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
     metricsManager = injector.getInstance(MetricsManager.class);
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
-    namespaceAdmin.create(NamespaceMeta.DEFAULT);
+
+    try {
+      namespaceAdmin.create(NamespaceMeta.DEFAULT);
+    } catch (NamespaceAlreadyExistsException e) {
+      // ignore, just want default namespace to exist
+      throw e;
+    }
   }
 
   private static TestManager getTestManager() {

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -27,7 +27,6 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.InMemoryProgramRunnerModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
-import co.cask.cdap.common.NamespaceAlreadyExistsException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -252,13 +251,7 @@ public class TestBase {
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
     metricsManager = injector.getInstance(MetricsManager.class);
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
-
-    try {
-      namespaceAdmin.create(NamespaceMeta.DEFAULT);
-    } catch (NamespaceAlreadyExistsException e) {
-      // ignore, just want default namespace to exist
-      throw e;
-    }
+    namespaceAdmin.create(NamespaceMeta.DEFAULT);
   }
 
   private static TestManager getTestManager() {


### PR DESCRIPTION
- In DefaultNamespaceAdmin.create, when creating the default namespace,
  don't throw NamespaceAlreadyExists. Instead create everything that is
  missing for the default namespace