### PR TITLE
Fix main-bower-files version to 2.11.0

### DIFF
--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -36,7 +36,7 @@
     "gulp-uglify": "^1.1.0",
     "gulp-util": "^3.0.4",
     "gulp-wrapper": "^0.1.5",
-    "main-bower-files": "^2.6.2",
+    "main-bower-files": "2.11.0",
     "merge-stream": "^0.1.7"
   },
   "dependencies": {


### PR DESCRIPTION
Note: This is cherrypicked from https://github.com/caskdata/cdap/pull/4837.
Because of a change in package `main-bower-files` that was released yesterday, the cdap-ui build no longer works. Issue is described in detail in the JIRA linked below.

http://builds.cask.co/browse/CDAP-RT326-1
https://issues.cask.co/browse/CDAP-4559