### PR TITLE
CDAP-4522 wait for tx service to be available on startup

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -37,6 +37,7 @@ import co.cask.http.NettyHttpService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.Futures;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.apache.twill.common.Cancellable;
@@ -120,13 +121,17 @@ public class AppFabricServer extends AbstractIdleService {
     LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Id.Namespace.SYSTEM.getId(),
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.APP_FABRIC_HTTP));
-    notificationService.start();
-    schedulerService.start();
-    applicationLifecycleService.start();
-    systemArtifactLoader.start();
-    programRuntimeService.start();
-    streamCoordinatorClient.start();
-    programLifecycleService.start();
+    Futures.allAsList(
+      ImmutableList.of(
+        notificationService.start(),
+        schedulerService.start(),
+        applicationLifecycleService.start(),
+        systemArtifactLoader.start(),
+        programRuntimeService.start(),
+        streamCoordinatorClient.start(),
+        programLifecycleService.start()
+      )
+    ).get();
 
     // Create handler hooks
     ImmutableList.Builder<HandlerHook> builder = ImmutableList.builder();

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -50,6 +50,7 @@ public final class Constants {
     public static final String CHECK_PACKAGES = "master.startup.checks.packages";
     public static final String CHECK_CLASSES = "master.startup.checks.classes";
     public static final String YARN_CONNECT_TIMEOUT_SECONDS = "master.startup.checks.yarn.connect.timeout.seconds";
+    public static final String STARTUP_SERVICE_TIMEOUT = "master.startup.service.timeout.seconds";
   }
 
   /**
@@ -211,7 +212,6 @@ public final class Constants {
     }
 
     public static final String SERVICE_DESCRIPTION = "Service that maintains transaction states.";
-
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/UnloggedExceptionIdleService.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/UnloggedExceptionIdleService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.service;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+
+import java.util.concurrent.Executor;
+
+/**
+ * An AbstractIdleService that overrides its executor to use one that doesn't print to stderr the exceptions
+ * it gets, so that error messaging is left to whoever is using the service.
+ */
+public abstract class UnloggedExceptionIdleService extends AbstractIdleService {
+  public static final Thread.UncaughtExceptionHandler UNCAUGHT_EXCEPTION_HANDLER =
+    new Thread.UncaughtExceptionHandler() {
+      @Override
+      public void uncaughtException(Thread t, Throwable e) {
+        // no-op
+      }
+    };
+
+  @SuppressWarnings("NullableProblems")
+  @Override
+  protected Executor executor(State state) {
+    final String name = getClass().getSimpleName() + " " + state;
+    return new Executor() {
+      @Override
+      public void execute(Runnable runnable) {
+        Thread t = new Thread(runnable, name);
+        t.setUncaughtExceptionHandler(UNCAUGHT_EXCEPTION_HANDLER);
+        t.start();
+      }
+    };
+  }
+}

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -899,6 +899,18 @@
     </description>
   </property>
 
+  <property>
+    <name>master.startup.service.timeout.seconds</name>
+    <value>600</value>
+    <description>
+      Timeout in seconds for master services to wait for their dependent services to be available.
+      For example, the dataset executor master service requires the transaction service, and will wait for
+      the transaction service to become available while it is starting up.
+      If the timeout is hit, the service will fail to start and the master will shut itself down.
+      If set to 0 or below, master services will not wait for their dependent services to start before starting themselves.
+    </description>
+  </property>
+
   <!-- Metadata Configuration -->
 
   <property>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
