### PR TITLE
(CDAP-4545) Improve LiveFileReader to read more efficiently

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/LocalLocation.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/LocalLocation.java
@@ -42,7 +42,8 @@ import java.util.UUID;
 /**
  * A concrete implementation of {@link Location} for the Local filesystem.
  */
-// TODO: This is a copy of twill class, Remove this class after updating twill version to 0.7.0 - CDAP-4408
+// TODO: This is a copy of twill class for TWILL-156 and TWILL-160
+// TODO: Remove this class after updating twill version to 0.7.0 - CDAP-4408
 final class LocalLocation implements Location {
   private final File file;
   private final LocalLocationFactory locationFactory;
@@ -75,10 +76,6 @@ final class LocalLocation implements Location {
    */
   @Override
   public InputStream getInputStream() throws IOException {
-    File parent = file.getParentFile();
-    if (!parent.exists()) {
-      parent.mkdirs();
-    }
     return new FileInputStream(file);
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/MultiLiveStreamFileReaderTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/MultiLiveStreamFileReaderTestBase.java
@@ -31,6 +31,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -43,6 +45,53 @@ public abstract class MultiLiveStreamFileReaderTestBase {
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
 
   protected abstract LocationFactory getLocationFactory();
+
+  @Test
+  public void testLiveFileReader() throws Exception {
+    String streamName = "liveReader";
+    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    Location location = getLocationFactory().create(streamName);
+    location.mkdirs();
+
+    // Create a stream with 5 seconds partition.
+    StreamConfig config = new StreamConfig(streamId, 5000, 1000, Long.MAX_VALUE, location, null, 1000);
+
+    // Write 5 events in the first partition
+    try (FileWriter<StreamEvent> writer = createWriter(config, "live.0")) {
+      for (int i = 0; i < 5; i++) {
+        writer.append(StreamFileTestUtils.createEvent(i, "Testing " + i));
+      }
+    }
+
+    // Writer 5 events in the forth partition (ts = 15 to 19)
+    try (FileWriter<StreamEvent> writer = createWriter(config, "live.0")) {
+      for (int i = 0; i < 5; i++) {
+        writer.append(StreamFileTestUtils.createEvent(i + 15, "Testing " + (i + 15)));
+      }
+    }
+
+    // Create a LiveStreamFileReader to read 10 events. It should be able to read them all.
+    Location partitionLocation = StreamUtils.createPartitionLocation(config.getLocation(), 0,
+                                                                     config.getPartitionDuration());
+    Location eventLocation = StreamUtils.createStreamLocation(partitionLocation, "live.0", 0, StreamFileType.EVENT);
+    List<StreamEvent> events = new ArrayList<>();
+    try (LiveStreamFileReader reader = new LiveStreamFileReader(config, new StreamFileOffset(eventLocation, 0, 0))) {
+      while (events.size() < 10) {
+        // It shouldn't have empty read.
+        Assert.assertTrue(reader.read(events, Integer.MAX_VALUE, 0, TimeUnit.SECONDS) > 0);
+      }
+    }
+    Assert.assertEquals(10, events.size());
+    // First 5 events must have timestamps 0-4
+    Iterator<StreamEvent> itor = events.iterator();
+    for (int i = 0; i < 5; i++) {
+      Assert.assertEquals(i, itor.next().getTimestamp());
+    }
+    // Next 5 events must have timestamps 15-19
+    for (int i = 15; i < 20; i++) {
+      Assert.assertEquals(i, itor.next().getTimestamp());
+    }
+  }
 
   @Test
   public void testMultiFileReader() throws Exception {


### PR DESCRIPTION
- Instead of returning zero events when reading an empty partition
  (which is a valid behavior of LiveFileReader, as it requires caller
   to keep calling the read() method),
  it will try to advance to the next event file and try reading
  events from it.