### PR TITLE
Fix main-bower-files version to 2.11.0

### DIFF
--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -38,7 +38,7 @@
     "karma": "^0.12.21",
     "karma-chrome-launcher": "^0.1.4",
     "karma-jasmine": "^0.3.0",
-    "main-bower-files": "^2.1.0",
+    "main-bower-files": "2.11.0",
     "merge-stream": "^0.1.5"
   },
   "dependencies": {


### PR DESCRIPTION
Because of a change in package `main-bower-files` that was released yesterday, the cdap-ui build no longer works. Issue is described in detail in the JIRA linked below.

http://builds.cask.co/browse/CDAP-RBTKEY283-1
https://issues.cask.co/browse/CDAP-4559