### PR TITLE
CDAP-4444 Make xmllint dependency optional

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -45,7 +45,7 @@ get_conf() {
       UBUNTU) die "Cannot locate xmllint, is libxml2-utils installed?" ;;
     esac
     # If we get here, die
-    die "Cannot locate xmllint, are XML tools installed?" ;;
+    die "Cannot locate xmllint, are XML tools installed?"
   }
   # Get property from file, return last result, if multiple are returned
   __property="cat //configuration/property[name='${__pn}']/value[text()]"


### PR DESCRIPTION
Fixes syntax error from https://github.com/caskdata/cdap/pull/4750.

```
Alis-MacBook-Pro-2:cdap alianwar$ bash cdap-common/bin/common.sh
cdap-common/bin/common.sh: line 48: syntax error near unexpected token `;;'
cdap-common/bin/common.sh: line 48: `    die "Cannot locate xmllint, are XML tools installed?" ;;'
```

Relevant: http://stackoverflow.com/questions/16905183/dash-double-semicolon-syntax