### PR TITLE
Fixes schema propagation while creating a hydrator pipeline

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag.html
+++ b/cdap-ui/app/directives/dag/my-dag.html
@@ -85,14 +85,27 @@
           <div class="node"
                 ng-mouseenter="MyDAGController.nodeMouseEnter(node)"
                 ng-mouseleave="MyDAGController.nodeMouseLeave(node)">
-            <div class="error-node-notification"
-                 ng-if="node.errorCount > 0"
-                 tooltip="Please see node configuration panel"
-                 tooltip-append-to-body="true"
-                 tooltip-class="tooltip-error">
-              <span class="badge" ng-class="{'badge-danger': node.error === true, 'badge-warning': node.warning === true}">
-                <span>{{node.errorCount}}</span>
-              </span>
+            <div ng-if="node.error">
+              <div class="error-node-notification"
+                   ng-if="node.errorCount > 0"
+                   tooltip="Please see node configuration panel"
+                   tooltip-append-to-body="true"
+                   tooltip-class="tooltip-error">
+                <span class="badge badge-danger">
+                  <span>{{node.errorCount}}</span>
+                </span>
+              </div>
+            </div>
+            <div ng-if="!node.error">
+              <div class="error-node-notification"
+                   ng-if="node.errorCount > 0"
+                   tooltip="Please see node configuration panel"
+                   tooltip-append-to-body="true"
+                   tooltip-class="tooltip-warning">
+                <span class="badge badge-warning">
+                  <span>{{node.errorCount}}</span>
+                </span>
+              </div>
             </div>
             <div class="fa fa-close"
                  ng-if="!MyDAGController.isDisabled"

--- a/cdap-ui/app/directives/dag/my-dag.less
+++ b/cdap-ui/app/directives/dag/my-dag.less
@@ -285,6 +285,40 @@ my-dag {
     padding-left: 20px;
   }
 }
+.badge-warning {
+  background-color: @brand-warning;
+}
+.badge-error {
+  background-color: @brand-danger;
+}
+.theme-cdap {
+  .tooltip-warning {
+    &.tooltip {
+      &.top {
+        .tooltip-arrow {
+          border-top-color: @brand-warning;
+        }
+      }
+    }
+    .tooltip-inner {
+      background-color: @brand-warning;
+      border-color: @brand-warning;
+    }
+  }
+  .tooltip-error {
+    &.tooltip {
+      &.top {
+        .tooltip-arrow {
+          border-top-color: @brand-danger;
+        }
+      }
+    }
+    .tooltip-inner {
+      background-color: @brand-danger;
+      border-color: @brand-danger;
+    }
+  }
+}
 
 .popover {
   min-width: 250px;

--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.less
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.less
@@ -18,24 +18,6 @@
 @import "../../../bower_components/bootstrap/less/mixins.less";
 @import "../../styles/themes/cdap/mixins.less";
 
-.tooltip.tooltip-error {
-  z-index: 1020; // lower z-index than modal
-
-  .tooltip-inner {
-    background-color: @brand-danger;
-    color: white;
-    border: 0;
-  }
-
-  &.tooltip.right .tooltip-arrow {
-    border-right-color: @brand-danger;
-  }
-
-  &.tooltip.top .tooltip-arrow {
-    border-top-color: @brand-danger;
-  }
-}
-
 my-side-panel {
   height: 100%;
   .side-panel {

--- a/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.js
@@ -22,8 +22,7 @@ angular.module(PKG.name + '.commons')
         model: '=ngModel',
         config: '=',
         pluginProperties: '=',
-        disabled: '=',
-        onModelUpdate: '='
+        disabled: '='
       },
       templateUrl: 'widget-container/widget-schema-editor/widget-schema-editor.html',
       controller: function($scope, myHelpers, EventPipe, IMPLICIT_SCHEMA) {
@@ -216,7 +215,8 @@ angular.module(PKG.name + '.commons')
         }
 
         initialize($scope.model);
-        $scope.$watch('onModelUpdate', function() {
+        EventPipe.on('plugin-outputschema.update', function() {
+          console.log('And the model is: ', $scope.model);
           initialize($scope.model);
         });
 

--- a/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.js
@@ -216,7 +216,6 @@ angular.module(PKG.name + '.commons')
 
         initialize($scope.model);
         EventPipe.on('plugin-outputschema.update', function() {
-          console.log('And the model is: ', $scope.model);
           initialize($scope.model);
         });
 
@@ -349,6 +348,7 @@ angular.module(PKG.name + '.commons')
           EventPipe.cancelEvent('schema.clear');
           EventPipe.cancelEvent('plugin.reset');
           EventPipe.cancelEvent('dataset.selected');
+          EventPipe.cancelEvent('plugin-outputschema.update');
         });
       }
     };

