### PR TITLE
[CDAP-4323] Allow a configuration to bypass access token validation for certain paths

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -699,6 +699,9 @@ public final class Constants {
 
       /** Default SSL keystore type */
       public static final String DEFAULT_SSL_KEYSTORE_TYPE = "JKS";
+
+      /** Paths to exclude from authentication, given by a single regular expression */
+      public static final String BYPASS_AUTHENTICATION_REGEX = "router.bypass.auth.regex";
     }
 
     /**

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/SecurityAuthenticationHttpHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/SecurityAuthenticationHttpHandler.java
@@ -53,6 +53,8 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Security handler that intercept HTTP message and validates the access token in
@@ -68,6 +70,7 @@ public class SecurityAuthenticationHttpHandler extends SimpleChannelHandler {
   private final Iterable<Discoverable> discoverables;
   private final CConfiguration configuration;
   private final String realm;
+  private final Pattern bypassPattern;
 
 
   public SecurityAuthenticationHttpHandler(String realm, TokenValidator tokenValidator,
@@ -80,6 +83,23 @@ public class SecurityAuthenticationHttpHandler extends SimpleChannelHandler {
     this.discoveryServiceClient = discoveryServiceClient;
     this.discoverables = discoveryServiceClient.discover(Constants.Service.EXTERNAL_AUTHENTICATION);
     this.configuration = configuration;
+    this.bypassPattern = createMatcher(configuration.get(Constants.Security.Router.BYPASS_AUTHENTICATION_REGEX));
+  }
+
+  private Pattern createMatcher(String s) {
+    if (s == null) {
+      return null;
+    }
+    try {
+      return Pattern.compile(s);
+    } catch (PatternSyntaxException e) {
+      throw new IllegalArgumentException(String.format("Invalid regular expression for %s",
+                                                       Constants.Security.Router.BYPASS_AUTHENTICATION_REGEX), e);
+    }
+  }
+
+  private boolean matchBypassPattern(HttpRequest req) {
+    return bypassPattern != null && bypassPattern.matcher(req.getUri()).matches();
   }
 
   /**
@@ -203,12 +223,11 @@ public class SecurityAuthenticationHttpHandler extends SimpleChannelHandler {
     } else {
       AuditLogEntry logEntry = new AuditLogEntry();
       ctx.setAttachment(logEntry);
-      if (validateSecuredInterception(ctx, (HttpRequest) msg, event.getChannel(), logEntry)) {
+      HttpRequest req = (HttpRequest) msg;
+      if (matchBypassPattern(req) || validateSecuredInterception(ctx, req, event.getChannel(), logEntry)) {
         Channels.fireMessageReceived(ctx, msg, event.getRemoteAddress());
-      } else {
-        // we write the response directly for authentication failure, so nothing to do
-        return;
       }
+      // we write the response directly for authentication failure, so nothing to do for else
     }
   }
 

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/MockAccessTokenTransfomer.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/MockAccessTokenTransfomer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.router;
+
+import co.cask.cdap.security.auth.AccessTokenIdentifier;
+import co.cask.cdap.security.auth.AccessTokenTransformer;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+
+public class MockAccessTokenTransfomer extends AccessTokenTransformer {
+
+  public MockAccessTokenTransfomer() {
+    super(null, null);
+  }
+
+  @Override
+  public AccessTokenIdentifierPair transform(String accessToken) throws IOException {
+    return new AccessTokenIdentifierPair("dummy", new AccessTokenIdentifier("dummy", new LinkedHashSet<String>(),
+                                                                            System.currentTimeMillis(),
+                                                                            System.currentTimeMillis() + 100000));
+  }
+}

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/MockTokenValidator.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/MockTokenValidator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.router;
+
+import co.cask.cdap.security.auth.TokenState;
+import co.cask.cdap.security.auth.TokenValidator;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.AbstractService;
+
+/**
+ * Simple {@link TokenValidator} implementation for test cases, which always returns
+ * {@link TokenState#INVALID} for a specific token, and {@link TokenState#VALID} for
+ * all other tokens.
+ */
+public class MockTokenValidator extends AbstractService implements TokenValidator {
+
+  private final String tokenToFail;
+
+  public MockTokenValidator(String tokenToFail) {
+    Preconditions.checkNotNull(tokenToFail);
+    this.tokenToFail = tokenToFail;
+  }
+
+  @Override
+  protected void doStart() {
+    notifyStarted();
+  }
+
+  @Override
+  protected void doStop() {
+    notifyStopped();
+  }
+
+  @Override
+  public TokenState validate(String token) {
+    return tokenToFail.equals(token) ? TokenState.INVALID : TokenState.VALID;
+  }
+}

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineAuthTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineAuthTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.router;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.conf.Constants;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import org.apache.twill.discovery.DiscoveryService;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Verify the ordering of events in the RouterPipeline.
+ */
+public class NettyRouterPipelineAuthTest {
+
+  private static final String HOSTNAME = "127.0.0.1";
+
+  private static final String GATEWAY_NAME = Constants.Router.GATEWAY_DISCOVERY_NAME;
+  private static final String SERVICE_NAME = Constants.Service.APP_FABRIC_HTTP;
+
+  private static final DiscoveryService DISCOVERY_SERVICE = new InMemoryDiscoveryService();
+  public static final RouterResource ROUTER = new RouterResource(HOSTNAME, DISCOVERY_SERVICE, ImmutableMap.of(
+    Constants.Security.ENABLED, "true",
+    Constants.Security.Router.BYPASS_AUTHENTICATION_REGEX, "(/v1/repeat/.*|/v1/echo/dontfail)"
+  ));
+  public static final ServerResource GATEWAY_SERVER = new ServerResource(HOSTNAME, DISCOVERY_SERVICE, SERVICE_NAME);
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  @SuppressWarnings("UnusedDeclaration")
+  @ClassRule
+  public static TestRule chain = RuleChain.outerRule(ROUTER).around(GATEWAY_SERVER);
+
+  @Test
+  public void testRouterAuthBypass() throws Exception {
+    // mock token validator passes for no token and any token other than "Bearer failme"
+    testGet(200, "hello"   , "/v1/echo/hello");
+    testGet(200, "hello"   , "/v1/echo/hello", ImmutableMap.of("Authorization", "Bearer x"));
+    // so this should fail
+    testGet(401, null      , "/v1/echo/hello", ImmutableMap.of("Authorization", "Bearer failme"));
+    // but /v1/echo/dontfail is configured to bypass auth
+    testGet(200, "dontfail", "/v1/echo/dontfail", ImmutableMap.of("Authorization", "Bearer failme"));
+    // it only bypasses on exact match, not prefix match
+    testGet(401, null      , "/v1/echo/dontfailme", ImmutableMap.of("Authorization", "Bearer failme"));
+
+    // /v1/repeat is configured to bypass auth validation, on prefix match
+    testGet(200, "hello", "/v1/repeat/hello");
+    testGet(200, "hello", "/v1/repeat/hello", ImmutableMap.of("Authorization", "Bearer x"));
+    testGet(200, "hello", "/v1/repeat/hello", ImmutableMap.of("Authorization", "Bearer failme"));
+    // even with a token that fails validation, we get the correct status code 404
+    testGet(404, null   , "/v1/repeat/dontfail/me", ImmutableMap.of("Authorization", "Bearer failme"));
+  }
+
+  private void testGet(int expectedStatus, String expectedResponse, String path) throws Exception {
+    testGet(expectedStatus, expectedResponse, path, Collections.<String, String>emptyMap());
+  }
+
+  private void testGet(int expectedStatus, String expectedResponse, String path, Map<String, String> headers)
+    throws Exception {
+
+    URL url = new URL("http", HOSTNAME, ROUTER.getServiceMap().get(GATEWAY_NAME), path);
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setRequestMethod("GET");
+    connection.setDoInput(true);
+    for (Map.Entry<String, String> header : headers.entrySet()) {
+      connection.setRequestProperty(header.getKey(), header.getValue());
+    }
+    connection.connect();
+    try {
+      Assert.assertEquals(expectedStatus, connection.getResponseCode());
+      if (expectedResponse != null) {
+        byte[] content = ByteStreams.toByteArray(connection.getInputStream());
+        Assert.assertEquals(expectedResponse, Bytes.toString(content));
+      }
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+}

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineAuthTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineAuthTest.java
@@ -61,21 +61,21 @@ public class NettyRouterPipelineAuthTest {
   @Test
   public void testRouterAuthBypass() throws Exception {
     // mock token validator passes for no token and any token other than "Bearer failme"
-    testGet(200, "hello"   , "/v1/echo/hello");
-    testGet(200, "hello"   , "/v1/echo/hello", ImmutableMap.of("Authorization", "Bearer x"));
+    testGet(200, "hello", "/v1/echo/hello");
+    testGet(200, "hello", "/v1/echo/hello", ImmutableMap.of("Authorization", "Bearer x"));
     // so this should fail
-    testGet(401, null      , "/v1/echo/hello", ImmutableMap.of("Authorization", "Bearer failme"));
+    testGet(401, null, "/v1/echo/hello", ImmutableMap.of("Authorization", "Bearer failme"));
     // but /v1/echo/dontfail is configured to bypass auth
     testGet(200, "dontfail", "/v1/echo/dontfail", ImmutableMap.of("Authorization", "Bearer failme"));
     // it only bypasses on exact match, not prefix match
-    testGet(401, null      , "/v1/echo/dontfailme", ImmutableMap.of("Authorization", "Bearer failme"));
+    testGet(401, null, "/v1/echo/dontfailme", ImmutableMap.of("Authorization", "Bearer failme"));
 
     // /v1/repeat is configured to bypass auth validation, on prefix match
     testGet(200, "hello", "/v1/repeat/hello");
     testGet(200, "hello", "/v1/repeat/hello", ImmutableMap.of("Authorization", "Bearer x"));
     testGet(200, "hello", "/v1/repeat/hello", ImmutableMap.of("Authorization", "Bearer failme"));
     // even with a token that fails validation, we get the correct status code 404
-    testGet(404, null   , "/v1/repeat/dontfail/me", ImmutableMap.of("Authorization", "Bearer failme"));
+    testGet(404, null, "/v1/repeat/dontfail/me", ImmutableMap.of("Authorization", "Bearer failme"));
   }
 
   private void testGet(int expectedStatus, String expectedResponse, String path) throws Exception {

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
@@ -17,33 +17,11 @@
 package co.cask.cdap.gateway.router;
 
 import co.cask.cdap.AllProgramsApp;
-import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.conf.SConfiguration;
-import co.cask.cdap.common.discovery.ResolvingDiscoverable;
-import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.internal.test.AppJarHelper;
-import co.cask.cdap.security.auth.AccessTokenTransformer;
-import co.cask.cdap.security.guice.SecurityModules;
-import co.cask.http.AbstractHttpHandler;
-import co.cask.http.BodyConsumer;
-import co.cask.http.ChunkResponder;
-import co.cask.http.HttpResponder;
-import co.cask.http.NettyHttpService;
-import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
-import com.google.common.net.InetAddresses;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
 import com.ning.http.client.AsyncCompletionHandler;
 import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.AsyncHttpClientConfig;
@@ -52,7 +30,6 @@ import com.ning.http.client.Request;
 import com.ning.http.client.RequestBuilder;
 import com.ning.http.client.Response;
 import com.ning.http.client.providers.netty.NettyAsyncHttpProvider;
-import org.apache.twill.common.Cancellable;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
@@ -60,14 +37,10 @@ import org.apache.twill.discovery.InMemoryDiscoveryService;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.handler.codec.http.HttpRequest;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
@@ -76,20 +49,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
 import java.net.URL;
-import java.nio.ByteBuffer;
-import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.QueryParam;
 
 /**
  * Verify the ordering of events in the RouterPipeline.
@@ -97,25 +61,15 @@ import javax.ws.rs.QueryParam;
 public class NettyRouterPipelineTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(NettyRouterPipelineTest.class);
-  private static final String hostname = "127.0.0.1";
-  private static final DiscoveryService discoveryService = new InMemoryDiscoveryService();
-  private static final String gatewayService = Constants.Service.APP_FABRIC_HTTP;
-  private static final String GATEWAY_LOOKUP = Constants.Router.GATEWAY_DISCOVERY_NAME;
-  private static final int maxUploadBytes = 10 * 1024 * 1024;
-  private static final int chunkSize = 1024 * 1024;      // NOTE: maxUploadBytes % chunkSize == 0
-  private static byte[] applicationJarInBytes;
+  private static final String HOSTNAME = "127.0.0.1";
+  private static final int MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 
-  private static final Supplier<String> gatewayServiceSupplier = new Supplier<String>() {
-    @Override
-    public String get() {
-      return gatewayService;
-    }
-  };
+  private static final String GATEWAY_NAME = Constants.Router.GATEWAY_DISCOVERY_NAME;
+  private static final String SERVICE_NAME = Constants.Service.APP_FABRIC_HTTP;
 
-  public static final RouterResource ROUTER = new RouterResource(hostname, discoveryService);
-
-  public static final ServerResource GATEWAY_SERVER = new ServerResource(hostname, discoveryService,
-                                                                         gatewayServiceSupplier);
+  private static final DiscoveryService DISCOVERY_SERVICE = new InMemoryDiscoveryService();
+  public static final RouterResource ROUTER = new RouterResource(HOSTNAME, DISCOVERY_SERVICE);
+  public static final ServerResource GATEWAY_SERVER = new ServerResource(HOSTNAME, DISCOVERY_SERVICE, SERVICE_NAME);
 
   @ClassRule
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
@@ -129,8 +83,7 @@ public class NettyRouterPipelineTest {
     GATEWAY_SERVER.clearNumRequests();
 
     // Wait for both servers of gatewayService to be registered
-    Iterable<Discoverable> discoverables = ((DiscoveryServiceClient) discoveryService).discover(
-      gatewayServiceSupplier.get());
+    Iterable<Discoverable> discoverables = ((DiscoveryServiceClient) DISCOVERY_SERVICE).discover(SERVICE_NAME);
     for (int i = 0; i < 50 && Iterables.size(discoverables) != 1; ++i) {
       TimeUnit.MILLISECONDS.sleep(50);
     }
@@ -147,7 +100,7 @@ public class NettyRouterPipelineTest {
 
     byte [] requestBody = generatePostData();
     final Request request = new RequestBuilder("POST")
-      .setUrl(String.format("http://%s:%d%s", hostname, ROUTER.getServiceMap().get(GATEWAY_LOOKUP), "/v1/upload"))
+      .setUrl(String.format("http://%s:%d%s", HOSTNAME, ROUTER.getServiceMap().get(GATEWAY_NAME), "/v1/upload"))
       .setContentLength(requestBody.length)
       .setBody(new ByteEntityWriter(requestBody))
       .build();
@@ -181,12 +134,12 @@ public class NettyRouterPipelineTest {
   private void deploy(int num) throws Exception {
 
     String path = String.format("http://%s:%d/v1/deploy",
-                                hostname, ROUTER.getServiceMap().get(GATEWAY_LOOKUP));
+                                HOSTNAME, ROUTER.getServiceMap().get(GATEWAY_NAME));
 
     LocationFactory lf = new LocalLocationFactory(TMP_FOLDER.newFolder());
     Location programJar = AppJarHelper.createDeploymentJar(lf, AllProgramsApp.class);
+    GATEWAY_SERVER.setExpectedJarBytes(ByteStreams.toByteArray(Locations.newInputSupplier(programJar)));
 
-    applicationJarInBytes = ByteStreams.toByteArray(Locations.newInputSupplier(programJar));
     for (int i = 0; i < num; i++) {
       LOG.info("Deploying {}/{}", i, num);
       URL url = new URL(path);
@@ -203,177 +156,6 @@ public class NettyRouterPipelineTest {
     }
   }
 
-  private static class RouterResource extends ExternalResource {
-    private final String hostname;
-    private final DiscoveryService discoveryService;
-    private final Map<String, Integer> serviceMap = Maps.newHashMap();
-
-    private NettyRouter router;
-
-    private RouterResource(String hostname, DiscoveryService discoveryService) {
-      this.hostname = hostname;
-      this.discoveryService = discoveryService;
-    }
-
-    @Override
-    protected void before() throws Throwable {
-      CConfiguration cConf = CConfiguration.create();
-      Injector injector = Guice.createInjector(new ConfigModule(cConf), new IOModule(),
-                                               new SecurityModules().getInMemoryModules(),
-                                               new DiscoveryRuntimeModule().getInMemoryModules());
-      DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
-      AccessTokenTransformer accessTokenTransformer = injector.getInstance(AccessTokenTransformer.class);
-      SConfiguration sConf = injector.getInstance(SConfiguration.class);
-      cConf.set(Constants.Router.ADDRESS, hostname);
-      cConf.setInt(Constants.Router.ROUTER_PORT, 0);
-      cConf.setInt(Constants.Router.WEBAPP_PORT, 0);
-      router =
-        new NettyRouter(cConf, sConf, InetAddresses.forString(hostname),
-                        new RouterServiceLookup((DiscoveryServiceClient) discoveryService,
-                                                new RouterPathLookup()),
-                        new SuccessTokenValidator(), accessTokenTransformer, discoveryServiceClient);
-      router.startAndWait();
-
-      for (Map.Entry<Integer, String> entry : router.getServiceLookup().getServiceMap().entrySet()) {
-        serviceMap.put(entry.getValue(), entry.getKey());
-      }
-    }
-
-    @Override
-    protected void after() {
-      router.stopAndWait();
-    }
-
-    public Map<String, Integer> getServiceMap() {
-      return serviceMap;
-    }
-  }
-
-  /**
-   * A generic server for testing router.
-   */
-  public static class ServerResource extends ExternalResource {
-    private static final Logger LOG = LoggerFactory.getLogger(ServerResource.class);
-
-    private final String hostname;
-    private final DiscoveryService discoveryService;
-    private final Supplier<String> serviceNameSupplier;
-    private final AtomicInteger numRequests = new AtomicInteger(0);
-
-    private NettyHttpService httpService;
-    private Cancellable cancelDiscovery;
-
-    private ServerResource(String hostname, DiscoveryService discoveryService, Supplier<String> serviceNameSupplier) {
-      this.hostname = hostname;
-      this.discoveryService = discoveryService;
-      this.serviceNameSupplier = serviceNameSupplier;
-    }
-
-    @Override
-    protected void before() throws Throwable {
-      GATEWAY_SERVER.clearNumRequests();
-
-      NettyHttpService.Builder builder = NettyHttpService.builder();
-      builder.addHttpHandlers(ImmutableSet.of(new ServerHandler()));
-      builder.setHost(hostname);
-      builder.setPort(0);
-      httpService = builder.build();
-      httpService.startAndWait();
-
-      registerServer();
-
-      LOG.info("Started test server on {}", httpService.getBindAddress());
-    }
-
-    @Override
-    protected void after() {
-      httpService.stopAndWait();
-    }
-
-    public int getNumRequests() {
-      return numRequests.get();
-    }
-
-    public void clearNumRequests() {
-      numRequests.set(0);
-    }
-
-    public void registerServer() {
-      // Register services of test server
-      LOG.info("Registering service {}", serviceNameSupplier.get());
-      cancelDiscovery = discoveryService.register(ResolvingDiscoverable.of(new Discoverable() {
-        @Override
-        public String getName() {
-          return serviceNameSupplier.get();
-        }
-
-        @Override
-        public InetSocketAddress getSocketAddress() {
-          return httpService.getBindAddress();
-        }
-      }));
-    }
-
-    public void cancelRegistration() {
-      cancelDiscovery.cancel();
-    }
-
-    /**
-     * Simple handler for server.
-     */
-    public class ServerHandler extends AbstractHttpHandler {
-      private final Logger log = LoggerFactory.getLogger(ServerHandler.class);
-      @POST
-      @Path("/v1/upload")
-      public void upload(HttpRequest request, final HttpResponder responder) throws InterruptedException, IOException {
-        ChannelBuffer content = request.getContent();
-
-        int readableBytes;
-        int bytesRead = 0;
-        ChunkResponder chunkResponder = responder.sendChunkStart(HttpResponseStatus.OK,
-                                                                 ImmutableMultimap.<String, String>of());
-        while ((readableBytes = content.readableBytes()) > 0) {
-          int read = Math.min(readableBytes, chunkSize);
-          bytesRead += read;
-          chunkResponder.sendChunk(content.readSlice(read));
-          //TimeUnit.MILLISECONDS.sleep(RANDOM.nextInt(1));
-        }
-        chunkResponder.close();
-      }
-
-      @POST
-      @Path("/v1/deploy")
-      public BodyConsumer deploy(HttpRequest request, final HttpResponder responder) throws InterruptedException {
-        return new BodyConsumer() {
-          ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-          int count = 0;
-          @Override
-          public void chunk(ChannelBuffer request, HttpResponder responder) {
-            count += request.readableBytes();
-            if (request.readableBytes() > 0) {
-            }
-            outputStream.write(request.array(), 0, request.readableBytes());
-          }
-
-          @Override
-          public void finished(HttpResponder responder) {
-
-            if (Bytes.compareTo(applicationJarInBytes, outputStream.toByteArray()) == 0) {
-              responder.sendStatus(HttpResponseStatus.OK);
-              return;
-            }
-            responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-          }
-
-          @Override
-          public void handleError(Throwable cause) {
-            throw Throwables.propagate(cause);
-          }
-        };
-      }
-    }
-  }
-
   private static class ByteEntityWriter implements Request.EntityWriter {
     private final byte [] bytes;
 
@@ -383,16 +165,16 @@ public class NettyRouterPipelineTest {
 
     @Override
     public void writeEntity(OutputStream out) throws IOException {
-      for (int i = 0; i < maxUploadBytes; i += chunkSize) {
-        out.write(bytes, i, chunkSize);
+      for (int i = 0; i < MAX_UPLOAD_BYTES; i += ServerResource.CHUNK_SIZE) {
+        out.write(bytes, i, ServerResource.CHUNK_SIZE);
       }
     }
   }
 
   private static byte [] generatePostData() {
-    byte [] bytes = new byte [maxUploadBytes];
+    byte [] bytes = new byte [MAX_UPLOAD_BYTES];
 
-    for (int i = 0; i < maxUploadBytes; ++i) {
+    for (int i = 0; i < MAX_UPLOAD_BYTES; ++i) {
       bytes[i] = (byte) i;
     }
 

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/ServerResource.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/ServerResource.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.router;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.discovery.ResolvingDiscoverable;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.BodyConsumer;
+import co.cask.http.ChunkResponder;
+import co.cask.http.HttpResponder;
+import co.cask.http.NettyHttpService;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryService;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * A generic server for testing router.
+ */
+public class ServerResource extends ExternalResource {
+  private static final Logger LOG = LoggerFactory.getLogger(ServerResource.class);
+
+  static final int CHUNK_SIZE = 1024 * 1024;      // NOTE: maxUploadBytes % CHUNK_SIZE == 0
+
+  private final String hostname;
+  private final DiscoveryService discoveryService;
+  private final String serviceName;
+  private final AtomicInteger numRequests = new AtomicInteger(0);
+
+  private NettyHttpService httpService;
+  private Cancellable cancelDiscovery;
+  private byte[] expectedJarBytes;
+
+  ServerResource(String hostname, DiscoveryService discoveryService, String serviceName) {
+    this.hostname = hostname;
+    this.discoveryService = discoveryService;
+    this.serviceName = serviceName;
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    NettyRouterPipelineTest.GATEWAY_SERVER.clearNumRequests();
+
+    NettyHttpService.Builder builder = NettyHttpService.builder();
+    builder.addHttpHandlers(ImmutableSet.of(new ServerHandler()));
+    builder.setHost(hostname);
+    builder.setPort(0);
+    httpService = builder.build();
+    httpService.startAndWait();
+
+    registerServer();
+
+    LOG.info("Started test server on {}", httpService.getBindAddress());
+  }
+
+  @Override
+  protected void after() {
+    httpService.stopAndWait();
+  }
+
+  public int getNumRequests() {
+    return numRequests.get();
+  }
+
+  public void clearNumRequests() {
+    numRequests.set(0);
+  }
+
+  public void registerServer() {
+    // Register services of test server
+    LOG.info("Registering service {}", serviceName);
+    cancelDiscovery = discoveryService.register(ResolvingDiscoverable.of(new Discoverable() {
+      @Override
+      public String getName() {
+        return serviceName;
+      }
+
+      @Override
+      public InetSocketAddress getSocketAddress() {
+        return httpService.getBindAddress();
+      }
+    }));
+  }
+
+  public void cancelRegistration() {
+    cancelDiscovery.cancel();
+  }
+
+  public void setExpectedJarBytes(byte[] expectedJarBytes) {
+    this.expectedJarBytes = expectedJarBytes;
+  }
+
+  /**
+   * Simple handler for server.
+   */
+  public class ServerHandler extends AbstractHttpHandler {
+
+    @GET
+    @Path("/v1/echo/{name}")
+    public void echo(HttpRequest request, final HttpResponder responder,
+                     @PathParam("name") String name) throws InterruptedException, IOException {
+      responder.sendString(HttpResponseStatus.OK, name);
+    }
+
+    @GET
+    @Path("/v1/repeat/{name}")
+    public void repeat(HttpRequest request, final HttpResponder responder,
+                       @PathParam("name") String name) throws InterruptedException, IOException {
+      responder.sendString(HttpResponseStatus.OK, name);
+    }
+
+    @POST
+    @Path("/v1/upload")
+    public void upload(HttpRequest request, final HttpResponder responder) throws InterruptedException, IOException {
+
+      ChannelBuffer content = request.getContent();
+
+      int readableBytes;
+      int bytesRead = 0;
+      ChunkResponder chunkResponder = responder.sendChunkStart(HttpResponseStatus.OK,
+                                                               ImmutableMultimap.<String, String>of());
+      while ((readableBytes = content.readableBytes()) > 0) {
+        int read = Math.min(readableBytes, CHUNK_SIZE);
+        bytesRead += read;
+        chunkResponder.sendChunk(content.readSlice(read));
+        //TimeUnit.MILLISECONDS.sleep(RANDOM.nextInt(1));
+      }
+      chunkResponder.close();
+    }
+
+    @POST
+    @Path("/v1/deploy")
+    public BodyConsumer deploy(HttpRequest request, final HttpResponder responder) throws InterruptedException {
+      return new BodyConsumer() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        int count = 0;
+        @Override
+        public void chunk(ChannelBuffer request, HttpResponder responder) {
+          count += request.readableBytes();
+          if (request.readableBytes() > 0) {
+          }
+          outputStream.write(request.array(), 0, request.readableBytes());
+        }
+
+        @Override
+        public void finished(HttpResponder responder) {
+
+          if (Bytes.compareTo(expectedJarBytes, outputStream.toByteArray()) == 0) {
+            responder.sendStatus(HttpResponseStatus.OK);
+            return;
+          }
+          responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        @Override
+        public void handleError(Throwable cause) {
+          throw Throwables.propagate(cause);
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
- introduces a new router configuration, specifying a regex. If the the regex matches the path of a request, then the router will skip authentication
- refactors the existing netty pipeline test
- adds a new test case to test auth and the new bypass option
- Jira: https://issues.cask.co/browse/CDAP-4323
- Build: http://builds.cask.co/browse/CDAP-RBT545
