### PR TITLE
adds correct search results breadcrumb label

### DIFF
--- a/cdap-ui/app/features/search/routes.js
+++ b/cdap-ui/app/features/search/routes.js
@@ -29,8 +29,7 @@ angular.module(`${PKG.name}.feature.search`)
           controller: 'SearchObjectWithTagsController',
           controllerAs: 'SearchObjectWithTagsController',
           ncyBreadcrumb: {
-            label: '{{$state.params.tag}}',
-            parent: 'search.list'
+            label: 'Search Results'
           }
         });
   });


### PR DESCRIPTION
*  Breadcrumbs label for search now always displayed as "Search Results"

![breadcrumbs](https://cloud.githubusercontent.com/assets/5335210/11855322/68e97cf2-a3fe-11e5-91ca-49ea43554ee4.gif)
