### PR TITLE
CDAP-4536 check infrastructure on master startup

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -238,7 +238,10 @@ cdap_set_hive_classpath() {
         HIVE_ERR_MSG=$(< ${ERR_FILE})
         rm ${ERR_FILE}
         if [ ${__ret} -ne 0 ]; then
-          echo "ERROR - Failed getting Hive settings using: hive -e 'set -v':"
+          echo "ERROR - While determining Hive classpath, failed to get Hive settings using: hive -e 'set -v'"
+          echo "If you do not want run CDAP with Hive functionality, set the 'explore.enabled' property in cdap-site.xml to 'false'"
+          echo "Otherwise, check that the Hive client is installed, and that Hive and HDFS are running."
+          echo "stderr:"
           echo "${HIVE_ERR_MSG}"
           return 1
         fi

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -43,6 +43,16 @@ public final class Constants {
   public static final String COLLECT_CONTAINER_LOGS = "master.collect.containers.log";
 
   /**
+   * Configuration for Master startup.
+   */
+  public static final class Startup {
+    public static final String CHECKS_ENABLED = "master.startup.checks.enabled";
+    public static final String CHECK_PACKAGES = "master.startup.checks.packages";
+    public static final String CHECK_CLASSES = "master.startup.checks.classes";
+    public static final String YARN_CONNECT_TIMEOUT_SECONDS = "master.startup.checks.yarn.connect.timeout.seconds";
+  }
+
+  /**
    * Global Service names.
    */
   public static final class Service {
@@ -587,6 +597,7 @@ public final class Constants {
   public static final class LogSaver {
     public static final String NUM_INSTANCES = "log.saver.num.instances";
     public static final String MEMORY_MB = "log.saver.run.memory.megs";
+    public static final String NUM_CORES = "log.saver.run.num.cores";
     public static final String MAX_INSTANCES = "log.saver.max.instances";
 
     public static final String LOG_SAVER_STATUS_HANDLER = "log.saver.status.handler";

--- a/cdap-common/src/main/java/co/cask/cdap/common/startup/Check.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/startup/Check.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.startup;
+
+/**
+ * Checks something at start up, throwing an exception if the check failed. Run by a {@link CheckRunner}.
+ * Checks are instantiated by the {@link CheckRunner} using an {@link com.google.inject.Injector} to give them access
+ * to objects they may need, such as a LocationFactory or CConfiguration.
+ */
+public abstract class Check {
+
+  /**
+   * Run the check, throwing an Exception if the check failed.
+   */
+  public abstract void run() throws Exception;
+
+  /**
+   * Return a short, descriptive name for the check.
+   *
+   * @return the name of the check
+   */
+  public String getName() {
+    return getClass().getSimpleName();
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/startup/CheckRunner.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/startup/CheckRunner.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.startup;
+
+import co.cask.cdap.common.internal.guava.ClassPath;
+import com.google.inject.Injector;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Runs a collection of {@link Check Checks}.
+ */
+public class CheckRunner {
+  private final Set<Check> checks;
+
+  private CheckRunner(Set<Check> checks) {
+    this.checks = checks;
+  }
+
+  /**
+   * Runs all checks, returning all the check failures.
+   *
+   * @return list of check failures
+   */
+  public List<Failure> runChecks() {
+    List<Failure> failures = new ArrayList<>();
+
+    for (Check check : checks) {
+      try {
+        check.run();
+      } catch (Exception e) {
+        failures.add(new Failure(check.getName(), e));
+      }
+    }
+
+    return failures;
+  }
+
+  /**
+   * Create a builder that uses the specified injector to instantiate checks to run.
+   *
+   * @param injector the injector to use to instantiate the checks
+   * @return builder to build a {@link CheckRunner}.
+   */
+  public static Builder builder(Injector injector) {
+    return new Builder(injector);
+  }
+
+  /**
+   * Builds a {@link CheckRunner}.
+   */
+  public static class Builder {
+    private final Set<Check> checks;
+    private final ClassLoader classLoader;
+    private final Injector injector;
+    private ClassPath classPath;
+
+    public Builder(Injector injector) {
+      this.checks = new HashSet<>();
+      this.classLoader = this.getClass().getClassLoader();
+      this.injector = injector;
+    }
+
+    /**
+     * Recursively search the specified package for any {@link Check Checks} and add them.
+     *
+     * @param pkg the package to search for checks
+     * @return this builder
+     * @throws IOException if there was a problem reading resources from the classpath
+     */
+    public Builder addChecksInPackage(String pkg) throws IOException {
+      ClassPath classPath = getClassPath();
+      for (ClassPath.ClassInfo classInfo : classPath.getAllClassesRecursive(pkg)) {
+        Class<?> cls = classInfo.load();
+        if (!Modifier.isInterface(cls.getModifiers()) &&
+          !Modifier.isAbstract(cls.getModifiers()) &&
+          Check.class.isAssignableFrom(cls)) {
+          checks.add((Check) injector.getInstance(cls));
+        }
+      }
+      return this;
+    }
+
+    /**
+     * Adds the {@link Check} given its class name.
+     *
+     * @param className the class name for the {@link Check}.
+     * @return the builder
+     * @throws ClassNotFoundException if the class could not be found
+     * @throws IllegalArgumentException if the specified class is not a {@link Check}.
+     */
+    public Builder addClass(String className) throws ClassNotFoundException {
+      Class<?> cls = classLoader.loadClass(className);
+      if (!Check.class.isAssignableFrom(cls)) {
+        throw new IllegalArgumentException(className + " does not implement " + Check.class.getName());
+      }
+      checks.add((Check) injector.getInstance(cls));
+      return this;
+    }
+
+    /**
+     * Build the {@link CheckRunner}.
+     *
+     * @return the {@link CheckRunner}
+     */
+    public CheckRunner build() {
+      return new CheckRunner(checks);
+    }
+
+    private ClassPath getClassPath() throws IOException {
+      if (classPath == null) {
+        classPath = ClassPath.from(classLoader);
+      }
+      return classPath;
+    }
+  }
+
+  /**
+   * Contains the name of a failed check and the exception that caused the failure.
+   */
+  public static class Failure {
+    private final String name;
+    private final Exception exception;
+
+    public Failure(String name, Exception exception) {
+      this.name = name;
+      this.exception = exception;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public Exception getException() {
+      return exception;
+    }
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/startup/ConfigurationLogger.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/startup/ConfigurationLogger.java
@@ -13,26 +13,42 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package co.cask.cdap.startup;
+package co.cask.cdap.common.startup;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URL;
+import java.net.URLClassLoader;
+
 /**
- *
+ * Logs important configuration information.
  */
 public class ConfigurationLogger {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConfigurationLogger.class);
 
   public static void logImportantConfig(CConfiguration cConf) {
+    ClassLoader cl = ClassLoader.getSystemClassLoader();
+
+    URL[] urls = ((URLClassLoader) cl).getURLs();
+
+    StringBuilder classPath = new StringBuilder();
+    LOG.info("Master classpath:");
+    for (URL url : urls) {
+      classPath.append(url.getFile()).append(":");
+    }
+    classPath.deleteCharAt(classPath.length() - 1);
+    LOG.info(classPath.toString());
+
+    LOG.info("Important config settings:");
     for (String featureToggleProp : Constants.FEATURE_TOGGLE_PROPS) {
-      LOG.info("{}: {}", featureToggleProp, cConf.get(featureToggleProp));
+      LOG.info("  {}: {}", featureToggleProp, cConf.get(featureToggleProp));
     }
     for (String portProp : Constants.PORT_PROPS) {
-      LOG.info("{}: {}", portProp, cConf.get(portProp));
+      LOG.info("  {}: {}", portProp, cConf.get(portProp));
     }
   }
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -90,6 +90,36 @@
   </property>
 
   <property>
+    <name>master.startup.checks.enabled</name>
+    <value>true</value>
+    <description>
+      Whether checks should be run before start up to determine if the master can be correctly run.
+      Which checks are run are determined by the master.startup.checks.packages and master.startup.checks.classes
+      settings. If any check fails, the CDAP master will fail to start instead of waiting for the problem to be fixed.
+      This setting only affects distributed CDAP. It does not apply to CDAP standalone.
+    </description>
+  </property>
+
+  <property>
+    <name>master.startup.checks.packages</name>
+    <value>co.cask.cdap.master.startup</value>
+    <description>
+      Comma separated list of packages containing checks that will be run before the master starts up.
+      If any of the checks fails, the master will not start up.
+      Checks will only be run if master.startup.checks.enabled is set to true.
+    </description>
+  </property>
+
+  <property>
+    <name>master.startup.checks.classes</name>
+    <description>
+      Comma separated list of classnames for checks that will be run before the master starts up.
+      If any of the checks fails, the master will not start up.
+      Checks will only be run if master.startup.checks.enabled is set to true.
+    </description>
+  </property>
+
+  <property>
     <name>thrift.max.read.buffer</name>
     <value>16777216</value>
     <description>
@@ -469,6 +499,22 @@
   </property>
 
   <property>
+    <name>dataset.executor.container.memory.mb</name>
+    <value>512</value>
+    <description>
+      Size of Memory in megabytes for each dataset executor instance
+    </description>
+  </property>
+
+  <property>
+    <name>dataset.executor.container.num.cores</name>
+    <value>1</value>
+    <description>
+      Number of virtual cores for each dataset executor instance
+    </description>
+  </property>
+
+  <property>
     <name>dataset.executor.max.instances</name>
     <value>${master.service.max.instances}</value>
     <description>
@@ -541,6 +587,22 @@
     <value>1</value>
     <description>
       Number of explore executor instances
+    </description>
+  </property>
+
+  <property>
+    <name>explore.executor.container.num.cores</name>
+    <value>1</value>
+    <description>
+      Number of virtual cores for each explore executor instance
+    </description>
+  </property>
+
+  <property>
+    <name>explore.executor.container.memory.mb</name>
+    <value>1024</value>
+    <description>
+      Size of Memory in megabytes for each explore executor instance
     </description>
   </property>
 
@@ -751,6 +813,14 @@
     <value>1024</value>
     <description>
       Memory in megabytes allocated for log saver instances to run in YARN
+    </description>
+  </property>
+
+  <property>
+    <name>log.saver.run.num.cores</name>
+    <value>2</value>
+    <description>
+      Number of cores for each log saver instance in YARN
     </description>
   </property>
 

--- a/cdap-common/src/test/java/co/cask/cdap/common/startup/CheckRunnerTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/startup/CheckRunnerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.startup.check.NoOpCheck;
+import co.cask.cdap.common.startup.check.fail.AlwaysFailCheck;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ */
+@SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+public class CheckRunnerTest {
+  private static final String FAILURE_MESSAGE = "test failure message";
+  private static Injector injector;
+
+  @BeforeClass
+  public static void setupTests() {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(AlwaysFailCheck.FAILURE_MESSAGE_KEY, FAILURE_MESSAGE);
+    injector = Guice.createInjector(new ConfigModule(cConf));
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void testNonexistentClassThrowsException() throws Exception {
+    CheckRunner.builder(injector).addClass("asdf").build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNonCheckClassThrowsException() throws Exception {
+    CheckRunner.builder(injector).addClass(getClass().getName());
+  }
+
+  @Test
+  public void testMultipleChecks() throws Exception {
+    CheckRunner checkRunner = CheckRunner.builder(injector)
+      .addChecksInPackage(NoOpCheck.class.getPackage().getName())
+      .build();
+
+    List<CheckRunner.Failure> failures = checkRunner.runChecks();
+    Assert.assertEquals(1, failures.size());
+    Assert.assertEquals(AlwaysFailCheck.NAME, failures.get(0).getName());
+    Assert.assertEquals(FAILURE_MESSAGE, failures.get(0).getException().getMessage());
+  }
+
+  @Test
+  public void testSingleCheck() throws Exception {
+    CheckRunner checkRunner = CheckRunner.builder(injector)
+      .addClass(NoOpCheck.class.getName())
+      .build();
+
+    List<CheckRunner.Failure> failures = checkRunner.runChecks();
+    Assert.assertTrue(failures.isEmpty());
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/startup/check/NoOpCheck.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/startup/check/NoOpCheck.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.startup.check;
+
+import co.cask.cdap.common.startup.Check;
+
+/**
+ * Check that doesn't do anything.
+ */
+public class NoOpCheck extends Check {
+
+  @Override
+  public void run() throws Exception {
+    // no-op
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/startup/check/fail/AlwaysFailCheck.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/startup/check/fail/AlwaysFailCheck.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.startup.check.fail;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.startup.Check;
+import com.google.inject.Inject;
+
+/**
+ * Check that always throws an exception with a configurable message. Used to check injection.
+ */
+public class AlwaysFailCheck extends Check {
+  public static final String FAILURE_MESSAGE_KEY = "cdap.test.check.failure.key";
+  public static final String NAME = "failure";
+  private final CConfiguration conf;
+
+  @Inject
+  private AlwaysFailCheck(CConfiguration conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public void run() throws Exception {
+    throw new Exception(conf.get(FAILURE_MESSAGE_KEY, "I always fail."));
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
@@ -30,6 +30,7 @@ import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetTypeMDS;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.MDSDatasets;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.MDSDatasetsRegistry;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.TypeConflictException;
 import co.cask.cdap.data2.dataset2.module.lib.DatasetModules;
@@ -133,8 +134,8 @@ public class DatasetTypeManager extends AbstractIdleService {
   public void addModule(final Id.DatasetModule datasetModuleId, final String className, final Location jarLocation)
     throws DatasetModuleConflictException {
 
-    LOG.info("adding module: {}, className: {}, jarLocation: {}",
-             datasetModuleId, className, jarLocation == null ? "[local]" : jarLocation);
+    LOG.debug("adding module: {}, className: {}, jarLocation: {}",
+              datasetModuleId, className, jarLocation == null ? "[local]" : jarLocation);
 
     try {
       mdsDatasets.execute(new TxCallable<MDSDatasets, Void>() {
@@ -411,7 +412,7 @@ public class DatasetTypeManager extends AbstractIdleService {
         addModule(defaultModule, module.getValue().getClass().getName(), null);
       } catch (DatasetModuleConflictException e) {
         // perfectly fine: we need to add default modules only the very first time service is started
-        LOG.info("Not adding {} module: it already exists", module.getKey());
+        LOG.debug("Not adding {} module: it already exists", module.getKey());
       } catch (Throwable th) {
         LOG.error("Failed to add {} module. Aborting.", module.getKey(), th);
         throw Throwables.propagate(th);
@@ -429,7 +430,7 @@ public class DatasetTypeManager extends AbstractIdleService {
         addModule(theModule, module.getValue().getClass().getName(), null);
       } catch (DatasetModuleConflictException e) {
         // perfectly fine: we need to add the modules only the very first time service is started
-        LOG.info("Not adding {} extension module: it already exists", module.getKey());
+        LOG.debug("Not adding {} extension module: it already exists", module.getKey());
       } catch (Throwable th) {
         LOG.error("Failed to add {} extension module. Aborting.", module.getKey(), th);
         throw Throwables.propagate(th);
@@ -437,25 +438,22 @@ public class DatasetTypeManager extends AbstractIdleService {
     }
   }
 
-  private void deleteSystemModules() {
-    try {
-      mdsDatasets.execute(new TxCallable<MDSDatasets, Void>() {
-        @Override
-        public Void call(MDSDatasets context) throws Exception {
-          DatasetTypeMDS typeMDS = context.getTypeMDS();
-          Collection<DatasetModuleMeta> allDatasets = typeMDS.getModules(Id.Namespace.SYSTEM);
-          for (DatasetModuleMeta ds : allDatasets) {
-            if (ds.getJarLocation() == null) {
-              LOG.info("Deleting system dataset module: {}", ds.toString());
-              typeMDS.deleteModule(Id.DatasetModule.from(Id.Namespace.SYSTEM, ds.getName()));
-            }
+  private void deleteSystemModules() throws DatasetManagementException, IOException, InterruptedException,
+    TransactionFailureException {
+    mdsDatasets.execute(new TxCallable<MDSDatasets, Void>() {
+      @Override
+      public Void call(MDSDatasets context) throws Exception {
+        DatasetTypeMDS typeMDS = context.getTypeMDS();
+        Collection<DatasetModuleMeta> allDatasets = typeMDS.getModules(Id.Namespace.SYSTEM);
+        for (DatasetModuleMeta ds : allDatasets) {
+          if (ds.getJarLocation() == null) {
+            LOG.debug("Deleting system dataset module: {}", ds.toString());
+            typeMDS.deleteModule(Id.DatasetModule.from(Id.Namespace.SYSTEM, ds.getName()));
           }
-          return null;
         }
-      });
-    } catch (Exception e) {
-      Throwables.propagate(e);
-    }
+        return null;
+      }
+    });
   }
 
   private class DependencyTrackingRegistry implements DatasetDefinitionRegistry {

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
@@ -93,12 +93,14 @@ public class MasterTwillApplication implements TwillApplication {
     Preconditions.checkArgument(numInstances > 0, "log saver num instances should be at least 1, got %s",
                                 numInstances);
 
-    int memory = cConf.getInt(Constants.LogSaver.MEMORY_MB, 1024);
+    int memory = cConf.getInt(Constants.LogSaver.MEMORY_MB);
     Preconditions.checkArgument(memory > 0, "Got invalid memory value for log saver %s", memory);
+    int cores = cConf.getInt(Constants.LogSaver.NUM_CORES);
+    Preconditions.checkArgument(cores > 0, "Got invalid num cores value for log saver %s", cores);
 
     ResourceSpecification spec = ResourceSpecification.Builder
       .with()
-      .setVirtualCores(2)
+      .setVirtualCores(cores)
       .setMemory(memory, ResourceSpecification.SizeUnit.MEGA)
       .setInstances(numInstances)
       .build();
@@ -113,8 +115,8 @@ public class MasterTwillApplication implements TwillApplication {
   private TwillSpecification.Builder.RunnableSetter addMetricsProcessor(TwillSpecification.Builder.MoreRunnable
                                                                           builder) {
 
-    int numCores = cConf.getInt(Constants.MetricsProcessor.NUM_CORES, 1);
-    int memoryMB = cConf.getInt(Constants.MetricsProcessor.MEMORY_MB, 512);
+    int numCores = cConf.getInt(Constants.MetricsProcessor.NUM_CORES);
+    int memoryMB = cConf.getInt(Constants.MetricsProcessor.MEMORY_MB);
     int instances = instanceCountMap.get(Constants.Service.METRICS_PROCESSOR);
 
     ResourceSpecification metricsProcessorSpec = ResourceSpecification.Builder
@@ -134,8 +136,8 @@ public class MasterTwillApplication implements TwillApplication {
 
   private TwillSpecification.Builder.RunnableSetter addMetricsService(TwillSpecification.Builder.MoreRunnable
                                                                         builder) {
-    int metricsNumCores = cConf.getInt(Constants.Metrics.NUM_CORES, 2);
-    int metricsMemoryMb = cConf.getInt(Constants.Metrics.MEMORY_MB, 2048);
+    int metricsNumCores = cConf.getInt(Constants.Metrics.NUM_CORES);
+    int metricsMemoryMb = cConf.getInt(Constants.Metrics.MEMORY_MB);
     int metricsInstances = instanceCountMap.get(Constants.Service.METRICS);
 
     ResourceSpecification metricsSpec = ResourceSpecification.Builder
@@ -155,8 +157,8 @@ public class MasterTwillApplication implements TwillApplication {
 
   private TwillSpecification.Builder.RunnableSetter addTransactionService(TwillSpecification.Builder.MoreRunnable
                                                                             builder) {
-    int txNumCores = cConf.getInt(Constants.Transaction.Container.NUM_CORES, 2);
-    int txMemoryMb = cConf.getInt(Constants.Transaction.Container.MEMORY_MB, 2048);
+    int txNumCores = cConf.getInt(Constants.Transaction.Container.NUM_CORES);
+    int txMemoryMb = cConf.getInt(Constants.Transaction.Container.MEMORY_MB);
     int txInstances = instanceCountMap.get(Constants.Service.TRANSACTION);
 
     ResourceSpecification transactionSpec = ResourceSpecification.Builder
@@ -178,8 +180,8 @@ public class MasterTwillApplication implements TwillApplication {
     int instances = instanceCountMap.get(Constants.Service.STREAMS);
 
     ResourceSpecification resourceSpec = ResourceSpecification.Builder.with()
-      .setVirtualCores(cConf.getInt(Constants.Stream.CONTAINER_VIRTUAL_CORES, 1))
-      .setMemory(cConf.getInt(Constants.Stream.CONTAINER_MEMORY_MB, 512), ResourceSpecification.SizeUnit.MEGA)
+      .setVirtualCores(cConf.getInt(Constants.Stream.CONTAINER_VIRTUAL_CORES))
+      .setMemory(cConf.getInt(Constants.Stream.CONTAINER_MEMORY_MB), ResourceSpecification.SizeUnit.MEGA)
       .setInstances(instances)
       .build();
 
@@ -195,8 +197,8 @@ public class MasterTwillApplication implements TwillApplication {
     int instances = instanceCountMap.get(Constants.Service.DATASET_EXECUTOR);
 
     ResourceSpecification resourceSpec = ResourceSpecification.Builder.with()
-      .setVirtualCores(cConf.getInt(Constants.Dataset.Executor.CONTAINER_VIRTUAL_CORES, 1))
-      .setMemory(cConf.getInt(Constants.Dataset.Executor.CONTAINER_MEMORY_MB, 512), ResourceSpecification.SizeUnit.MEGA)
+      .setVirtualCores(cConf.getInt(Constants.Dataset.Executor.CONTAINER_VIRTUAL_CORES))
+      .setMemory(cConf.getInt(Constants.Dataset.Executor.CONTAINER_MEMORY_MB), ResourceSpecification.SizeUnit.MEGA)
       .setInstances(instances)
       .build();
 
@@ -213,8 +215,8 @@ public class MasterTwillApplication implements TwillApplication {
     int instances = instanceCountMap.get(Constants.Service.EXPLORE_HTTP_USER_SERVICE);
 
     ResourceSpecification resourceSpec = ResourceSpecification.Builder.with()
-      .setVirtualCores(cConf.getInt(Constants.Explore.CONTAINER_VIRTUAL_CORES, 1))
-      .setMemory(cConf.getInt(Constants.Explore.CONTAINER_MEMORY_MB, 1024), ResourceSpecification.SizeUnit.MEGA)
+      .setVirtualCores(cConf.getInt(Constants.Explore.CONTAINER_VIRTUAL_CORES))
+      .setMemory(cConf.getInt(Constants.Explore.CONTAINER_MEMORY_MB), ResourceSpecification.SizeUnit.MEGA)
       .setInstances(instances)
       .build();
 

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/AbstractMasterCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/AbstractMasterCheck.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.startup.Check;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+/**
+ * Base for master startup checks.
+ */
+abstract class AbstractMasterCheck extends Check {
+  protected final CConfiguration cConf;
+  protected final Set<ServiceResourceKeys> systemServicesResourceKeys;
+
+  protected AbstractMasterCheck(CConfiguration cConf) {
+    this.cConf = cConf;
+    ImmutableSet.Builder<ServiceResourceKeys> builder = ImmutableSet.<ServiceResourceKeys>builder()
+      .add(new ServiceResourceKeys(Constants.Service.TRANSACTION,
+                                   Constants.Transaction.Container.MEMORY_MB,
+                                   Constants.Transaction.Container.NUM_CORES,
+                                   Constants.Transaction.Container.NUM_INSTANCES,
+                                   Constants.Transaction.Container.MAX_INSTANCES))
+      .add(new ServiceResourceKeys(Constants.Service.STREAMS,
+                                   Constants.Stream.CONTAINER_MEMORY_MB,
+                                   Constants.Stream.CONTAINER_VIRTUAL_CORES,
+                                   Constants.Stream.CONTAINER_INSTANCES,
+                                   Constants.Stream.MAX_INSTANCES))
+      .add(new ServiceResourceKeys(Constants.Service.METRICS,
+                                   Constants.Metrics.MEMORY_MB,
+                                   Constants.Metrics.NUM_CORES,
+                                   Constants.Metrics.NUM_INSTANCES,
+                                   Constants.Metrics.MAX_INSTANCES))
+      .add(new ServiceResourceKeys(Constants.Service.METRICS_PROCESSOR,
+                                   Constants.MetricsProcessor.MEMORY_MB,
+                                   Constants.MetricsProcessor.NUM_CORES,
+                                   Constants.MetricsProcessor.NUM_INSTANCES,
+                                   Constants.MetricsProcessor.MAX_INSTANCES))
+      .add(new ServiceResourceKeys(Constants.Service.LOGSAVER,
+                                   Constants.LogSaver.MEMORY_MB,
+                                   Constants.LogSaver.NUM_CORES,
+                                   Constants.LogSaver.NUM_INSTANCES,
+                                   Constants.LogSaver.MAX_INSTANCES));
+    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
+      builder.add(new ServiceResourceKeys(Constants.Service.EXPLORE_HTTP_USER_SERVICE,
+                                          Constants.Explore.CONTAINER_MEMORY_MB,
+                                          Constants.Explore.CONTAINER_VIRTUAL_CORES,
+                                          Constants.Explore.CONTAINER_INSTANCES,
+                                          Constants.Explore.MAX_INSTANCES));
+    }
+    this.systemServicesResourceKeys = builder.build();
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/ConfigurationCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/ConfigurationCheck.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import com.google.common.base.Joiner;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Checks the CDAP Configuration for bad settings.
+ */
+// class is picked up through classpath examination
+@SuppressWarnings("unused")
+class ConfigurationCheck extends AbstractMasterCheck {
+  private static final Logger LOG = LoggerFactory.getLogger(ConfigurationCheck.class);
+
+  @Inject
+  private ConfigurationCheck(CConfiguration cConf) {
+    super(cConf);
+  }
+
+  // TODO: (CDAP-4517) add more checks, like zookeeper settings.
+  @Override
+  public void run() {
+    LOG.info("Checking that config settings are valid.");
+
+    Set<String> problemKeys = new HashSet<>();
+    checkServiceResources(problemKeys);
+
+    if (!problemKeys.isEmpty()) {
+      throw new RuntimeException("Invalid configuration settings for keys: " + Joiner.on(',').join(problemKeys));
+    }
+    LOG.info("  Configuration successfully verified.");
+  }
+
+  // checks that instances, max instances, memory, and vcores for system services are positive integers,
+  // and the instances does not exceed max instances
+  private void checkServiceResources(Set<String> problemKeys) {
+    for (ServiceResourceKeys serviceResourceKeys : systemServicesResourceKeys) {
+      // verify memory and vcores are positive integers
+      if (!isPositiveInteger(serviceResourceKeys.getMemoryKey())) {
+        LOG.error("  {} must be a positive integer", serviceResourceKeys.getMemoryKey());
+        problemKeys.add(serviceResourceKeys.getMemoryKey());
+      }
+      if (!isPositiveInteger(serviceResourceKeys.getVcoresKey())) {
+        LOG.error("  {} must be a positive integer", serviceResourceKeys.getVcoresKey());
+        problemKeys.add(serviceResourceKeys.getVcoresKey());
+      }
+
+      // verify instances and max instances are positive integers
+      boolean instancesIsPositive = isPositiveInteger(serviceResourceKeys.getInstancesKey());
+      boolean maxInstancesIsPositive = isPositiveInteger(serviceResourceKeys.getMaxInstancesKey());
+      if (!instancesIsPositive) {
+        LOG.error("  {} must be a positive integer", serviceResourceKeys.getInstancesKey());
+        problemKeys.add(serviceResourceKeys.getInstancesKey());
+      }
+      if (!maxInstancesIsPositive) {
+        LOG.error("  {} must be a positive integer", serviceResourceKeys.getMaxInstancesKey());
+        problemKeys.add(serviceResourceKeys.getMaxInstancesKey());
+      }
+
+      // verify instances <= maxInstances
+      if (instancesIsPositive && maxInstancesIsPositive) {
+        int instances = cConf.getInt(serviceResourceKeys.getInstancesKey());
+        int maxInstances = cConf.getInt(serviceResourceKeys.getMaxInstancesKey());
+        if (instances > maxInstances) {
+          LOG.error("  {}={} must not be greater than {}={}",
+                    serviceResourceKeys.getInstancesKey(), instances,
+                    serviceResourceKeys.getMaxInstancesKey(), maxInstances);
+          problemKeys.add(serviceResourceKeys.getInstancesKey());
+        }
+      }
+    }
+  }
+
+  private boolean isPositiveInteger(String key) {
+    try {
+      return cConf.getInt(key) > 0;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/FileSystemCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/FileSystemCheck.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import com.google.inject.Inject;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Checks that the configured FileSystem is available and the root path has the correct permissions.
+ */
+// class is picked up through classpath examination
+@SuppressWarnings("unused")
+public class FileSystemCheck extends AbstractMasterCheck {
+  private static final Logger LOG = LoggerFactory.getLogger(FileSystemCheck.class);
+  private final LocationFactory locationFactory;
+  private final Configuration hConf;
+
+  @Inject
+  private FileSystemCheck(CConfiguration cConf, Configuration hConf, LocationFactory locationFactory) {
+    super(cConf);
+    this.hConf = hConf;
+    this.locationFactory = locationFactory;
+  }
+
+  @Override
+  public void run() {
+    String user = cConf.get(Constants.CFG_HDFS_USER);
+    String rootPath = cConf.get(Constants.CFG_HDFS_NAMESPACE);
+
+    LOG.info("Checking FileSystem availability.");
+    Location rootLocation = locationFactory.create(rootPath);
+    boolean rootExists;
+    try {
+      rootExists = rootLocation.exists();
+      LOG.info("  FileSystem availability successfully verified.");
+      if (rootExists) {
+        if (!rootLocation.isDirectory()) {
+          throw new RuntimeException(String.format(
+            "%s is not a directory. Change it to a directory, or update %s to point to a different location.",
+            rootPath, Constants.CFG_HDFS_NAMESPACE));
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(String.format(
+        "Unable to connect to the FileSystem with %s set to %s. " +
+          "Please check that the FileSystem is running and that the correct " +
+          "Hadoop configuration (e.g. core-site.xml, hdfs-site.xml) " +
+          "and Hadoop libraries are included in the CDAP Master classpath.",
+        CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY,
+        hConf.get(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY)), e);
+    }
+
+    LOG.info("Checking that user {} has permission to write to {} on the FileSystem.", user, rootPath);
+    if (rootExists) {
+      // try creating a tmp file to check permissions
+      try {
+        Location tmpFile = rootLocation.getTempFile("tmp");
+        if (!tmpFile.createNew()) {
+          throw new RuntimeException(String.format(
+            "Could not make a temp file in directory %s on the FileSystem. " +
+              "Please check that user %s has permission to write to %s, " +
+              "or create the directory manually with write permissions.",
+            rootPath, user, rootPath));
+        } else {
+          tmpFile.delete();
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(String.format(
+          "Could not make a temp file in directory %s on the FileSystem. " +
+            "Please check that user %s has permission to write to %s, " +
+            "or create the directory manually with write permissions.",
+          rootPath, user, rootPath), e);
+      }
+    } else {
+      // try creating the directory to check permissions
+      try {
+        if (!rootLocation.mkdirs()) {
+          throw new RuntimeException(String.format(
+            "Could not make directory %s on the FileSystem. " +
+              "Please check that user %s has permission to write to %s, " +
+              "or create the directory manually with write permissions.",
+            rootPath, user, rootPath));
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(String.format(
+          "Could not make directory %s on the FileSystem. " +
+            "Please check that user %s has permission to write to %s, " +
+            "or create the directory manually with write permissions.",
+          rootPath, user, rootPath), e);
+      }
+    }
+
+    LOG.info("  FileSystem permissions successfully verified.");
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/HBaseCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/HBaseCheck.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.startup;
+
+import co.cask.cdap.common.startup.Check;
+import com.google.inject.Inject;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.HConnection;
+import org.apache.hadoop.hbase.client.HConnectionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Checks that HBase is available.
+ */
+// class is picked up through classpath examination
+@SuppressWarnings("unused")
+class HBaseCheck extends Check {
+  private static final Logger LOG = LoggerFactory.getLogger(HBaseCheck.class);
+  private final Configuration hConf;
+
+  @Inject
+  private HBaseCheck(Configuration hConf) {
+    this.hConf = hConf;
+  }
+
+  @Override
+  public void run() {
+    LOG.info("Checking HBase availability.");
+    try (final HConnection hbaseConnection = HConnectionManager.createConnection(hConf)) {
+      hbaseConnection.listTables();
+      LOG.info("  HBase availability successfully verified.");
+    } catch (IOException e) {
+      throw new RuntimeException(
+        "Unable to connect to HBase. " +
+          "Please check that HBase is running and that the correct HBase configuration (hbase-site.xml) " +
+          "and libraries are included in the CDAP master classpath.", e);
+    }
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/ServiceResourceKeys.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/ServiceResourceKeys.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.startup;
+
+/**
+ * Convenience class to group config keys for memory, cores, and instances for each system service.
+ */
+class ServiceResourceKeys {
+  private final String serviceName;
+  private final String memoryKey;
+  private final String vcoresKey;
+  private final String instancesKey;
+  private final String maxInstancesKey;
+
+  ServiceResourceKeys(String serviceName, String memoryKey, String vcoresKey,
+                             String instancesKey, String maxInstancesKey) {
+    this.serviceName = serviceName;
+    this.memoryKey = memoryKey;
+    this.vcoresKey = vcoresKey;
+    this.instancesKey = instancesKey;
+    this.maxInstancesKey = maxInstancesKey;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  public String getMemoryKey() {
+    return memoryKey;
+  }
+
+  public String getVcoresKey() {
+    return vcoresKey;
+  }
+
+  public String getInstancesKey() {
+    return instancesKey;
+  }
+
+  public String getMaxInstancesKey() {
+    return maxInstancesKey;
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/YarnCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/YarnCheck.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import com.google.common.base.Joiner;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Inject;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.NodeReport;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Checks that YARN is available and has enough resources to run all system services.
+ */
+// class is picked up through classpath examination
+@SuppressWarnings("unused")
+class YarnCheck extends AbstractMasterCheck {
+  private static final Logger LOG = LoggerFactory.getLogger(YarnCheck.class);
+  private final Configuration hConf;
+
+  @Inject
+  private YarnCheck(CConfiguration cConf, Configuration hConf) {
+    super(cConf);
+    this.hConf = hConf;
+  }
+
+  @Override
+  public void run() {
+    int yarnConnectTimeout = cConf.getInt(Constants.Startup.YARN_CONNECT_TIMEOUT_SECONDS, 60);
+    LOG.info("Checking YARN availability -- may take up to {} seconds.", yarnConnectTimeout);
+
+    final YarnClient yarnClient = YarnClient.createYarnClient();
+    yarnClient.init(hConf);
+
+    List<NodeReport> nodeReports;
+    // if yarn is not up, yarnClient.start() will hang.
+    ExecutorService executorService = Executors.newSingleThreadExecutor(
+      new ThreadFactoryBuilder().setNameFormat("startup-checker").build());
+    try {
+      Future<List<NodeReport>> result = executorService.submit(new Callable<List<NodeReport>>() {
+        @Override
+        public List<NodeReport> call() throws Exception {
+          yarnClient.start();
+          return yarnClient.getNodeReports();
+        }
+      });
+      nodeReports = result.get(yarnConnectTimeout, TimeUnit.SECONDS);
+      LOG.info("  YARN availability successfully verified.");
+    } catch (Exception e) {
+      throw new RuntimeException(
+        "Unable to get status of YARN nodemanagers. " +
+          "Please check that YARN is running " +
+          "and that the correct Hadoop configuration (core-site.xml, yarn-site.xml) and libraries " +
+          "are included in the CDAP master classpath.", e);
+    } finally {
+      try {
+        yarnClient.stop();
+      } catch (Exception e) {
+        LOG.warn("Error stopping yarn client.", e);
+      } finally {
+        executorService.shutdown();
+      }
+    }
+
+    checkResources(nodeReports);
+  }
+
+  private void checkResources(List<NodeReport> nodeReports) {
+    LOG.info("Checking that YARN has enough resources to run all system services.");
+    int availableMemoryMB = 0;
+    int availableVCores = 0;
+    int availableNodes = 0;
+    for (NodeReport nodeReport : nodeReports) {
+      if (!nodeReport.getNodeState().isUnusable()) {
+        Resource nodeCapability = nodeReport.getCapability();
+        Resource nodeUsed = nodeReport.getUsed();
+        availableMemoryMB += nodeCapability.getMemory() - nodeUsed.getMemory();
+        availableVCores += nodeCapability.getVirtualCores() - nodeUsed.getVirtualCores();
+        availableNodes++;
+      }
+    }
+    LOG.debug("YARN has {} MB of memory and {} virtual cores available from {} available nodemanagers.",
+              availableMemoryMB, availableVCores, availableNodes);
+
+    // calculate memory and vcores required by CDAP
+    int requiredMemoryMB = 0;
+    int requiredVCores = 0;
+    Set<String> invalidKeys = new HashSet<>();
+    for (ServiceResourceKeys serviceResourceKeys : systemServicesResourceKeys) {
+      boolean hasConfigError = false;
+      int instances = 0;
+      int memoryMB = 0;
+      int vcores = 0;
+
+      try {
+        instances = cConf.getInt(serviceResourceKeys.getInstancesKey());
+      } catch (Exception e) {
+        invalidKeys.add(serviceResourceKeys.getInstancesKey());
+        hasConfigError = true;
+      }
+      try {
+        memoryMB = cConf.getInt(serviceResourceKeys.getMemoryKey());
+      } catch (Exception e) {
+        invalidKeys.add(serviceResourceKeys.getMemoryKey());
+        hasConfigError = true;
+      }
+      try {
+        vcores = cConf.getInt(serviceResourceKeys.getVcoresKey());
+      } catch (Exception e) {
+        invalidKeys.add(serviceResourceKeys.getVcoresKey());
+        hasConfigError = true;
+      }
+
+      if (!hasConfigError) {
+        LOG.debug("Resource settings for system service {}: {}={}, {}={}, {}={}",
+                  serviceResourceKeys.getServiceName(),
+                  serviceResourceKeys.getInstancesKey(), instances,
+                  serviceResourceKeys.getMemoryKey(), memoryMB,
+                  serviceResourceKeys.getVcoresKey(), vcores);
+        requiredMemoryMB += memoryMB * instances;
+        requiredVCores += vcores * instances;
+      }
+    }
+
+    if (!invalidKeys.isEmpty()) {
+      throw new RuntimeException(
+        "YARN resources check failed to invalid config settings for keys: " + Joiner.on(',').join(invalidKeys));
+    }
+
+    LOG.debug("{} MB of memory and {} virtual cores are required.", requiredMemoryMB, requiredVCores);
+    boolean noErrors = true;
+    if (requiredMemoryMB > availableMemoryMB || requiredVCores > availableVCores) {
+      throw new RuntimeException(String.format(
+        "Services require %d MB of memory and %d vcores, " +
+          "but the cluster only has %d MB of memory and %d vcores available.",
+        requiredMemoryMB, requiredVCores, availableMemoryMB, availableVCores));
+    }
+    LOG.info("  YARN resources successfully verified.");
+  }
+}

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/kafka/KafkaNotificationService.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/kafka/KafkaNotificationService.java
@@ -27,6 +27,7 @@ import co.cask.cdap.notifications.service.NotificationHandler;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionSystemClient;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -29,6 +29,7 @@ import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.io.URLConnections;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
+import co.cask.cdap.common.startup.ConfigurationLogger;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.common.utils.OSDetector;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -58,7 +59,6 @@ import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModu
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.security.guice.SecurityModules;
 import co.cask.cdap.security.server.ExternalAuthenticationServer;
-import co.cask.cdap.startup.ConfigurationLogger;
 import co.cask.tephra.inmemory.InMemoryTransactionService;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;


### PR DESCRIPTION
adding some sanity checks on master startup to make sure hdfs,
yarn, and hbase are available before starting up the master.
If any are not, master will shut down. Also adding a config
setting to turn off these checks in case there is any faulty
logic, or in case this behavior is not desired and we want to
start up anyway and just wait for those systems to come up.