### PR TITLE
Bugfix: [CDAP-3824] flaky HBaseTableTest

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestBase.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.data.hbase;
 
-import co.cask.cdap.common.utils.Networks;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Futures;
@@ -80,10 +79,10 @@ public abstract class HBaseTestBase extends ExternalResource {
     getConfiguration().setInt("hbase.regionserver.handler.count", 10);
 
     // Set to random port
-    getConfiguration().setInt("hbase.master.port", Networks.getRandomPort());
-    getConfiguration().setInt("hbase.master.info.port", Networks.getRandomPort());
-    getConfiguration().setInt("hbase.regionserver.port", Networks.getRandomPort());
-    getConfiguration().setInt("hbase.regionserver.info.port", Networks.getRandomPort());
+    getConfiguration().setInt("hbase.master.port", 0);
+    getConfiguration().setInt("hbase.master.info.port", 0);
+    getConfiguration().setInt("hbase.regionserver.port", 0);
+    getConfiguration().setInt("hbase.regionserver.info.port", 0);
 
     doStartHBase();
   }


### PR DESCRIPTION
Summary: configure port 0 for all the HBase ports instead of using Networks.getRandomPort(). I have tested this on my laptop, and I have run the test case 4 times concurrently. It works. I am not sure why we did not use port 0 before as that is the standard way to obtain a random free port. Perhaps older HBase versions did not work that way. 

