### PR TITLE
Fixes node icons when we add same node multiple times

### DIFF
--- a/cdap-ui/app/features/hydrator/services/hydrator-service.js
+++ b/cdap-ui/app/features/hydrator/services/hydrator-service.js
@@ -38,18 +38,18 @@ class HydratorService {
       .map( node => {
         node.type = artifact.transform;
         node.label = node.label || node.name;
-        node.icon = this.MyDAGFactory.getIcon(node.name);
+        node.icon = this.MyDAGFactory.getIcon(node.plugin.name);
         return node;
       });
     let sinks = angular.copy(pipeline.config.sinks)
       .map( node => {
         node.type = artifact.sink;
-        node.icon = this.MyDAGFactory.getIcon(node.name);
+        node.icon = this.MyDAGFactory.getIcon(node.plugin.name);
         return node;
       });
 
     source.type = artifact.source;
-    source.icon = this.MyDAGFactory.getIcon(source.name);
+    source.icon = this.MyDAGFactory.getIcon(source.plugin.name);
     // replace with backend id
     nodes.push(source);
     nodes = nodes.concat(transforms);


### PR DESCRIPTION
Fixes the case where when the user adds the same node twice, the icon of the second (or subsequent nodes) gets defaulted to ```fa-plugin``` icon instead of appropriate node's icon.

![duplicatenodenames](https://cloud.githubusercontent.com/assets/1452845/12336767/05cb5428-babb-11e5-9f78-4025db636e5c.gif)
