### PR TITLE
Fix Documentation Build

### DIFF
--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="e8cc6ab35e17a8c28adafb02d65027b5"
+DEFAULT_XML_MD5_HASH="8b574d59b5390f5adce4a932f8f0d45b"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -19,4 +19,4 @@ WITH_JAVADOCS="$WITHOUT"
 MANUALS="introduction developers-manual cdap-apps admin-manual integrations examples-manual reference-manual faqs"
 
 # This needs to be explicitly set as Git has trouble identifying it.
-GIT_BRANCH_PARENT="release/3.3"
+GIT_BRANCH_PARENT="develop"


### PR DESCRIPTION
Corrects the branch parent. 

``develop`` and any feature branches from it, should always have the ``GIT_BRANCH_PARENT`` as ``develop``.

Fixes the MD5 hash for cdap-default.xml.
Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB78-1).