### PR TITLE
Fix/cdap 3887 router connection timeout

### DIFF
--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/OutboundHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/OutboundHandler.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.gateway.router.handlers;
 
 import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelStateEvent;
@@ -41,13 +42,10 @@ public class OutboundHandler extends SimpleChannelUpstreamHandler {
 
   @Override
   public void messageReceived(ChannelHandlerContext ctx, MessageEvent event) throws Exception {
-    ChannelBuffer msg = (ChannelBuffer) event.getMessage();
-    int readerIndex = msg.readerIndex();
-    int writerIndex = msg.writerIndex();
+    // write the channel buffer to inbound channel
+    ChannelBuffer wrappedMessage = ChannelBuffers.wrappedBuffer((ChannelBuffer) event.getMessage());
+    Channels.write(inboundChannel, wrappedMessage);
     super.messageReceived(ctx, event);
-    // write the same channel buffer to inbound channel
-    msg.setIndex(readerIndex, writerIndex);
-    Channels.write(inboundChannel, msg);
   }
 
   @Override

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterTestBase.java
@@ -485,6 +485,14 @@ public abstract class NettyRouterTestBase {
     // however, the connection to defaultServer2 is not timed out, because we've been making requests to it
     Assert.assertEquals(1, defaultServer2.getNumConnectionsOpened());
     Assert.assertEquals(0, defaultServer2.getNumConnectionsClosed());
+
+    defaultServer2.registerServer();
+    defaultServer1.cancelRegistration();
+    url = new URL(resolveURI(Constants.Router.GATEWAY_DISCOVERY_NAME, "/v2/ping"));
+    urlConnection = openURL(url);
+    Assert.assertEquals(200, urlConnection.getResponseCode());
+    urlConnection.getInputStream().close();
+    urlConnection.disconnect();
   }
 
   @Test


### PR DESCRIPTION
Fixing a race condition.

Performance testing against cluster yields results (similar to before these changes):
- `/explore/status` endpoint - 44-50k req/s with one client, and 56k req/s with two clients - 10 explore service containers
- 4KB stream ingest (async) - 28-32k req/s with one client, and 31-34k req/s with two clients - 10 stream containers

https://issues.cask.co/browse/CDAP-3887
http://builds.cask.co/browse/CDAP-RBT554-4