### PR TITLE
CDAP-4581 protect against root directory in url classloader

### DIFF
--- a/cdap-common/bin/service
+++ b/cdap-common/bin/service
@@ -103,6 +103,7 @@ _start_java() {
     cdap_set_hbase || exit 1
     # Master requires this local directory
     cdap_check_or_create_master_local_dir || die "Could not create Master local directory"
+    logecho "Running startup checks -- this may take a few minutes"
     "${JAVA}" "${JAVA_HEAPMAX}" -Dexplore.conf.files=${EXPLORE_CONF_FILES} -Dexplore.classpath=${EXPLORE_CLASSPATH} ${OPTS} -cp ${CLASSPATH} co.cask.cdap.master.startup.MasterStartupTool </dev/null >>${loglog} 2>&1
     if [ $? -ne 0 ]; then
       die "Master startup checks failed. Please check ${loglog} to address issues."


### PR DESCRIPTION
fixing a problem with the startup check runner when the classpath
contains empty entries and the tool is run from the root directory.
In those cases, the working directory, which is the root directory,
gets added as a uri for the url classloader, which will cause
ClassPath to scan the entire filesystem.