### PR TITLE
Modifies the key (json file name) that needs to be generated to fetch the config json for a plugin

### DIFF
--- a/cdap-ui/app/features/admin/controllers/namespace/templates-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/templates-ctrl.js
@@ -260,6 +260,7 @@ angular.module(PKG.name + '.feature.admin')
       };
 
       vm.groups = {};
+      // FIXME: This is no longer valid. We need to fix this. The fundamental API is wrong. It shouldn't be using PluginConfigFactory.fetch.
       PluginConfigFactory.fetch(
         $scope,
         vm.templateType,

--- a/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -70,11 +70,10 @@ class NodeConfigController {
     if (this.state.noproperty) {
       var artifactName = this.myHelpers.objectQuery(this.state.node, 'plugin', 'artifact', 'name') || this.GLOBALS.artifact.default.name;
       var artifactVersion = this.myHelpers.objectQuery(this.state.node, 'plugin', 'artifact', 'version') || this.GLOBALS.artifact.default.version;
-      var key = this.state.node.plugin.name + (this.GLOBALS.pluginConvert[this.state.node.type] !== this.GLOBALS.pluginConvert['transform']? '-' + this.state.node.type: '');
       this.PluginConfigFactory.fetch(
         artifactName,
         artifactVersion,
-        key
+        this.state.node.plugin.name + '-' + this.state.node.type
       )
         .then(
           (res) => {

--- a/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -70,11 +70,11 @@ class NodeConfigController {
     if (this.state.noproperty) {
       var artifactName = this.myHelpers.objectQuery(this.state.node, 'plugin', 'artifact', 'name') || this.GLOBALS.artifact.default.name;
       var artifactVersion = this.myHelpers.objectQuery(this.state.node, 'plugin', 'artifact', 'version') || this.GLOBALS.artifact.default.version;
-
+      var key = this.state.node.plugin.name + (this.GLOBALS.pluginConvert[this.state.node.type] !== this.GLOBALS.pluginConvert['transform']? '-' + this.state.node.type: '');
       this.PluginConfigFactory.fetch(
         artifactName,
         artifactVersion,
-        this.state.node.plugin.name
+        key
       )
         .then(
           (res) => {

--- a/cdap-ui/app/features/hydrator/services/plugin-config-factory.js
+++ b/cdap-ui/app/features/hydrator/services/plugin-config-factory.js
@@ -111,12 +111,12 @@ class PluginConfigFactory {
           groupsConfig.outputSchema.implicitSchema = output.schema;
         } else {
           index = propertiesFromBackend.indexOf(output.name);
-          groupsConfig.outputSchema.isOutputSchemaExists = true;
-          groupsConfig.outputSchema.outputSchemaProperty = [output.name];
-          groupsConfig.outputSchema.schemaProperties = output['widget-attributes'];
-          groupsConfig.outputSchema.isOutputSchemaRequired = backendProperties[output.name].required;
           if (index !== -1) {
             propertiesFromBackend.splice(index, 1);
+            groupsConfig.outputSchema.isOutputSchemaExists = true;
+            groupsConfig.outputSchema.outputSchemaProperty = [output.name];
+            groupsConfig.outputSchema.schemaProperties = output['widget-attributes'];
+            groupsConfig.outputSchema.isOutputSchemaRequired = backendProperties[output.name].required;
           }
         }
       });


### PR DESCRIPTION
- Modifies the way we generate the key while fetching a config for a plugin. (pluginname-plugintype) (eg: ```http://127.0.0.1:10000/v3/namespaces/default/artifacts/mongodb-plugins/versions/1.2.0-SNAPSHOT/properties?scope=system&keys=widgets.MongoDB-batchsink```)
- Handles the case where ```output``` array has a schema property but that property is not from backend. If thats the case we don't show the output schema for a sink and default the input schema to output schema for source and transform.

This PR is dependent on this one - https://github.com/caskdata/hydrator-plugins/pull/75. We should merge this once that is merged.
