### PR TITLE
CDAP-4508 Extract Property fields only once in Flowlet

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowletDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowletDefinition.java
@@ -27,10 +27,8 @@ import co.cask.cdap.internal.flow.DefaultFlowletConfigurer;
 import co.cask.cdap.internal.flowlet.DefaultFlowletSpecification;
 import co.cask.cdap.internal.io.SchemaGenerator;
 import co.cask.cdap.internal.lang.Reflections;
-import co.cask.cdap.internal.specification.DataSetFieldExtractor;
 import co.cask.cdap.internal.specification.OutputEmitterFieldExtractor;
 import co.cask.cdap.internal.specification.ProcessMethodExtractor;
-import co.cask.cdap.internal.specification.PropertyFieldExtractor;
 
 import java.lang.reflect.Type;
 import java.util.Collections;
@@ -67,23 +65,19 @@ public final class FlowletDefinition {
 
     this.instances = instances;
 
-    Set<String> datasets = new HashSet<>(flowletSpec.getDataSets());
     Map<String, Set<Type>> inputTypes = new HashMap<>();
     Map<String, Set<Type>> outputTypes = new HashMap<>();
-    Map<String, String> properties = new HashMap<>(flowletSpec.getProperties());
     Reflections.visit(flowlet, flowlet.getClass(),
-                      new DataSetFieldExtractor(datasets),
-                      new PropertyFieldExtractor(properties),
                       new OutputEmitterFieldExtractor(outputTypes),
                       new ProcessMethodExtractor(inputTypes));
 
-    this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
+    this.datasets = Collections.unmodifiableSet(new HashSet<>(flowletSpec.getDataSets()));
     this.inputTypes = immutableCopyOf(inputTypes);
     this.outputTypes = immutableCopyOf(outputTypes);
     this.flowletSpec = new DefaultFlowletSpecification(flowlet.getClass().getName(),
                                                        flowletName == null ? flowletSpec.getName() : flowletName,
                                                        flowletSpec.getDescription(), flowletSpec.getFailurePolicy(),
-                                                       datasets, properties,
+                                                       flowletSpec.getDataSets(), flowletSpec.getProperties(),
                                                        flowletSpec.getResources());
     this.streams = Collections.unmodifiableMap(flowletConfigurer.getStreams());
     this.datasetModules = Collections.unmodifiableMap(flowletConfigurer.getDatasetModules());

--- a/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowletConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowletConfigurer.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.flow.flowlet.FlowletSpecification;
 import co.cask.cdap.internal.api.DefaultDatasetConfigurer;
 import co.cask.cdap.internal.flowlet.DefaultFlowletSpecification;
 import co.cask.cdap.internal.lang.Reflections;
+import co.cask.cdap.internal.specification.DataSetFieldExtractor;
 import co.cask.cdap.internal.specification.PropertyFieldExtractor;
 
 import java.util.HashMap;
@@ -56,8 +57,10 @@ public class DefaultFlowletConfigurer extends DefaultDatasetConfigurer implement
     this.properties = new HashMap<>();
     this.datasets = new HashSet<>();
 
-    // Grab all @Property fields
-    Reflections.visit(flowlet, flowlet.getClass(), new PropertyFieldExtractor(propertyFields));
+    // Grab all @Property, @UseDataset fields
+    Reflections.visit(flowlet, flowlet.getClass(),
+                      new PropertyFieldExtractor(propertyFields),
+                      new DataSetFieldExtractor(datasets));
   }
 
   @Override
@@ -102,6 +105,6 @@ public class DefaultFlowletConfigurer extends DefaultDatasetConfigurer implement
     Map<String, String> properties = new HashMap<>(this.properties);
     properties.putAll(propertyFields);
     return new DefaultFlowletSpecification(this.className, this.name, this.description, this.failurePolicy,
-                                           this.datasets, this.properties, this.resources);
+                                           this.datasets, properties, this.resources);
   }
 }


### PR DESCRIPTION
We grab the PropertyFields in ``FlowletDefinition`` class. So we don't have to do it twice for Flowlets.

JIRA : https://issues.cask.co/browse/CDAP-4508
Build : http://builds.cask.co/browse/CDAP-RBT547