### PR TITLE
Feature/ui persistant plugin versions in ui

### DIFF
--- a/cdap-ui/app/features/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/leftpanel-ctrl.js
@@ -70,6 +70,7 @@ class LeftPanelController {
   onLeftSidePanelItemClicked(event, node) {
     event.stopPropagation();
     var item = this.LeftPanelStore.getSpecificPluginVersion(node);
+    this.LeftPanelStore.updatePluginDefaultVersion(node);
     let config;
     if (item.pluginTemplate) {
       config = {

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/leftpanel-plugin-popover.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/leftpanel-plugin-popover.html
@@ -32,11 +32,8 @@
     <li class="list-group-item">
       <h6>
         {{contentData.defaultVersion}}
-        <small ng-if="!contentData.showAllVersion">
+        <small ng-if="!contentData.showAllVersion && contentData.allVersions.length > 1">
           <a href="#" ng-click="contentData.showAllVersion = !contentData.showAllVersion">Change</a>
-        </small>
-        <small ng-if="contentData.showAllVersion">
-          <a href="#" ng-click="contentData.showAllVersion=!contentData.showAllVersion">Back</a>
         </small>
       </h6>
     </li>


### PR DESCRIPTION
- Use user store to store default versions of plugins
- Updates the user store when a plugin is removed.
- On each load check if the map has any value, if it does then update the appropriate plugin with the default version.
- Start a cleanup process and wait for all sources, sinks & transforms are fetched.
- Minor refactor in LeftPanelStore to remove functions that are generic.