### PR TITLE
CDAP-4429 override appender stop to stop delegates as well

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/log/LogStageAppender.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/log/LogStageAppender.java
@@ -46,6 +46,26 @@ public class LogStageAppender extends AppenderBase<ILoggingEvent> {
     }
   }
 
+  @Override
+  public void stop() {
+    super.stop();
+    RuntimeException ex = null;
+    for (Appender appender : appenders) {
+      try {
+        appender.stop();
+      } catch (Throwable t) {
+        if (ex == null) {
+          ex = new RuntimeException(t);
+        } else {
+          ex.addSuppressed(t);
+        }
+      }
+    }
+    if (ex != null) {
+      throw ex;
+    }
+  }
+
   /**
    * Wrapper around ILoggingEvent that prefixes messages with the stage name if it exists.
    */


### PR DESCRIPTION
Without this, the original root appenders will never be stopped,
and the program will hang on shutdown. This is because we will
have a KafkaAppender from Twill that will not shutdown its
scheduler or zk and kafka services.