### PR TITLE
CDAP-4548 remove app logs from the master log

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -202,8 +202,10 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
             twillPreparer.withResources(logbackURI);
           }
 
-          if (cConf.getBoolean(Constants.COLLECT_CONTAINER_LOGS)) {
+          if (cConf.getBoolean(Constants.COLLECT_APP_CONTAINER_LOGS)) {
             twillPreparer.addLogHandler(new PrinterLogHandler(new PrintWriter(System.out)));
+          } else {
+            twillPreparer.addJVMOptions("-Dtwill.disable.kafka=true");
           }
 
           String yarnAppClassPath = hConf.get(YarnConfiguration.YARN_APPLICATION_CLASSPATH,

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -41,6 +41,7 @@ public final class Constants {
   public static final String ARCHIVE_DIR = "archive";
   public static final String ROOT_NAMESPACE = "root.namespace";
   public static final String COLLECT_CONTAINER_LOGS = "master.collect.containers.log";
+  public static final String COLLECT_APP_CONTAINER_LOGS = "master.collect.app.containers.log";
 
   /**
    * Configuration for Master startup.

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/TwillModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/TwillModule.java
@@ -63,9 +63,6 @@ public class TwillModule extends PrivateModule {
 
     // Set JVM options based on configuration
     String jvmOpts = configuration.get(Constants.AppFabric.PROGRAM_JVM_OPTS);
-    if (!configuration.getBoolean(Constants.COLLECT_CONTAINER_LOGS)) {
-      jvmOpts += " -Dtwill.disable.kafka=true";
-    }
     runner.setJVMOptions(jvmOpts);
 
     return runner;

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -871,13 +871,13 @@
     <name>master.collect.containers.log</name>
     <value>true</value>
     <description>
-      Determines if container logs are streamed back to the CDAP Master process log
+      Determines if master service container logs are streamed back to the CDAP Master process log
     </description>
   </property>
 
   <property>
     <name>master.collect.app.containers.log</name>
-    <value>false</value>
+    <value>true</value>
     <description>
       Determines if application container logs are streamed back to the CDAP Master process log
     </description>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -876,6 +876,14 @@
   </property>
 
   <property>
+    <name>master.collect.app.containers.log</name>
+    <value>false</value>
+    <description>
+      Determines if application container logs are streamed back to the CDAP Master process log
+    </description>
+  </property>
+
+  <property>
     <name>master.service.max.instances</name>
     <value>5</value>
     <description>

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -641,6 +641,8 @@ public class MasterServiceMain extends DaemonMain {
 
         if (cConf.getBoolean(Constants.COLLECT_CONTAINER_LOGS)) {
           preparer.addLogHandler(new PrinterLogHandler(new PrintWriter(System.out)));
+        } else {
+          preparer.addJVMOptions("-Dtwill.disable.kafka=true");
         }
 
         // Add logback xml


### PR DESCRIPTION
turn off streaming app logs to the master log by default. It can
still be turned back on through configuration, but the default
behavior should not be to include app logs.