### PR TITLE
[CDAP-4475] Fix Hydrator Metrics Issue

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -144,6 +144,12 @@ angular.module(PKG.name + '.commons')
           }
 
           $scope.$watch('metricsData', function () {
+            if (Object.keys($scope.metricsData).length === 0) {
+              angular.forEach(nodePopovers, function (value) {
+                value.scope.data.metrics = 0;
+              });
+            }
+
             angular.forEach($scope.metricsData, function (value, key) {
               nodePopovers[key].scope.data.metrics = value;
             });
@@ -151,6 +157,8 @@ angular.module(PKG.name + '.commons')
             angular.forEach(labels, function (endpoint) {
               var label = endpoint.getOverlay('metricLabel');
               if ($scope.metricsData[endpoint.elementId] === null || $scope.metricsData[endpoint.elementId] === undefined) {
+                angular.element(label.getElement())
+                  .text(0);
                 return;
               }
 

--- a/cdap-ui/app/features/hydrator/controllers/detail/tabs/metrics-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/detail/tabs/metrics-ctrl.js
@@ -17,7 +17,7 @@
 angular.module(PKG.name + '.feature.hydrator')
   .controller('HydratorDetailMetricsController', function(DetailRunsStore, MetricsStore, PipelineDetailMetricsActionFactory, $scope, NodesStore) {
 
-    var currentRunId;
+    // var currentRunId;
     this.setState = function() {
       this.state = {
         metrics: MetricsStore.getMetrics(),
@@ -28,72 +28,72 @@ angular.module(PKG.name + '.feature.hydrator')
     this.setState();
 
     MetricsStore.registerOnChangeListener(this.setState.bind(this));
-    DetailRunsStore.registerOnChangeListener(checkAndPollForMetrics.bind(this));
+    // DetailRunsStore.registerOnChangeListener(checkAndPollForMetrics.bind(this));
 
-    function checkAndPollForMetrics() {
-      var latestRun;
-      if (DetailRunsStore.getRunsCount()) {
-        latestRun = DetailRunsStore.getLatestRun();
-        if (latestRun && latestRun.status !== 'RUNNING') {
-          currentRunId = null;
-          /*
-            TL;DR - This is to avoid the in-consistent value that appears in UI due to delay in stopping a poll.
+    // function checkAndPollForMetrics() {
+    //   var latestRun;
+    //   if (DetailRunsStore.getRunsCount()) {
+    //     latestRun = DetailRunsStore.getLatestRun();
+    //     if (latestRun && latestRun.status !== 'RUNNING') {
+    //       currentRunId = null;
+    //       /*
+    //         TL;DR - This is to avoid the in-consistent value that appears in UI due to delay in stopping a poll.
 
-            Bigger version -
-            Say we started a poll and we are actively polling for metrics for a runid (poll interval is 10sec default).
+    //         Bigger version -
+    //         Say we started a poll and we are actively polling for metrics for a runid (poll interval is 10sec default).
 
-            t=1 -> made a new request for metrics
-            t=2,3,4,5,6,7,8 -> Do nothing
-            t=9 -> Stop the poll for metrics (meaning stop the run).
+    //         t=1 -> made a new request for metrics
+    //         t=2,3,4,5,6,7,8 -> Do nothing
+    //         t=9 -> Stop the poll for metrics (meaning stop the run).
 
-            In the past 8 seconds the metrics could have changed (we don't know for sure).
-            So at the moment for a killed run we show a metric that is 8 seconds old.
-            But when the user refreshes the page he/she would see the latest metric value before it is stopped.
+    //         In the past 8 seconds the metrics could have changed (we don't know for sure).
+    //         So at the moment for a killed run we show a metric that is 8 seconds old.
+    //         But when the user refreshes the page he/she would see the latest metric value before it is stopped.
 
-            To avoid this in-consistency we make a final request before stopping the poll for a runid.
-          */
-          getMetricsForLatestRunId(false);
-          PipelineDetailMetricsActionFactory.stopMetricsPoll();
-          PipelineDetailMetricsActionFactory.stopMetricValuesPoll();
-        } else {
-          getMetricsForLatestRunId(true);
-          this.setState();
-        }
-      }
-    }
+    //         To avoid this in-consistency we make a final request before stopping the poll for a runid.
+    //       */
+    //       getMetricsForLatestRunId(false);
+    //       PipelineDetailMetricsActionFactory.stopMetricsPoll();
+    //       PipelineDetailMetricsActionFactory.stopMetricValuesPoll();
+    //     } else {
+    //       getMetricsForLatestRunId(true);
+    //       this.setState();
+    //     }
+    //   }
+    // }
 
-    // No matter what get the metrics for the current run (since its an aggregate).
-    getMetricsForLatestRunId(false);
-    checkAndPollForMetrics.call(this);
+    // // No matter what get the metrics for the current run (since its an aggregate).
+    // getMetricsForLatestRunId(false);
+    // checkAndPollForMetrics.call(this);
 
-    function getMetricsForLatestRunId(isPoll) {
-      var latestRunId = DetailRunsStore.getLatestMetricRunId();
-      if (!latestRunId) {
-        return;
-      }
-      if (latestRunId === currentRunId) {
-        return;
-      }
-      currentRunId = latestRunId;
-      var appParams = angular.copy(DetailRunsStore.getParams());
-      var logsParams = angular.copy(DetailRunsStore.getLogsParams());
-      var metricParams = {
-        namespace: appParams.namespace,
-        app: appParams.app,
-        run: latestRunId
-      };
-      var programType = DetailRunsStore.getMetricProgramType();
-      metricParams[programType] = logsParams.programId;
-      if (metricParams.run) {
-        if (isPoll) {
-          PipelineDetailMetricsActionFactory.pollForMetrics(metricParams);
-        } else {
-          PipelineDetailMetricsActionFactory.requestForMetrics(metricParams);
-        }
-      }
-    }
+    // function getMetricsForLatestRunId(isPoll) {
+    //   var latestRunId = DetailRunsStore.getLatestMetricRunId();
+    //   if (!latestRunId) {
+    //     return;
+    //   }
+    //   if (latestRunId === currentRunId) {
+    //     return;
+    //   }
+    //   currentRunId = latestRunId;
+    //   var appParams = angular.copy(DetailRunsStore.getParams());
+    //   var logsParams = angular.copy(DetailRunsStore.getLogsParams());
+    //   var metricParams = {
+    //     namespace: appParams.namespace,
+    //     app: appParams.app,
+    //     run: latestRunId
+    //   };
+    //   var programType = DetailRunsStore.getMetricProgramType();
+    //   metricParams[programType] = logsParams.programId;
+    //   if (metricParams.run) {
+    //     if (isPoll) {
+    //       PipelineDetailMetricsActionFactory.pollForMetrics(metricParams);
+    //     } else {
+    //       PipelineDetailMetricsActionFactory.requestForMetrics(metricParams);
+    //     }
+    //   }
+    // }
 
-    $scope.$on('$destroy', function() {
-      PipelineDetailMetricsActionFactory.reset();
-    });
+    // $scope.$on('$destroy', function() {
+    //   PipelineDetailMetricsActionFactory.reset();
+    // });
   });

--- a/cdap-ui/app/features/hydrator/controllers/detail/tabs/metrics-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/detail/tabs/metrics-ctrl.js
@@ -17,7 +17,6 @@
 angular.module(PKG.name + '.feature.hydrator')
   .controller('HydratorDetailMetricsController', function(DetailRunsStore, MetricsStore, PipelineDetailMetricsActionFactory, $scope, NodesStore) {
 
-    // var currentRunId;
     this.setState = function() {
       this.state = {
         metrics: MetricsStore.getMetrics(),
@@ -28,72 +27,4 @@ angular.module(PKG.name + '.feature.hydrator')
     this.setState();
 
     MetricsStore.registerOnChangeListener(this.setState.bind(this));
-    // DetailRunsStore.registerOnChangeListener(checkAndPollForMetrics.bind(this));
-
-    // function checkAndPollForMetrics() {
-    //   var latestRun;
-    //   if (DetailRunsStore.getRunsCount()) {
-    //     latestRun = DetailRunsStore.getLatestRun();
-    //     if (latestRun && latestRun.status !== 'RUNNING') {
-    //       currentRunId = null;
-    //       /*
-    //         TL;DR - This is to avoid the in-consistent value that appears in UI due to delay in stopping a poll.
-
-    //         Bigger version -
-    //         Say we started a poll and we are actively polling for metrics for a runid (poll interval is 10sec default).
-
-    //         t=1 -> made a new request for metrics
-    //         t=2,3,4,5,6,7,8 -> Do nothing
-    //         t=9 -> Stop the poll for metrics (meaning stop the run).
-
-    //         In the past 8 seconds the metrics could have changed (we don't know for sure).
-    //         So at the moment for a killed run we show a metric that is 8 seconds old.
-    //         But when the user refreshes the page he/she would see the latest metric value before it is stopped.
-
-    //         To avoid this in-consistency we make a final request before stopping the poll for a runid.
-    //       */
-    //       getMetricsForLatestRunId(false);
-    //       PipelineDetailMetricsActionFactory.stopMetricsPoll();
-    //       PipelineDetailMetricsActionFactory.stopMetricValuesPoll();
-    //     } else {
-    //       getMetricsForLatestRunId(true);
-    //       this.setState();
-    //     }
-    //   }
-    // }
-
-    // // No matter what get the metrics for the current run (since its an aggregate).
-    // getMetricsForLatestRunId(false);
-    // checkAndPollForMetrics.call(this);
-
-    // function getMetricsForLatestRunId(isPoll) {
-    //   var latestRunId = DetailRunsStore.getLatestMetricRunId();
-    //   if (!latestRunId) {
-    //     return;
-    //   }
-    //   if (latestRunId === currentRunId) {
-    //     return;
-    //   }
-    //   currentRunId = latestRunId;
-    //   var appParams = angular.copy(DetailRunsStore.getParams());
-    //   var logsParams = angular.copy(DetailRunsStore.getLogsParams());
-    //   var metricParams = {
-    //     namespace: appParams.namespace,
-    //     app: appParams.app,
-    //     run: latestRunId
-    //   };
-    //   var programType = DetailRunsStore.getMetricProgramType();
-    //   metricParams[programType] = logsParams.programId;
-    //   if (metricParams.run) {
-    //     if (isPoll) {
-    //       PipelineDetailMetricsActionFactory.pollForMetrics(metricParams);
-    //     } else {
-    //       PipelineDetailMetricsActionFactory.requestForMetrics(metricParams);
-    //     }
-    //   }
-    // }
-
-    // $scope.$on('$destroy', function() {
-    //   PipelineDetailMetricsActionFactory.reset();
-    // });
   });

--- a/cdap-ui/app/features/hydrator/services/detail/actions/pipeline-detail-actions.js
+++ b/cdap-ui/app/features/hydrator/services/detail/actions/pipeline-detail-actions.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.hydrator')
-  .service('PipelineDetailActionFactory', function(PipelineDetailDispatcher, myPipelineApi) {
+  .service('PipelineDetailActionFactory', function(PipelineDetailDispatcher,PipelineDetailMetricsActionFactory, myPipelineApi) {
     var dispatcher = PipelineDetailDispatcher.getDispatcher();
     this.startPipeline = function (api, params) {
       return api.start(params).$promise;

--- a/cdap-ui/app/features/hydrator/services/detail/actions/pipeline-detail-actions.js
+++ b/cdap-ui/app/features/hydrator/services/detail/actions/pipeline-detail-actions.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.hydrator')
-  .service('PipelineDetailActionFactory', function(PipelineDetailDispatcher,PipelineDetailMetricsActionFactory, myPipelineApi) {
+  .service('PipelineDetailActionFactory', function(PipelineDetailDispatcher, myPipelineApi) {
     var dispatcher = PipelineDetailDispatcher.getDispatcher();
     this.startPipeline = function (api, params) {
       return api.start(params).$promise;

--- a/cdap-ui/app/features/hydrator/services/detail/actions/pipeline-detail-metrics-actions.js
+++ b/cdap-ui/app/features/hydrator/services/detail/actions/pipeline-detail-metrics-actions.js
@@ -15,11 +15,12 @@
  */
 
 angular.module(PKG.name + '.feature.hydrator')
-  .service('PipelineDetailMetricsActionFactory', function(DetailRunsStore, PipelineDetailMetricslDispatcher, MyCDAPDataSource, $filter, MyMetricsQueryHelper, DetailNonRunsStore) {
+  .service('PipelineDetailMetricsActionFactory', function(DetailRunsStore, PipelineDetailMetricslDispatcher, MyCDAPDataSource, MetricsStore, $filter, MyMetricsQueryHelper, DetailNonRunsStore) {
+
+    // var pipelineDispatcher = PipelineDetailDispatcher.getDispatcher();
 
     var dispatcher = PipelineDetailMetricslDispatcher.getDispatcher();
     var metricsPollId;
-    var metricValuesPollId;
     // FIXME: This is a memory leak. We need to fix this.
     var dataSrc = new MyCDAPDataSource();
     var filter = $filter('filter');
@@ -58,17 +59,22 @@ angular.module(PKG.name + '.feature.hydrator')
             metricQuery = metricQuery.concat(filter(res, node));
           });
 
-          if (metricQuery.length === 0) { return; }
-          this.stopMetricValuesPoll();
+          if (metricQuery.length === 0) {
+            dispatcher.dispatch('onEmptyMetrics');
+            return;
+          }
 
-          metricValuesPollId = api({
+          /**
+           *  Since the parent block is already a poll, we don't need another poll for
+           *  the values of each metrics.
+           **/
+          dataSrc.request({
             method: 'POST',
             _cdapPath: '/metrics/query?' + metricParams + '&metric=' + metricQuery.join('&metric=')
-          }, function(metrics) {
+          }).then(function(metrics) {
             dispatcher.dispatch('onMetricsFetch', metrics);
           });
 
-          metricValuesPollId = metricValuesPollId.__pollId__;
         }
       }.bind(this));
 
@@ -82,16 +88,8 @@ angular.module(PKG.name + '.feature.hydrator')
       }
     };
 
-    this.stopMetricValuesPoll = function() {
-      if (metricValuesPollId) {
-        dataSrc.stopPoll(metricValuesPollId);
-        metricValuesPollId = null;
-      }
-    };
-
     this.reset = function() {
       this.stopMetricsPoll();
-      this.stopMetricValuesPoll();
       dispatcher.dispatch('onReset');
     };
 

--- a/cdap-ui/app/features/hydrator/services/detail/actions/pipeline-detail-metrics-actions.js
+++ b/cdap-ui/app/features/hydrator/services/detail/actions/pipeline-detail-metrics-actions.js
@@ -17,8 +17,6 @@
 angular.module(PKG.name + '.feature.hydrator')
   .service('PipelineDetailMetricsActionFactory', function(DetailRunsStore, PipelineDetailMetricslDispatcher, MyCDAPDataSource, MetricsStore, $filter, MyMetricsQueryHelper, DetailNonRunsStore) {
 
-    // var pipelineDispatcher = PipelineDetailDispatcher.getDispatcher();
-
     var dispatcher = PipelineDetailMetricslDispatcher.getDispatcher();
     var metricsPollId;
     // FIXME: This is a memory leak. We need to fix this.

--- a/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-metrics-store.js
+++ b/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-metrics-store.js
@@ -37,6 +37,11 @@ angular.module(PKG.name + '.feature.hydrator')
       }.bind(this));
     };
 
+    this.emptyMetrics = function () {
+      this.state.metrics = [];
+      this.emitChange();
+    };
+
     this.setState = function(metrics) {
       var metricObj = {};
       angular.forEach(metrics.series, function (metric) {
@@ -66,5 +71,6 @@ angular.module(PKG.name + '.feature.hydrator')
       this.emitChange();
     };
     dispatcher.register('onMetricsFetch', this.setState.bind(this));
+    dispatcher.register('onEmptyMetrics', this.emptyMetrics.bind(this));
     dispatcher.register('onReset', this.setDefaults.bind(this));
   });


### PR DESCRIPTION
Root cause: We are polling for the available metrics, and then inside the callback, we start polling for the values again, but only retaining 1 poll-id for the values. So when the stop-poll happen, it only stop the latest values poll, not the previous polls.