### PR TITLE
fixes search style transitions on hover/active

### DIFF
--- a/cdap-ui/app/directives/search/search-ctrl.js
+++ b/cdap-ui/app/directives/search/search-ctrl.js
@@ -25,8 +25,9 @@ angular.module(PKG.name + '.commons')
       }
     };
     this.escapeSearch = function () {
-      this.searchTxt = '';
-      this.displaySearchBox = false;
+      if (this.searchTxt === '') {
+        this.displaySearchBox = false;
+      }
     };
 
   });

--- a/cdap-ui/app/directives/search/search-ctrl.js
+++ b/cdap-ui/app/directives/search/search-ctrl.js
@@ -23,6 +23,7 @@ angular.module(PKG.name + '.commons')
       if (event.keyCode === 13) {
         $state.go('search.objectswithtags', {tag: this.searchTxt});
         this.searchTxt = '';
+        this.displaySearchBox = false;
       }
     };
     this.escapeSearch = function () {

--- a/cdap-ui/app/directives/search/search-ctrl.js
+++ b/cdap-ui/app/directives/search/search-ctrl.js
@@ -22,6 +22,7 @@ angular.module(PKG.name + '.commons')
     this.onSearch = function(event) {
       if (event.keyCode === 13) {
         $state.go('search.objectswithtags', {tag: this.searchTxt});
+        this.searchTxt = '';
       }
     };
     this.escapeSearch = function () {

--- a/cdap-ui/app/directives/search/search.html
+++ b/cdap-ui/app/directives/search/search.html
@@ -23,7 +23,7 @@
            ng-keyup="MySearchCtrl.onSearch($event)"
            type="text"
            class="form-control"
-           placeholder="Search Tags"
+           placeholder="Search Metadata"
            my-escape-close="MySearchCtrl.escapeSearch()" />
     <div class="input-group-addon">
       <span class="fa fa-search"></span>

--- a/cdap-ui/app/directives/search/search.html
+++ b/cdap-ui/app/directives/search/search.html
@@ -16,7 +16,7 @@
 
 <div class="search-box">
   <div class="input-group"
-       ng-class="{'search-active': MySearchCtrl.displaySearchBox}"
+       ng-class="{'search-active': MySearchCtrl.displaySearchBox || MySearchCtrl.searchTxt.length}"
        ng-mouseover="MySearchCtrl.displaySearchBox = true"
        ng-mouseleave="MySearchCtrl.escapeSearch()">
     <input ng-model="MySearchCtrl.searchTxt"

--- a/cdap-ui/app/directives/search/search.less
+++ b/cdap-ui/app/directives/search/search.less
@@ -21,17 +21,17 @@
 my-search{
   .search-box {
     @media (min-width: @screen-lg-min) {
-      height: 51px;
+      height: 32px;
     }
     div.input-group {
       background-color: rgb(39, 43, 52);
       padding: 0 12px;
-      .transition(padding 100ms ease-in);
-      .transition(background-color 100ms ease-in);
+      .transition(all 0.2s ease-in);
       .border-radius(12px);
       @media (min-width: @screen-lg-min) {
         background-color: transparent;
-        line-height: 51px;
+        line-height: 32px;
+        text-align: right;
       }
       .form-control {
         color: white;
@@ -40,10 +40,11 @@ my-search{
         padding: 0 6px 0 0;
         .placeholder-color(@color: white, @font-weight: 400);
         .box-shadow(none);
-        .transition(opacity 100ms ease-in);
-        .transition(width 100ms ease-in);
+        .transition(all 100ms ease-in);
         @media (min-width: @screen-lg-min) {
+          float: none;
           width: 1px;
+          .appearance(none);
           .opacity(0);
         }
         &:focus {


### PR DESCRIPTION
*  Keeps search bar open if user has entered text and then mouses away
*  Search bar now opens from the search icon and closes toward it

![searchbar](https://cloud.githubusercontent.com/assets/5335210/11857208/1f643092-a40b-11e5-932a-e3b2f5ea57c2.gif)
