### PR TITLE
CDAP-4397 NextRunTime endpoint should not return any time if the triggers are paused

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -55,6 +55,7 @@ import org.quartz.utils.Key;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -240,8 +241,7 @@ final class TimeScheduler implements Scheduler {
   private List<ScheduledRuntime> getScheduledRuntime(Id.Program program, SchedulableProgramType programType,
                                                      boolean previousRuntimeRequested) throws SchedulerException {
     checkInitialized();
-
-    List<ScheduledRuntime> scheduledRuntimes = Lists.newArrayList();
+    List<ScheduledRuntime> scheduledRuntimes = new ArrayList<>();
     try {
       for (Trigger trigger : scheduler.getTriggersOfJob(jobKeyFor(program, programType))) {
         long time;
@@ -252,6 +252,10 @@ final class TimeScheduler implements Scheduler {
           }
           time = trigger.getPreviousFireTime().getTime();
         } else {
+          if (scheduler.getTriggerState(trigger.getKey()) == Trigger.TriggerState.PAUSED) {
+            // if the trigger is paused, then skip getting the next fire time
+            continue;
+          }
           time = trigger.getNextFireTime().getTime();
         }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -262,8 +262,14 @@ public class SchedulerServiceTest {
     checkState(Scheduler.ScheduleState.SUSPENDED, scheduleIds);
 
     List<ScheduledRuntime> oldScheduledRuntimes = schedulerService.nextScheduledRuntime(program, programType);
+    // schedule is paused and thus the nextRuntime should be empty
+    Assert.assertTrue(oldScheduledRuntimes.isEmpty());
 
-    // update an newly created schedule whih is in suspended state
+    schedulerService.resumeSchedule(program, programType, oldSchedule.getName());
+    oldScheduledRuntimes = schedulerService.nextScheduledRuntime(program, programType);
+    schedulerService.suspendSchedule(program, programType, oldSchedule.getName());
+
+    // update a newly created schedule which is in suspended state
     schedulerService.updateSchedule(program, programType, newSchedule);
 
     scheduleIds = schedulerService.getScheduleIds(program, programType);
@@ -274,7 +280,10 @@ public class SchedulerServiceTest {
 
     // time schedules will have nextRuntime associated with it so verify that they are correct after update
     if (oldSchedule instanceof TimeSchedule && newSchedule instanceof TimeSchedule) {
+      // resume schedule before verifying next runtime
+      schedulerService.resumeSchedule(program, programType, newSchedule.getName());
       verifyUpdatedNextRuntime(oldScheduledRuntimes);
+      schedulerService.suspendSchedule(program, programType, newSchedule.getName());
     }
 
     // the state of an resumed schedule should remain resumed even after update

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ScheduleClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ScheduleClientTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -102,7 +102,9 @@ public class ScheduleClientTestRun extends ClientTestBase {
     status = scheduleClient.getStatus(schedule);
     Assert.assertEquals("SUSPENDED", status);
 
+    scheduleClient.resume(schedule);
     List<ScheduledRuntime> scheduledRuntimes = scheduleClient.nextRuntimes(workflow);
+    scheduleClient.suspend(schedule);
     Assert.assertEquals(1, scheduledRuntimes.size());
     // simply assert that its scheduled for some time in the future (or scheduled for now, but hasn't quite
     // executed yet


### PR DESCRIPTION
Summary: Check if the trigger is paused and if not return the next scheduled fire time for that trigger.

JIRA : https://issues.cask.co/browse/CDAP-4397

Build : http://builds.cask.co/browse/CDAP-RBT563
