### PR TITLE
CDAP-3964 Check if the tmp directory is present before attempting to delete it.

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -464,6 +464,11 @@ public class MasterServiceMain extends DaemonMain {
   private void cleanupTempDir() {
     File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+
+    if (!tmpDir.isDirectory()) {
+      return;
+    }
+
     try {
       DirUtils.deleteDirectoryContents(tmpDir, true);
     } catch (IOException e) {

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -257,6 +257,11 @@ public class StandaloneMain {
   private void cleanupTempDir() {
     File tmpDir = new File(configuration.get(Constants.CFG_LOCAL_DATA_DIR),
                            configuration.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+
+    if (!tmpDir.isDirectory()) {
+      return;
+    }
+
     try {
       DirUtils.deleteDirectoryContents(tmpDir, true);
     } catch (IOException e) {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-3964

During initialization of the `StandAloneMain` or the `MasterServiceMain`, we first attempt to clear the tmp directory. If the directory is not present we see the following exception in the log file - 

```java
2015-10-09 01:05:29,127 - DEBUG [main:c.c.c.d.r.m.MasterServiceMain@429] - Failed to cleanup temp directory /var/tmp/cdap/data/tmp
java.io.IOException: Not a directory: /var/tmp/cdap/data/tmp
        at co.cask.cdap.common.utils.DirUtils.deleteDirectoryContents(DirUtils.java:61) ~[co.cask.cdap.cdap-common-3.2.0.jar:na]
        at co.cask.cdap.data.runtime.main.MasterServiceMain.cleanupTempDir(MasterServiceMain.java:426) [co.cask.cdap.cdap-master-3.2.0.jar:na]
        at co.cask.cdap.data.runtime.main.MasterServiceMain.init(MasterServiceMain.java:172) [co.cask.cdap.cdap-master-3.2.0.jar:na]
        at co.cask.cdap.common.runtime.DaemonMain.doMain(DaemonMain.java:36) [co.cask.cdap.cdap-common-3.2.0.jar:na]
        at co.cask.cdap.data.runtime.main.MasterServiceMain.main(MasterServiceMain.java:147) [co.cask.cdap.cdap-master-3.2.0.jar:na]
```

Check if the directory exist before attempting the cleanup.

Release build is running here - http://builds.cask.co/browse/CDAP-RBT583-1