### PR TITLE
adds correct badge color + no errors message

### DIFF
--- a/cdap-ui/app/directives/error/error-popover.html
+++ b/cdap-ui/app/directives/error/error-popover.html
@@ -22,14 +22,15 @@
         <h4>Errors</h4>
       </div>
       <div class="col-xs-6">
-        <button class="btn btn-sm btn-default pull-right" ng-click="clear()">Clear All</button>
+        <div ng-if="alerts.length">
+          <button class="btn btn-sm btn-default pull-right" ng-click="clear()">Clear All</button>
+        </div>
       </div>
     </div>
   </div>
   <div class="popover-content">
 
-    <div class="clearfix">
-
+    <div ng-if="alerts.length" class="clearfix">
       <div class="row alert-danger" ng-repeat="alert in alerts track by $index">
         <div class="col-xs-10">
           <span class="badge" ng-if="alert.count > 1">{{alert.count}}</span>
@@ -42,7 +43,15 @@
           <span class="pull-right" ng-click="remove(alert)"><i class="fa fa-times"></i></span>
         </div>
       </div>
-
     </div>
+
+    <div ng-if="!alerts.length">
+      <div class="row alert-muted">
+        <div class="col-xs-12">
+          <span>No errors to display.</span>
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>

--- a/cdap-ui/app/directives/error/error-template.html
+++ b/cdap-ui/app/directives/error/error-template.html
@@ -15,14 +15,13 @@
 -->
 
 <div class="error-button"
-     ng-if="!emptyError()"
      data-placement="bottom"
      data-auto-close="true"
      data-template="error/error-popover.html"
      bs-popover>
   <span class="fa fa-bolt">
-    <sup>
-      <span class="fa fa-circle text-success"></span>
+    <sup ng-if="!emptyError()">
+      <span class="fa fa-circle text-danger"></span>
     </sup>
   </span>
 </div>

--- a/cdap-ui/app/directives/error/error.less
+++ b/cdap-ui/app/directives/error/error.less
@@ -82,6 +82,10 @@ my-error {
       background-image: none;
       color: @brand-danger;
     }
+    .alert-muted {
+      background-color: #dcdce4;
+      border-color: darken(@well-bg, 10%);
+    }
     .fa-times:hover {
       cursor: pointer;
     }


### PR DESCRIPTION
*  Notification icon (fa-bolt) now displays regardless of errors
*  Changes badge color from green to red
*  Adds default message if there are no errors
*  Hides Clear All button if there are no errors

![errors](https://cloud.githubusercontent.com/assets/5335210/11852838/36474fc2-a3ef-11e5-98ab-7b53261db2b0.gif)
