### PR TITLE
Fix config-tool after changes from #4712

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -98,7 +98,7 @@ cdap_kinit() {
   return 0
 }
 
-# Attempts to find JAVA in few ways.
+# Attempts to find JAVA in few ways. This is used by UI's config-tool, so verify that changes here do not break that
 cdap_set_java () {
   # Determine the Java command to use to start the JVM.
   if [ -n "${JAVA_HOME}" ] ; then

--- a/cdap-ui/bin/config-tool
+++ b/cdap-ui/bin/config-tool
@@ -36,7 +36,7 @@ fi
 source ${bin}/common.sh
 
 # Find java and set $JAVA
-set_java
+cdap_set_java || (echo "Failed to setup Java" && exit 1)
 
 # Load the configuration too.
 if [ -d ${CDAP_CONF} ]; then


### PR DESCRIPTION
The `config-tool` script in the CDAP UI uses a function from `common.sh` which was missed in #4712 