### PR TITLE
CDAP-4547: Make SPARK_DIST_CLASSPATH classes available to spark/workflow containters

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedSparkProgramRunner.java
@@ -40,7 +40,6 @@ import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.Map;
 
 /**
@@ -76,14 +75,14 @@ public class DistributedSparkProgramRunner extends AbstractDistributedProgramRun
     SparkSpecification spec = appSpec.getSpark().get(program.getName());
     Preconditions.checkNotNull(spec, "Missing SparkSpecification for %s", program.getId());
 
-    // Localize the spark-assembly jar
-    File sparkAssemblyJar = SparkUtils.locateSparkAssemblyJar();
-    localizeResources.put(sparkAssemblyJar.getName(), new LocalizeResource(sparkAssemblyJar));
+    // Localize the spark-assembly and its dependency jars
+    Map<String, LocalizeResource> sparkLocalizeResources = SparkUtils.getSparkLocalizeResources();
+    localizeResources.putAll(sparkLocalizeResources);
 
     LOG.info("Launching Spark program: {}", program.getId());
     TwillController controller = launcher.launch(
       new SparkTwillApplication(program, spec, localizeResources, eventHandler),
-      sparkAssemblyJar.getName());
+      sparkLocalizeResources.keySet());
 
     RunId runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
     return new SparkTwillProgramController(program.getId(), controller, runId).startListen();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -88,21 +88,19 @@ public final class DistributedWorkflowProgramRunner extends AbstractDistributedP
     WorkflowSpecification workflowSpec = appSpec.getWorkflows().get(program.getName());
     Preconditions.checkNotNull(workflowSpec, "Missing WorkflowSpecification for %s", program.getName());
 
-    // It the workflow has Spark, localize the spark-assembly jar
     List<String> extraClassPaths = new ArrayList<>();
 
     // See if the Workflow has Spark in it
     Resources resources = findSparkDriverResources(program.getApplicationSpecification().getSpark(), workflowSpec);
     if (resources != null) {
-      // Has Spark
-      File sparkAssemblyJar = SparkUtils.locateSparkAssemblyJar();
-      localizeResources.put(sparkAssemblyJar.getName(), new LocalizeResource(sparkAssemblyJar));
-      extraClassPaths.add(sparkAssemblyJar.getName());
+      Map<String, LocalizeResource> sparkLocalizeResources = SparkUtils.getSparkLocalizeResources();
+      extraClassPaths.addAll(sparkLocalizeResources.keySet());
+      localizeResources.putAll(sparkLocalizeResources);
     } else {
       // No Spark
       resources = new Resources();
     }
-    
+
     // Add classpaths for MR framework
     extraClassPaths.addAll(MapReduceContainerHelper.localizeFramework(hConf, localizeResources));
 


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-4547

- Localize and add to classpath all spark dependencies in spark and workflow containers which have spark.
- This is needed to support running spark jobs from CDAP on hadoop-less spark installation (where spark_asssembly jar does not contain hadoop classes) for example as in case of Spark deployed through Cloudera Manager. 
- This assumes that in case of hadoop-less spark build SPARK_DIST_CLASSPATH is set with all dependencies jars. In case of Spark deployed through CM the spark-env.sh script is modified by CM to set this env variable and in this case we will source this script and set the variable. But in case of custom hadoop-less install it's not guaranteed that the spark-env.sh will have these changes and in this case we will assume the user to set this according to instruction through Spark: https://spark.apache.org/docs/latest/hadoop-provided.html
- The master script changes will be coming in another PR from @dereklwood. We have an issue opened here: https://issues.cask.co/browse/CDAP-4556

Related Tasks: 
- [ ] Test these changes through CM with master script changes
- [ ] Run integration tests
- [ ] Port to 3.3