### PR TITLE
support workflow log retrieval in CDAP CLI

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -523,6 +523,8 @@ public class CLIMainTest {
       cli, String.format("get workflow token %s %s at node %s scope user key %s", workflow, runId,
                          FakeWorkflow.FakeAction.ANOTHER_FAKE_NAME, FakeWorkflow.FakeAction.TOKEN_KEY), fakeNodeValue);
 
+    testCommandOutputContains(cli, "get workflow logs " + workflow, "Starting Workflow");
+
     // stop workflow
     testCommandOutputContains(cli, "stop workflow " + workflow,
                               String.format("400: Program '%s' is not running", fakeWorkflowId));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ElementType.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ElementType.java
@@ -63,7 +63,7 @@ public enum ElementType {
 
   WORKFLOW("workflow", new Noun("workflow"), new Noun("Workflow"), ProgramType.WORKFLOW, null,
            ArgumentName.WORKFLOW,
-           Capability.RUNS, Capability.STATUS, Capability.START, Capability.STOP,
+           Capability.RUNS, Capability.LOGS, Capability.STATUS, Capability.START, Capability.STOP,
            Capability.LIST, Capability.RUNTIME_ARGS, Capability.PREFERENCES),
 
   FLOWLET("flowlet", new Noun("flowlet"), new Noun("Flowlet"), null, ProgramType.FLOW,


### PR DESCRIPTION
http://builds.cask.co/browse/CDAP-RBT555-1

Workflow logs retrieval wasn't supported in CDAP CLI previously. It now looks like this:
![image](https://cloud.githubusercontent.com/assets/2440977/11886783/d8497054-a4e2-11e5-9b8e-6fc8dfc9f4a6.png)