### PR TITLE
Feature/cdap 3887 router connection timeout

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -391,22 +391,12 @@ public final class Constants {
     public static final String SERVER_WORKER_THREADS = "router.server.worker.threads";
     public static final String CLIENT_BOSS_THREADS = "router.client.boss.threads";
     public static final String CLIENT_WORKER_THREADS = "router.client.worker.threads";
+    public static final String CONNECTION_TIMEOUT_SECS = "router.connection.idle.timeout.secs";
 
     /**
      * Defaults.
      */
     public static final String DEFAULT_ROUTER_PORT = "10000";
-    public static final String DEFAULT_WEBAPP_PORT = "20000";
-    public static final String DEFAULT_ROUTER_SSL_PORT = "10443";
-    public static final String DEFAULT_WEBAPP_SSL_PORT = "20443";
-    public static final boolean DEFAULT_WEBAPP_ENABLED = false;
-
-
-    public static final int DEFAULT_BACKLOG = 20000;
-    public static final int DEFAULT_SERVER_BOSS_THREADS = 1;
-    public static final int DEFAULT_SERVER_WORKER_THREADS = 10;
-    public static final int DEFAULT_CLIENT_BOSS_THREADS = 1;
-    public static final int DEFAULT_CLIENT_WORKER_THREADS = 10;
 
     public static final String GATEWAY_DISCOVERY_NAME = Service.GATEWAY;
     public static final String WEBAPP_DISCOVERY_NAME = "webapp/$HOST";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1110,7 +1110,7 @@
     <name>notification.transport.system</name>
     <value>kafka</value>
     <description>
-      Transport system used by the Notification system - can be kafka/stream
+      Transport system used by the Notification system: can be kafka/stream
     </description>
   </property>
 
@@ -1163,11 +1163,49 @@
   </property>
 
   <property>
+    <name>router.client.boss.threads</name>
+    <value>1</value>
+    <description>The number of boss threads in the router client</description>
+  </property>
+
+  <property>
+    <name>router.client.worker.threads</name>
+    <value>10</value>
+    <description>The number of worker threads in the router client</description>
+  </property>
+
+  <property>
+    <name>router.connection.backlog</name>
+    <value>20000</value>
+    <description>The connection backlog in the router server</description>
+  </property>
+
+  <property>
+    <name>router.connection.idle.timeout.secs</name>
+    <value>15</value>
+    <description>
+      The number of seconds after an http request completes that idle router connections are closed
+    </description>
+  </property>
+
+  <property>
+    <name>router.server.boss.threads</name>
+    <value>1</value>
+    <description>The number of boss threads in the router server</description>
+  </property>
+
+  <property>
     <name>router.server.port</name>
     <value>${router.bind.port}</value>
     <description>
       Router port to which CDAP UI connects
     </description>
+  </property>
+
+  <property>
+    <name>router.server.worker.threads</name>
+    <value>10</value>
+    <description>The number of worker threads in the Router server</description>
   </property>
 
   <property>

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,17 +21,18 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.SConfiguration;
 import co.cask.cdap.gateway.router.handlers.HttpRequestHandler;
 import co.cask.cdap.gateway.router.handlers.HttpStatusRequestHandler;
+import co.cask.cdap.gateway.router.handlers.IdleEventProcessor;
 import co.cask.cdap.gateway.router.handlers.SecurityAuthenticationHttpHandler;
 import co.cask.cdap.security.auth.AccessTokenTransformer;
 import co.cask.cdap.security.auth.TokenValidator;
 import co.cask.cdap.security.tools.SSLHandlerFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import org.apache.hadoop.hbase.util.Threads;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.jboss.netty.bootstrap.ClientBootstrap;
 import org.jboss.netty.bootstrap.ServerBootstrap;
@@ -52,13 +53,18 @@ import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 import org.jboss.netty.channel.socket.nio.NioWorkerPool;
 import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
 import org.jboss.netty.handler.codec.http.HttpRequestEncoder;
+import org.jboss.netty.handler.codec.http.HttpResponseDecoder;
 import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
+import org.jboss.netty.handler.timeout.IdleStateHandler;
+import org.jboss.netty.util.HashedWheelTimer;
+import org.jboss.netty.util.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -74,52 +80,38 @@ public class NettyRouter extends AbstractIdleService {
   private final int serverBossThreadPoolSize;
   private final int serverWorkerThreadPoolSize;
   private final int serverConnectionBacklog;
-
   private final int clientBossThreadPoolSize;
   private final int clientWorkerThreadPoolSize;
   private final InetAddress hostname;
   private final Map<String, Integer> serviceToPortMap;
-
   private final ChannelGroup channelGroup = new DefaultChannelGroup("server channels");
   private final RouterServiceLookup serviceLookup;
-
   private final boolean securityEnabled;
   private final TokenValidator tokenValidator;
   private final AccessTokenTransformer accessTokenTransformer;
   private final CConfiguration configuration;
-  private final SConfiguration sConfiguration;
   private final String realm;
+  private final boolean sslEnabled;
+  private final SSLHandlerFactory sslHandlerFactory;
+  private final int connectionTimeout;
 
+  private Timer timer;
   private ServerBootstrap serverBootstrap;
   private ClientBootstrap clientBootstrap;
-
   private DiscoveryServiceClient discoveryServiceClient;
-
-  private final boolean sslEnabled;
-  private final boolean webAppEnabled;
-  private final SSLHandlerFactory sslHandlerFactory;
 
   @Inject
   public NettyRouter(CConfiguration cConf, SConfiguration sConf, @Named(Constants.Router.ADDRESS) InetAddress hostname,
                      RouterServiceLookup serviceLookup, TokenValidator tokenValidator,
                      AccessTokenTransformer accessTokenTransformer,
                      DiscoveryServiceClient discoveryServiceClient) {
-
-    this.serverBossThreadPoolSize = cConf.getInt(Constants.Router.SERVER_BOSS_THREADS,
-                                                 Constants.Router.DEFAULT_SERVER_BOSS_THREADS);
-    this.serverWorkerThreadPoolSize = cConf.getInt(Constants.Router.SERVER_WORKER_THREADS,
-                                                   Constants.Router.DEFAULT_SERVER_WORKER_THREADS);
-    this.serverConnectionBacklog = cConf.getInt(Constants.Router.BACKLOG_CONNECTIONS,
-                                                Constants.Router.DEFAULT_BACKLOG);
-
-    this.clientBossThreadPoolSize = cConf.getInt(Constants.Router.CLIENT_BOSS_THREADS,
-                                                 Constants.Router.DEFAULT_CLIENT_BOSS_THREADS);
-    this.clientWorkerThreadPoolSize = cConf.getInt(Constants.Router.CLIENT_WORKER_THREADS,
-                                                   Constants.Router.DEFAULT_CLIENT_WORKER_THREADS);
-
+    this.serverBossThreadPoolSize = cConf.getInt(Constants.Router.SERVER_BOSS_THREADS);
+    this.serverWorkerThreadPoolSize = cConf.getInt(Constants.Router.SERVER_WORKER_THREADS);
+    this.serverConnectionBacklog = cConf.getInt(Constants.Router.BACKLOG_CONNECTIONS);
+    this.clientBossThreadPoolSize = cConf.getInt(Constants.Router.CLIENT_BOSS_THREADS);
+    this.clientWorkerThreadPoolSize = cConf.getInt(Constants.Router.CLIENT_WORKER_THREADS);
     this.hostname = hostname;
-    this.serviceToPortMap = Maps.newHashMap();
-
+    this.serviceToPortMap = new HashMap<>();
     this.serviceLookup = serviceLookup;
     this.securityEnabled = cConf.getBoolean(Constants.Security.ENABLED, false);
     this.realm = cConf.get(Constants.Security.CFG_REALM);
@@ -127,18 +119,14 @@ public class NettyRouter extends AbstractIdleService {
     this.accessTokenTransformer = accessTokenTransformer;
     this.discoveryServiceClient = discoveryServiceClient;
     this.configuration = cConf;
-    this.sConfiguration = sConf;
-
     this.sslEnabled = cConf.getBoolean(Constants.Security.SSL_ENABLED);
-    this.webAppEnabled = cConf.getBoolean(Constants.Router.WEBAPP_ENABLED);
+    boolean webAppEnabled = cConf.getBoolean(Constants.Router.WEBAPP_ENABLED);
     if (isSSLEnabled()) {
       this.serviceToPortMap.put(Constants.Router.GATEWAY_DISCOVERY_NAME,
-                                Integer.parseInt(cConf.get(Constants.Router.ROUTER_SSL_PORT,
-                                                           Constants.Router.DEFAULT_ROUTER_SSL_PORT)));
+                                cConf.getInt(Constants.Router.ROUTER_SSL_PORT));
       if (webAppEnabled) {
         this.serviceToPortMap.put(Constants.Router.WEBAPP_DISCOVERY_NAME,
-                                  Integer.parseInt(cConf.get(Constants.Router.WEBAPP_SSL_PORT,
-                                                             Constants.Router.DEFAULT_WEBAPP_SSL_PORT)));
+                                  cConf.getInt(Constants.Router.WEBAPP_SSL_PORT));
       }
 
       File keystore;
@@ -154,22 +142,20 @@ public class NettyRouter extends AbstractIdleService {
                                                      sConf.get(Constants.Security.Router.SSL_KEYSTORE_PASSWORD),
                                                      sConf.get(Constants.Security.Router.SSL_KEYPASSWORD));
     } else {
-      this.serviceToPortMap.put(Constants.Router.GATEWAY_DISCOVERY_NAME,
-                        Integer.parseInt(cConf.get(Constants.Router.ROUTER_PORT,
-                                                   Constants.Router.DEFAULT_ROUTER_PORT)));
+      this.serviceToPortMap.put(Constants.Router.GATEWAY_DISCOVERY_NAME, cConf.getInt(Constants.Router.ROUTER_PORT));
       if (webAppEnabled) {
-        this.serviceToPortMap.put(Constants.Router.WEBAPP_DISCOVERY_NAME,
-                                  Integer.parseInt(cConf.get(Constants.Router.WEBAPP_PORT,
-                                                             Constants.Router.DEFAULT_WEBAPP_PORT)));
+        this.serviceToPortMap.put(Constants.Router.WEBAPP_DISCOVERY_NAME, cConf.getInt(Constants.Router.WEBAPP_PORT));
       }
       this.sslHandlerFactory = null;
     }
+    this.connectionTimeout = cConf.getInt(Constants.Router.CONNECTION_TIMEOUT_SECS);
+    LOG.info("Using connection timeout: {}", connectionTimeout);
     LOG.info("Service to Port Mapping - {}", this.serviceToPortMap);
   }
 
   @Override
   protected void startUp() throws Exception {
-    ChannelUpstreamHandler connectionTracker =  new SimpleChannelUpstreamHandler() {
+    ChannelUpstreamHandler connectionTracker = new SimpleChannelUpstreamHandler() {
       @Override
       public void handleUpstream(ChannelHandlerContext ctx, ChannelEvent e)
         throws Exception {
@@ -179,6 +165,7 @@ public class NettyRouter extends AbstractIdleService {
     };
 
     tokenValidator.startAndWait();
+    timer = new HashedWheelTimer(Threads.newDaemonThreadFactory("router-idle-event-generator-timer"));
     bootstrapClient(connectionTracker);
 
     bootstrapServer(connectionTracker);
@@ -198,6 +185,7 @@ public class NettyRouter extends AbstractIdleService {
       clientBootstrap.releaseExternalResources();
       serverBootstrap.releaseExternalResources();
       tokenValidator.stopAndWait();
+      timer.stop();
     }
 
     LOG.info("Stopped Netty Router.");
@@ -289,12 +277,19 @@ public class NettyRouter extends AbstractIdleService {
         new NioClientBossPool(clientBossExecutor, clientBossThreadPoolSize),
         new NioWorkerPool(clientWorkerExecutor, clientWorkerThreadPoolSize)));
 
+
     clientBootstrap.setPipelineFactory(new ChannelPipelineFactory() {
       @Override
       public ChannelPipeline getPipeline() throws Exception {
         ChannelPipeline pipeline = Channels.pipeline();
         pipeline.addLast("tracker", connectionTracker);
         pipeline.addLast("request-encoder", new HttpRequestEncoder());
+        // outbound handler gets dynamically added here (after 'request-encoder')
+        pipeline.addLast("response-decoder", new HttpResponseDecoder());
+        // disable the read-specific and write-specific timeouts; we only utilize IdleState#ALL_IDLE
+        pipeline.addLast("idle-event-generator",
+                         new IdleStateHandler(timer, 0, 0, connectionTimeout));
+        pipeline.addLast("idle-event-processor", new IdleEventProcessor());
         return pipeline;
       }
     });

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterModules.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -55,6 +55,7 @@ public class RouterModules extends RuntimeModule {
 
       @Provides
       @Named(Constants.Router.ADDRESS)
+      @SuppressWarnings("unused")
       public final InetAddress providesHostname(CConfiguration cConf) {
         return Networks.resolve(cConf.get(Constants.Router.ADDRESS),
                                 new InetSocketAddress("localhost", 0).getAddress());

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpRequestHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,7 +20,6 @@ import co.cask.cdap.common.HandlerException;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.gateway.router.ProxyRule;
 import co.cask.cdap.gateway.router.RouterServiceLookup;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.io.Closeables;
 import org.apache.twill.discovery.Discoverable;
@@ -47,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -76,7 +76,7 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler {
                             List<ProxyRule> proxyRules) {
     this.clientBootstrap = clientBootstrap;
     this.serviceLookup = serviceLookup;
-    this.discoveryLookup = Maps.newHashMap();
+    this.discoveryLookup = new HashMap<>();
     this.proxyRules = proxyRules;
   }
 

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/IdleEventProcessor.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/IdleEventProcessor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.router.handlers;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.handler.codec.http.HttpChunk;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.timeout.IdleState;
+import org.jboss.netty.handler.timeout.IdleStateAwareChannelHandler;
+import org.jboss.netty.handler.timeout.IdleStateEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles states when a channel has been idle for a configured time interval, by closing the channel if an
+ * HTTP Request is not in progress.
+ */
+public class IdleEventProcessor extends IdleStateAwareChannelHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(IdleEventProcessor.class);
+  private boolean requestInProgress;
+
+  @Override
+  public void channelIdle(ChannelHandlerContext ctx, IdleStateEvent e) throws Exception {
+    if (IdleState.ALL_IDLE == e.getState()) {
+      if (requestInProgress) {
+        LOG.trace("Request is in progress, so not closing channel.");
+      } else {
+        // No data has been sent or received for a while. Close channel.
+        Channel channel = ctx.getChannel();
+        channel.close();
+        LOG.debug("No data has been sent or received for channel '{}' for more than the configured idle timeout. " +
+                    "Closing the channel. Local Address: {}, Remote Address: {}",
+                  channel, channel.getLocalAddress(), channel.getRemoteAddress());
+      }
+    }
+  }
+
+  @Override
+  public void messageReceived(ChannelHandlerContext ctx, MessageEvent e)
+    throws Exception {
+    Object message = e.getMessage();
+    if (message instanceof HttpResponse) {
+      HttpResponse response = (HttpResponse) message;
+      if (!response.isChunked()) {
+        requestInProgress = false;
+      }
+    } else if (message instanceof HttpChunk) {
+      HttpChunk chunk = (HttpChunk) message;
+
+      if (chunk.isLast()) {
+        requestInProgress = false;
+      }
+    }
+
+    ctx.sendUpstream(e);
+  }
+
+  @Override
+  public void writeRequested(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+    Object message = e.getMessage();
+    if (message instanceof HttpRequest || message instanceof HttpChunk) {
+      requestInProgress = true;
+    }
+    ctx.sendDownstream(e);
+  }
+}

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/OutboundHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/OutboundHandler.java
@@ -18,8 +18,11 @@ package co.cask.cdap.gateway.router.handlers;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelFutureListener;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.Channels;
 import org.jboss.netty.channel.ExceptionEvent;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
@@ -39,9 +42,15 @@ public class OutboundHandler extends SimpleChannelUpstreamHandler {
   }
 
   @Override
-  public void messageReceived(ChannelHandlerContext ctx, final MessageEvent e) throws Exception {
+  public void messageReceived(final ChannelHandlerContext ctx, final MessageEvent e) throws Exception {
     ChannelBuffer msg = (ChannelBuffer) e.getMessage();
-    inboundChannel.write(msg);
+
+    Channels.write(inboundChannel, msg).addListener(new ChannelFutureListener() {
+      @Override
+      public void operationComplete(ChannelFuture future) throws Exception {
+        OutboundHandler.super.messageReceived(ctx, e);
+      }
+    });
   }
 
   @Override

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamViewHttpHandlerTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamViewHttpHandlerTest.java
@@ -65,9 +65,8 @@ public class StreamViewHttpHandlerTest extends GatewayTestBase {
 
     List<String> views = execute(
       200, HttpRequest.get(resolve("/v3/namespaces/default/streams/foo/views")).build(),
-      new TypeToken<List<String>>() {
-      }.getType());
-    Assert.assertEquals(ImmutableList.of(), views);
+      new TypeToken<List<String>>() { }.getType());
+    Assert.assertEquals(ImmutableList.<String>of(), views);
 
     Schema schema = Schema.recordOf("foo", Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
     FormatSpecification formatSpec = new FormatSpecification(
@@ -120,7 +119,7 @@ public class StreamViewHttpHandlerTest extends GatewayTestBase {
     views = execute(
       200, HttpRequest.get(resolve("/v3/namespaces/default/streams/foo/views")).build(),
       new TypeToken<List<String>>() { }.getType());
-    Assert.assertEquals(ImmutableList.of(), views);
+    Assert.assertEquals(ImmutableList.<String>of(), views);
 
     // Deleting a stream should also delete the associated views
     execute(200, HttpRequest.delete(resolve("/v3/namespaces/default/streams/foo")).build());

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,11 +28,13 @@ import com.google.common.collect.Maps;
 import com.google.common.net.InetAddresses;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import org.apache.commons.net.DefaultSocketFactory;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.util.Map;
+import javax.net.SocketFactory;
 
 /**
  * Tests Netty Router running on HTTP.
@@ -57,6 +59,11 @@ public class NettyRouterHttpTest extends NettyRouterTestBase {
   @Override
   protected DefaultHttpClient getHTTPClient() throws Exception {
     return new DefaultHttpClient();
+  }
+
+  @Override
+  protected SocketFactory getSocketFactory() throws Exception {
+    return new DefaultSocketFactory();
   }
 
   private static class HttpRouterService extends RouterService {
@@ -84,6 +91,7 @@ public class NettyRouterHttpTest extends NettyRouterTestBase {
       cConf.setInt(Constants.Router.ROUTER_PORT, 0);
       cConf.setBoolean(Constants.Router.WEBAPP_ENABLED, true);
       cConf.setInt(Constants.Router.WEBAPP_PORT, 0);
+      cConf.setInt(Constants.Router.CONNECTION_TIMEOUT_SECS, CONNECTION_IDLE_TIMEOUT_SECS);
       router =
         new NettyRouter(cConf, sConfiguration, InetAddresses.forString(hostname),
                         new RouterServiceLookup((DiscoveryServiceClient) discoveryService,

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpsTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -43,7 +43,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.Map;
+import javax.net.SocketFactory;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -106,6 +108,28 @@ public class NettyRouterHttpsTest extends NettyRouterTestBase {
     return new DefaultHttpClient(cm);
   }
 
+  @Override
+  protected SocketFactory getSocketFactory() throws Exception {
+    SSLContext sc = SSLContext.getInstance("TLS");
+    sc.init(null, new TrustManager[]{new X509TrustManager() {
+      @Override
+      public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+
+      }
+
+      @Override
+      public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+
+      }
+
+      @Override
+      public X509Certificate[] getAcceptedIssuers() {
+        return new X509Certificate[0];
+      }
+    }}, new java.security.SecureRandom());
+    return sc.getSocketFactory();
+  }
+
   private static class HttpsRouterService extends RouterService {
     private final String hostname;
     private final DiscoveryService discoveryService;
@@ -116,7 +140,6 @@ public class NettyRouterHttpsTest extends NettyRouterTestBase {
     private HttpsRouterService(String hostname, DiscoveryService discoveryService) {
       this.hostname = hostname;
       this.discoveryService = discoveryService;
-
     }
 
     @Override
@@ -137,6 +160,7 @@ public class NettyRouterHttpsTest extends NettyRouterTestBase {
       cConf.setInt(Constants.Router.ROUTER_PORT, 0);
       cConf.setBoolean(Constants.Router.WEBAPP_ENABLED, true);
       cConf.setInt(Constants.Router.WEBAPP_PORT, 0);
+      cConf.setInt(Constants.Router.CONNECTION_TIMEOUT_SECS, CONNECTION_IDLE_TIMEOUT_SECS);
 
       sConf.set(Constants.Security.Router.SSL_KEYSTORE_PATH, certUrl.getPath());
 

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
@@ -76,16 +76,20 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 
 /**
  * Verify the ordering of events in the RouterPipeline.
@@ -97,7 +101,6 @@ public class NettyRouterPipelineTest {
   private static final DiscoveryService discoveryService = new InMemoryDiscoveryService();
   private static final String gatewayService = Constants.Service.APP_FABRIC_HTTP;
   private static final String GATEWAY_LOOKUP = Constants.Router.GATEWAY_DISCOVERY_NAME;
-  private static final String webappService = "$HOST";
   private static final int maxUploadBytes = 10 * 1024 * 1024;
   private static final int chunkSize = 1024 * 1024;      // NOTE: maxUploadBytes % chunkSize == 0
   private static byte[] applicationJarInBytes;
@@ -178,8 +181,7 @@ public class NettyRouterPipelineTest {
   private void deploy(int num) throws Exception {
 
     String path = String.format("http://%s:%d/v1/deploy",
-                                hostname,
-                                ROUTER.getServiceMap().get(GATEWAY_LOOKUP));
+                                hostname, ROUTER.getServiceMap().get(GATEWAY_LOOKUP));
 
     LocationFactory lf = new LocalLocationFactory(TMP_FOLDER.newFolder());
     Location programJar = AppJarHelper.createDeploymentJar(lf, AllProgramsApp.class);
@@ -196,6 +198,7 @@ public class NettyRouterPipelineTest {
 
       ByteStreams.copy(Locations.newInputSupplier(programJar), urlConn.getOutputStream());
       Assert.assertEquals(200, urlConn.getResponseCode());
+      urlConn.getInputStream().close();
       urlConn.disconnect();
     }
   }
@@ -359,8 +362,8 @@ public class NettyRouterPipelineTest {
               responder.sendStatus(HttpResponseStatus.OK);
               return;
             }
-              responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-            }
+            responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+          }
 
           @Override
           public void handleError(Throwable cause) {
@@ -368,7 +371,6 @@ public class NettyRouterPipelineTest {
           }
         };
       }
-
     }
   }
 


### PR DESCRIPTION
NettyRouter now closes connections if there has been no HTTP request in flight for a given timeout.
IdleStateHandler sends an event when the connection has been idle. IdleEventProcessor gets this event and closes the channel if no HTTP Request is in progress.

https://issues.cask.co/browse/CDAP-3887
http://builds.cask.co/browse/CDAP-RBT536-3

Note: Opening this PR for review; once reviewed, these changes will be back-ported to 2.8.3.

This PR is a continuation of https://github.com/caskdata/cdap/pull/4675