### PR TITLE
Fix WorkflowHttpHandlerTest#testWorkflowForkApp

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -532,7 +532,13 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     verifyProgramRuns(programId, "completed");
   }
 
-  private String getRunIdOfRunningProgram(Id.Program programId) throws Exception {
+  private String getRunIdOfRunningProgram(final Id.Program programId) throws Exception {
+    Tasks.waitFor(1, new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return getProgramRuns(programId, "running").size();
+      }
+    }, 5, TimeUnit.SECONDS);
     List<RunRecord> historyRuns = getProgramRuns(programId, "running");
     Assert.assertEquals(1, historyRuns.size());
     RunRecord record = historyRuns.get(0);


### PR DESCRIPTION
The issue is that a program could go into 'RUNNING' state, but the run record for it being stopped hasn't been updated yet.
So, retry for up to 5 seconds for the expected run record.
Note - the fix is similar to as in https://github.com/caskdata/cdap/pull/4506.

Failing test case which this should fix: http://builds.cask.co/browse/CDAP-RBT548-JOB1-4/test/case/37752036

Build for this PR: http://builds.cask.co/browse/CDAP-RBT560-1