### PR TITLE
Fixes mySettings factory to have API token when authentication is enabled

### DIFF
--- a/cdap-ui/app/services/data/my-cdap-datasource.js
+++ b/cdap-ui/app/services/data/my-cdap-datasource.js
@@ -46,12 +46,12 @@ angular.module(PKG.name + '.services')
       return this.MyDataSource.stopPoll(resourceId);
     };
 
-    MyCDAPDataSource.prototype.config = function(resource) {
+    MyCDAPDataSource.prototype.config = function(resource, cb, errorCb) {
       resource.actionName = 'template-config';
-      return this.MyDataSource.config(resource);
+      return this.MyDataSource.config(resource, cb, errorCb);
     };
 
-    MyCDAPDataSource.prototype.request = function(resource, cb) {
+    MyCDAPDataSource.prototype.request = function(resource, cb, errorCb) {
       if ($rootScope.currentUser && $rootScope.currentUser.token) {
         resource.headers = {
           Authorization: 'Bearer '+ $rootScope.currentUser.token
@@ -63,7 +63,7 @@ angular.module(PKG.name + '.services')
         resource.url = myCdapUrl.constructUrl(resource);
       }
 
-      return this.MyDataSource.request(resource, cb);
+      return this.MyDataSource.request(resource, cb, errorCb);
     };
 
     return MyCDAPDataSource;


### PR DESCRIPTION
- Fixes fetching data from user store (adds API token to the header).
- Fixes MyCDAPDatasource's (request, poll & config) calls to use success and errorCallback if available (callback vs promise versions)

This PR is related to this PR (https://github.com/caskdata/ng-capsules/pull/39) Please don't merge before ng-capsules PR is merged.