### PR TITLE
removing unused constants

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -146,11 +146,6 @@ public final class Constants {
      */
     public static final String QUERY_PARAM_LIMIT = "limit";
 
-    /**
-     * Default history results limit.
-     */
-    public static final int DEFAULT_HISTORY_RESULTS_LIMIT = 100;
-
     public static final String SERVICE_DESCRIPTION = "Service for managing application lifecycle.";
 
     /**
@@ -178,8 +173,6 @@ public final class Constants {
    * Plugin Artifacts constants.
    */
   public static final class Plugin {
-    public static final String DIRECTORY = "artifacts";
-
     // Key to be used in hConf to store location of the plugin artifact jar
     public static final String ARCHIVE = "cdap.program.plugin.archive";
   }
@@ -258,15 +251,6 @@ public final class Constants {
     }
 
     /**
-     * Twill Runnable configuration.
-     */
-    public static final class Container {
-      public static final String NUM_INSTANCES = "dataset.service.num.instances";
-      public static final String NUM_CORES = "dataset.service.num.cores";
-      public static final String MEMORY_MB = "dataset.service.memory.mb";
-    }
-
-    /**
      * DatasetUserService configuration.
      */
     public static final class Executor {
@@ -276,9 +260,7 @@ public final class Constants {
       /** for the address (hostname) of the dataset server. */
       public static final String ADDRESS = "dataset.executor.bind.address";
 
-      public static final String BACKLOG_CONNECTIONS = "dataset.executor.connection.backlog";
       public static final String EXEC_THREADS = "dataset.executor.exec.threads";
-      public static final String BOSS_THREADS = "dataset.executor.boss.threads";
       public static final String WORKER_THREADS = "dataset.executor.worker.threads";
       public static final String OUTPUT_DIR = "dataset.executor.output.dir";
 
@@ -818,7 +800,6 @@ public final class Constants {
   }
 
   public static final String CFG_LOCAL_DATA_DIR = "local.data.dir";
-  public static final String CFG_YARN_USER = "yarn.user";
   public static final String CFG_HDFS_USER = "hdfs.user";
   public static final String CFG_HDFS_NAMESPACE = "hdfs.namespace";
   public static final String CFG_HDFS_LIB_DIR = "hdfs.lib.dir";
@@ -830,7 +811,7 @@ public final class Constants {
   /**
    * Data Fabric.
    */
-  public static enum InMemoryPersistenceType {
+  public enum InMemoryPersistenceType {
     MEMORY,
     LEVELDB,
     HSQLDB
@@ -845,7 +826,6 @@ public final class Constants {
   /**
    * Defaults for Data Fabric.
    */
-  public static final String DEFAULT_DATA_INMEMORY_PERSISTENCE = InMemoryPersistenceType.MEMORY.name();
   public static final String DEFAULT_DATA_LEVELDB_DIR = "data";
   public static final int DEFAULT_DATA_LEVELDB_BLOCKSIZE = 1024;
   public static final long DEFAULT_DATA_LEVELDB_CACHESIZE = 1024 * 1024 * 100;

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -136,14 +136,6 @@
   </property>
 
   <property>
-    <name>yarn.user</name>
-    <value>yarn</value>
-    <description>
-      User name for running applications in YARN
-    </description>
-  </property>
-
-  <property>
     <name>zookeeper.quorum</name>
     <value>127.0.0.1:2181/${root.namespace}</value>
     <description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="a9977d5391f992535cd00b7accd27064"
+DEFAULT_XML_MD5_HASH="7c451b0be3f71c93f75f718675dc920e"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"


### PR DESCRIPTION
Removed yarn.user from cdap-default.xml and from Constants.java
since it is unused in the code. Also tried setting it in the conf
to verify that it doesn't do anything.
Other than that, all other constants are unused in the code and
not in cdap-default.xml.