### PR TITLE
Fix third-party example

### DIFF
--- a/cdap-docs/cdap-apps/source/hydrator/plugins/third-party.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/plugins/third-party.rst
@@ -28,14 +28,14 @@ A sample JDBC Driver Plugin configuration:
         {
           "name" : "mysql",
           "type" : "jdbc",
-          "className" : "com.mysql.jdbc.Driver"
-          "description" : "Plugin for MySQL JDBC driver",
+          "className" : "com.mysql.jdbc.Driver",
+          "description" : "Plugin for MySQL JDBC driver"
         },
         {
           "name" : "postgresql",
           "type" : "jdbc",
-          "className" : "org.postgresql.Driver"
-          "description" : "Plugin for PostgreSQL JDBC driver",
+          "className" : "org.postgresql.Driver",
+          "description" : "Plugin for PostgreSQL JDBC driver"
         }
       ]
     }

--- a/cdap-docs/cdap-apps/source/hydrator/plugins/third-party.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/plugins/third-party.rst
@@ -26,16 +26,16 @@ A sample JDBC Driver Plugin configuration:
       "parents": [ "cdap-etl-batch[|version|,\ |version|]" ],
       "config": [
         {
-          "type" : "JDBC",
-          "name" : "MySQL JDBC",
-          "description" : "Plugin for MySQL JDBC driver",
+          "name" : "mysql",
+          "type" : "jdbc",
           "className" : "com.mysql.jdbc.Driver"
+          "description" : "Plugin for MySQL JDBC driver",
         },
         {
-          "type" : "JDBC",
-          "name" : "PostgreSQL JDBC",
-          "description" : "Plugin for PostgreSQL JDBC driver",
+          "name" : "postgresql",
+          "type" : "jdbc",
           "className" : "org.postgresql.Driver"
+          "description" : "Plugin for PostgreSQL JDBC driver",
         }
       ]
     }


### PR DESCRIPTION
Corrects four errors in the "Using Third-Party JARs" example; the contents of the *type* and *name* fields were all incorrectly shown; they must be lowercase, and with no spaces as they are specific identifiers.

Changed the order of the fields to match the other examples in the documentation.