### PR TITLE
Use IntelliJ 15.0.2

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -89,7 +89,7 @@
         },
         "idea": {
           "setup_dir": "/opt",
-          "version": "14.1.4"
+          "version": "15.0.2"
         },
         "hadoop": {
           "distribution": "hdp",

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
@@ -87,7 +87,7 @@
         },
         "idea": {
           "setup_dir": "/opt",
-          "version": "14.1.4"
+          "version": "15.0.2"
         },
         "hadoop": {
           "distribution": "hdp",


### PR DESCRIPTION
Use latest IntelliJ as VM builds are failing with:
```
06-Jan-2016 01:25:05	    cdap-sdk-vm: [2016-01-06T01:31:15+00:00] ERROR: remote_file[/var/chef/cache/ideaIC-14.1.4.tar.gz] (idea::default line 37) had an error: Net::HTTPServerException: 403 "Forbidden"
```

Files are on S3, so cannot browse directory.