### PR TITLE
[CDAP-4421] Provide Hive tokens to twill containers

### DIFF
--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -149,6 +149,10 @@
       <artifactId>MockFtpServer</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-service</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/hive/ExploreUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/hive/ExploreUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hive;
+
+import co.cask.cdap.common.conf.Constants;
+import com.google.common.base.Function;
+import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * * Helper class for loading Hive classes.
+ */
+public final class ExploreUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExploreUtils.class);
+  private static ClassLoader exploreClassLoader = null;
+
+  /**
+   * Builds a class loader with the class path provided.
+   */
+  public static synchronized ClassLoader getExploreClassloader() {
+    if (exploreClassLoader != null) {
+      return exploreClassLoader;
+    }
+
+    // EXPLORE_CLASSPATH and EXPLORE_CONF_FILES will be defined in startup scripts if Hive is installed.
+    String exploreClassPathStr = System.getProperty(Constants.Explore.EXPLORE_CLASSPATH);
+    LOG.debug("Explore classpath = {}", exploreClassPathStr);
+    if (exploreClassPathStr == null) {
+      throw new RuntimeException("System property " + Constants.Explore.EXPLORE_CLASSPATH + " is not set.");
+    }
+
+    String exploreConfPathStr = System.getProperty(Constants.Explore.EXPLORE_CONF_FILES);
+    LOG.debug("Explore confPath = {}", exploreConfPathStr);
+    if (exploreConfPathStr == null) {
+      throw new RuntimeException("System property " + Constants.Explore.EXPLORE_CONF_FILES + " is not set.");
+    }
+
+    Iterable<File> hiveClassPath = getClassPathJarsFiles(exploreClassPathStr);
+    Iterable<File> hiveConfFiles = getClassPathJarsFiles(exploreConfPathStr);
+    ImmutableList.Builder<URL> builder = ImmutableList.builder();
+    for (File file : Iterables.concat(hiveClassPath, hiveConfFiles)) {
+      try {
+        if (file.getName().matches(".*\\.xml")) {
+          builder.add(file.getParentFile().toURI().toURL());
+        } else {
+          builder.add(file.toURI().toURL());
+        }
+      } catch (MalformedURLException e) {
+        LOG.error("Jar URL is malformed", e);
+        throw Throwables.propagate(e);
+      }
+    }
+    exploreClassLoader = new URLClassLoader(Iterables.toArray(builder.build(), URL.class),
+                                            ClassLoader.getSystemClassLoader());
+    return exploreClassLoader;
+  }
+
+  /**
+   * Get all the files contained in a class path.
+   */
+  public static Iterable<File> getClassPathJarsFiles(String hiveClassPath) {
+    if (hiveClassPath == null) {
+      return null;
+    }
+    return Iterables.transform(Splitter.on(':').split(hiveClassPath), STRING_FILE_FUNCTION);
+  }
+
+  private static final Function<String, File> STRING_FILE_FUNCTION =
+    new Function<String, File>() {
+      @Override
+      public File apply(String input) {
+        return new File(input).getAbsoluteFile();
+      }
+    };
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -23,20 +23,18 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.io.FileContextLocationFactory;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
-import co.cask.cdap.common.security.YarnTokenUtils;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
 import co.cask.cdap.common.twill.HadoopClassExcluder;
 import co.cask.cdap.common.utils.DirUtils;
-import co.cask.cdap.data.security.HBaseTokenUtils;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
+import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -50,12 +48,9 @@ import com.google.common.io.Resources;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.mapreduce.JobContext;
-import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.EventHandler;
 import org.apache.twill.api.TwillApplication;
@@ -64,10 +59,7 @@ import org.apache.twill.api.TwillPreparer;
 import org.apache.twill.api.TwillRunner;
 import org.apache.twill.api.logging.PrinterLogHandler;
 import org.apache.twill.common.Threads;
-import org.apache.twill.filesystem.HDFSLocationFactory;
 import org.apache.twill.filesystem.LocationFactory;
-import org.apache.twill.internal.yarn.YarnUtils;
-import org.apache.twill.yarn.YarnSecureStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +72,6 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
@@ -102,6 +93,7 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
   protected final YarnConfiguration hConf;
   protected final CConfiguration cConf;
   protected final EventHandler eventHandler;
