### PR TITLE
Fix monitor handler test. It was failing because after setting explor…

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
@@ -63,7 +63,7 @@ public class MonitorHandlerTest extends AppFabricTestBase {
     List<SystemServiceMeta> actual = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
                                                        Charsets.UTF_8), token);
 
-    Assert.assertEquals(8, actual.size());
+    Assert.assertEquals(9, actual.size());
     urlConn.disconnect();
   }
 
@@ -78,7 +78,7 @@ public class MonitorHandlerTest extends AppFabricTestBase {
 
     Map<String, String> result = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
                                                Charsets.UTF_8), token);
-    Assert.assertEquals(8, result.size());
+    Assert.assertEquals(9, result.size());
     urlConn.disconnect();
     Assert.assertEquals("OK", result.get(Constants.Service.APP_FABRIC_HTTP));
   }


### PR DESCRIPTION
…e.enabled to true in cdap-default.xml, one extra service (explore.service) is now running as the 9th system service in this test.