### PR TITLE
fixes namespace dropdown styling

### DIFF
--- a/cdap-ui/app/directives/navbar-hydrator/namespace.html
+++ b/cdap-ui/app/directives/navbar-hydrator/namespace.html
@@ -16,8 +16,8 @@
 
 <ul class="dropdown-menu" role="menu" ng-show="currentUser">
   <li ng-repeat="ns in namespaces | orderBy : 'name'" ng-show="namespaces.length > 1 && ns.name !== $state.params.namespace">
-    <a role="menuitem" ui-sref="hydrator.list({namespace: ns.name})" tabindex="-1">
-      <span ng-bind="ns.name | myEllipsis: 24"></span>
+    <a role="menuitem" ui-sref="hydrator.list({namespace: ns.name})" tabindex="-1" title="{{ns.name}}">
+      <span ng-bind="ns.name | myEllipsis: 32"></span>
     </a>
   </li>
   <li role="menuitem" ng-show="namespaces.length === 1" class="disabled">

--- a/cdap-ui/app/directives/navbar-hydrator/navbar.html
+++ b/cdap-ui/app/directives/navbar-hydrator/navbar.html
@@ -38,9 +38,9 @@
 
   <ul class="navbar-namespace" id="navbar-namespace">
     <li class="dropdown">
-      <a href="" class="hy-dropdown-toggle clearfix">
-        <span class="pull-left" ng-bind="$state.params.namespace && getDisplayName($state.params.namespace) | myEllipsis: 10"></span>
-        <span class="fa fa-caret-down pull-right"></span>
+      <a href="" class="hy-dropdown-toggle clearfix" title="{{getDisplayName($state.params.namespace)}}">
+        <span class="pull-left" ng-bind="$state.params.namespace && getDisplayName($state.params.namespace) | myEllipsis: 12"></span>
+        <span class="fa fa-angle-down pull-right"></span>
       </a>
     </li>
   </ul>

--- a/cdap-ui/app/directives/navbar-hydrator/navbar.js
+++ b/cdap-ui/app/directives/navbar-hydrator/navbar.js
@@ -30,6 +30,7 @@ function myNavbarHydratorDirective (myAuth, MY_CONFIG, $dropdown) {
       $dropdown(angular.element(toggles), {
         template: 'navbar-hydrator/namespace.html',
         animation: 'none',
+        placement: 'bottom-right',
         scope: scope
       });
 

--- a/cdap-ui/app/directives/navbar-hydrator/navbar.less
+++ b/cdap-ui/app/directives/navbar-hydrator/navbar.less
@@ -107,46 +107,31 @@ body {
         margin: 0;
         padding: 0;
         position: absolute;
-        top: 15px;
+        top: 14px;
         right: 100px;
         li.dropdown {
           list-style-type: none;
-          .transition(all 0.2s ease);
           &:hover {
             cursor: pointer;
           }
           a.hy-dropdown-toggle {
             display: block;
-            padding: 5px;
-            .border-radius(4px);
+            min-width: 125px;
+            padding: 6px 10px;
             span:first-child {
               font-weight: 500;
               padding-right: 15px;
             }
-            span.fa-caret-down {
+            span.fa-angle-down {
               line-height: 18px;
-            }
-          }
-          &.open {
-            min-width: 160px;
-            a.hy-dropdown-toggle {
-              padding-top: 8px;
-              padding-bottom: 8px;
-              padding-left: 14px;
-              .border-radius(0);
-            }
-            span.fa-caret-down {
-              display: none;
-            }
-            ul.dropdown-menu {
-              .border-radius(0);
             }
           }
         }
 
         ul.dropdown-menu {
-          float: none;
-          margin-top: 8px;
+          margin-top: 2px;
+          max-height: 360px;
+          overflow-y: scroll;
           padding: 0;
           z-index: 9999;
           li a {
@@ -194,6 +179,8 @@ body {
             a.hy-dropdown-toggle {
               background-color: white;
               color: #666;
+              .border-radius(4px);
+              .transition(all 0.2s ease);
               &:hover, &:focus {
                 text-decoration: none;
               }
@@ -201,8 +188,12 @@ body {
             &.open {
               a.hy-dropdown-toggle {
                 background-color: rgb(111, 111, 113);
-                border: 1px solid rgb(111, 111, 113);
                 color: white;
+              }
+              ul.dropdown-menu {
+                .border-radius(0);
+                @box-shadow: 0 7px 7px fade(black, 10%), 0 19px 59px fade(black, 20%);
+                .box-shadow(@box-shadow);
               }
             }
           }


### PR DESCRIPTION
*  Adds more consistent styling to the dropdown toggle (open vs. closed)
*  Changes display limit to 32 character in dropdown menu and 12 characters for displayed namespace
*  Limits number of displayed namespaces to 10, after which a vertical scroll is used

![ns](https://cloud.githubusercontent.com/assets/5335210/11732308/b6d0b8aa-9f57-11e5-9b50-27ce4e0edfa2.gif)