@@ -18,6 +18,8 @@ package co.cask.cdap.data.runtime;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.queue.QueueClientFactory;
+import co.cask.cdap.data2.transaction.DistributedTransactionSystemClientService;
+import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.data2.transaction.metrics.TransactionManagerMetricsCollector;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
@@ -60,6 +62,7 @@ public class DataFabricDistributedModule extends AbstractModule {
 
     // bind transactions
     bind(TxMetricsCollector.class).to(TransactionManagerMetricsCollector.class).in(Scopes.SINGLETON);
+    bind(TransactionSystemClientService.class).to(DistributedTransactionSystemClientService.class);
     install(new TransactionModules().getDistributedModules());
     install(new TransactionExecutorModule());
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricInMemoryModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricInMemoryModule.java
@@ -16,6 +16,8 @@
 package co.cask.cdap.data.runtime;
 
 import co.cask.cdap.data2.queue.QueueClientFactory;
+import co.cask.cdap.data2.transaction.DelegatingTransactionSystemClientService;
+import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.data2.transaction.metrics.TransactionManagerMetricsCollector;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.queue.inmemory.InMemoryQueueAdmin;
@@ -40,6 +42,7 @@ public class DataFabricInMemoryModule extends AbstractModule {
 
     // bind transactions
     bind(TxMetricsCollector.class).to(TransactionManagerMetricsCollector.class).in(Scopes.SINGLETON);
+    bind(TransactionSystemClientService.class).to(DelegatingTransactionSystemClientService.class);
     install(new TransactionModules().getInMemoryModules());
     install(new TransactionExecutorModule());
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricLevelDBModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricLevelDBModule.java
@@ -17,6 +17,8 @@ package co.cask.cdap.data.runtime;
 
 import co.cask.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
 import co.cask.cdap.data2.queue.QueueClientFactory;
+import co.cask.cdap.data2.transaction.DelegatingTransactionSystemClientService;
+import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.data2.transaction.metrics.TransactionManagerMetricsCollector;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.queue.leveldb.LevelDBQueueAdmin;
@@ -41,6 +43,7 @@ public class DataFabricLevelDBModule extends AbstractModule {
 
     // bind transactions
     bind(TxMetricsCollector.class).to(TransactionManagerMetricsCollector.class).in(Scopes.SINGLETON);
+    bind(TransactionSystemClientService.class).to(DelegatingTransactionSystemClientService.class);
     install(new TransactionModules().getInMemoryModules());
     install(new TransactionExecutorModule());
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/LocalDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/LocalDatasetOpExecutor.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.datafabric.dataset.service.executor;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import com.google.inject.Inject;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -27,8 +28,10 @@ public class LocalDatasetOpExecutor extends RemoteDatasetOpExecutor {
   private final DatasetOpExecutorService executorServer;
 
   @Inject
-  public LocalDatasetOpExecutor(DiscoveryServiceClient discoveryClient, DatasetOpExecutorService executorServer) {
-    super(discoveryClient);
+  public LocalDatasetOpExecutor(CConfiguration cConf,
+                                DiscoveryServiceClient discoveryClient,
+                                DatasetOpExecutorService executorServer) {
+    super(cConf, discoveryClient);
     this.executorServer = executorServer;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/YarnDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/YarnDatasetOpExecutor.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.datafabric.dataset.service.executor;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import com.google.inject.Inject;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -29,8 +30,8 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 public class YarnDatasetOpExecutor extends RemoteDatasetOpExecutor {
 
   @Inject
-  public YarnDatasetOpExecutor(DiscoveryServiceClient discoveryClient) {
-    super(discoveryClient);
+  public YarnDatasetOpExecutor(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
+    super(cConf, discoveryClient);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/MDSDatasetsRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/MDSDatasetsRegistry.java
@@ -21,7 +21,7 @@ import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.tx.TransactionalDatasetRegistry;
-import co.cask.tephra.TransactionSystemClient;
+import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -38,7 +38,7 @@ public class MDSDatasetsRegistry extends TransactionalDatasetRegistry<MDSDataset
   private DatasetMetaTableUtil util;
 
   @Inject
-  public MDSDatasetsRegistry(TransactionSystemClient txClient,
+  public MDSDatasetsRegistry(TransactionSystemClientService txClient,
                              @Named("datasetMDS") DatasetFramework framework) {
     super(txClient);
     this.dsFramework = framework;
@@ -46,11 +46,13 @@ public class MDSDatasetsRegistry extends TransactionalDatasetRegistry<MDSDataset
 
   @Override
   public void startUp() throws Exception {
+    super.startUp();
     this.util = new DatasetMetaTableUtil(dsFramework);
   }
 
   @Override
   public void shutDown() throws Exception {
+
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
@@ -87,7 +87,7 @@ public class DatasetTypeManager extends AbstractIdleService {
     this.cConf = cConf;
     this.mdsDatasets = mdsDatasets;
     this.locationFactory = locationFactory;
-    this.defaultModules = new LinkedHashMap<String, DatasetModule>(defaultModules);
+    this.defaultModules = new LinkedHashMap<>(defaultModules);
     this.allowDatasetUncheckedUpgrade = cConf.getBoolean(Constants.Dataset.DATASET_UNCHECKED_UPGRADE);
     this.extensionModules = getExtensionModules(this.cConf);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -120,7 +120,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
     namespaces.add(Id.Namespace.SYSTEM);
     DatasetDefinitionRegistry systemRegistry = registryFactory.create();
     for (Map.Entry<String, DatasetModule> entry : defaultModules.entrySet()) {
-      LOG.info("Adding Default module {} to system namespace", entry.getKey());
+      LOG.debug("Adding Default module {} to system namespace", entry.getKey());
       String moduleName = entry.getKey();
       DatasetModule module = entry.getValue();
       entry.getValue().register(systemRegistry);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/DelegatingTransactionSystemClientService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/DelegatingTransactionSystemClientService.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction;
+
+import co.cask.tephra.InvalidTruncateTimeException;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionCouldNotTakeSnapshotException;
+import co.cask.tephra.TransactionNotInProgressException;
+import co.cask.tephra.TransactionSystemClient;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Delegates all transaction methods to a TransactionSystemClient and does nothing during startup and shutdown.
+ */
+public class DelegatingTransactionSystemClientService
+  extends AbstractIdleService implements TransactionSystemClientService {
+
+  private final TransactionSystemClient delegate;
+
+  @Inject
+  public DelegatingTransactionSystemClientService(TransactionSystemClient delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Transaction startShort() {
+    return delegate.startShort();
+  }
+
+  @Override
+  public Transaction startShort(int timeout) {
+    return delegate.startShort(timeout);
+  }
+
+  @Override
+  public Transaction startLong() {
+    return delegate.startLong();
+  }
+
+  @Override
+  public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+    return delegate.canCommit(tx, changeIds);
+  }
+
+  @Override
+  public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+    return delegate.commit(tx);
+  }
+
+  @Override
+  public void abort(Transaction tx) {
+    delegate.abort(tx);
+  }
+
+  @Override
+  public boolean invalidate(long tx) {
+    return delegate.invalidate(tx);
+  }
+
+  @Override
+  public Transaction checkpoint(Transaction tx) throws TransactionNotInProgressException {
+    return delegate.checkpoint(tx);
+  }
+
+  @Override
+  public InputStream getSnapshotInputStream() throws TransactionCouldNotTakeSnapshotException {
+    return delegate.getSnapshotInputStream();
+  }
+
+  @Override
+  public String status() {
+    return delegate.status();
+  }
+
+  @Override
+  public void resetState() {
+    delegate.resetState();
+  }
+
+  @Override
+  public boolean truncateInvalidTx(Set<Long> invalidTxIds) {
+    return delegate.truncateInvalidTx(invalidTxIds);
+  }
+
+  @Override
+  public boolean truncateInvalidTxBefore(long time) throws InvalidTruncateTimeException {
+    return delegate.truncateInvalidTxBefore(time);
+  }
+
+  @Override
+  public int getInvalidSize() {
+    return delegate.getInvalidSize();
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    // no-op
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    // no-op
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/DistributedTransactionSystemClientService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/DistributedTransactionSystemClientService.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.service.UnloggedExceptionIdleService;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.tephra.InvalidTruncateTimeException;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionCouldNotTakeSnapshotException;
+import co.cask.tephra.TransactionNotInProgressException;
+import co.cask.tephra.TransactionSystemClient;
+import com.google.inject.Inject;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A Service for Tephra's TransactionSystemClient that waits on startup for the transaction system to be available.
+ * Everything else is just delegated to a TransactionSystemClient.
+ */
+public class DistributedTransactionSystemClientService
+  extends UnloggedExceptionIdleService implements TransactionSystemClientService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DistributedTransactionSystemClientService.class);
+  private final CConfiguration cConf;
+  private final TransactionSystemClient delegate;
+  private final DiscoveryServiceClient discoveryServiceClient;
+
+  @Inject
+  public DistributedTransactionSystemClientService(CConfiguration cConf,
+                                                   DiscoveryServiceClient discoveryServiceClient,
+                                                   TransactionSystemClient delegate) {
+    this.cConf = cConf;
+    this.delegate = delegate;
+    this.discoveryServiceClient = discoveryServiceClient;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting TransactionSystemClientService.");
+    int timeout = cConf.getInt(Constants.Startup.STARTUP_SERVICE_TIMEOUT);
+    if (timeout > 0) {
+      LOG.debug("Waiting for transaction system to be available. Will timeout after {} seconds.", timeout);
+      try {
+        Tasks.waitFor(true, new Callable<Boolean>() {
+          @Override
+          public Boolean call() throws Exception {
+            return discoveryServiceClient.discover(Constants.Service.TRANSACTION).iterator().hasNext();
+          }
+        }, timeout, TimeUnit.SECONDS, Math.min(timeout, Math.max(10, timeout / 10)), TimeUnit.SECONDS);
+        LOG.info("TransactionSystemClientService started.");
+      } catch (TimeoutException e) {
+        // its not a nice message... throw one with a better message
+        throw new TimeoutException(String.format(
+          "Timed out after %d seconds while waiting to discover the %s service. " +
+            "Check the logs for the service to see what went wrong.",
+          timeout, Constants.Service.TRANSACTION));
+      } catch (InterruptedException e) {
+        throw new RuntimeException(String.format("Interrupted while waiting to discover the %s service.",
+                                                 Constants.Service.TRANSACTION));
+      } catch (ExecutionException e) {
+        throw new RuntimeException(String.format("Error while waiting to discover the %s service.",
+                                                 Constants.Service.TRANSACTION), e);
+      }
+    }
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    // no-op
+  }
+
+  @Override
+  public Transaction startShort() {
+    return delegate.startShort();
+  }
+
+  @Override
+  public Transaction startShort(int timeout) {
+    return delegate.startShort(timeout);
+  }
+
+  @Override
+  public Transaction startLong() {
+    return delegate.startLong();
+  }
+
+  @Override
+  public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+    return delegate.canCommit(tx, changeIds);
+  }
+
+  @Override
+  public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+    return delegate.commit(tx);
+  }
+
+  @Override
+  public void abort(Transaction tx) {
+    delegate.abort(tx);
+  }
+
+  @Override
+  public boolean invalidate(long tx) {
+    return delegate.invalidate(tx);
+  }
+
+  @Override
+  public Transaction checkpoint(Transaction tx) throws TransactionNotInProgressException {
+    return delegate.checkpoint(tx);
+  }
+
+  @Override
+  public InputStream getSnapshotInputStream() throws TransactionCouldNotTakeSnapshotException {
+    return delegate.getSnapshotInputStream();
+  }
+
+  @Override
+  public String status() {
+    return delegate.status();
+  }
+
+  @Override
+  public void resetState() {
+    delegate.resetState();
+  }
+
+  @Override
+  public boolean truncateInvalidTx(Set<Long> invalidTxIds) {
+    return delegate.truncateInvalidTx(invalidTxIds);
+  }
+
+  @Override
+  public boolean truncateInvalidTxBefore(long time) throws InvalidTruncateTimeException {
+    return delegate.truncateInvalidTxBefore(time);
+  }
+
+  @Override
+  public int getInvalidSize() {
+    return delegate.getInvalidSize();
+  }
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionSystemClientService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionSystemClientService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction;
+
+import co.cask.tephra.TransactionSystemClient;
+import com.google.common.util.concurrent.Service;
+
+/**
+ * A Service for Tephra's TransactionSystemClient to perform lifecycle operations.
+ */
+public interface TransactionSystemClientService extends TransactionSystemClient, Service {
+
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -43,6 +43,8 @@ import co.cask.cdap.data2.dataset2.SingleTypeModule;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
+import co.cask.cdap.data2.transaction.DelegatingTransactionSystemClientService;
+import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.proto.Id;
@@ -101,6 +103,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     txManager = new TransactionManager(txConf);
     txManager.startAndWait();
     InMemoryTxSystemClient txSystemClient = new InMemoryTxSystemClient(txManager);
+    TransactionSystemClientService txSystemClientService = new DelegatingTransactionSystemClientService(txSystemClient);
 
     LocalLocationFactory locationFactory = new LocalLocationFactory(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
     NamespacedLocationFactory namespacedLocationFactory = new DefaultNamespacedLocationFactory(cConf, locationFactory);
@@ -121,7 +124,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
       .build();
 
     InMemoryDatasetFramework mdsFramework = new InMemoryDatasetFramework(registryFactory, modules, cConf);
-    MDSDatasetsRegistry mdsDatasetsRegistry = new MDSDatasetsRegistry(txSystemClient, mdsFramework);
+    MDSDatasetsRegistry mdsDatasetsRegistry = new MDSDatasetsRegistry(txSystemClientService, mdsFramework);
 
     ExploreFacade exploreFacade = new ExploreFacade(new DiscoveryExploreClient(discoveryService), cConf);
     DatasetInstanceService instanceService = new DatasetInstanceService(

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -44,6 +44,8 @@ import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
+import co.cask.cdap.data2.transaction.DelegatingTransactionSystemClientService;
+import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.internal.test.AppJarHelper;
@@ -136,6 +138,7 @@ public abstract class DatasetServiceTestBase {
     txManager = new TransactionManager(txConf);
     txManager.startAndWait();
     InMemoryTxSystemClient txSystemClient = new InMemoryTxSystemClient(txManager);
+    TransactionSystemClientService txSystemClientService = new DelegatingTransactionSystemClientService(txSystemClient);
 
     final Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
@@ -173,7 +176,7 @@ public abstract class DatasetServiceTestBase {
     TransactionExecutorFactory txExecutorFactory = injector.getInstance(TransactionExecutorFactory.class);
 
     MDSDatasetsRegistry mdsDatasetsRegistry =
-      new MDSDatasetsRegistry(txSystemClient, new InMemoryDatasetFramework(registryFactory, modules, cConf));
+      new MDSDatasetsRegistry(txSystemClientService, new InMemoryDatasetFramework(registryFactory, modules, cConf));
 
     ExploreFacade exploreFacade = new ExploreFacade(new DiscoveryExploreClient(discoveryService), cConf);
     namespaceClient = new InMemoryNamespaceClient();

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -54,6 +54,7 @@ import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.NoOpLineageWriter;
 import co.cask.cdap.data2.registry.UsageRegistry;
+import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactStore;
@@ -67,7 +68,6 @@ import co.cask.cdap.metrics.store.MetricDatasetFactory;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
-import co.cask.tephra.TransactionSystemClient;
 import co.cask.tephra.distributed.TransactionService;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -202,7 +202,7 @@ public class UpgradeTool {
         @Singleton
         @Named("mdsDatasetsRegistry")
         @SuppressWarnings("unused")
-        public MDSDatasetsRegistry getMDSDatasetsRegistry(TransactionSystemClient txClient,
+        public MDSDatasetsRegistry getMDSDatasetsRegistry(TransactionSystemClientService txClient,
                                                           @Named("datasetMDS") DatasetFramework framework) {
           return new MDSDatasetsRegistry(txClient, framework);
         }

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/inmemory/InMemoryNotificationService.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/inmemory/InMemoryNotificationService.java
@@ -17,11 +17,11 @@
 package co.cask.cdap.notifications.service.inmemory;
 
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.service.AbstractNotificationService;
 import co.cask.cdap.notifications.service.NotificationException;
 import co.cask.cdap.proto.Id;
-import co.cask.tephra.TransactionSystemClient;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -39,7 +39,8 @@ public class InMemoryNotificationService extends AbstractNotificationService {
   private ListeningExecutorService executorService;
 
   @Inject
-  public InMemoryNotificationService(DatasetFramework dsFramework, TransactionSystemClient transactionSystemClient,
+  public InMemoryNotificationService(DatasetFramework dsFramework,
+                                     TransactionSystemClientService transactionSystemClient,
                                      NotificationFeedManager feedManager) {
     super(dsFramework, transactionSystemClient, feedManager);
   }

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/kafka/KafkaNotificationService.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/kafka/KafkaNotificationService.java
@@ -18,6 +18,7 @@ package co.cask.cdap.notifications.service.kafka;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.notifications.feeds.NotificationFeedException;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.NotificationFeedNotFoundException;
@@ -26,8 +27,6 @@ import co.cask.cdap.notifications.service.NotificationException;
 import co.cask.cdap.notifications.service.NotificationHandler;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
-import co.cask.tephra.TransactionSystemClient;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -73,7 +72,7 @@ public class KafkaNotificationService extends AbstractNotificationService {
 
   @Inject
   public KafkaNotificationService(CConfiguration cConf, KafkaClient kafkaClient, DatasetFramework dsFramework,
-                                  TransactionSystemClient transactionSystemClient,
+                                  TransactionSystemClientService transactionSystemClient,
                                   NotificationFeedManager feedManager) {
     super(dsFramework, transactionSystemClient, feedManager);
     this.kafkaClient = kafkaClient;
@@ -86,6 +85,7 @@ public class KafkaNotificationService extends AbstractNotificationService {
 
   @Override
   protected void startUp() throws Exception {
+    super.startUp();
     kafkaPublisher = kafkaClient.getPublisher(ack, Compression.SNAPPY);
     publishingExecutor = MoreExecutors.listeningDecorator(
       Executors.newSingleThreadExecutor(Threads.createDaemonThreadFactory("notification-publisher-%d")));
@@ -94,6 +94,7 @@ public class KafkaNotificationService extends AbstractNotificationService {
   @Override
   protected void shutDown() throws Exception {
     publishingExecutor.shutdownNow();
+    super.shutDown();
   }
 
   @Override


### PR DESCRIPTION
changes to services to wait for the transaction service or
dataset op serivces to be up while they are starting.
This is to improve the user experience so that they dont see
a flurry of errors in the log when the master first starts up.