### PR TITLE
CDAP-4539 only set hive classpath for master service

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -232,10 +232,14 @@ set_hive_classpath() {
       fi
 
       if [[ $(which hive 2>/dev/null) ]]; then
-        HIVE_VAR_OUT=$(hive -e 'set -v' 2>/dev/null)
+        ERR_FILE=$(mktemp)
+        HIVE_VAR_OUT=$(hive -e 'set -v' 2>${ERR_FILE})
         __ret=$?
+        HIVE_ERR_MSG=$(< ${ERR_FILE})
+        rm ${ERR_FILE}
         if [ ${__ret} -ne 0 ]; then
-          echo "ERROR - Failed getting Hive settings using: hive -e 'set -v'"
+          echo "ERROR - Failed getting Hive settings using: hive -e 'set -v':"
+          echo "${HIVE_ERR_MSG}"
           return 1
         fi
         HIVE_VARS=$(echo ${HIVE_VAR_OUT} | tr ' ' '\n')

--- a/cdap-common/bin/service
+++ b/cdap-common/bin/service
@@ -94,13 +94,14 @@ _start_java() {
   check_and_set_classpath_for_dev_environment "${CDAP_HOME}"
   # Setup classpaths.
   set_classpath "${COMPONENT_HOME}" "${CDAP_CONF}"
-  set_hive_classpath || exit 1
   # Setup Java
   set_java || exit 1
-  # Add proper HBase compatibility to CLASSPATH
-  set_hbase || exit 1
-  # Master requires this local directory
   if [ "${PKGNAME}" == "master" ]; then
+    # Master requires setting hive classpath
+    set_hive_classpath || exit 1
+    # Add proper HBase compatibility to CLASSPATH
+    set_hbase || exit 1
+    # Master requires this local directory
     check_or_create_master_local_dir || die "Could not create Master local directory"
   fi
   check_before_start || exit 1


### PR DESCRIPTION
Fixing init scripts so that only the master service tries to set
the explore classpath, instead of all cdap services.
Also tweaking the set hive classpath function to print the
contents of stderr for the hive command when it fails so that the
user has some idea of what went wrong.