### PR TITLE
Feature/ui fix hydrator clone+spark mapreduce engines

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -427,11 +427,6 @@ angular.module(PKG.name + '.commons')
         });
 
       }, true);
-
-      $scope.$watchCollection('connections', function () {
-        console.log('ChangeConnection', $scope.connections);
-      });
-
       // This is needed to redraw connections and endpoints on browser resize
       angular.element($window).on('resize', function() {
         vm.instance.repaintEverything();

--- a/cdap-ui/app/directives/my-popover/my-popover.js
+++ b/cdap-ui/app/directives/my-popover/my-popover.js
@@ -115,6 +115,7 @@ angular.module(PKG.name + '.commons')
           popoverElement.on('mouseleave', delayClose.bind(null, 200));
         }
         initPopover();
+        scope.$on('$destroy', destroyPopover);
       }
     };
   });

--- a/cdap-ui/app/features/apps/controllers/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/apps/controllers/tabs/status-ctrl.js
@@ -19,8 +19,8 @@ class AppDetailStatusController {
     DetailNonRunsStore.init(rPipelineDetail);
     NodeConfigStore.init();
 
-    var obj = DetailNonRunsStore.getDAGConfig();
-    NodesActionsFactory.createGraphFromConfig(obj.nodes, obj.connections);
+    var obj = DetailNonRunsStore.getCloneConfig();
+    NodesActionsFactory.createGraphFromConfig(obj.__ui__.nodes, obj.config.connections);
 
     $scope.$on('$destroy', function() {
       // FIXME: This should essentially be moved to a scaffolding service that will do stuff for a state/view

--- a/cdap-ui/app/features/hydrator/controllers/detail/canvas-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/detail/canvas-ctrl.js
@@ -34,8 +34,8 @@ angular.module(PKG.name + '.feature.hydrator')
     };
     this.setState();
     BottomPanelStore.registerOnChangeListener(this.setState.bind(this));
-    var obj = DetailNonRunsStore.getDAGConfig();
-    NodesActionsFactory.createGraphFromConfig(obj.nodes, obj.connections);
+    var obj = DetailNonRunsStore.getCloneConfig();
+    NodesActionsFactory.createGraphFromConfig(obj.__ui__.nodes, obj.config.connections);
 
     this.updateNodesAndConnections = function () {
       var activeNode = this.NodesStore.getActiveNodeId();

--- a/cdap-ui/app/features/hydrator/controllers/detail/tabs/pipeline-config-tab-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/detail/tabs/pipeline-config-tab-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.hydrator')
-  .controller('HydratorDetailStatusController', function(DetailNonRunsStore) {
+  .controller('HydratorDetailPipelineConfigController', function(DetailNonRunsStore) {
     this.setState = function() {
       this.config = DetailNonRunsStore.getConfigJson();
     };

--- a/cdap-ui/app/features/hydrator/controllers/detail/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/detail/tabs/status-ctrl.js
@@ -15,33 +15,10 @@
  */
 
 angular.module(PKG.name + '.feature.hydrator')
-  .controller('HydratorDetailStatusController', function(DetailRunsStore, GLOBALS, PipelineDetailActionFactory, $scope, DetailNonRunsStore) {
-    var params;
+  .controller('HydratorDetailStatusController', function(DetailNonRunsStore) {
     this.setState = function() {
-      this.runsCount = DetailRunsStore.getRunsCount();
-      var runs = DetailRunsStore.getRuns();
-      var status, i;
-      for (i=0 ; i<runs.length; i++) {
-        status = runs[i].status;
-        if (['RUNNING', 'STARTING', 'STOPPING'].indexOf(status) === -1) {
-          this.lastFinished = runs[i];
-          break;
-        }
-      }
-      this.lastRunTime = runs.length > 0 && runs[0].end ? runs[0].end - runs[0].start : 'N/A';
-      this.averageRunTime = DetailRunsStore.getStatistics().avgRunTime || 'N/A';
       this.config = DetailNonRunsStore.getConfigJson();
     };
     this.setState();
-    this.GLOBALS = GLOBALS;
-    this.pipelineType = DetailNonRunsStore.getPipelineType();
-    if (this.pipelineType === GLOBALS.etlBatch) {
-      params = angular.copy(DetailRunsStore.getParams());
-      params.scope = $scope;
-      PipelineDetailActionFactory.pollStatistics(
-        DetailRunsStore.getApi(),
-        params
-      );
-    }
-    DetailRunsStore.registerOnChangeListener(this.setState.bind(this));
+    DetailNonRunsStore.registerOnChangeListener(this.setState.bind(this));
   });

--- a/cdap-ui/app/features/hydrator/controllers/detail/top-panel-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/detail/top-panel-ctrl.js
@@ -54,7 +54,7 @@ angular.module(PKG.name + '.feature.hydrator')
       } else {
         this.avgRunTime = 'N/A';
       }
-      this.config = DetailNonRunsStore.getConfigJson();
+      this.config = DetailNonRunsStore.getCloneConfig();
     };
     this.setState();
 

--- a/cdap-ui/app/features/hydrator/controllers/list-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/list-ctrl.js
@@ -173,11 +173,13 @@ angular.module(PKG.name + '.feature.hydrator')
     function fetchDrafts() {
       mySettings.get('adapterDrafts')
         .then(function(res) {
-          if (res && Object.keys(res).length) {
-            angular.forEach(res, function(value, key) {
-
+          let draftsList = myHelpers.objectQuery(res, $stateParams.namespace);
+          if (!angular.isObject(draftsList)) {
+            return;
+          }
+          if (draftsList.length) {
+            angular.forEach(res[$stateParams.namespace], function(value, key) {
               vm.statusCount.draft++;
-
               vm.pipelineList.push({
                 isDraft: true,
                 name: key,
@@ -190,7 +192,6 @@ angular.module(PKG.name + '.feature.hydrator')
                   lastStartTime: 'N/A'
                 }
               });
-
             });
           }
         });
@@ -199,8 +200,8 @@ angular.module(PKG.name + '.feature.hydrator')
     vm.deleteDraft = function(draftName) {
       mySettings.get('adapterDrafts')
         .then(function(res) {
-          if (res[draftName]) {
-            delete res[draftName];
+          if (myHelpers.objectQuery(res, $stateParams.namespace, draftName)) {
+            delete res[$stateParams.namespace][draftName];
           }
           return mySettings.set('adapterDrafts', res);
         })

--- a/cdap-ui/app/features/hydrator/controllers/list-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/list-ctrl.js
@@ -177,7 +177,7 @@ angular.module(PKG.name + '.feature.hydrator')
           if (!angular.isObject(draftsList)) {
             return;
           }
-          if (draftsList.length) {
+          if (Object.keys(draftsList).length) {
             angular.forEach(res[$stateParams.namespace], function(value, key) {
               vm.statusCount.draft++;
               vm.pipelineList.push({

--- a/cdap-ui/app/features/hydrator/routes.js
+++ b/cdap-ui/app/features/hydrator/routes.js
@@ -58,12 +58,12 @@ angular.module(PKG.name + '.feature.hydrator')
               data: null
             },
             resolve: {
-              rConfig: function($stateParams, mySettings, $q) {
+              rConfig: function($stateParams, mySettings, $q, myHelpers) {
                 var defer = $q.defer();
                 if ($stateParams.name) {
                   mySettings.get('adapterDrafts')
                     .then(function(res) {
-                      var draft = res[$stateParams.name];
+                      var draft = myHelpers.objectQuery(res, $stateParams.namespace, $stateParams.name);
                       if (angular.isObject(draft)) {
                         draft.name = $stateParams.name;
                         defer.resolve(draft);

--- a/cdap-ui/app/features/hydrator/routes.js
+++ b/cdap-ui/app/features/hydrator/routes.js
@@ -108,6 +108,9 @@ angular.module(PKG.name + '.feature.hydrator')
                 controller: 'BottomPanelController as BottomPanelController'
               }
             },
+            onExit: function($modalStack) {
+              $modalStack.dismissAll();
+            }
           })
 
         .state('hydrator.detail', {

--- a/cdap-ui/app/features/hydrator/services/create/actions/config-actions.js
+++ b/cdap-ui/app/features/hydrator/services/create/actions/config-actions.js
@@ -15,7 +15,7 @@
  */
 
 class ConfigActionsFactory {
-  constructor(ConfigDispatcher, myPipelineApi, $state, ConfigStore, mySettings, ConsoleActionsFactory, HydratorErrorFactory, EventPipe, myAppsApi, GLOBALS) {
+  constructor(ConfigDispatcher, myPipelineApi, $state, ConfigStore, mySettings, ConsoleActionsFactory, HydratorErrorFactory, EventPipe, myAppsApi, GLOBALS, myHelpers, $stateParams) {
     this.ConfigStore = ConfigStore;
     this.mySettings = mySettings;
     this.$state = $state;
@@ -25,6 +25,8 @@ class ConfigActionsFactory {
     this.EventPipe = EventPipe;
     this.myAppsApi = myAppsApi;
     this.GLOBALS = GLOBALS;
+    this.myHelpers = myHelpers;
+    this.$stateParams = $stateParams;
 
     this.dispatcher = ConfigDispatcher.getDispatcher();
   }
@@ -73,8 +75,9 @@ class ConfigActionsFactory {
         .get('adapterDrafts')
         .then(
           (res) => {
-            if (angular.isObject(res)) {
-              delete res[adapterName];
+            var savedDraft = this.myHelpers.objectQuery(res, this.$stateParams.namespace, adapterName);
+            if (savedDraft) {
+              delete res[this.$stateParams.namespace][adapterName];
               return this.mySettings.set('adapterDrafts', res);
             }
           },
@@ -139,6 +142,6 @@ class ConfigActionsFactory {
   }
 }
 
-ConfigActionsFactory.$inject = ['ConfigDispatcher', 'myPipelineApi', '$state', 'ConfigStore', 'mySettings', 'ConsoleActionsFactory', 'HydratorErrorFactory', 'EventPipe', 'myAppsApi', 'GLOBALS'];
+ConfigActionsFactory.$inject = ['ConfigDispatcher', 'myPipelineApi', '$state', 'ConfigStore', 'mySettings', 'ConsoleActionsFactory', 'HydratorErrorFactory', 'EventPipe', 'myAppsApi', 'GLOBALS', 'myHelpers', '$stateParams'];
 angular.module(`${PKG.name}.feature.hydrator`)
   .service('ConfigActionsFactory', ConfigActionsFactory);

--- a/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
@@ -301,28 +301,29 @@ class ConfigStore {
   saveAsDraft(config) {
     this.state.__ui__.isEditing = false;
     this.mySettings.get('adapterDrafts')
-       .then(res => {
-         if (!angular.isObject(this.myHelpers.objectQuery(res, this.$stateParams.namespace))) {
-           res[this.$stateParams.namespace] = {};
-         }
-         res[this.$stateParams.namespace][config.name] = config;
-         return this.mySettings.set('adapterDrafts', res);
-       })
-       .then(
-          () => {
-            this.ConsoleActionsFactory.addMessage({
-              type: 'success',
-              content: `Draft ${config.name} saved successfully.`
-            });
-          },
-          err => {
-            this.state.__ui__.isEditing = true;
-            this.ConsoleActionsFactory.addMessage({
-              type: 'error',
-              content: err
-            });
-          }
-        );
+      .then(res => {
+        res = res || {isMigrated: true};
+        if (!angular.isObject(this.myHelpers.objectQuery(res, this.$stateParams.namespace))) {
+          res[this.$stateParams.namespace] = {};
+        }
+        res[this.$stateParams.namespace][config.name] = config;
+        return this.mySettings.set('adapterDrafts', res);
+      })
+      .then(
+        () => {
+          this.ConsoleActionsFactory.addMessage({
+            type: 'success',
+            content: `Draft ${config.name} saved successfully.`
+          });
+        },
+        err => {
+          this.state.__ui__.isEditing = true;
+          this.ConsoleActionsFactory.addMessage({
+            type: 'error',
+            content: err
+          });
+        }
+      );
   }
 }
 

--- a/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
@@ -15,12 +15,15 @@
  */
 
 class ConfigStore {
-  constructor(ConfigDispatcher, CanvasFactory, GLOBALS, mySettings, ConsoleActionsFactory){
+  constructor(ConfigDispatcher, CanvasFactory, GLOBALS, mySettings, ConsoleActionsFactory, $stateParams, myHelpers){
     this.state = {};
     this.mySettings = mySettings;
     this.ConsoleActionsFactory = ConsoleActionsFactory;
     this.CanvasFactory = CanvasFactory;
     this.GLOBALS = GLOBALS;
+    this.$stateParams = $stateParams;
+    this.myHelpers = myHelpers;
+
     this.changeListeners = [];
     this.setDefaults();
     this.configDispatcher = ConfigDispatcher.getDispatcher();
@@ -288,10 +291,10 @@ class ConfigStore {
     this.state.__ui__.isEditing = false;
     this.mySettings.get('adapterDrafts')
        .then(res => {
-         if (!angular.isObject(res)) {
-           res = {};
+         if (!angular.isObject(this.myHelpers.objectQuery(res, this.$stateParams.namespace))) {
+           res[this.$stateParams.namespace] = {};
          }
-         res[config.name] = config;
+         res[this.$stateParams.namespace][config.name] = config;
          return this.mySettings.set('adapterDrafts', res);
        })
        .then(
@@ -312,6 +315,6 @@ class ConfigStore {
   }
 }
 
-ConfigStore.$inject = ['ConfigDispatcher', 'CanvasFactory', 'GLOBALS', 'mySettings', 'ConsoleActionsFactory'];
+ConfigStore.$inject = ['ConfigDispatcher', 'CanvasFactory', 'GLOBALS', 'mySettings', 'ConsoleActionsFactory', '$stateParams', 'myHelpers'];
 angular.module(`${PKG.name}.feature.hydrator`)
   .service('ConfigStore', ConfigStore);

--- a/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
@@ -47,15 +47,6 @@ class ConfigStore {
         scope: 'SYSTEM',
         version: ''
       },
-      config: {
-        source: {
-          name: '',
-          plugin: {}
-        },
-        sinks: [],
-        transforms: [],
-        connections: []
-      },
       __ui__: {
         nodes: [],
         isEditing: true
@@ -63,9 +54,11 @@ class ConfigStore {
       description: '',
       name: ''
     };
+    angular.extend(this.state, {config: this.getDefaultConfig()});
     // This will be eventually used when we just pass on a config to the store to draw the dag.
     if (config) {
       angular.extend(this.state, config);
+      this.setArtifact(this.state.artifact);
     }
   }
   init(config) {

--- a/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
@@ -62,6 +62,7 @@ class ConfigStore {
     if (config) {
       angular.extend(this.state, config);
       this.setArtifact(this.state.artifact);
+      this.setEngine(this.state.config.engine);
     }
   }
   init(config) {
@@ -159,9 +160,10 @@ class ConfigStore {
     });
     let appType = this.getAppType();
     if ( appType=== this.GLOBALS.etlBatch) {
-      config.schedule = this.state.config.schedule;
+      config.schedule = this.getSchedule();
+      config.engine = this.getEngine();
     } else if (appType === this.GLOBALS.etlRealtime) {
-      config.instance = this.state.config.instance;
+      config.instance = this.getInstance();
     }
     config.connections = connections.map(conn => {
       delete conn.visited;
@@ -230,6 +232,14 @@ class ConfigStore {
     }
     this.emitChange();
   }
+  setEngine(engine) {
+    if (this.state.config.artifact === this.GLOBALS.etlBatch) {
+      this.state.config.engine = engine || 'mapreduce';
+    }
+  }
+  getEngine() {
+    return this.state.config.engine || 'mapreduce';
+  }
   setArtifact(artifact) {
     this.state.artifact.name = artifact.name;
     this.state.artifact.version = artifact.version;
@@ -243,6 +253,7 @@ class ConfigStore {
 
     this.emitChange();
   }
+
   setNodes(nodes) {
     this.state.__ui__.nodes = nodes;
   }

--- a/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
+++ b/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
@@ -121,7 +121,6 @@ angular.module(PKG.name + '.feature.hydrator')
       appConfig.cloneConfig = {
         name: app.name,
         artifact: app.artifact,
-        template: app.artifact.name,
         description: app.description,
         __ui__: appConfig.DAGConfig,
         config: {

--- a/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
+++ b/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
@@ -114,8 +114,7 @@ angular.module(PKG.name + '.feature.hydrator')
         app.config = appConfig.configJson;
         uiConfig = this.HydratorService.getNodesAndConnectionsFromConfig(app);
         appConfig.DAGConfig = {
-          nodes: uiConfig.nodes,
-          connections: uiConfig.connections
+          nodes: uiConfig.nodes
         };
       }
       appConfig.type = app.artifact.name;
@@ -124,13 +123,14 @@ angular.module(PKG.name + '.feature.hydrator')
         artifact: app.artifact,
         template: app.artifact.name,
         description: app.description,
-        ui: appConfig.DAGConfig,
+        __ui__: appConfig.DAGConfig,
         config: {
           source: appConfig.configJson.source,
           sinks: appConfig.configJson.sinks,
           transforms: appConfig.configJson.transforms,
-          instances: app.instance,
-          schedule: appConfig.configJson.schedule
+          instances: appConfig.configJson.instance,
+          schedule: appConfig.configJson.schedule,
+          connections: uiConfig.connections
         }
       };
       appConfig.streams = app.streams.map(function (stream) {

--- a/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-runs-store.js
+++ b/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-runs-store.js
@@ -160,6 +160,7 @@ angular.module(PKG.name + '.feature.hydrator')
       programType = app.artifact.name === GLOBALS.etlBatch ? 'WORKFLOWS' : 'WORKER';
 
       if (programType === 'WORKFLOWS') {
+        let engineType = JSON.parse(app.configuration).engine;
         angular.forEach(app.programs, function (program) {
           if (program.type === 'Workflow') {
             appLevelParams.programName = program.id;
@@ -168,7 +169,7 @@ angular.module(PKG.name + '.feature.hydrator')
             metricProgramType = program.type.toLowerCase();
 
             logsLevelParams.programId = program.id;
-            logsLevelParams.programType = program.type.toLowerCase();
+            logsLevelParams.programType = engineType || 'mapreduce';
           }
         });
       } else {

--- a/cdap-ui/app/features/hydrator/templates/detail/tabs/configuration.html
+++ b/cdap-ui/app/features/hydrator/templates/detail/tabs/configuration.html
@@ -14,6 +14,6 @@
   the License.
 -->
 
-<pre ng-controller="HydratorDetailStatusController as StatusCtrl">
-  {{ StatusCtrl.config | json: 4 }}
+<pre ng-controller="HydratorDetailPipelineConfigController as PipelineConfigCtrl">
+  {{ PipelineConfigCtrl.config | json: 4 }}
 </pre>

--- a/cdap-ui/app/main.js
+++ b/cdap-ui/app/main.js
@@ -226,6 +226,38 @@ angular
       tables: true
     });
   }])
+  /*
+    FIXME: This is a one time only thing. Once all old users who migrated to 3.3 have their drafts moved from global level to
+          namespace level this snippet can be removed. Ideally in 4.* we should be able to remove this.
+  */
+  .run(function(mySettings, EventPipe, $state, $alert, $q) {
+    mySettings.get('adapterDrafts')
+      .then(
+        function success(res) {
+          var namespacedDrafts = {
+            default: {}
+          };
+          if (res && !res.isMigrated) {
+            angular.forEach(res, function(draft, name) {
+               namespacedDrafts.default[name] = draft;
+            });
+
+            namespacedDrafts.isMigrated = true;
+            return mySettings.set('adapterDrafts', namespacedDrafts);
+          } else {
+            return $q.reject(false);
+          }
+        }
+      )
+      .then(
+        function showAlert() {
+          $alert({
+            type: 'info',
+            content: 'All your global drafts have been moved to default namespace. Going forward all pipeline drafts will be namespaced.'
+          });
+        }
+      );
+  })
 
   .run(function (MYSOCKET_EVENT, myAlert, EventPipe) {
     EventPipe.on(MYSOCKET_EVENT.closed, function (angEvent, data) {

--- a/cdap-ui/app/main.js
+++ b/cdap-ui/app/main.js
@@ -253,7 +253,7 @@ angular
         function showAlert() {
           $alert({
             type: 'info',
-            content: 'All your global drafts have been moved to default namespace. Going forward all pipeline drafts will be namespaced.'
+            content: 'All current drafts can be found in Default namespace.'
           });
         }
       );


### PR DESCRIPTION
- Fixes pipeline drafts to be namespace'd
- Adds ```engine``` attribute to the configuration for batch pipeline
- Fixes clone behavior in hydrator detailed view
- Minor cleanup with modals & popovers while leaving state.