+  private final TokenSecureStoreUpdater secureStoreUpdater;
 
   /**
    * An interface for launching TwillApplication. Used by sub-classes only.
@@ -147,12 +139,14 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
   }
 
   protected AbstractDistributedProgramRunner(TwillRunner twillRunner, LocationFactory locationFactory,
-                                             YarnConfiguration hConf, CConfiguration cConf) {
+                                             YarnConfiguration hConf, CConfiguration cConf,
+                                             TokenSecureStoreUpdater tokenSecureStoreUpdater) {
     this.twillRunner = twillRunner;
     this.locationFactory = locationFactory;
     this.hConf = hConf;
     this.cConf = cConf;
     this.eventHandler = createEventHandler(cConf);
+    this.secureStoreUpdater = tokenSecureStoreUpdater;
   }
 
   protected EventHandler createEventHandler(CConfiguration cConf) {
@@ -214,7 +208,12 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
 
           String yarnAppClassPath = hConf.get(YarnConfiguration.YARN_APPLICATION_CLASSPATH,
                                            Joiner.on(",").join(YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH));
-          TwillController twillController = addSecureStore(twillPreparer, locationFactory, hConf)
+          // Add secure tokens
+          if (User.isHBaseSecurityEnabled(hConf) || UserGroupInformation.isSecurityEnabled()) {
+            // TokenSecureStoreUpdater.update() ignores parameters
+            twillPreparer.addSecureStore(secureStoreUpdater.update(null, null));
+          }
+          TwillController twillController = twillPreparer
             .withDependencies(HBaseTableUtilFactory.getHBaseTableUtilClass())
             .withClassPaths(Iterables.concat(extraClassPaths, Splitter.on(',').trimResults()
               .split(hConf.get(YarnConfiguration.YARN_APPLICATION_CLASSPATH, ""))))
@@ -349,47 +348,5 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
     controller.onRunning(cleanup, Threads.SAME_THREAD_EXECUTOR);
     controller.onTerminated(cleanup, Threads.SAME_THREAD_EXECUTOR);
     return controller;
-  }
-
-  /**
-   * Add secure tokens to the {@link TwillPreparer}.
-   */
-  private TwillPreparer addSecureStore(TwillPreparer preparer, LocationFactory locationFactory,
-                                       YarnConfiguration yarnConf) {
-    Credentials credentials = new Credentials();
-
-    if (UserGroupInformation.isSecurityEnabled()) {
-      YarnTokenUtils.obtainToken(yarnConf, credentials);
-    }
-
-    if (User.isHBaseSecurityEnabled(hConf)) {
-      HBaseTokenUtils.obtainToken(hConf, credentials);
-    }
-
-    // Perform different logic to get delegation tokens based on the location factory type.
-    // This method is needed because Twill is not able to deal with {@link FileContextLocationFactory} yet.
-    // Remove after (CDAP-3498)
-    try {
-      if (UserGroupInformation.isSecurityEnabled()) {
-        if (locationFactory instanceof HDFSLocationFactory) {
-          YarnUtils.addDelegationTokens(hConf, locationFactory, credentials);
-        } else if (locationFactory instanceof FileContextLocationFactory) {
-          List<Token<?>> tokens = ((FileContextLocationFactory) locationFactory).getFileContext().getDelegationTokens(
-            new Path(Locations.toURI(locationFactory.getHomeLocation())), YarnUtils.getYarnTokenRenewer(hConf)
-          );
-          for (Token<?> token : tokens) {
-            credentials.addToken(token.getService(), token);
-          }
-        }
-      }
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
-
-    if (!credentials.getAllTokens().isEmpty()) {
-      preparer.addSecureStore(YarnSecureStore.create(credentials));
-    }
-
-    return preparer;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
@@ -32,6 +32,7 @@ import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.security.TokenSecureStoreUpdater;
 import co.cask.tephra.TransactionExecutorFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -62,8 +63,9 @@ public final class DistributedFlowProgramRunner extends AbstractDistributedProgr
   @Inject
   DistributedFlowProgramRunner(TwillRunner twillRunner, LocationFactory locationFactory, YarnConfiguration hConf,
                                CConfiguration cConfig, QueueAdmin queueAdmin, StreamAdmin streamAdmin,
-                               TransactionExecutorFactory txExecutorFactory) {
-    super(twillRunner, locationFactory, hConf, cConfig);
+                               TransactionExecutorFactory txExecutorFactory,
+                               TokenSecureStoreUpdater tokenSecureStoreUpdater) {
+    super(twillRunner, locationFactory, hConf, cConfig, tokenSecureStoreUpdater);
     this.queueAdmin = queueAdmin;
     this.streamAdmin = streamAdmin;
     this.txExecutorFactory = txExecutorFactory;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
@@ -26,6 +26,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -50,8 +51,9 @@ public final class DistributedMapReduceProgramRunner extends AbstractDistributed
 
   @Inject
   public DistributedMapReduceProgramRunner(TwillRunner twillRunner, LocationFactory locationFactory,
-                                           YarnConfiguration hConf, CConfiguration cConf) {
-    super(twillRunner, locationFactory, hConf, cConf);
+                                           YarnConfiguration hConf, CConfiguration cConf,
+                                           TokenSecureStoreUpdater tokenSecureStoreUpdater) {
+    super(twillRunner, locationFactory, hConf, cConf, tokenSecureStoreUpdater);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -49,8 +50,9 @@ public class DistributedServiceProgramRunner extends AbstractDistributedProgramR
 
   @Inject
   DistributedServiceProgramRunner(TwillRunner twillRunner, LocationFactory locationFactory,
-                                  YarnConfiguration hConf, CConfiguration cConf) {
-    super(twillRunner, locationFactory, hConf, cConf);
+                                  YarnConfiguration hConf, CConfiguration cConf,
+                                  TokenSecureStoreUpdater tokenSecureStoreUpdater) {
+    super(twillRunner, locationFactory, hConf, cConf, tokenSecureStoreUpdater);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedSparkProgramRunner.java
@@ -29,6 +29,7 @@ import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.spark.SparkContextConfig;
 import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -53,8 +54,9 @@ public class DistributedSparkProgramRunner extends AbstractDistributedProgramRun
 
   @Inject
   public DistributedSparkProgramRunner(TwillRunner twillRunner, LocationFactory locationFactory,
-                                       YarnConfiguration hConf, CConfiguration cConf) {
-    super(twillRunner, locationFactory, createConfiguration(hConf), cConf);
+                                       YarnConfiguration hConf, CConfiguration cConf,
+                                       TokenSecureStoreUpdater tokenSecureStoreUpdater) {
+    super(twillRunner, locationFactory, createConfiguration(hConf), cConf, tokenSecureStoreUpdater);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
@@ -23,6 +23,7 @@ import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -44,8 +45,9 @@ public final class DistributedWebappProgramRunner extends AbstractDistributedPro
 
   @Inject
   public DistributedWebappProgramRunner(TwillRunner twillRunner, LocationFactory locationFactory,
-                                        YarnConfiguration hConf, CConfiguration cConf) {
-    super(twillRunner, locationFactory, hConf, cConf);
+                                        YarnConfiguration hConf, CConfiguration cConf,
+                                        TokenSecureStoreUpdater tokenSecureStoreUpdater) {
+    super(twillRunner, locationFactory, hConf, cConf, tokenSecureStoreUpdater);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
@@ -52,8 +53,9 @@ public class DistributedWorkerProgramRunner extends AbstractDistributedProgramRu
 
   @Inject
   DistributedWorkerProgramRunner(TwillRunner twillRunner, LocationFactory locationFactory,
-                                 YarnConfiguration hConf, CConfiguration cConf) {
-    super(twillRunner, locationFactory, hConf, cConf);
+                                 YarnConfiguration hConf, CConfiguration cConf,
+                                 TokenSecureStoreUpdater tokenSecureStoreUpdater) {
+    super(twillRunner, locationFactory, hConf, cConf, tokenSecureStoreUpdater);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -38,6 +38,7 @@ import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHel
 import co.cask.cdap.internal.app.runtime.spark.SparkContextConfig;
 import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -63,8 +64,9 @@ public final class DistributedWorkflowProgramRunner extends AbstractDistributedP
 
   @Inject
   public DistributedWorkflowProgramRunner(TwillRunner twillRunner, LocationFactory locationFactory,
-                                          YarnConfiguration hConf, CConfiguration cConf) {
-    super(twillRunner, locationFactory, createConfiguration(hConf), cConf);
+                                          YarnConfiguration hConf, CConfiguration cConf,
+                                          TokenSecureStoreUpdater tokenSecureStoreUpdater) {
+    super(twillRunner, locationFactory, createConfiguration(hConf), cConf, tokenSecureStoreUpdater);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreUpdater.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreUpdater.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.data.runtime.main;
+package co.cask.cdap.security;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -22,9 +22,9 @@ import co.cask.cdap.common.io.FileContextLocationFactory;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.security.YarnTokenUtils;
 import co.cask.cdap.data.security.HBaseTokenUtils;
-import co.cask.cdap.explore.security.HiveTokenUtils;
-import co.cask.cdap.explore.security.JobHistoryServerTokenUtils;
-import co.cask.cdap.explore.service.ExploreServiceUtils;
+import co.cask.cdap.hive.ExploreUtils;
+import co.cask.cdap.security.hive.HiveTokenUtils;
+import co.cask.cdap.security.hive.JobHistoryServerTokenUtils;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
@@ -114,7 +114,7 @@ public final class TokenSecureStoreUpdater implements SecureStoreUpdater {
    * Call this method only if explore is enabled.
    */
   private Configuration getHiveConf() {
-    ClassLoader hiveClassloader = ExploreServiceUtils.getExploreClassLoader();
+    ClassLoader hiveClassloader = ExploreUtils.getExploreClassloader();
     ClassLoader contextClassloader = Thread.currentThread().getContextClassLoader();
     Thread.currentThread().setContextClassLoader(hiveClassloader);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/HiveTokenUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/HiveTokenUtils.java
@@ -14,9 +14,9 @@
  * the License.
  */
 
-package co.cask.cdap.explore.security;
+package co.cask.cdap.security.hive;
 
-import co.cask.cdap.explore.service.ExploreServiceUtils;
+import co.cask.cdap.hive.ExploreUtils;
 import com.google.common.base.Throwables;
 import org.apache.hadoop.hive.thrift.DelegationTokenIdentifier;
 import org.apache.hadoop.io.Text;
@@ -36,7 +36,7 @@ public final class HiveTokenUtils {
   private static final Logger LOG = LoggerFactory.getLogger(HiveTokenUtils.class);
 
   public static Credentials obtainToken(Credentials credentials) {
-    ClassLoader hiveClassloader = ExploreServiceUtils.getExploreClassLoader();
+    ClassLoader hiveClassloader = ExploreUtils.getExploreClassloader();
     ClassLoader contextClassloader = Thread.currentThread().getContextClassLoader();
     Thread.currentThread().setContextClassLoader(hiveClassloader);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/JobHistoryServerTokenUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/JobHistoryServerTokenUtils.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.explore.security;
+package co.cask.cdap.security.hive;
 
 import co.cask.cdap.common.security.YarnTokenUtils;
 import com.google.common.base.Throwables;

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
@@ -24,14 +24,12 @@ import co.cask.cdap.explore.service.hive.Hive12CDH5ExploreService;
 import co.cask.cdap.explore.service.hive.Hive12ExploreService;
 import co.cask.cdap.explore.service.hive.Hive13ExploreService;
 import co.cask.cdap.explore.service.hive.Hive14ExploreService;
+import co.cask.cdap.hive.ExploreUtils;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import org.apache.hadoop.conf.Configuration;
@@ -56,7 +54,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
@@ -115,71 +112,10 @@ public class ExploreServiceUtils {
 
   // Caching the dependencies so that we don't trace them twice
   private static Set<File> exploreDependencies = null;
-  // Caching explore class loader
-  private static ClassLoader exploreClassLoader = null;
 
   private static final Pattern HIVE_SITE_FILE_PATTERN = Pattern.compile("^.*/hive-site\\.xml$");
   private static final Pattern YARN_SITE_FILE_PATTERN = Pattern.compile("^.*/yarn-site\\.xml$");
   private static final Pattern MAPRED_SITE_FILE_PATTERN = Pattern.compile("^.*/mapred-site\\.xml$");
-
-  /**
-   * Get all the files contained in a class path.
-   */
-  public static Iterable<File> getClassPathJarsFiles(String hiveClassPath) {
-    if (hiveClassPath == null) {
-      return null;
-    }
-    return Iterables.transform(Splitter.on(':').split(hiveClassPath), STRING_FILE_FUNCTION);
-  }
-
-  private static final Function<String, File> STRING_FILE_FUNCTION =
-    new Function<String, File>() {
-      @Override
-      public File apply(String input) {
-        return new File(input).getAbsoluteFile();
-      }
-    };
-
-  /**
-   * Builds a class loader with the class path provided.
-   */
-  public static ClassLoader getExploreClassLoader() {
-    if (exploreClassLoader != null) {
-      return exploreClassLoader;
-    }
-
-    // EXPLORE_CLASSPATH and EXPLORE_CONF_FILES will be defined in startup scripts if Hive is installed.
-    String exploreClassPathStr = System.getProperty(Constants.Explore.EXPLORE_CLASSPATH);
-    LOG.debug("Explore classpath = {}", exploreClassPathStr);
-    if (exploreClassPathStr == null) {
-      throw new RuntimeException("System property " + Constants.Explore.EXPLORE_CLASSPATH + " is not set.");
-    }
-
-    String exploreConfPathStr = System.getProperty(Constants.Explore.EXPLORE_CONF_FILES);
-    LOG.debug("Explore confPath = {}", exploreConfPathStr);
-    if (exploreConfPathStr == null) {
-      throw new RuntimeException("System property " + Constants.Explore.EXPLORE_CONF_FILES + " is not set.");
-    }
-
-    Iterable<File> hiveClassPath = getClassPathJarsFiles(exploreClassPathStr);
-    Iterable<File> hiveConfFiles = getClassPathJarsFiles(exploreConfPathStr);
-    ImmutableList.Builder<URL> builder = ImmutableList.builder();
-    for (File file : Iterables.concat(hiveClassPath, hiveConfFiles)) {
-      try {
-        if (file.getName().matches(".*\\.xml")) {
-          builder.add(file.getParentFile().toURI().toURL());
-        } else {
-          builder.add(file.toURI().toURL());
-        }
-      } catch (MalformedURLException e) {
-        LOG.error("Jar URL is malformed", e);
-        throw Throwables.propagate(e);
-      }
-    }
-    exploreClassLoader = new URLClassLoader(Iterables.toArray(builder.build(), URL.class),
-                                            ClassLoader.getSystemClassLoader());
-    return exploreClassLoader;
-  }
 
   public static Class<? extends ExploreService> getHiveService() {
     HiveSupport hiveVersion = checkHiveSupport(null);
@@ -187,11 +123,11 @@ public class ExploreServiceUtils {
   }
 
   public static HiveSupport checkHiveSupport() {
-    return checkHiveSupport(getExploreClassLoader());
+    return checkHiveSupport(ExploreUtils.getExploreClassloader());
   }
 
   public static String getHiveVersion() {
-    return getHiveVersion(getExploreClassLoader());
+    return getHiveVersion(ExploreUtils.getExploreClassloader());
   }
 
   public static String getHiveVersion(@Nullable ClassLoader hiveClassLoader) {
@@ -268,7 +204,7 @@ public class ExploreServiceUtils {
       return exploreDependencies;
     }
 
-    ClassLoader classLoader = getExploreClassLoader();
+    ClassLoader classLoader = ExploreUtils.getExploreClassloader();
     return traceExploreDependencies(classLoader, tmpDir);
   }
 
@@ -301,11 +237,8 @@ public class ExploreServiceUtils {
         * */
       @Override
       public boolean accept(String className, URL classUrl, URL classPathUrl) {
-        if (bootstrapClassPaths.contains(classPathUrl.getFile()) ||
-          className.startsWith("com.esotericsoftware.kryo")) {
-          return false;
-        }
-        return true;
+        return !(bootstrapClassPaths.contains(classPathUrl.getFile()) ||
+          className.startsWith("com.esotericsoftware.kryo"));
       }
     };
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -51,6 +51,7 @@ import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.explore.service.ExploreServiceUtils;
+import co.cask.cdap.hive.ExploreUtils;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
 import co.cask.cdap.logging.guice.LoggingModules;
@@ -58,6 +59,7 @@ import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -803,7 +805,7 @@ public class MasterServiceMain extends DaemonMain {
     // Add all the conf files needed by hive as resources available to containers
     File tempDir = DirUtils.createTempDir(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                                                    cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile());
-    Iterable<File> hiveConfFilesFiles = ExploreServiceUtils.getClassPathJarsFiles(hiveConfFiles);
+    Iterable<File> hiveConfFilesFiles = ExploreUtils.getClassPathJarsFiles(hiveConfFiles);
     Set<String> addedFiles = Sets.newHashSet();
     for (File file : hiveConfFilesFiles) {
       if (file.getName().matches(".*\\.xml") && !file.getName().equals("logback.xml")) {


### PR DESCRIPTION
- Move HiveTokenUtils and JobHistoryServerTokenUtils and some helper method to app-fabric
- Make Hive tokens available to all program runners

Build: http://builds.cask.co/browse/CDAP-DUT3315-1
Issue: https://issues.cask.co/browse/CDAP-4421