--- a/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.js
@@ -22,7 +22,8 @@ angular.module(PKG.name + '.commons')
         model: '=ngModel',
         config: '=',
         pluginProperties: '=',
-        disabled: '='
+        disabled: '=',
+        onModelUpdate: '='
       },
       templateUrl: 'widget-container/widget-schema-editor/widget-schema-editor.html',
       controller: function($scope, myHelpers, EventPipe, IMPLICIT_SCHEMA) {
@@ -215,6 +216,9 @@ angular.module(PKG.name + '.commons')
         }
 
         initialize($scope.model);
+        $scope.$watch('onModelUpdate', function() {
+          initialize($scope.model);
+        });
 
         EventPipe.on('plugin.reset', function () {
           $scope.model = angular.copy(modelCopy);

--- a/cdap-ui/app/features/hydrator/bottompanel.less
+++ b/cdap-ui/app/features/hydrator/bottompanel.less
@@ -246,6 +246,11 @@ body.theme-cdap.state-hydrator {
         margin-top: 20px;
       }
     }
+    .output-schema {
+      .schema-propagation-confirm {
+        padding-top: 10px;
+      }
+    }
     .input-schema {
       @media (max-width: @screen-md-max) {
         margin-bottom: 15px;

--- a/cdap-ui/app/features/hydrator/bottompanel.less
+++ b/cdap-ui/app/features/hydrator/bottompanel.less
@@ -366,6 +366,9 @@ body.theme-cdap.state-hydrator {
         outline: 0;
       }
     }
+    .loading-message {
+      margin-left: 10px;
+    }
     .bottompanel-header {
       border-bottom: 1px solid @table-border-color;
       padding: 15px 10px;

--- a/cdap-ui/app/features/hydrator/controllers/create/canvas-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/canvas-ctrl.js
@@ -35,7 +35,6 @@ class HydratorCreateCanvasController {
 
     this.updateNodesAndConnections();
     NodesStore.registerOnChangeListener(this.updateNodesAndConnections.bind(this));
-
   }
 
   setStateAndUpdateConfigStore() {
@@ -47,7 +46,6 @@ class HydratorCreateCanvasController {
   }
 
   updateNodesAndConnections() {
-    this.setStateAndUpdateConfigStore();
     var activeNode = this.NodesStore.getActiveNodeId();
     if (!activeNode) {
       this.deleteNode();

--- a/cdap-ui/app/features/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/leftpanel-ctrl.js
@@ -105,13 +105,7 @@ class LeftPanelController {
         warning: true
       };
     }
-
-    // this.ConfigActionsFactory.addPlugin(config, this.GLOBALS.pluginConvert[config.type]);
-    this.HydratorService.fetchBackendProperties(config)
-      .then( () => {
-        this.NodesActionsFactory.addNode(config);
-      });
-
+    this.NodesActionsFactory.addNode(config);
   }
 }
 

--- a/cdap-ui/app/features/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/leftpanel-ctrl.js
@@ -87,6 +87,7 @@ class LeftPanelController {
         icon: this.MyDAGFactory.getIcon(item.pluginName),
         type: item.pluginType,
         outputSchema: item.outputSchema,
+        inputSchema: item.inputSchema,
         pluginTemplate: item.pluginTemplate,
         lock: item.lock
       };

--- a/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -29,6 +29,7 @@ class NodeConfigController {
     this.ConfigActionsFactory = ConfigActionsFactory;
     this.NonStorePipelineErrorFactory = NonStorePipelineErrorFactory;
     this.requiredPropertyError = this.GLOBALS.en.hydrator.studio.error['GENERIC-MISSING-REQUIRED-FIELDS'];
+    this.showPropagateConfirm = false; // confirmation dialog in node config for schema propagation.
 
     this.setDefaults({});
     NodeConfigStore.registerOnChangeListener(this.setState.bind(this));

--- a/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -140,7 +140,11 @@ class NodeConfigController {
               // If yes then set it as output schema and everytime when a user edits the output schema the value has to
               // be transitioned to the respective plugin property.
               if (configOutputSchema.isOutputSchemaExists) {
-                if (this.state.node.plugin.properties[configOutputSchema.outputSchemaProperty[0]] !== this.state.node.outputSchema) {
+                let schemaProperty = configOutputSchema.outputSchemaProperty[0];
+                let pluginProperties = this.state.node.plugin.properties;
+                if (pluginProperties[schemaProperty]) {
+                  this.state.node.outputSchema = pluginProperties[schemaProperty];
+                } else if (pluginProperties[schemaProperty] !== this.state.node.outputSchema) {
                   this.state.node.plugin.properties[configOutputSchema.outputSchemaProperty[0]] = this.state.node.outputSchema;
                 }
                 this.state.watchers.push(

--- a/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -98,7 +98,9 @@ class NodeConfigController {
      // One more reason we should have used Flux/Redux so that we could have eliminated these hacks.
      // The side effects of 3-way-binding (user, external & copy to output) we have different event pipe events
      // plugin.reset, schema.clear, dataset.selected, plugin-outputschema.update
-     this.EventPipe.emit('plugin-outputschema.update');
+     this.$timeout(() => {
+       this.EventPipe.emit('plugin-outputschema.update');
+     });
      this.ConfigActionsFactory.editPlugin(this.state.node.name, this.state.node);
   }
   propagateSchemaDownStream() {

--- a/cdap-ui/app/features/hydrator/services/create/actions/config-actions.js
+++ b/cdap-ui/app/features/hydrator/services/create/actions/config-actions.js
@@ -56,6 +56,9 @@ class ConfigActionsFactory {
   editPlugin(pluginId, pluginProperties) {
     this.dispatcher.dispatch('onPluginEdit', pluginId, pluginProperties);
   }
+  propagateSchemaDownStream(pluginId) {
+    this.dispatcher.dispatch('onSchemaPropagationDownStream', pluginId);
+  }
   setSchedule(schedule) {
     this.dispatcher.dispatch('onSetSchedule', schedule);
   }

--- a/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
@@ -337,6 +337,17 @@ class ConfigStore {
       if (node.outputSchemaProperty) {
         node.outputSchema = node.plugin.properties[node.outputSchemaProperty];
       }
+      if (nodeConfig.outputSchema.implicitSchema) {
+        let keys = Object.keys(nodeConfig.outputSchema.implicitSchema);
+        let formattedSchema = [];
+        angular.forEach(keys, (key) => {
+          formattedSchema.push({
+            name: key,
+            type: nodeConfig.outputSchema.implicitSchema[key]
+          });
+        });
+        node.outputSchema = JSON.stringify({ fields: formattedSchema });
+      }
     };
     if (nodesWOutBackendProps) {
       nodesWOutBackendProps.forEach( n => {

--- a/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
@@ -15,7 +15,7 @@
  */
 
 class ConfigStore {
-  constructor(ConfigDispatcher, CanvasFactory, GLOBALS, mySettings, ConsoleActionsFactory, $stateParams, myHelpers, NonStorePipelineErrorFactory){
+  constructor(ConfigDispatcher, CanvasFactory, GLOBALS, mySettings, ConsoleActionsFactory, $stateParams, myHelpers, NonStorePipelineErrorFactory, HydratorService, $q, PluginConfigFactory){
     this.state = {};
     this.mySettings = mySettings;
     this.ConsoleActionsFactory = ConsoleActionsFactory;
@@ -24,6 +24,9 @@ class ConfigStore {
     this.$stateParams = $stateParams;
     this.myHelpers = myHelpers;
     this.NonStorePipelineErrorFactory = NonStorePipelineErrorFactory;
+    this.HydratorService = HydratorService;
+    this.$q = $q;
+    this.PluginConfigFactory = PluginConfigFactory;
 
     this.changeListeners = [];
     this.setDefaults();
@@ -317,11 +320,61 @@ class ConfigStore {
 
   setNodes(nodes) {
     this.state.__ui__.nodes = nodes;
-    this.validateState();
+    let listOfPromises = [];
+    // Prepopulate nodes with backend properties;
+    // This will be used for cases where we import/use a predefined app and when we render the entire
+    // dag we need to show #of errors in each node (badge on the top right corner of each node).
+    let nodesWOutBackendProps = this.state.__ui__.nodes.filter(
+      node => !angular.isObject(node._backendProperties)
+    );
+    let parseNodeConfig = (node, res) => {
+      let nodeConfig = this.PluginConfigFactory.generateNodeConfig(node._backendProperties, res);
+      node.implicitSchema = nodeConfig.outputSchema.implicitSchema;
+      node.outputSchemaProperty = nodeConfig.outputSchema.outputSchemaProperty;
+      if (angular.isArray(node.outputSchemaProperty)) {
+        node.outputSchemaProperty = node.outputSchemaProperty[0];
+      }
+      if (node.outputSchemaProperty) {
+        node.outputSchema = node.plugin.properties[node.outputSchemaProperty];
+      }
+    };
+    if (nodesWOutBackendProps) {
+      nodesWOutBackendProps.forEach( n => {
+        listOfPromises.push(this.HydratorService.fetchBackendProperties(n, this.getAppType()));
+      });
+
+    } else {
+      listOfPromises.push(this.$q.when(true));
+    }
+    this.$q.all(listOfPromises)
+      .then(
+        () => {
+          if(!this.validateState()) {
+            this.emitChange();
+          }
+          // Once the backend properties are fetched for all nodes, fetch their config jsons.
+          // This will be used for schema propagation where we import/use a predefined app/open a published pipeline
+          // the user should directly click on the last node and see what is the incoming schema
+          // without having to open the subsequent nodes.
+          nodesWOutBackendProps.forEach( n => {
+            this.PluginConfigFactory.fetchWidgetJson(
+              n.plugin.artifact.name,
+              n.plugin.artifact.version,
+              `widgets.${n.plugin.name}-${n.type}`
+            ).then(parseNodeConfig.bind(null, n));
+          });
+        },
+        (err) => console.log('ERROR fetching backend properties for nodes', err)
+      );
+
   }
   setConnections(connections) {
     this.state.config.connections = connections;
   }
+  // This is for the user to forcefully propagate the output schema of a node
+  // down the stream to all its connections.
+  // Its a simple BFS down the graph to propagate the schema. Right now it doesn't catch cycles.
+  // The assumption there are no cycles in the dag we create.
   propagateIOSchemas(pluginId) {
     let adjacencyMap = {},
         nodesMap = {},
@@ -341,9 +394,16 @@ class ConfigStore {
       if (!node) {
         return;
       }
+      // If we encounter an implicit schema down the stream while propagation stop there and return.
+      if (node.isImplicitSchema) {
+        return;
+      }
       node.forEach( n => {
         nodesMap[n].outputSchema = outputSchema;
         nodesMap[n].inputSchema = outputSchema;
+        if (nodesMap[n].outputSchemaProperty) {
+          nodesMap[n].plugin.properties[nodesMap[n].outputSchemaProperty] = outputSchema;
+        }
         traverseMap(adjacencyMap[n], outputSchema);
       });
     };
@@ -377,7 +437,9 @@ class ConfigStore {
     if (match.length) {
       match = match[0];
       angular.forEach(nodeConfig, (pValue, pName) => match[pName] = pValue);
-      this.validateState();
+      if (!this.validateState()) {
+        this.emitChange();
+      }
     }
   }
   getSchedule() {
@@ -517,6 +579,6 @@ class ConfigStore {
   }
 }
 
-ConfigStore.$inject = ['ConfigDispatcher', 'CanvasFactory', 'GLOBALS', 'mySettings', 'ConsoleActionsFactory', '$stateParams', 'myHelpers', 'NonStorePipelineErrorFactory'];
+ConfigStore.$inject = ['ConfigDispatcher', 'CanvasFactory', 'GLOBALS', 'mySettings', 'ConsoleActionsFactory', '$stateParams', 'myHelpers', 'NonStorePipelineErrorFactory', 'HydratorService', '$q', 'PluginConfigFactory'];
 angular.module(`${PKG.name}.feature.hydrator`)
   .service('ConfigStore', ConfigStore);

--- a/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nodeconfig-store.js
+++ b/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nodeconfig-store.js
@@ -114,7 +114,7 @@ angular.module(PKG.name + '.feature.hydrator')
     function configurePluginInfo(pluginDetails) {
       var pluginId = this.state.node.name;
       var input;
-      var sourceConn = $filter('filter')(this.ConfigStore.getConnections(), { to: pluginId });
+      var sourceConn = this.ConfigStore.getSourceNodes(pluginId).filter( node => typeof node.outputSchema === 'string');
       var sourceSchema = null;
       var isStreamSource = false;
 
@@ -124,7 +124,7 @@ angular.module(PKG.name + '.feature.hydrator')
 
       var source;
       if (sourceConn && sourceConn.length) {
-        source = this.ConfigStore.getNode(sourceConn[0].from);
+        source = sourceConn[0];
         sourceSchema = source.outputSchema;
 
         if (source.name === 'Stream') {
@@ -180,9 +180,6 @@ angular.module(PKG.name + '.feature.hydrator')
         }
       });
 
-      if (!this.state.node.outputSchema && input) {
-        this.state.node.outputSchema = JSON.stringify(input) || null;
-      }
 
       this.state.node._backendProperties = pluginDetails._backendProperties || this.state.node._backendProperties;
       this.state.node.description = pluginDetails.description || this.state.node.description;

--- a/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
+++ b/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
@@ -79,6 +79,11 @@ angular.module(PKG.name + '.feature.hydrator')
     this.getNodes = function() {
       return this.state.DAGConfig.nodes;
     };
+    this.getSourceNodes = function(nodeId) {
+      let nodesMap = {};
+      this.state.DAGConfig.nodes.forEach( node => nodesMap[node.name] = node );
+      return this.state.DAGConfig.connections.filter( conn => conn.to === nodeId ).map( matchedConnection => nodesMap[matchedConnection.from] );
+    };
     this.getDatasets = function() {
       return this.state.datasets;
     };
@@ -114,7 +119,8 @@ angular.module(PKG.name + '.feature.hydrator')
         app.config = appConfig.configJson;
         uiConfig = this.HydratorService.getNodesAndConnectionsFromConfig(app);
         appConfig.DAGConfig = {
-          nodes: uiConfig.nodes
+          nodes: uiConfig.nodes,
+          connections: uiConfig.connections
         };
 
         appConfig.description = appConfig.configJson.description ? appConfig.configJson.description : appConfig.description;

--- a/cdap-ui/app/features/hydrator/services/hydrator-service.js
+++ b/cdap-ui/app/features/hydrator/services/hydrator-service.js
@@ -15,7 +15,7 @@
  */
 
 class HydratorService {
-  constructor(GLOBALS, MyDAGFactory, uuid, $state, $rootScope, myPipelineApi, $q, ConfigStore, IMPLICIT_SCHEMA, NodesStore) {
+  constructor(GLOBALS, MyDAGFactory, uuid, $state, $rootScope, myPipelineApi, $q, IMPLICIT_SCHEMA, NodesStore) {
     this.GLOBALS = GLOBALS;
     this.MyDAGFactory = MyDAGFactory;
     this.uuid = uuid;
@@ -23,7 +23,6 @@ class HydratorService {
     this.$rootScope = $rootScope;
     this.myPipelineApi = myPipelineApi;
     this.$q = $q;
-    this.ConfigStore = ConfigStore;
     this.IMPLICIT_SCHEMA = IMPLICIT_SCHEMA;
     this.NodesStore = NodesStore;
   }
@@ -80,7 +79,7 @@ class HydratorService {
     // happening
     var params = {
       namespace: this.$state.params.namespace,
-      pipelineType: appType || this.ConfigStore.getAppType(),
+      pipelineType: appType,
       version: (node.artifact && node.artifact.version ) || this.$rootScope.cdapVersion,
       extensionType: node.type,
       pluginName: node.plugin.name
@@ -178,6 +177,6 @@ class HydratorService {
   }
 
 }
-HydratorService.$inject = ['GLOBALS', 'MyDAGFactory', 'uuid', '$state', '$rootScope', 'myPipelineApi', '$q', 'ConfigStore', 'IMPLICIT_SCHEMA', 'NodesStore'];
+HydratorService.$inject = ['GLOBALS', 'MyDAGFactory', 'uuid', '$state', '$rootScope', 'myPipelineApi', '$q', 'IMPLICIT_SCHEMA', 'NodesStore'];
 angular.module(`${PKG.name}.feature.hydrator`)
   .service('HydratorService', HydratorService);

--- a/cdap-ui/app/features/hydrator/services/plugin-config-factory.js
+++ b/cdap-ui/app/features/hydrator/services/plugin-config-factory.js
@@ -19,8 +19,14 @@ class PluginConfigFactory {
     this.myHelpers = myHelpers;
     this.myPipelineApi = myPipelineApi;
     this.$state = $state;
+    this.data = {};
   }
   fetchWidgetJson(artifactName, artifactVersion, key) {
+    let cache = this.data[`${artifactName}-${artifactVersion}-${key}`];
+    if (cache) {
+      return this.$q.when(cache);
+    }
+
     return this.myPipelineApi.fetchArtifactProperties({
       namespace: this.$state.params.namespace,
       artifactName,
@@ -34,6 +40,7 @@ class PluginConfigFactory {
             let config = res[key];
             if (config) {
               config = JSON.parse(config);
+              this.data[`${artifactName}-${artifactVersion}-${key}`] = config;
               return config;
             } else {
               throw 'NO_JSON_FOUND';

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-form.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-form.html
@@ -30,44 +30,51 @@
 
 
 -->
+<div ng-if="NodeConfigController.state.configfetched">
+  <div class="bottompanel-header clearfix" ng-init="showinfo = false">
+    <div class="pull-left">
+      <h3>
+        {{NodeConfigController.state.node.plugin.name}} Properties
+        <small>{{ NodeConfigController.state.node.plugin.artifact.version }}</small>
+        <small class="text-danger" ng-if="NodeConfigController.state.noConfigMessage">({{NodeConfigController.state.noConfigMessage}})</small>
+      </h3>
+      <p>{{NodeConfigController.state.node.description}}</p>
+    </div>
+  </div>
 
-<div class="bottompanel-header clearfix" ng-init="showinfo = false">
-  <div class="pull-left">
-    <h3>
-      {{NodeConfigController.state.node.plugin.name}} Properties
-      <small>{{ NodeConfigController.state.node.plugin.artifact.version }}</small>
-      <small class="text-danger" ng-if="NodeConfigController.state.noConfigMessage">({{NodeConfigController.state.noConfigMessage}})</small>
-    </h3>
-    <p>{{NodeConfigController.state.node.description}}</p>
+  <div class="bottompanel-body" ng-class="{'modal-sink': NodeConfigController.state.node.type === 'sink'}">
+    <div ng-show="!showinfo">
+      <div ng-if="NodeConfigController.state.configfetched">
+
+        <div ng-if="NodeConfigController.state.noproperty !== 0">
+          <div ng-if="NodeConfigController.state.noconfig" ng-include="'/assets/features/hydrator/templates/create/popovers/plugin-edit-noconfig-form.html'"></div>
+
+          <div ng-if="(NodeConfigController.state.configfetched && !NodeConfigController.state.noconfig)">
+            <div ng-include="'/assets/features/hydrator/templates/create/popovers/plugin-edit-config-form.html'"></div>
+          </div>
+        </div>
+
+        <div ng-if="NodeConfigController.state.noproperty === 0">
+          <div class="well well-lg">
+            <p>No Properties for this Plugin.</p>
+          </div>
+        </div>
+      </div>
+
+      <div ng-if="!NodeConfigController.state.configfetched">
+        <h3>
+          <span class="fa fa-spinner fa-spin"></span>
+          <span>Loading...</span>
+        </h3>
+      </div>
+
+    </div>
+
   </div>
 </div>
-
-<div class="bottompanel-body" ng-class="{'modal-sink': NodeConfigController.state.node.type === 'sink'}">
-  <div ng-show="!showinfo">
-    <div ng-if="NodeConfigController.state.configfetched">
-
-      <div ng-if="NodeConfigController.state.noproperty !== 0">
-        <div ng-if="NodeConfigController.state.noconfig" ng-include="'/assets/features/hydrator/templates/create/popovers/plugin-edit-noconfig-form.html'"></div>
-
-        <div ng-if="(NodeConfigController.state.configfetched && !NodeConfigController.state.noconfig)">
-          <div ng-include="'/assets/features/hydrator/templates/create/popovers/plugin-edit-config-form.html'"></div>
-        </div>
-      </div>
-
-      <div ng-if="NodeConfigController.state.noproperty === 0">
-        <div class="well well-lg">
-          <p>No Properties for this Plugin.</p>
-        </div>
-      </div>
-    </div>
-
-    <div ng-if="!NodeConfigController.state.configfetched">
-      <h3>
-        <span class="fa fa-spinner fa-spin"></span>
-        <span>Loading...</span>
-      </h3>
-    </div>
-
-  </div>
-
+<div ng-if="!NodeConfigController.state.configfetched" class="loading-message">
+  <h3>
+    <small class="fa fa-spin fa-spinner"></small>
+    Loading...
+  </h3>
 </div>

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-input-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-input-schema.html
@@ -19,7 +19,8 @@
       <h4>Input Schema</h4>
       <button class="btn btn-default"
               ng-if="!NodeConfigController.configOutputSchema.implicitSchema"
-              ng-click="NodeConfigController.copyInputToOutputSchema()">
+              ng-click="NodeConfigController.copyInputToOutputSchema()"
+              ng-disabled="isDisabled">
           Copy to Output
       </button>
       <table class="table">

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-input-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-input-schema.html
@@ -18,9 +18,8 @@
     <div class="schema-inner" ng-if="NodeConfigController.state.node.inputSchema">
       <h4>Input Schema</h4>
       <button class="btn btn-default"
-              ng-if="!NodeConfigController.configOutputSchema.implicitSchema"
-              ng-click="NodeConfigController.copyInputToOutputSchema()"
-              ng-disabled="isDisabled">
+              ng-if="!NodeConfigController.configOutputSchema.implicitSchema && !isDisabled"
+              ng-click="NodeConfigController.copyInputToOutputSchema()">
           Copy to Output
       </button>
       <table class="table">

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-input-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-input-schema.html
@@ -17,6 +17,11 @@
 <div class="input-schema">
     <div class="schema-inner" ng-if="NodeConfigController.state.node.inputSchema">
       <h4>Input Schema</h4>
+      <button class="btn btn-default"
+              ng-if="!NodeConfigController.configOutputSchema.implicitSchema"
+              ng-click="NodeConfigController.copyInputToOutputSchema()">
+          Copy to Output
+      </button>
       <table class="table">
         <thead>
           <th>

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
@@ -21,7 +21,6 @@
       <li class="text-danger" ng-repeat="error in NodeConfigController.state.errors">{{ error }}</li>
     </ul>
   </div>
-
   <h4>
     <span ng-if="!NodeConfigController.state.isSink">Output Schema</span>
     <span ng-if="NodeConfigController.state.isSink">Schema</span>
@@ -61,7 +60,6 @@
     <div ng-if="!isDisabled">
       <my-schema-editor
         ng-model="NodeConfigController.state.node.outputSchema"
-        data-on-model-update="NodeConfigController.state.outputSchemaUpdate"
         data-disabled="NodeConfigController.state.groupsConfig.outputSchema.implicitSchema"
         plugin-properties="NodeConfigController.state.node.plugin.properties"
         config="NodeConfigController.state.groupsConfig.outputSchema.schemaProperties">

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
@@ -38,6 +38,7 @@
     <button class="btn btn-default"
              tooltip="Propagates schema to all down-stream nodes."
              tooltip-popup-delay="500"
+             ng-if="!isDisabled"
              ng-click="NodeConfigController.showPropagateConfirm = true">
       Propagate
     </button>

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
@@ -42,7 +42,6 @@
              ng-click="NodeConfigController.propagateSchemaDownStream()">
       Propagate
     </button>
-    aa: {{NodeConfigController.state.node.outputSchema}}
     <div ng-if="isDisabled">
       <my-schema-editor
         ng-model="NodeConfigController.state.node.outputSchema"

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
@@ -36,6 +36,13 @@
     </button>
   </h4>
   <fieldset class="clearfix" ng-disabled="isDisabled">
+    <button class="btn btn-default"
+             tooltip="Propagates schema to all down-stream nodes."
+             tooltip-popup-delay="500"
+             ng-click="NodeConfigController.propagateSchemaDownStream()">
+      Propagate
+    </button>
+    aa: {{NodeConfigController.state.node.outputSchema}}
     <div ng-if="isDisabled">
       <my-schema-editor
         ng-model="NodeConfigController.state.node.outputSchema"
@@ -48,6 +55,7 @@
     <div ng-if="!isDisabled">
       <my-schema-editor
         ng-model="NodeConfigController.state.node.outputSchema"
+        data-on-model-update="NodeConfigController.state.outputSchemaUpdate"
         data-disabled="NodeConfigController.state.groupsConfig.outputSchema.implicitSchema"
         plugin-properties="NodeConfigController.state.node.plugin.properties"
         config="NodeConfigController.state.groupsConfig.outputSchema.schemaProperties">

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
@@ -39,9 +39,16 @@
     <button class="btn btn-default"
              tooltip="Propagates schema to all down-stream nodes."
              tooltip-popup-delay="500"
-             ng-click="NodeConfigController.propagateSchemaDownStream()">
+             ng-click="NodeConfigController.showPropagateConfirm = true">
       Propagate
     </button>
+    <div class="schema-propagation-confirm">
+      <div class="well well-xs" ng-if="NodeConfigController.showPropagateConfirm">
+        Existing schema will be over-written. Continue?
+        <button ng-click="NodeConfigController.propagateSchemaDownStream(); NodeConfigController.showPropagateConfirm=false;" class="btn btn-default">Yes</button>
+        <button ng-click="NodeConfigController.showPropagateConfirm = false" class="btn btn-default">No</button>
+      </div>
+    </div>
     <div ng-if="isDisabled">
       <my-schema-editor
         ng-model="NodeConfigController.state.node.outputSchema"


### PR DESCRIPTION
#### FIXME
  - ~~Right now the schema propagation doesn't work for implicit schemas. The reason being, the first node have to be opened up to fetch the ui config from node proxy to get the implicit schema. And this happens only when we connect all the nodes and just click on schema icons on the edges without opening any node (I am assuming that if people have already used a plugin, say Twitter, and they know that it has an implicit schema and expect that to propagate automatically without even opening the node).~~
- We fetch the properties and node config for a node as soon as its added to the canvas. So now we have this information and whenever we encounter an implicit schema down the line we stop the propagation there for that particular path.

- We need to re-word the confirmation message we show while propagating the schema. 