### PR TITLE
Allow disabling verification of SSL certs in integration tests.

### DIFF
--- a/cdap-integration-test/README.rst
+++ b/cdap-integration-test/README.rst
@@ -21,14 +21,16 @@ Running tests against a remote CDAP instance
 ::
 
   cd <your-test-module>
-  mvn test -DargLine="-DinstanceUri=<instance URI> -DaccessToken=<access token>"
+  mvn test -DargLine="-DinstanceUri=<instance URI> -Dcdap.username=<username> -Dcdap.password=<password> -DverifySSL=<verify ssl>"
 
 - ``<instance URI>`` is the URI used to connect to your CDAP router 
   (for example, ``http://example.com:10000``)
-- ``<access token>`` is the access token obtained from your CDAP authentication server by 
-  logging in as user. **Note:** This is unnecessary in a non-secure CDAP instance.
+- ``<username>`` and ``<password>`` are the credentials for your CDAP authentication server by
+  **Note:** These are unnecessary in a non-secure CDAP instance.
+- ``<verify ssl>`` is whether to verify the certificate in SSL connections.
+  **Note:** This is unnecessary in a non-SSL CDAP instance.
 
 For example, to run tests against a CDAP instance at ``http://example.com:10000`` with
-access token ``abc123``::
+user ``abc123`` and password ``123456``::
 
-  mvn test -DargLine="-DinstanceUri=http://example.com:10000 -DaccessToken=abc123"
+  mvn test -DargLine="-DinstanceUri=http://example.com:10000 -Dcdap.username=abc123 -Dcdap.password=123456"

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -235,6 +235,11 @@ public abstract class IntegrationTestBase {
       builder.setAccessToken(accessToken);
     }
 
+    String verifySSL = System.getProperty("verifySSL");
+    if (verifySSL != null) {
+      builder.setVerifySSLCert(Boolean.valueOf(verifySSL));
+    }
+
     builder.setDefaultConnectTimeout(120000);
     builder.setDefaultReadTimeout(120000);
     builder.setUploadConnectTimeout(0);


### PR DESCRIPTION
I tried to run the integration tests cases against a cluster running SSL, but wasn't able to because IntegrationTestBase always had `verifySSL` as true.

http://builds.cask.co/browse/CDAP-DUT3336-2