### PR TITLE
CDAP-4619 set inputformat and outputformat class after config settings

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -583,9 +583,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       // If only one output is configured through the context, then set it as the root OutputFormat
       Map.Entry<String, OutputFormatProvider> next = outputFormatProviders.entrySet().iterator().next();
       OutputFormatProvider outputFormatProvider = next.getValue();
-      for (Map.Entry<String, String> entry : outputFormatProvider.getOutputFormatConfiguration().entrySet()) {
-        job.getConfiguration().set(entry.getKey(), entry.getValue());
-      }
+      ConfigurationUtil.setAll(outputFormatProvider.getOutputFormatConfiguration(), job.getConfiguration());
       job.getConfiguration().set(Job.OUTPUT_FORMAT_CLASS_ATTR, outputFormatProvider.getOutputFormatClassName());
       return;
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -545,8 +545,8 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
 
     if (provider != null) {
       Configuration jobConf = job.getConfiguration();
-      jobConf.set(Job.INPUT_FORMAT_CLASS_ATTR, provider.getInputFormatClassName());
       ConfigurationUtil.setAll(provider.getInputFormatConfiguration(), jobConf);
+      jobConf.set(Job.INPUT_FORMAT_CLASS_ATTR, provider.getInputFormatClassName());
 
       // A bit hacky for stream.
       // For stream, we need to do two extra steps.
@@ -583,10 +583,10 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       // If only one output is configured through the context, then set it as the root OutputFormat
       Map.Entry<String, OutputFormatProvider> next = outputFormatProviders.entrySet().iterator().next();
       OutputFormatProvider outputFormatProvider = next.getValue();
-      job.getConfiguration().set(Job.OUTPUT_FORMAT_CLASS_ATTR, outputFormatProvider.getOutputFormatClassName());
       for (Map.Entry<String, String> entry : outputFormatProvider.getOutputFormatConfiguration().entrySet()) {
         job.getConfiguration().set(entry.getKey(), entry.getValue());
       }
+      job.getConfiguration().set(Job.OUTPUT_FORMAT_CLASS_ATTR, outputFormatProvider.getOutputFormatClassName());
       return;
     }
     // multiple output formats configured via the context. We should use a RecordWriter that doesn't support writing


### PR DESCRIPTION
this is to try and stupid proof against users who set an
InputFormatProvider or OutputFormatProvider that has the format
class set to one thing, but then sets
"mapreduce.job.outputformat.class" or "mapreduce.job.inputformat.class"
to something else in its configuration settings.