### PR TITLE
adds correct helper class for table height calculation

### DIFF
--- a/cdap-ui/app/features/hydrator/bottompanel.less
+++ b/cdap-ui/app/features/hydrator/bottompanel.less
@@ -80,20 +80,7 @@ body.theme-cdap.state-hydrator {
       }
     }
   }
-  &.state-hydrator-create-studio {
-    div.console {
-      &.maximized {
-        top: 120px;
-        .node-config .bottompanel-body {
-          div.config-table {
-            height: ~"-moz-calc(100vh - 284px)";
-            height: ~"-webkit-calc(100vh - 284px)";
-            height: ~"calc(100vh - 284px)";
-          }
-        }
-      }
-    }
-  }
+
   div.console {
     background-color: white;
     position: relative;
@@ -141,6 +128,13 @@ body.theme-cdap.state-hydrator {
       div.console-tabs {
         border-top: 0;
         .box-shadow(0 7px 7px fade(black, 10%), 0 19px 59px fade(black, 25%););
+      }
+      .node-config .bottompanel-body {
+        div.config-table {
+          height: ~"-moz-calc(100vh - 284px)";
+          height: ~"-webkit-calc(100vh - 284px)";
+          height: ~"calc(100vh - 284px)";
+        }
       }
     }
   }

--- a/cdap-ui/app/features/hydrator/bottompanel.less
+++ b/cdap-ui/app/features/hydrator/bottompanel.less
@@ -27,15 +27,15 @@ body.theme-cdap.state-hydrator {
     }
 
     div.console {
-      &.maximized {
-        .node-config .bottompanel-body {
-          div.config-table {
-            height: ~"-moz-calc(100vh - 284px)";
-            height: ~"-webkit-calc(100vh - 284px)";
-            height: ~"calc(100vh - 284px)";
-          }
-        }
-      }
+      // &.maximized {
+      //   .node-config .bottompanel-body {
+      //     div.config-table {
+      //       height: ~"-moz-calc(100vh - 284px)";
+      //       height: ~"-webkit-calc(100vh - 284px)";
+      //       height: ~"calc(100vh - 284px)";
+      //     }
+      //   }
+      // }
       div.console-tabs ul.nav-tabs li {
         margin-bottom: -1px;
       }
@@ -89,7 +89,7 @@ body.theme-cdap.state-hydrator {
       }
     }
   }
-  &.state-hydrator-studio {
+  &.state-hydrator-create-studio {
     div.console {
       &.maximized {
         top: 120px;

--- a/cdap-ui/app/features/hydrator/bottompanel.less
+++ b/cdap-ui/app/features/hydrator/bottompanel.less
@@ -27,15 +27,6 @@ body.theme-cdap.state-hydrator {
     }
 
     div.console {
-      // &.maximized {
-      //   .node-config .bottompanel-body {
-      //     div.config-table {
-      //       height: ~"-moz-calc(100vh - 284px)";
-      //       height: ~"-webkit-calc(100vh - 284px)";
-      //       height: ~"calc(100vh - 284px)";
-      //     }
-      //   }
-      // }
       div.console-tabs ul.nav-tabs li {
         margin-bottom: -1px;
       }


### PR DESCRIPTION
*  Fixes helper class name so that .config-table can calculate viewport height

Chrome:
![chrome](https://cloud.githubusercontent.com/assets/5335210/11944177/082113ae-a7f9-11e5-8a85-e577ad88b092.gif)

Safari:
![safari](https://cloud.githubusercontent.com/assets/5335210/11944181/127cf458-a7f9-11e5-9567-8a9e123e545e.gif)

Firefox:
![ff](https://cloud.githubusercontent.com/assets/5335210/11944187/1971bb0e-a7f9-11e5-9710-4a52cf831c55.gif)
