### PR TITLE
CDAP-3742 Increment MAP_OUTPUT_RECORDS and REDUCE_OUTPUT_RECORDS, eve…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -162,8 +162,10 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
           program = programRef.get();
         }
         MapReduceSpecification spec = program.getApplicationSpecification().getMapReduce().get(program.getName());
-        MapReduceMetrics.TaskType taskType = MapReduceMetrics.TaskType.from(key.getTaskAttemptID().getTaskType());
-
+        MapReduceMetrics.TaskType taskType = null;
+        if (MapReduceMetrics.TaskType.hasType(key.getTaskAttemptID().getTaskType())) {
+          taskType = MapReduceMetrics.TaskType.from(key.getTaskAttemptID().getTaskType());
+        }
         // if this is not for a mapper or a reducer, we don't need the metrics collection service
         MetricsCollectionService metricsCollectionService =
           (taskType == null) ? null : injector.getInstance(MetricsCollectionService.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionConsumingTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionConsumingTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -33,6 +33,7 @@ package co.cask.cdap.partitioned;
 import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.ProgramManager;
@@ -42,6 +43,7 @@ import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
@@ -53,6 +55,7 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -72,6 +75,14 @@ public class PartitionConsumingTestRun extends TestFrameworkTestBase {
         return input.getMapReduceManager(AppWithPartitionConsumers.WordCountMapReduce.NAME).start();
       }
     });
+    Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, "default",
+                                               Constants.Metrics.Tag.APP, "AppWithPartitionConsumers",
+                                               Constants.Metrics.Tag.MAPREDUCE, "WordCountMapReduce",
+                                               Constants.Metrics.Tag.MR_TASK_TYPE, "r");
+    long totalIn = getMetricsManager().getTotalMetric(tags, "system.process.entries.in");
+    long totalOut = getMetricsManager().getTotalMetric(tags, "system.process.entries.out");
+    Assert.assertEquals(9, totalIn);
+    Assert.assertEquals(10, totalOut);
   }
 
   @Test


### PR DESCRIPTION
Increment MAP_OUTPUT_RECORDS and REDUCE_OUTPUT_RECORDS, even when using multiple outputs of MapReduce.
Previously, output metrics were not being emitted, when multiple outputs of a MapReduce was being used.
This resulted in the UI showing 0 output records for MapReduce jobs that had multiple outputs.

https://issues.cask.co/browse/CDAP-3742
http://builds.cask.co/browse/CDAP-RBT548-5

Tested on cluster.