### PR TITLE
CDAP-4417 Remove default value for scheduler.max.thread.pool.size in …

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -384,8 +384,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
     private org.quartz.Scheduler getScheduler(JobStore store,
                                               CConfiguration cConf) throws SchedulerException {
 
-      int threadPoolSize = cConf.getInt(Constants.Scheduler.CFG_SCHEDULER_MAX_THREAD_POOL_SIZE,
-                                        Constants.Scheduler.DEFAULT_THREAD_POOL_SIZE);
+      int threadPoolSize = cConf.getInt(Constants.Scheduler.CFG_SCHEDULER_MAX_THREAD_POOL_SIZE);
       ExecutorThreadPool threadPool = new ExecutorThreadPool(threadPoolSize);
       threadPool.initialize();
       String schedulerName = DirectSchedulerFactory.DEFAULT_SCHEDULER_NAME;

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -159,7 +159,6 @@ public final class Constants {
    */
   public class Scheduler {
     public static final String CFG_SCHEDULER_MAX_THREAD_POOL_SIZE = "scheduler.max.thread.pool.size";
-    public static final int DEFAULT_THREAD_POOL_SIZE = 100;
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -236,7 +236,7 @@
 
   <property>
     <name>scheduler.max.thread.pool.size</name>
-    <value>30</value>
+    <value>100</value>
     <description>
       Size of the scheduler thread pool
     </description>


### PR DESCRIPTION
…code and bump up the value in cdap-default.xml to 100

JIRA: https://issues.cask.co/browse/CDAP-4417
Note, more work needs to be carried out (visibility into current and max thread pool size should be accessible to the user so that he/she can take action if the current count is approaching max count). Will open separate JIRA for that.

Build: http://builds.cask.co/browse/CDAP-RBT559

Tested on cluster