### PR TITLE
[CDAP-4423] fix the flaky MultiThreadDatasetCacheTest.java

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/SingleThreadDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/SingleThreadDatasetCache.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.data2.dataset2;
 
-import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.data.DatasetProvider;
 import co.cask.cdap.api.dataset.Dataset;
@@ -53,7 +52,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
- * Implementation of {@link DatasetContext} that allows to dynamically load datasets
+ * Implementation of {@link DatasetProvider} that allows to dynamically load datasets
  * into a started {@link TransactionContext}. Datasets acquired from this context are distinct from any
  * Datasets instantiated outside this class.
  */

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/TestDataset.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/TestDataset.java
@@ -33,7 +33,7 @@ public class TestDataset extends AbstractDataset implements Comparable<TestDatas
   private final String value;
 
   public static String generateSystemProperty(String name, String key, String value, String operation) {
-    return String.format("TestDataset.%s.%s.%s.%s", name, key, value, operation);
+    return String.format("TestDataset.%s.%s.%s.%s.%d", name, key, value, operation, Thread.currentThread().getId());
   }
 
   private void setSystemProperty(String operation, String valueToSet) {


### PR DESCRIPTION
Root cause of the problem was that the test uses system properties to implement some checks. Concurrent threads sometimes clashed on setting the same property. 

Secondary issue was that these threads might fail but that does not fail the test case. That failure would have made the actual issue a lot clearer. Added additional checks to make sure the test fails early in that case.

