### PR TITLE
CDAP-4294 namespace isolation for system artifact plugins

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
@@ -73,21 +73,21 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
   private final Map<String, WorkerSpecification> workers = new HashMap<>();
 
   // passed app to be used to resolve default name and description
-  public DefaultAppConfigurer(Application app) {
-    super(null, null, null);
+  public DefaultAppConfigurer(Id.Namespace namespace, Application app) {
+    super(namespace, null, null, null);
     this.name = app.getClass().getSimpleName();
     this.description = "";
   }
 
   // TODO: Remove this constructor when app templates are removed and when all applications are created from artifacts
-  public DefaultAppConfigurer(Application app, String configuration) {
-    this(app);
+  public DefaultAppConfigurer(Id.Namespace namespace, Application app, String configuration) {
+    this(namespace, app);
     this.configuration = configuration;
   }
 
-  public DefaultAppConfigurer(Id.Artifact artifactId, Application app, String configuration,
+  public DefaultAppConfigurer(Id.Namespace namespace, Id.Artifact artifactId, Application app, String configuration,
                               ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
-    super(artifactId, artifactRepository, pluginInstantiator);
+    super(namespace, artifactId, artifactRepository, pluginInstantiator);
     this.name = app.getClass().getSimpleName();
     this.description = "";
     this.configuration = configuration;
@@ -121,7 +121,8 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
   @Override
   public void addMapReduce(MapReduce mapReduce) {
     Preconditions.checkArgument(mapReduce != null, "MapReduce cannot be null.");
-    DefaultMapReduceConfigurer configurer = new DefaultMapReduceConfigurer(mapReduce, artifactId, artifactRepository,
+    DefaultMapReduceConfigurer configurer = new DefaultMapReduceConfigurer(mapReduce, deployNamespace, artifactId,
+                                                                           artifactRepository,
                                                                            pluginInstantiator);
     mapReduce.configure(configurer);
 
@@ -136,7 +137,8 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
   @Override
   public void addSpark(Spark spark) {
     Preconditions.checkArgument(spark != null, "Spark cannot be null.");
-    DefaultSparkConfigurer configurer = new DefaultSparkConfigurer(spark, artifactId, artifactRepository,
+    DefaultSparkConfigurer configurer = new DefaultSparkConfigurer(spark, deployNamespace, artifactId,
+                                                                   artifactRepository,
                                                                    pluginInstantiator);
     spark.configure(configurer);
 
@@ -159,8 +161,8 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
 
   public void addService(Service service) {
     Preconditions.checkArgument(service != null, "Service cannot be null.");
-    DefaultServiceConfigurer configurer = new DefaultServiceConfigurer(service, artifactId, artifactRepository,
-                                                                       pluginInstantiator);
+    DefaultServiceConfigurer configurer = new DefaultServiceConfigurer(service, deployNamespace, artifactId,
+                                                                       artifactRepository, pluginInstantiator);
     service.configure(configurer);
 
     ServiceSpecification spec = configurer.createSpecification();
@@ -174,7 +176,8 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
   @Override
   public void addWorker(Worker worker) {
     Preconditions.checkArgument(worker != null, "Worker cannot be null.");
-    DefaultWorkerConfigurer configurer = new DefaultWorkerConfigurer(worker, artifactId, artifactRepository,
+    DefaultWorkerConfigurer configurer = new DefaultWorkerConfigurer(worker, deployNamespace, artifactId,
+                                                                     artifactRepository,
                                                                      pluginInstantiator);
     worker.configure(configurer);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
@@ -50,9 +50,13 @@ public class DefaultPluginConfigurer extends DefaultDatasetConfigurer implements
   private final ArtifactRepository artifactRepository;
   private final PluginInstantiator pluginInstantiator;
   private final Map<String, Plugin> plugins;
+  // this is the namespace that the app will be deployed in, which can be different than the namespace of
+  // the artifact. If the artifact is a system artifact, it will have the system namespace.
+  protected final Id.Namespace deployNamespace;
 
-  public DefaultPluginConfigurer(Id.Artifact artifactId,
+  public DefaultPluginConfigurer(Id.Namespace deployNamespace, Id.Artifact artifactId,
                                  ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
+    this.deployNamespace = deployNamespace;
     this.artifactId = artifactId;
     this.artifactRepository = artifactRepository;
     this.pluginInstantiator = pluginInstantiator;
@@ -151,7 +155,7 @@ public class DefaultPluginConfigurer extends DefaultDatasetConfigurer implements
 
     Map.Entry<ArtifactDescriptor, PluginClass> pluginEntry;
     try {
-      pluginEntry = artifactRepository.findPlugin(artifactId, pluginType, pluginName, selector);
+      pluginEntry = artifactRepository.findPlugin(deployNamespace, artifactId, pluginType, pluginName, selector);
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/Specifications.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/Specifications.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.app.Application;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.app.DefaultAppConfigurer;
 import co.cask.cdap.app.DefaultApplicationContext;
+import co.cask.cdap.proto.Id;
 
 /**
  * Util for building app spec for tests.
@@ -28,7 +29,7 @@ public final class Specifications {
   private Specifications() {}
 
   public static ApplicationSpecification from(Application app) {
-    DefaultAppConfigurer appConfigurer = new DefaultAppConfigurer(app);
+    DefaultAppConfigurer appConfigurer = new DefaultAppConfigurer(Id.Namespace.DEFAULT, app);
     app.configure(appConfigurer, new DefaultApplicationContext());
     return appConfigurer.createSpecification();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
@@ -71,6 +71,9 @@ public final class InMemoryConfigurator implements Configurator {
   private final String configString;
   private final ArtifactClassLoaderFactory artifactClassLoaderFactory;
   private final File baseUnpackDir;
+  // this is the namespace that the app will be in, which may be different than the namespace of the artifact.
+  // if the artifact is a system artifact, the namespace will be the system namespace.
+  private final Id.Namespace appNamespace;
 
   private ArtifactRepository artifactRepository;
 
@@ -79,17 +82,20 @@ public final class InMemoryConfigurator implements Configurator {
   private String appClassName;
   private Id.Artifact artifactId;
 
-  public InMemoryConfigurator(CConfiguration cConf, Id.Artifact artifactId, String appClassName,
+  public InMemoryConfigurator(CConfiguration cConf, Id.Namespace appNamespace, Id.Artifact artifactId,
+                              String appClassName,
                               Location artifact, @Nullable String configString, ArtifactRepository artifactRepository) {
-    this(cConf, artifact, configString);
+    this(cConf, appNamespace, artifact, configString);
     this.artifactId = artifactId;
     this.appClassName = appClassName;
     this.artifactRepository = artifactRepository;
   }
 
   // remove once app templates are gone
-  public InMemoryConfigurator(CConfiguration cConf, Location artifact, @Nullable String configString) {
+  public InMemoryConfigurator(CConfiguration cConf, Id.Namespace namespace,
+                              Location artifact, @Nullable String configString) {
     Preconditions.checkNotNull(artifact);
+    this.appNamespace = namespace;
     this.artifact = artifact;
     this.configString = configString;
     this.cConf = cConf;
@@ -162,8 +168,8 @@ public final class InMemoryConfigurator implements Configurator {
     try (PluginInstantiator pluginInstantiator = new PluginInstantiator(
       cConf, app.getClass().getClassLoader(), tempDir)) {
       configurer = artifactId == null ?
-        new DefaultAppConfigurer(app, configString) :
-        new DefaultAppConfigurer(artifactId, app, configString, artifactRepository, pluginInstantiator);
+        new DefaultAppConfigurer(appNamespace, app, configString) :
+        new DefaultAppConfigurer(appNamespace, artifactId, app, configString, artifactRepository, pluginInstantiator);
 
       Config appConfig;
       Type configType = Artifacts.getConfigType(app.getClass());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
@@ -82,7 +82,8 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
     String configString = deploymentInfo.getConfigString();
 
     InMemoryConfigurator inMemoryConfigurator =
-      new InMemoryConfigurator(cConf, artifactId, appClassName, artifactLocation, configString, artifactRepository);
+      new InMemoryConfigurator(cConf, namespace, artifactId, appClassName,
+                               artifactLocation, configString, artifactRepository);
 
     ListenableFuture<ConfigResponse> result = inMemoryConfigurator.config();
     ConfigResponse response = result.get(120, TimeUnit.SECONDS);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
@@ -46,9 +46,10 @@ public final class DefaultMapReduceConfigurer extends DefaultPluginConfigurer im
   private Resources mapperResources;
   private Resources reducerResources;
 
-  public DefaultMapReduceConfigurer(MapReduce mapReduce, Id.Artifact artifactId, ArtifactRepository artifactRepository,
+  public DefaultMapReduceConfigurer(MapReduce mapReduce, Id.Namespace deployNamespace, Id.Artifact artifactId,
+                                    ArtifactRepository artifactRepository,
                                     PluginInstantiator pluginInstantiator) {
-    super(artifactId, artifactRepository, pluginInstantiator);
+    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
     this.className = mapReduce.getClass().getName();
     this.name = mapReduce.getClass().getSimpleName();
     this.description = "";

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -196,14 +196,15 @@ public class ArtifactRepository {
    * are sorted by the {@link ArtifactDescriptor} for the artifact that contains plugins available to the given
    * artifact.
    *
+   * @param namespace the namespace to get plugins from
    * @param artifactId the id of the artifact to get plugins for
    * @return an unmodifiable sorted map from plugin artifact to plugins in that artifact
    * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws IOException if there was an exception reading plugin metadata from the artifact store
    */
-  public SortedMap<ArtifactDescriptor, List<PluginClass>> getPlugins(Id.Artifact artifactId)
+  public SortedMap<ArtifactDescriptor, List<PluginClass>> getPlugins(Id.Namespace namespace, Id.Artifact artifactId)
     throws IOException, ArtifactNotFoundException {
-    return artifactStore.getPluginClasses(artifactId);
+    return artifactStore.getPluginClasses(namespace, artifactId);
   }
 
   /**
@@ -211,15 +212,17 @@ public class ArtifactRepository {
    * The keys are sorted by the {@link ArtifactDescriptor} for the artifact that contains plugins available to the given
    * artifact.
    *
+   * @param namespace the namespace to get plugins from
    * @param artifactId the id of the artifact to get plugins for
    * @param pluginType the type of plugins to get
    * @return an unmodifiable sorted map from plugin artifact to plugins in that artifact
    * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws IOException if there was an exception reading plugin metadata from the artifact store
    */
-  public SortedMap<ArtifactDescriptor, List<PluginClass>> getPlugins(Id.Artifact artifactId, String pluginType)
+  public SortedMap<ArtifactDescriptor, List<PluginClass>> getPlugins(Id.Namespace namespace, Id.Artifact artifactId,
+                                                                     String pluginType)
     throws IOException, ArtifactNotFoundException {
-    return artifactStore.getPluginClasses(artifactId, pluginType);
+    return artifactStore.getPluginClasses(namespace, artifactId, pluginType);
   }
 
   /**
@@ -227,6 +230,7 @@ public class ArtifactRepository {
    * are sorted by the {@link ArtifactDescriptor} for the artifact that contains plugins available to the given
    * artifact.
    *
+   * @param namespace the namespace to get plugins from
    * @param artifactId the id of the artifact to get plugins for
    * @param pluginType the type of plugins to get
    * @param pluginName the name of plugins to get
@@ -234,15 +238,16 @@ public class ArtifactRepository {
    * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws IOException if there was an exception reading plugin metadata from the artifact store
    */
-  public SortedMap<ArtifactDescriptor, PluginClass> getPlugins(Id.Artifact artifactId, String pluginType,
-                                                               String pluginName)
+  public SortedMap<ArtifactDescriptor, PluginClass> getPlugins(Id.Namespace namespace, Id.Artifact artifactId,
+                                                               String pluginType, String pluginName)
     throws IOException, PluginNotExistsException, ArtifactNotFoundException {
-    return artifactStore.getPluginClasses(artifactId, pluginType, pluginName);
+    return artifactStore.getPluginClasses(namespace, artifactId, pluginType, pluginName);
   }
 
   /**
    * Returns a {@link Map.Entry} representing the plugin information for the plugin being requested.
    *
+   * @param namespace the namespace to get plugins from
    * @param artifactId the id of the artifact to get plugins for
    * @param pluginType plugin type name
    * @param pluginName plugin name
@@ -252,11 +257,12 @@ public class ArtifactRepository {
    * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws PluginNotExistsException if no plugins of the given type and name are available to the given artifact
    */
-  public Map.Entry<ArtifactDescriptor, PluginClass> findPlugin(Id.Artifact artifactId, String pluginType,
-                                                               String pluginName, PluginSelector selector)
+  public Map.Entry<ArtifactDescriptor, PluginClass> findPlugin(Id.Namespace namespace, Id.Artifact artifactId,
+                                                               String pluginType, String pluginName,
+                                                               PluginSelector selector)
     throws IOException, PluginNotExistsException, ArtifactNotFoundException {
     SortedMap<ArtifactDescriptor, PluginClass> pluginClasses = artifactStore.getPluginClasses(
-      artifactId, pluginType, pluginName);
+      namespace, artifactId, pluginType, pluginName);
     SortedMap<ArtifactId, PluginClass> artifactIds = Maps.newTreeMap();
     for (Map.Entry<ArtifactDescriptor, PluginClass> pluginClassEntry : pluginClasses.entrySet()) {
       artifactIds.put(pluginClassEntry.getKey().getArtifactId(), pluginClassEntry.getValue());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -33,6 +33,7 @@ import co.cask.cdap.common.ArtifactAlreadyExistsException;
 import co.cask.cdap.common.ArtifactNotFoundException;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
@@ -388,7 +389,8 @@ public class ArtifactStore {
    * @throws ArtifactNotFoundException if the artifact to find plugins for does not exist
    * @throws IOException if there was an exception reading metadata from the metastore
    */
-  public SortedMap<ArtifactDescriptor, List<PluginClass>> getPluginClasses(final Id.Artifact parentArtifactId)
+  public SortedMap<ArtifactDescriptor, List<PluginClass>> getPluginClasses(final Id.Namespace namespace,
+                                                                           final Id.Artifact parentArtifactId)
     throws ArtifactNotFoundException, IOException {
 
     SortedMap<ArtifactDescriptor, List<PluginClass>> pluginClasses = metaTable.executeUnchecked(
@@ -401,10 +403,11 @@ public class ArtifactStore {
             return null;
           }
 
+          // should be able to scan by column prefix as well... instead, we have to filter out by namespace
           Scanner scanner = table.scan(scanPlugins(parentArtifactId));
           Row row;
           while ((row = scanner.next()) != null) {
-            addPluginsToMap(parentArtifactId, result, row);
+            addPluginsToMap(namespace, parentArtifactId, result, row);
           }
           scanner.close();
 
@@ -429,7 +432,8 @@ public class ArtifactStore {
    * @throws ArtifactNotFoundException if the artifact to find plugins for does not exist
    * @throws IOException if there was an exception reading metadata from the metastore
    */
-  public SortedMap<ArtifactDescriptor, List<PluginClass>> getPluginClasses(final Id.Artifact parentArtifactId,
+  public SortedMap<ArtifactDescriptor, List<PluginClass>> getPluginClasses(final Id.Namespace namespace,
+                                                                           final Id.Artifact parentArtifactId,
                                                                            final String type)
     throws IOException, ArtifactNotFoundException {
 
@@ -446,7 +450,7 @@ public class ArtifactStore {
           Scanner scanner = table.scan(scanPlugins(parentArtifactId, type));
           Row row;
           while ((row = scanner.next()) != null) {
-            addPluginsToMap(parentArtifactId, result, row);
+            addPluginsToMap(namespace, parentArtifactId, result, row);
           }
           scanner.close();
 
@@ -472,7 +476,8 @@ public class ArtifactStore {
    * @throws PluginNotExistsException if no plugin with the given type and name exists in the namespace
    * @throws IOException if there was an exception reading metadata from the metastore
    */
-  public SortedMap<ArtifactDescriptor, PluginClass> getPluginClasses(final Id.Artifact parentArtifactId,
+  public SortedMap<ArtifactDescriptor, PluginClass> getPluginClasses(final Id.Namespace namespace,
+                                                                     final Id.Artifact parentArtifactId,
                                                                      final String type, final String name)
     throws IOException, ArtifactNotFoundException, PluginNotExistsException {
 
@@ -507,13 +512,11 @@ public class ArtifactStore {
           if (!row.isEmpty()) {
             // column is the artifact name and version, value is the serialized PluginClass
             for (Map.Entry<byte[], byte[]> column : row.getColumns().entrySet()) {
-              ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
-              PluginData pluginData = gson.fromJson(Bytes.toString(column.getValue()), PluginData.class);
-              // filter out plugins that don't extend this version of the parent artifact
-              if (pluginData.usableBy.versionIsInRange(parentArtifactId.getVersion())) {
-                ArtifactDescriptor artifactInfo = new ArtifactDescriptor(
-                  artifactColumn.artifactId.toArtifactId(), locationFactory.create(pluginData.artifactLocationURI));
-                result.put(artifactInfo, pluginData.pluginClass);
+              ImmutablePair<ArtifactDescriptor, PluginClass> pluginEntry =
+                getPluginEntry(namespace, parentArtifactId, column);
+
+              if (pluginEntry != null) {
+                result.put(pluginEntry.getFirst(), pluginEntry.getSecond());
               }
             }
           }
@@ -854,26 +857,50 @@ public class ArtifactStore {
     }
   }
 
-  // this method examines all plugins in the given row and checks if they extend the given parent artifact.
+  // this method examines all plugins in the given row and checks if they extend the given parent artifact
+  // and are from an artifact in the given namespace.
   // if so, information about the plugin artifact and the plugin details are added to the given map.
-  private void addPluginsToMap(Id.Artifact parentArtifactId, SortedMap<ArtifactDescriptor, List<PluginClass>> map,
+  private void addPluginsToMap(Id.Namespace namespace, Id.Artifact parentArtifactId,
+                               SortedMap<ArtifactDescriptor, List<PluginClass>> map,
                                Row row) throws IOException {
     // column is the artifact namespace, name, and version. value is the serialized PluginData
     for (Map.Entry<byte[], byte[]> column : row.getColumns().entrySet()) {
-      ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
-      PluginData pluginData = gson.fromJson(Bytes.toString(column.getValue()), PluginData.class);
-
-      // filter out plugins that don't extend this version of the parent artifact
-      if (pluginData.usableBy.versionIsInRange(parentArtifactId.getVersion())) {
-        ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(
-          artifactColumn.artifactId.toArtifactId(), locationFactory.create(pluginData.artifactLocationURI));
-
+      ImmutablePair<ArtifactDescriptor, PluginClass> pluginEntry = getPluginEntry(namespace, parentArtifactId, column);
+      if (pluginEntry != null) {
+        ArtifactDescriptor artifactDescriptor = pluginEntry.getFirst();
         if (!map.containsKey(artifactDescriptor)) {
           map.put(artifactDescriptor, Lists.<PluginClass>newArrayList());
         }
-        map.get(artifactDescriptor).add(pluginData.pluginClass);
+        map.get(artifactDescriptor).add(pluginEntry.getSecond());
       }
     }
+  }
+
+  /**
+   * Decode the PluginClass from the table column if it is from an artifact in the given namespace and
+   * extends the given parent artifact. If the plugin's artifact is not in the given namespace, or it does not
+   * extend the given parent artifact, return null.
+   */
+  private ImmutablePair<ArtifactDescriptor, PluginClass> getPluginEntry(Id.Namespace namespace,
+                                                                        Id.Artifact parentArtifactId,
+                                                                        Map.Entry<byte[], byte[]> column) {
+    // column is the artifact namespace, name, and version. value is the serialized PluginData
+    ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
+    Id.Namespace artifactNamespace = artifactColumn.artifactId.getNamespace();
+    // filter out plugins whose artifacts are not in the system namespace and not in this namespace
+    if (!Id.Namespace.SYSTEM.equals(artifactNamespace) && !artifactNamespace.equals(namespace)) {
+      return null;
+    }
+    PluginData pluginData = gson.fromJson(Bytes.toString(column.getValue()), PluginData.class);
+
+    // filter out plugins that don't extend this version of the parent artifact
+    if (pluginData.usableBy.versionIsInRange(parentArtifactId.getVersion())) {
+      ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(
+        artifactColumn.artifactId.toArtifactId(), locationFactory.create(pluginData.artifactLocationURI));
+
+      return ImmutablePair.of(artifactDescriptor, pluginData.pluginClass);
+    }
+    return null;
   }
 
   private Scan scanArtifacts(Id.Namespace namespace) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
@@ -55,10 +55,12 @@ public class DefaultHttpServiceHandlerConfigurer extends DefaultPluginConfigurer
    *
    * @param handler the handler for the service
    */
-  public DefaultHttpServiceHandlerConfigurer(HttpServiceHandler handler, Id.Artifact artifactId,
+  public DefaultHttpServiceHandlerConfigurer(HttpServiceHandler handler,
+                                             Id.Namespace deployNamespace,
+                                             Id.Artifact artifactId,
                                              ArtifactRepository artifactRepository,
                                              PluginInstantiator pluginInstantiator) {
-    super(artifactId, artifactRepository, pluginInstantiator);
+    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
     this.propertyFields = Maps.newHashMap();
     this.className = handler.getClass().getName();
     this.name = handler.getClass().getSimpleName();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
@@ -65,9 +65,9 @@ public class DefaultServiceConfigurer extends DefaultPluginConfigurer implements
   /**
    * Create an instance of {@link DefaultServiceConfigurer}
    */
-  public DefaultServiceConfigurer(Service service, Id.Artifact artifactId, ArtifactRepository artifactRepository,
-                                  PluginInstantiator pluginInstantiator) {
-    super(artifactId, artifactRepository, pluginInstantiator);
+  public DefaultServiceConfigurer(Service service, Id.Namespace namespace, Id.Artifact artifactId,
+                                  ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
+    super(namespace, artifactId, artifactRepository, pluginInstantiator);
     this.className = service.getClass().getName();
     this.name = service.getClass().getSimpleName();
     this.description = "";
@@ -120,7 +120,7 @@ public class DefaultServiceConfigurer extends DefaultPluginConfigurer implements
     Map<String, HttpServiceHandlerSpecification> handleSpecs = Maps.newHashMap();
     for (HttpServiceHandler handler : handlers) {
       DefaultHttpServiceHandlerConfigurer configurer = new DefaultHttpServiceHandlerConfigurer(
-        handler, artifactId, artifactRepository, pluginInstantiator);
+        handler, deployNamespace, artifactId, artifactRepository, pluginInstantiator);
       handler.configure(configurer);
       HttpServiceHandlerSpecification spec = configurer.createSpecification();
       Preconditions.checkArgument(!handleSpecs.containsKey(spec.getName()),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
@@ -45,9 +45,9 @@ public final class DefaultSparkConfigurer extends DefaultPluginConfigurer implem
   private Resources driverResources;
   private Resources executorResources;
 
-  public DefaultSparkConfigurer(Spark spark, Id.Artifact artifactId,
+  public DefaultSparkConfigurer(Spark spark, Id.Namespace deployNamespace, Id.Artifact artifactId,
                                 ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
-    super(artifactId, artifactRepository, pluginInstantiator);
+    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
     this.spark = spark;
     this.name = spark.getClass().getSimpleName();
     this.description = "";

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/DefaultWorkerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/DefaultWorkerConfigurer.java
@@ -50,9 +50,10 @@ public class DefaultWorkerConfigurer extends DefaultPluginConfigurer implements 
   private Map<String, String> properties;
   private Set<String> datasets;
 
-  public DefaultWorkerConfigurer(Worker worker, Id.Artifact artifactId, ArtifactRepository artifactRepository,
+  public DefaultWorkerConfigurer(Worker worker, Id.Namespace deployNamespace, Id.Artifact artifactId,
+                                 ArtifactRepository artifactRepository,
                                  PluginInstantiator pluginInstantiator) {
-    super(artifactId, artifactRepository, pluginInstantiator);
+    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
     this.name = worker.getClass().getSimpleName();
     this.className = worker.getClass().getName();
     this.propertyFields = Maps.newHashMap();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/ScheduleSpecificationCodecTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/ScheduleSpecificationCodecTest.java
@@ -30,7 +30,9 @@ import co.cask.cdap.app.DefaultApplicationContext;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.internal.schedule.StreamSizeSchedule;
 import co.cask.cdap.internal.schedule.TimeSchedule;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.codec.ScheduleSpecificationCodec;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -108,7 +110,7 @@ public class ScheduleSpecificationCodecTest {
                          "workflow");
       }
     };
-    DefaultAppConfigurer configurer = new DefaultAppConfigurer(app);
+    DefaultAppConfigurer configurer = new DefaultAppConfigurer(Id.Namespace.DEFAULT, app);
     app.configure(configurer, new DefaultApplicationContext());
     ApplicationSpecification specification = configurer.createSpecification();
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -26,6 +26,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.Id;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gson.Gson;
 import org.apache.twill.filesystem.LocalLocationFactory;
@@ -66,7 +67,7 @@ public class ConfiguratorTest {
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, WordCountApp.class);
 
     // Create a configurator that is testable. Provide it a application.
-    Configurator configurator = new InMemoryConfigurator(conf, appJar, "");
+    Configurator configurator = new InMemoryConfigurator(conf, Id.Namespace.DEFAULT, appJar, "");
 
     // Extract response from the configurator.
     ListenableFuture<ConfigResponse> result = configurator.config();
@@ -88,7 +89,7 @@ public class ConfiguratorTest {
 
     ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("myStream", "myTable");
     Configurator configuratorWithConfig =
-      new InMemoryConfigurator(conf, appJar, new Gson().toJson(config));
+      new InMemoryConfigurator(conf, Id.Namespace.DEFAULT, appJar, new Gson().toJson(config));
 
     ListenableFuture<ConfigResponse> result = configuratorWithConfig.config();
     ConfigResponse response = result.get(10, TimeUnit.SECONDS);
@@ -102,7 +103,7 @@ public class ConfiguratorTest {
     Assert.assertTrue(specification.getDatasets().size() == 1);
     Assert.assertTrue(specification.getDatasets().containsKey("myTable"));
 
-    Configurator configuratorWithoutConfig = new InMemoryConfigurator(conf, appJar, null);
+    Configurator configuratorWithoutConfig = new InMemoryConfigurator(conf, Id.Namespace.DEFAULT, appJar, null);
     result = configuratorWithoutConfig.config();
     response = result.get(10, TimeUnit.SECONDS);
     Assert.assertNotNull(response);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -140,14 +140,14 @@ public class ArtifactRepositoryTest {
   @Test
   public void testAddSystemArtifacts() throws Exception {
     Id.Artifact systemAppArtifactId = Id.Artifact.from(Id.Namespace.SYSTEM, "PluginTest", "1.0.0");
-    createAppJar(PluginTestApp.class, new File(systemArtifactsDir1, "PluginTest-1.0.0.jar"),
+    File systemAppJar = createAppJar(PluginTestApp.class, new File(systemArtifactsDir1, "PluginTest-1.0.0.jar"),
       createManifest(ManifestFields.EXPORT_PACKAGE, PluginTestRunnable.class.getPackage().getName()));
 
     // write plugins jar
     Id.Artifact pluginArtifactId1 = Id.Artifact.from(Id.Namespace.SYSTEM, "APlugin", "1.0.0");
 
     Manifest manifest = createManifest(ManifestFields.EXPORT_PACKAGE, TestPlugin.class.getPackage().getName());
-    createPluginJar(TestPlugin.class, new File(systemArtifactsDir1, "APlugin-1.0.0.jar"), manifest);
+    File pluginJar1 = createPluginJar(TestPlugin.class, new File(systemArtifactsDir1, "APlugin-1.0.0.jar"), manifest);
 
     // write plugins config file
     Map<String, PluginPropertyField> emptyMap = Collections.emptyMap();
@@ -171,7 +171,7 @@ public class ArtifactRepositoryTest {
     Id.Artifact pluginArtifactId2 = Id.Artifact.from(Id.Namespace.SYSTEM, "BPlugin", "1.0.0");
 
     manifest = createManifest(ManifestFields.EXPORT_PACKAGE, TestPlugin.class.getPackage().getName());
-    createPluginJar(TestPlugin.class, new File(systemArtifactsDir2, "BPlugin-1.0.0.jar"), manifest);
+    File pluginJar2 = createPluginJar(TestPlugin.class, new File(systemArtifactsDir2, "BPlugin-1.0.0.jar"), manifest);
 
     // write plugins config file
     Set<PluginClass> manuallyAddedPlugins2 = ImmutableSet.of(
@@ -190,41 +190,49 @@ public class ArtifactRepositoryTest {
     }
 
     artifactRepository.addSystemArtifacts();
+    systemAppJar.delete();
+    pluginJar1.delete();
+    pluginJar2.delete();
 
-    // check app artifact added correctly
-    ArtifactDetail appArtifactDetail = artifactRepository.getArtifact(systemAppArtifactId);
-    Map<ArtifactDescriptor, List<PluginClass>> plugins = artifactRepository.getPlugins(systemAppArtifactId);
-    Assert.assertEquals(2, plugins.size());
-    List<PluginClass> pluginClasses = plugins.values().iterator().next();
+    try {
+      // check app artifact added correctly
+      ArtifactDetail appArtifactDetail = artifactRepository.getArtifact(systemAppArtifactId);
+      Map<ArtifactDescriptor, List<PluginClass>> plugins =
+        artifactRepository.getPlugins(Id.Namespace.DEFAULT, systemAppArtifactId);
+      Assert.assertEquals(2, plugins.size());
+      List<PluginClass> pluginClasses = plugins.values().iterator().next();
 
-    Set<String> pluginNames = Sets.newHashSet();
-    for (PluginClass pluginClass : pluginClasses) {
-      pluginNames.add(pluginClass.getName());
+      Set<String> pluginNames = Sets.newHashSet();
+      for (PluginClass pluginClass : pluginClasses) {
+        pluginNames.add(pluginClass.getName());
+      }
+      Assert.assertEquals(Sets.newHashSet("manual1", "manual2", "TestPlugin", "TestPlugin2"), pluginNames);
+      Assert.assertEquals(systemAppArtifactId.getName(), appArtifactDetail.getDescriptor().getArtifactId().getName());
+      Assert.assertEquals(systemAppArtifactId.getVersion(),
+                          appArtifactDetail.getDescriptor().getArtifactId().getVersion());
+
+      // check plugin artifact added correctly
+      ArtifactDetail pluginArtifactDetail = artifactRepository.getArtifact(pluginArtifactId1);
+      Assert.assertEquals(pluginArtifactId1.getName(), pluginArtifactDetail.getDescriptor().getArtifactId().getName());
+      Assert.assertEquals(pluginArtifactId1.getVersion(),
+                          pluginArtifactDetail.getDescriptor().getArtifactId().getVersion());
+      // check manually added plugins are there
+      Assert.assertTrue(pluginArtifactDetail.getMeta().getClasses().getPlugins().containsAll(manuallyAddedPlugins1));
+      // check properties are there
+      Assert.assertEquals(pluginConfig1.getProperties(), pluginArtifactDetail.getMeta().getProperties());
+
+      // check other plugin artifact added correctly
+      pluginArtifactDetail = artifactRepository.getArtifact(pluginArtifactId2);
+      Assert.assertEquals(pluginArtifactId2.getName(), pluginArtifactDetail.getDescriptor().getArtifactId().getName());
+      Assert.assertEquals(pluginArtifactId2.getVersion(),
+                          pluginArtifactDetail.getDescriptor().getArtifactId().getVersion());
+      // check manually added plugins are there
+      Assert.assertTrue(pluginArtifactDetail.getMeta().getClasses().getPlugins().containsAll(manuallyAddedPlugins2));
+      // check properties are there
+      Assert.assertEquals(pluginConfig2.getProperties(), pluginArtifactDetail.getMeta().getProperties());
+    } finally {
+      artifactRepository.clear(Id.Namespace.SYSTEM);
     }
-    Assert.assertEquals(Sets.newHashSet("manual1", "manual2", "TestPlugin", "TestPlugin2"), pluginNames);
-    Assert.assertEquals(systemAppArtifactId.getName(), appArtifactDetail.getDescriptor().getArtifactId().getName());
-    Assert.assertEquals(systemAppArtifactId.getVersion(),
-                        appArtifactDetail.getDescriptor().getArtifactId().getVersion());
-
-    // check plugin artifact added correctly
-    ArtifactDetail pluginArtifactDetail = artifactRepository.getArtifact(pluginArtifactId1);
-    Assert.assertEquals(pluginArtifactId1.getName(), pluginArtifactDetail.getDescriptor().getArtifactId().getName());
-    Assert.assertEquals(pluginArtifactId1.getVersion(),
-                        pluginArtifactDetail.getDescriptor().getArtifactId().getVersion());
-    // check manually added plugins are there
-    Assert.assertTrue(pluginArtifactDetail.getMeta().getClasses().getPlugins().containsAll(manuallyAddedPlugins1));
-    // check properties are there
-    Assert.assertEquals(pluginConfig1.getProperties(), pluginArtifactDetail.getMeta().getProperties());
-
-    // check other plugin artifact added correctly
-    pluginArtifactDetail = artifactRepository.getArtifact(pluginArtifactId2);
-    Assert.assertEquals(pluginArtifactId2.getName(), pluginArtifactDetail.getDescriptor().getArtifactId().getName());
-    Assert.assertEquals(pluginArtifactId2.getVersion(),
-      pluginArtifactDetail.getDescriptor().getArtifactId().getVersion());
-    // check manually added plugins are there
-    Assert.assertTrue(pluginArtifactDetail.getMeta().getClasses().getPlugins().containsAll(manuallyAddedPlugins2));
-    // check properties are there
-    Assert.assertEquals(pluginConfig2.getProperties(), pluginArtifactDetail.getMeta().getProperties());
   }
 
   @Test
@@ -252,7 +260,8 @@ public class ArtifactRepositoryTest {
     artifactRepository.addArtifact(artifactId, jarFile, parents);
 
     // check the parent can see the plugins
-    SortedMap<ArtifactDescriptor, List<PluginClass>> plugins = artifactRepository.getPlugins(APP_ARTIFACT_ID);
+    SortedMap<ArtifactDescriptor, List<PluginClass>> plugins =
+      artifactRepository.getPlugins(Id.Namespace.DEFAULT, APP_ARTIFACT_ID);
     Assert.assertEquals(1, plugins.size());
     Assert.assertEquals(2, plugins.get(plugins.firstKey()).size());
 
@@ -277,7 +286,8 @@ public class ArtifactRepositoryTest {
   public void testPluginSelector() throws Exception {
     // No plugin yet
     try {
-      artifactRepository.findPlugin(APP_ARTIFACT_ID, "plugin", "TestPlugin2", new PluginSelector());
+      artifactRepository.findPlugin(Id.Namespace.DEFAULT, APP_ARTIFACT_ID,
+                                    "plugin", "TestPlugin2", new PluginSelector());
       Assert.fail();
     } catch (PluginNotExistsException e) {
       // expected
@@ -298,7 +308,8 @@ public class ArtifactRepositoryTest {
 
     // Should get the only version.
     Map.Entry<ArtifactDescriptor, PluginClass> plugin =
-      artifactRepository.findPlugin(APP_ARTIFACT_ID, "plugin", "TestPlugin2", new PluginSelector());
+      artifactRepository.findPlugin(Id.Namespace.DEFAULT, APP_ARTIFACT_ID,
+                                    "plugin", "TestPlugin2", new PluginSelector());
     Assert.assertNotNull(plugin);
     Assert.assertEquals(new ArtifactVersion("1.0"), plugin.getKey().getArtifactId().getVersion());
     Assert.assertEquals("TestPlugin2", plugin.getValue().getName());
@@ -311,7 +322,8 @@ public class ArtifactRepositoryTest {
     artifactRepository.addArtifact(artifact2Id, jarFile, parents);
 
     // Should select the latest version
-    plugin = artifactRepository.findPlugin(APP_ARTIFACT_ID, "plugin", "TestPlugin2", new PluginSelector());
+    plugin = artifactRepository.findPlugin(Id.Namespace.DEFAULT, APP_ARTIFACT_ID,
+                                           "plugin", "TestPlugin2", new PluginSelector());
     Assert.assertNotNull(plugin);
     Assert.assertEquals(new ArtifactVersion("2.0"), plugin.getKey().getArtifactId().getVersion());
     Assert.assertEquals("TestPlugin2", plugin.getValue().getName());
@@ -324,7 +336,8 @@ public class ArtifactRepositoryTest {
       Class<?> pluginClass = pluginClassLoader.loadClass(TestPlugin2.class.getName());
 
       // Use a custom plugin selector to select with smallest version
-      plugin = artifactRepository.findPlugin(APP_ARTIFACT_ID, "plugin", "TestPlugin2", new PluginSelector() {
+      plugin = artifactRepository.findPlugin(Id.Namespace.DEFAULT, APP_ARTIFACT_ID,
+                                             "plugin", "TestPlugin2", new PluginSelector() {
         @Override
         public Map.Entry<ArtifactId, PluginClass> select(SortedMap<ArtifactId, PluginClass> plugins) {
           return plugins.entrySet().iterator().next();
@@ -413,6 +426,50 @@ public class ArtifactRepositoryTest {
     artifactRepository.deleteArtifactProperties(APP_ARTIFACT_ID);
     detail = artifactRepository.getArtifact(APP_ARTIFACT_ID);
     Assert.assertEquals(0, detail.getMeta().getProperties().size());
+  }
+
+  @Test
+  public void testNamespaceIsolation() throws Exception {
+    // create system app artifact
+    Id.Artifact systemAppArtifactId = Id.Artifact.from(Id.Namespace.SYSTEM, "PluginTest", "1.0.0");
+    File jar = createAppJar(PluginTestApp.class, new File(systemArtifactsDir1, "PluginTest-1.0.0.jar"),
+                 createManifest(ManifestFields.EXPORT_PACKAGE, PluginTestRunnable.class.getPackage().getName()));
+    artifactRepository.addSystemArtifacts();
+    jar.delete();
+
+    Set<ArtifactRange> parents = ImmutableSet.of(
+      new ArtifactRange(systemAppArtifactId.getNamespace(), systemAppArtifactId.getName(),
+                        new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0")));
+    Id.Namespace namespace1 = Id.Namespace.from("ns1");
+    Id.Namespace namespace2 = Id.Namespace.from("ns2");
+
+    Id.Artifact pluginArtifactId1 = Id.Artifact.from(namespace1, "myPlugin", "1.0");
+    Id.Artifact pluginArtifactId2 = Id.Artifact.from(namespace2, "myPlugin", "1.0");
+
+    try {
+      // create plugin artifact in namespace1 that extends the system artifact
+      // There should be two plugins there (TestPlugin and TestPlugin2).
+      Manifest manifest = createManifest(ManifestFields.EXPORT_PACKAGE, TestPlugin.class.getPackage().getName());
+      File jarFile = createPluginJar(TestPlugin.class, new File(tmpDir, "myPlugin-1.0.jar"), manifest);
+      artifactRepository.addArtifact(pluginArtifactId1, jarFile, parents);
+
+      // create plugin artifact in namespace2 that extends the system artifact
+      artifactRepository.addArtifact(pluginArtifactId2, jarFile, parents);
+
+      // check that only plugins from the artifact in the namespace are returned, and not plugins from both
+      SortedMap<ArtifactDescriptor, List<PluginClass>> extensions =
+        artifactRepository.getPlugins(namespace1, systemAppArtifactId);
+      Assert.assertEquals(1, extensions.keySet().size());
+      Assert.assertEquals(2, extensions.values().iterator().next().size());
+
+      extensions = artifactRepository.getPlugins(namespace2, systemAppArtifactId);
+      Assert.assertEquals(1, extensions.keySet().size());
+      Assert.assertEquals(2, extensions.values().iterator().next().size());
+    } finally {
+      artifactRepository.clear(Id.Namespace.SYSTEM);
+      artifactRepository.clear(namespace1);
+      artifactRepository.clear(namespace2);
+    }
   }
 
   private static ClassLoader createAppClassLoader(File jarFile) throws IOException {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -496,7 +496,7 @@ public class DefaultStoreTest {
   public void testServiceInstances() throws Exception {
     AppFabricTestHelper.deployApplication(AppWithServices.class);
     AbstractApplication app = new AppWithServices();
-    DefaultAppConfigurer appConfigurer = new DefaultAppConfigurer(app);
+    DefaultAppConfigurer appConfigurer = new DefaultAppConfigurer(Id.Namespace.DEFAULT, app);
     app.configure(appConfigurer, new DefaultApplicationContext());
 
     ApplicationSpecification appSpec = appConfigurer.createSpecification();


### PR DESCRIPTION
Fix a bug where users in one namespace could see plugins from
another namespace when using a system application artifact.
To fix this, when deploying an app, we need to pass down the
namespace the app will be in to filter out plugin artifacts from
other namespaces. Most of the changes revolve around passing
namespace to the configurers that require it.