### PR TITLE
Fix Broken Doc Build: Correct case and text of descriptions; updated MD5 hash.

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1028,8 +1028,8 @@
     <name>metrics.processor.max.instances</name>
     <value>${master.service.max.instances}</value>
     <description>
-      Maximum number of instances for Metrics Processor Service Apache Twill
-      Runnable
+      Maximum number of instances for metrics processor service Apache Twill
+      runnable
     </description>
   </property>
 
@@ -1037,8 +1037,8 @@
     <name>metrics.processor.memory.mb</name>
     <value>512</value>
     <description>
-      Size of Memory in megabytes for Metrics Processor Service Apache Twill
-      Runnable
+      Size of memory in megabytes for metrics processor service Apache Twill
+      runnable
     </description>
   </property>
 
@@ -1046,7 +1046,7 @@
     <name>metrics.processor.num.cores</name>
     <value>1</value>
     <description>
-      Number of cores for Metrics Processor Service Apache Twill Runnable
+      Number of cores for metrics processor service Apache Twill runnable
     </description>
   </property>
 
@@ -1054,8 +1054,8 @@
     <name>metrics.processor.num.instances</name>
     <value>1</value>
     <description>
-      Number of instances for Metrics Processor Service Apache Twill
-      Runnable
+      Number of instances for metrics processor service Apache Twill
+      runnable
     </description>
   </property>
 
@@ -1063,7 +1063,7 @@
     <name>metrics.processor.status.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Default inet address for binding metrics processor HTTP service
+      Default iNet address for binding metrics processor HTTP service
     </description>
   </property>
 
@@ -1098,8 +1098,8 @@
     <name>monitor.handler.service.discovery.timeout.seconds</name>
     <value>1</value>
     <description>
-      Timeout in seconds for service discovery used in Monitor Handler
-      Service Status check
+      Timeout in seconds for service discovery used in monitor handler
+      service status check
     </description>
   </property>
 
@@ -1110,7 +1110,7 @@
     <name>notification.transport.system</name>
     <value>kafka</value>
     <description>
-      Transport system used by the Notification system: can be kafka/stream
+      Transport system used by the notification system; can be either kafka or stream
     </description>
   </property>
 
@@ -1158,7 +1158,7 @@
     <name>router.bind.port</name>
     <value>10000</value>
     <description>
-      Port number that the CDAP router should bind to for HTTP connections
+      Port number that the CDAP Router should bind to for HTTP connections
     </description>
   </property>
 
@@ -1177,21 +1177,21 @@
   <property>
     <name>router.connection.backlog</name>
     <value>20000</value>
-    <description>The connection backlog in the router server</description>
+    <description>The connection backlog in the CDAP Router</description>
   </property>
 
   <property>
     <name>router.connection.idle.timeout.secs</name>
     <value>15</value>
     <description>
-      The number of seconds after an http request completes that idle router connections are closed
+      The number of seconds after an HTTP request completes that idle router connections are closed
     </description>
   </property>
 
   <property>
     <name>router.server.boss.threads</name>
     <value>1</value>
-    <description>The number of boss threads in the router server</description>
+    <description>The number of boss threads in the CDAP Router</description>
   </property>
 
   <property>
@@ -1205,14 +1205,14 @@
   <property>
     <name>router.server.worker.threads</name>
     <value>10</value>
-    <description>The number of worker threads in the Router server</description>
+    <description>The number of worker threads in the CDAP Router</description>
   </property>
 
   <property>
     <name>router.ssl.bind.port</name>
     <value>10443</value>
     <description>
-      Port number that the CDAP router should bind to for HTTPS connections
+      Port number that the CDAP Router should bind to for HTTPS connections
     </description>
   </property>
 
@@ -1243,7 +1243,7 @@
     <name>router.webapp.enabled</name>
     <value>false</value>
     <description>
-      Determines if the webapp listening service should be started at router
+      Determines if the webapp listening service should be started at the CDAP Router
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="e8cc6ab35e17a8c28adafb02d65027b5"
+DEFAULT_XML_MD5_HASH="a9977d5391f992535cd00b7accd27064"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"


### PR DESCRIPTION
Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB77-1)