### PR TITLE
CDAP-3816 Correctly apply limit on run record retrieval.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -273,9 +273,10 @@ public class AppMetadataStore extends MetadataStoreDataset {
                                      @Nullable Predicate<RunRecordMeta> filter) {
     if (status.equals(ProgramRunStatus.ALL)) {
       List<RunRecordMeta> resultRecords = Lists.newArrayList();
-      resultRecords.addAll(getSuspendedRuns(program, startTime, endTime, limit, filter));
       resultRecords.addAll(getActiveRuns(program, startTime, endTime, limit, filter));
-      resultRecords.addAll(getHistoricalRuns(program, status, startTime, endTime, limit, filter));
+      resultRecords.addAll(getSuspendedRuns(program, startTime, endTime, limit - resultRecords.size(), filter));
+      resultRecords.addAll(getHistoricalRuns(program, status, startTime, endTime,
+                                             limit - resultRecords.size(), filter));
       return resultRecords;
     } else if (status.equals(ProgramRunStatus.RUNNING)) {
       return getActiveRuns(program, startTime, endTime, limit, filter);


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-3816
http://builds.cask.co/browse/CDAP-RBT588-2

When not specifying the status, it individually applies the limit and adds the run records together.
Instead, the limit value passed in should be an upper limit over all the run records.