### PR TITLE
Fix WorkflowHttpHandlerTest#testWorkflowToken - flaky test case.

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ProgramClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ProgramClientTestRun.java
@@ -206,6 +206,12 @@ public class ProgramClientTestRun extends ClientTestBase {
 
     programClient.start(workflow, false, ImmutableMap.of("done.file", doneFile.getAbsolutePath()));
     assertProgramRunning(programClient, workflow);
+    Tasks.waitFor(1, new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return programClient.getProgramRuns(workflow, "running", Long.MIN_VALUE, Long.MAX_VALUE, 100).size();
+      }
+    }, 5, TimeUnit.SECONDS);
     List<RunRecord> runRecords = programClient.getProgramRuns(workflow, "running", Long.MIN_VALUE, Long.MAX_VALUE, 100);
     Assert.assertEquals(1, runRecords.size());
 


### PR DESCRIPTION
The issue is that a program could stop 'RUNNING' (go into 'STOPPING') state, but the run record for it being stopped hasn't been written yet.
So, retry for up to 5 seconds for the stopped run record.
Note - the fix is similar to as in https://github.com/caskdata/cdap/pull/4506.

One failing test case is: http://builds.cask.co/browse/CDAP-RBT-JOB1-999/test/case/31581011
Other failing test case is: http://builds.cask.co/browse/CDAP-RBT-JOB1-974/test/case/990418

Build for this PR: http://builds.cask.co/browse/CDAP-RBT558-2