### PR TITLE
(CDAP-4264) Added system metadata for all CDAP entities

### DIFF
--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/FormatSpecification.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/FormatSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -34,6 +34,7 @@ public final class FormatSpecification {
   private final Map<String, String> settings;
 
   // for Gson deserialization, to make sure settings is an empty map and not null.
+  @SuppressWarnings("unused")
   private FormatSpecification() {
     this(null, null, Collections.<String, String>emptyMap());
   }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -47,10 +47,11 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
     this.nodes = Collections.unmodifiableList(new ArrayList<>(nodes));
     this.nodeIdMap = Collections.unmodifiableMap(generateNodeIdMap(nodes));
   }
+
   /**
-   +   * Visit all the nodes in the {@link Workflow} and generate the map of node id to
-   +   * the {@link WorkflowNode}.
-   +   */
+   * Visit all the nodes in the {@link Workflow} and generate the map of node id to
+   * the {@link WorkflowNode}.
+   */
   private Map<String, WorkflowNode> generateNodeIdMap(List<WorkflowNode> nodesInWorkflow) {
     Map<String, WorkflowNode> nodeIdMap = new HashMap<>();
     Queue<WorkflowNode> nodes = new LinkedList<>(nodesInWorkflow);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -36,6 +36,7 @@ import co.cask.cdap.internal.app.deploy.pipeline.DeletedProgramHandlerStage;
 import co.cask.cdap.internal.app.deploy.pipeline.DeployDatasetModulesStage;
 import co.cask.cdap.internal.app.deploy.pipeline.LocalArtifactLoaderStage;
 import co.cask.cdap.internal.app.deploy.pipeline.ProgramGenerationStage;
+import co.cask.cdap.internal.app.deploy.pipeline.SystemMetadataWriterStage;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.pipeline.Pipeline;
@@ -72,15 +73,15 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
   private final MetadataStore metadataStore;
 
   @Inject
-  public LocalApplicationManager(CConfiguration configuration, PipelineFactory pipelineFactory,
-                                 NamespacedLocationFactory namespacedLocationFactory,
-                                 Store store, StreamConsumerFactory streamConsumerFactory,
-                                 QueueAdmin queueAdmin, DatasetFramework datasetFramework,
-                                 @Named("datasetMDS") DatasetFramework inMemoryDatasetFramework,
-                                 StreamAdmin streamAdmin, Scheduler scheduler,
-                                 @Assisted ProgramTerminator programTerminator, MetricStore metricStore,
-                                 UsageRegistry usageRegistry, ArtifactRepository artifactRepository,
-                                 MetadataStore metadataStore) {
+  LocalApplicationManager(CConfiguration configuration, PipelineFactory pipelineFactory,
+                          NamespacedLocationFactory namespacedLocationFactory,
+                          Store store, StreamConsumerFactory streamConsumerFactory,
+                          QueueAdmin queueAdmin, DatasetFramework datasetFramework,
+                          @Named("datasetMDS") DatasetFramework inMemoryDatasetFramework,
+                          StreamAdmin streamAdmin, Scheduler scheduler,
+                          @Assisted ProgramTerminator programTerminator, MetricStore metricStore,
+                          UsageRegistry usageRegistry, ArtifactRepository artifactRepository,
+                          MetadataStore metadataStore) {
     this.configuration = configuration;
     this.namespacedLocationFactory = namespacedLocationFactory;
     this.pipelineFactory = pipelineFactory;
@@ -112,6 +113,7 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
     pipeline.addLast(new ProgramGenerationStage(configuration, namespacedLocationFactory));
     pipeline.addLast(new ApplicationRegistrationStage(store, usageRegistry));
     pipeline.addLast(new CreateSchedulesStage(scheduler));
+    pipeline.addLast(new SystemMetadataWriterStage(metadataStore));
     return pipeline.execute(input);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStage.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.deploy.pipeline;
+
+import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.service.ServiceSpecification;
+import co.cask.cdap.api.spark.SparkSpecification;
+import co.cask.cdap.api.worker.WorkerSpecification;
+import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
+import co.cask.cdap.data2.metadata.system.AppSystemMetadataWriter;
+import co.cask.cdap.data2.metadata.system.ProgramSystemMetadataWriter;
+import co.cask.cdap.pipeline.AbstractStage;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.reflect.TypeToken;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Stage to write system metadata for an application.
+ */
+public class SystemMetadataWriterStage extends AbstractStage<ApplicationWithPrograms> {
+
+  private final MetadataStore metadataStore;
+
+  public SystemMetadataWriterStage(MetadataStore metadataStore) {
+    super(TypeToken.of(ApplicationWithPrograms.class));
+    this.metadataStore = metadataStore;
+  }
+
+  @Override
+  public void process(ApplicationWithPrograms input) throws Exception {
+    // add system metadata for apps
+    ApplicationSpecification appSpec = input.getSpecification();
+    AbstractSystemMetadataWriter appSystemMetadataWriter = new AppSystemMetadataWriter(metadataStore, input.getId(),
+                                                                                       appSpec);
+    appSystemMetadataWriter.write();
+
+    // add system metadata for programs
+    writeProgramSystemMetadata(input.getId(), ProgramType.FLOW, appSpec.getFlows().values());
+    writeProgramSystemMetadata(input.getId(), ProgramType.MAPREDUCE, appSpec.getMapReduce().values());
+    writeProgramSystemMetadata(input.getId(), ProgramType.SERVICE, appSpec.getServices().values());
+    writeProgramSystemMetadata(input.getId(), ProgramType.SPARK, appSpec.getSpark().values());
+    writeProgramSystemMetadata(input.getId(), ProgramType.WORKER, appSpec.getWorkers().values());
+    writeProgramSystemMetadata(input.getId(), ProgramType.WORKFLOW, appSpec.getWorkflows().values());
+
+    // Emit input to the next stage
+    emit(input);
+  }
+
+  private void writeProgramSystemMetadata(Id.Application appId, ProgramType programType,
+                                          Iterable<? extends ProgramSpecification> specs) {
+    for (ProgramSpecification spec : specs) {
+      Id.Program programId = Id.Program.from(appId, programType, spec.getName());
+      ProgramSystemMetadataWriter writer = new ProgramSystemMetadataWriter(metadataStore, programId, spec);
+      writer.write();
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -32,10 +32,13 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.common.utils.ImmutablePair;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.data2.metadata.system.ArtifactSystemMetadataWriter;
 import co.cask.cdap.internal.app.runtime.plugin.PluginNotExistsException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ApplicationClassInfo;
 import co.cask.cdap.proto.artifact.ApplicationClassSummary;
+import co.cask.cdap.proto.artifact.ArtifactInfo;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import com.google.common.annotations.VisibleForTesting;
@@ -73,9 +76,10 @@ public class ArtifactRepository {
   private final ArtifactInspector artifactInspector;
   private final List<File> systemArtifactDirs;
   private final ArtifactConfigReader configReader;
+  private final MetadataStore metadataStore;
 
   @Inject
-  ArtifactRepository(CConfiguration cConf, ArtifactStore artifactStore) {
+  ArtifactRepository(CConfiguration cConf, ArtifactStore artifactStore, MetadataStore metadataStore) {
     this.artifactStore = artifactStore;
     File baseUnpackDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
       cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
@@ -91,6 +95,7 @@ public class ArtifactRepository {
       systemArtifactDirs.add(file);
     }
     this.configReader = new ArtifactConfigReader();
+    this.metadataStore = metadataStore;
   }
 
   /**
@@ -392,7 +397,15 @@ public class ArtifactRepository {
     try {
       ArtifactClasses artifactClasses = inspectArtifact(artifactId, artifactFile, additionalPlugins, parentClassLoader);
       ArtifactMeta meta = new ArtifactMeta(artifactClasses, parentArtifacts, properties);
-      return artifactStore.write(artifactId, meta, Files.newInputStreamSupplier(artifactFile));
+      ArtifactDetail artifactDetail = artifactStore.write(artifactId, meta, Files.newInputStreamSupplier(artifactFile));
+      ArtifactDescriptor descriptor = artifactDetail.getDescriptor();
+      // info hides some fields that are available in detail, such as the location of the artifact
+      ArtifactInfo artifactInfo = new ArtifactInfo(descriptor.getArtifactId(), artifactDetail.getMeta().getClasses(),
+                                                   artifactDetail.getMeta().getProperties());
+      // add system metadata for artifacts
+      ArtifactSystemMetadataWriter writer = new ArtifactSystemMetadataWriter(metadataStore, artifactId, artifactInfo);
+      writer.write();
+      return artifactDetail;
     } finally {
       parentClassLoader.close();
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -42,9 +42,11 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Type;
+import java.net.URLDecoder;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -75,24 +77,24 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   @GET
   @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata")
   public void getAppMetadata(HttpRequest request, HttpResponder responder,
-                                @PathParam("namespace-id") String namespaceId,
-                                @PathParam("app-id") String appId) throws NotFoundException {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getMetadata(MetadataScope.USER, Id.Application.from(namespaceId, appId)),
-                       SET_METADATA_RECORD_TYPE, GSON);
+                             @PathParam("namespace-id") String namespaceId,
+                             @PathParam("app-id") String appId,
+                             @QueryParam("scope") MetadataScope scope) throws NotFoundException {
+    Id.Application app = Id.Application.from(namespaceId, appId);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(app, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/metadata")
   public void getProgramMetadata(HttpRequest request, HttpResponder responder,
-                                    @PathParam("namespace-id") String namespaceId,
-                                    @PathParam("app-id") String appId,
-                                    @PathParam("program-type") String programType,
-                                    @PathParam("program-id") String programId) throws NotFoundException {
+                                 @PathParam("namespace-id") String namespaceId,
+                                 @PathParam("app-id") String appId,
+                                 @PathParam("program-type") String programType,
+                                 @PathParam("program-id") String programId,
+                                 @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
                                          ProgramType.valueOfCategoryName(programType), programId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getMetadata(MetadataScope.USER, program),
-                       SET_METADATA_RECORD_TYPE, GSON);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(program, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
@@ -100,50 +102,51 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void getArtifactMetadata(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("artifact-name") String artifactName,
-                                  @PathParam("artifact-version") String artifactVersionStr) throws NotFoundException {
+                                  @PathParam("artifact-version") String artifactVersionStr,
+                                  @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getMetadata(MetadataScope.USER, artifactId),
-                       SET_METADATA_RECORD_TYPE, GSON);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(artifactId, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/metadata")
   public void getDatasetMetadata(HttpRequest request, HttpResponder responder,
                                  @PathParam("namespace-id") String namespaceId,
-                                 @PathParam("dataset-id") String datasetId) throws NotFoundException {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getMetadata(MetadataScope.USER, Id.DatasetInstance.from(namespaceId, datasetId)),
-                       SET_METADATA_RECORD_TYPE, GSON);
+                                 @PathParam("dataset-id") String datasetId,
+                                 @QueryParam("scope") MetadataScope scope) throws NotFoundException {
+    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(namespaceId, datasetId);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(datasetInstance, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/metadata")
   public void getStreamMetadata(HttpRequest request, HttpResponder responder,
                                 @PathParam("namespace-id") String namespaceId,
-                                @PathParam("stream-id") String streamId) throws Exception {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getMetadata(MetadataScope.USER, Id.Stream.from(namespaceId, streamId)),
-                       SET_METADATA_RECORD_TYPE, GSON);
+                                @PathParam("stream-id") String streamId,
+                                @QueryParam("scope") MetadataScope scope) throws Exception {
+    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(stream, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata")
   public void getViewMetadata(HttpRequest request, HttpResponder responder,
-                                @PathParam("namespace-id") String namespaceId,
-                                @PathParam("stream-id") String streamId,
-                                @PathParam("view-id") String viewId) throws NotFoundException {
+                              @PathParam("namespace-id") String namespaceId,
+                              @PathParam("stream-id") String streamId,
+                              @PathParam("view-id") String viewId,
+                              @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getMetadata(MetadataScope.USER, view),
-                       SET_METADATA_RECORD_TYPE, GSON);
+    responder.sendJson(HttpResponseStatus.OK, getMetadata(view, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata/properties")
   public void getAppProperties(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
-                               @PathParam("app-id") String appId) throws NotFoundException {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getProperties(MetadataScope.USER, Id.Application.from(namespaceId, appId)));
+                               @PathParam("app-id") String appId,
+                               @QueryParam("scope") MetadataScope scope) throws NotFoundException {
+    Id.Application app = Id.Application.from(namespaceId, appId);
+    responder.sendJson(HttpResponseStatus.OK, getProperties(app, scope));
   }
 
   @GET
@@ -151,9 +154,10 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void getArtifactProperties(HttpRequest request, HttpResponder responder,
                                     @PathParam("namespace-id") String namespaceId,
                                     @PathParam("artifact-name") String artifactName,
-                                    @PathParam("artifact-version") String artifactVersionStr) throws NotFoundException {
+                                    @PathParam("artifact-version") String artifactVersionStr,
+                                    @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getProperties(MetadataScope.USER, artifactId));
+    responder.sendJson(HttpResponseStatus.OK, getProperties(artifactId, scope));
   }
 
   @GET
@@ -162,39 +166,42 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                    @PathParam("namespace-id") String namespaceId,
                                    @PathParam("app-id") String appId,
                                    @PathParam("program-type") String programType,
-                                   @PathParam("program-id") String programId) throws NotFoundException {
+                                   @PathParam("program-id") String programId,
+                                   @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
                                          ProgramType.valueOfCategoryName(programType), programId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getProperties(MetadataScope.USER, program));
+    responder.sendJson(HttpResponseStatus.OK, getProperties(program, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/metadata/properties")
   public void getDatasetProperties(HttpRequest request, HttpResponder responder,
                                    @PathParam("namespace-id") String namespaceId,
-                                   @PathParam("dataset-id") String datasetId) throws NotFoundException {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getProperties(MetadataScope.USER,
-                                                   Id.DatasetInstance.from(namespaceId, datasetId)));
+                                   @PathParam("dataset-id") String datasetId,
+                                   @QueryParam("scope") MetadataScope scope) throws NotFoundException {
+    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(namespaceId, datasetId);
+    responder.sendJson(HttpResponseStatus.OK, getProperties(datasetInstance, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/metadata/properties")
   public void getStreamProperties(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
-                                  @PathParam("stream-id") String streamId) throws NotFoundException {
-    responder.sendJson(HttpResponseStatus.OK,
-                       metadataAdmin.getProperties(MetadataScope.USER, Id.Stream.from(namespaceId, streamId)));
+                                  @PathParam("stream-id") String streamId,
+                                  @QueryParam("scope") MetadataScope scope) throws NotFoundException {
+    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    responder.sendJson(HttpResponseStatus.OK, getProperties(stream, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/properties")
   public void getViewProperties(HttpRequest request, HttpResponder responder,
-                                  @PathParam("namespace-id") String namespaceId,
-                                  @PathParam("stream-id") String streamId,
-                                  @PathParam("view-id") String viewId) throws NotFoundException {
+                                @PathParam("namespace-id") String namespaceId,
+                                @PathParam("stream-id") String streamId,
+                                @PathParam("view-id") String viewId,
+                                @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getProperties(MetadataScope.USER, view));
+    responder.sendJson(HttpResponseStatus.OK, getProperties(view, scope));
   }
 
   @POST
@@ -564,9 +571,10 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata/tags")
   public void getAppTags(HttpRequest request, HttpResponder responder,
                          @PathParam("namespace-id") String namespaceId,
-                         @PathParam("app-id") String appId) throws NotFoundException {
+                         @PathParam("app-id") String appId,
+                         @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Application app = Id.Application.from(namespaceId, appId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, app));
+    responder.sendJson(HttpResponseStatus.OK, getTags(app, scope));
   }
 
   @GET
@@ -574,10 +582,11 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void getArtifactTags(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId,
                               @PathParam("artifact-name") String artifactName,
-                              @PathParam("artifact-version") String artifactVersionStr)
+                              @PathParam("artifact-version") String artifactVersionStr,
+                              @QueryParam("scope") MetadataScope scope)
     throws BadRequestException, NotFoundException {
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, artifactId));
+    responder.sendJson(HttpResponseStatus.OK, getTags(artifactId, scope));
   }
 
   @GET
@@ -586,38 +595,42 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                              @PathParam("namespace-id") String namespaceId,
                              @PathParam("app-id") String appId,
                              @PathParam("program-type") String programType,
-                             @PathParam("program-id") String programId) throws NotFoundException {
+                             @PathParam("program-id") String programId,
+                             @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
                                          ProgramType.valueOfCategoryName(programType), programId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, program));
+    responder.sendJson(HttpResponseStatus.OK, getTags(program, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/metadata/tags")
   public void getDatasetTags(HttpRequest request, HttpResponder responder,
                              @PathParam("namespace-id") String namespaceId,
-                             @PathParam("dataset-id") String datasetId) throws NotFoundException {
+                             @PathParam("dataset-id") String datasetId,
+                             @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, dataset));
+    responder.sendJson(HttpResponseStatus.OK, getTags(dataset, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/metadata/tags")
   public void getStreamTags(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId,
-                            @PathParam("stream-id") String streamId) throws NotFoundException {
+                            @PathParam("stream-id") String streamId,
+                            @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Stream stream = Id.Stream.from(namespaceId, streamId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, stream));
+    responder.sendJson(HttpResponseStatus.OK, getTags(stream, scope));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}/streams/{stream-id}/views/{view-id}/metadata/tags")
   public void getViewTags(HttpRequest request, HttpResponder responder,
-                            @PathParam("namespace-id") String namespaceId,
-                            @PathParam("stream-id") String streamId,
-                            @PathParam("view-id") String viewId) throws NotFoundException {
+                          @PathParam("namespace-id") String namespaceId,
+                          @PathParam("stream-id") String streamId,
+                          @PathParam("view-id") String viewId,
+                          @QueryParam("scope") MetadataScope scope) throws NotFoundException {
     Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
-    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(MetadataScope.USER, view));
+    responder.sendJson(HttpResponseStatus.OK, getTags(view, scope));
   }
 
   @DELETE
@@ -820,9 +833,25 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     } else {
       metadataSearchTargetType = null;
     }
-    Set<MetadataSearchResultRecord> results = metadataAdmin.searchMetadata(namespaceId, searchQuery,
+    Set<MetadataSearchResultRecord> results = metadataAdmin.searchMetadata(namespaceId,
+                                                                           URLDecoder.decode(searchQuery, "UTF-8"),
                                                                            metadataSearchTargetType);
 
     responder.sendJson(HttpResponseStatus.OK, results, SET_METADATA_SEARCH_RESULT_TYPE, GSON);
+  }
+
+  private Set<MetadataRecord> getMetadata(Id.NamespacedId entityId,
+                                          @Nullable MetadataScope scope) throws NotFoundException {
+    return  (scope == null) ? metadataAdmin.getMetadata(entityId) : metadataAdmin.getMetadata(scope, entityId);
+  }
+
+  private Map<String, String> getProperties(Id.NamespacedId entityId,
+                                            @Nullable MetadataScope scope) throws NotFoundException {
+    return  (scope == null) ? metadataAdmin.getProperties(entityId) : metadataAdmin.getProperties(scope, entityId);
+  }
+
+  private Set<String> getTags(Id.NamespacedId entityId,
+                              @Nullable MetadataScope scope) throws NotFoundException {
+    return  (scope == null) ? metadataAdmin.getTags(entityId) : metadataAdmin.getTags(scope, entityId);
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AllProgramsApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AllProgramsApp.java
@@ -16,19 +16,28 @@
 
 package co.cask.cdap;
 
+import co.cask.cdap.api.ProgramLifecycle;
 import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.annotation.ProcessInput;
 import co.cask.cdap.api.annotation.UseDataSet;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.api.data.stream.Stream;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.lib.ObjectMappedTable;
+import co.cask.cdap.api.dataset.lib.ObjectMappedTableProperties;
 import co.cask.cdap.api.flow.AbstractFlow;
 import co.cask.cdap.api.flow.flowlet.AbstractFlowlet;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.schedule.Schedules;
 import co.cask.cdap.api.service.AbstractService;
 import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
@@ -47,6 +56,7 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.spark.api.java.JavaPairRDD;
+import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,6 +78,12 @@ public class AllProgramsApp extends AbstractApplication {
   public static final String NAME = "App";
   public static final String STREAM_NAME = "stream";
   public static final String DATASET_NAME = "kvt";
+  public static final String PLUGIN_DESCRIPTION = "test plugin";
+  public static final String PLUGIN_NAME = "mytestplugin";
+  public static final String PLUGIN_TYPE = "testplugin";
+  public static final String SCHEDULE_NAME = "testschedule";
+  public static final String SCHEDULE_DESCRIPTION = "EveryMinute";
+  public static final String DS_WITH_SCHEMA_NAME = "dsWithSchema";
 
   @Override
   public void configure() {
@@ -81,6 +97,22 @@ public class AllProgramsApp extends AbstractApplication {
     addWorker(new NoOpWorker());
     addSpark(new NoOpSpark());
     addService(new NoOpService());
+    scheduleWorkflow(Schedules.builder(SCHEDULE_NAME)
+                       .setDescription(SCHEDULE_DESCRIPTION)
+                       .createTimeSchedule("* * * * *"),
+                     NoOpWorkflow.NAME);
+    try {
+      createDataset(DS_WITH_SCHEMA_NAME, ObjectMappedTable.class,
+                    ObjectMappedTableProperties.builder().setType(DsSchema.class).build());
+    } catch (UnsupportedTypeException e) {
+      // ignore for test
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class DsSchema {
+    String field1;
+    int field2;
   }
 
   /**
@@ -91,7 +123,7 @@ public class AllProgramsApp extends AbstractApplication {
     public static final String NAME = "NoOpFlow";
 
     @Override
-    protected void configureFlow() {
+    protected void configure() {
       setName(NAME);
       setDescription("NoOpflow");
       addFlowlet(A.NAME, new A());
@@ -141,12 +173,24 @@ public class AllProgramsApp extends AbstractApplication {
     }
   }
 
-  public static class NoOpMapper extends Mapper<LongWritable, BytesWritable, Text, Text> {
+  public static class NoOpMapper extends Mapper<LongWritable, BytesWritable, Text, Text>
+    implements ProgramLifecycle<MapReduceContext> {
     @Override
     protected void map(LongWritable key, BytesWritable value,
                        Context context) throws IOException, InterruptedException {
       Text output = new Text(value.copyBytes());
       context.write(output, output);
+    }
+
+    @Override
+    public void initialize(MapReduceContext context) throws Exception {
+      Object obj = context.newPluginInstance("mrid");
+      Assert.assertEquals("value", obj.toString());
+    }
+
+    @Override
+    public void destroy() {
+
     }
   }
 
@@ -285,6 +329,21 @@ public class AllProgramsApp extends AbstractApplication {
         table.write("no-op-service", "no-op-service");
         responder.sendStatus(200);
       }
+    }
+  }
+
+  public static class PConfig extends PluginConfig {
+    private double y;
+  }
+
+  @Plugin(type = PLUGIN_TYPE)
+  @Name(PLUGIN_NAME)
+  @Description(PLUGIN_DESCRIPTION)
+  public static class AppPlugin {
+    private PConfig pluginConf;
+
+    public double doSomething() {
+      return pluginConf.y;
     }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -543,6 +543,13 @@ public abstract class AppFabricTestBase {
     }, timeout, timeoutUnit, 100, TimeUnit.MILLISECONDS);
   }
 
+  protected List<JsonObject> getArtifacts(String namespace) throws Exception {
+    HttpResponse response = doGet(getVersionedAPIPath("artifacts", namespace));
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    Type typeToken = new TypeToken<List<JsonObject>>() { }.getType();
+    return readResponse(response, typeToken);
+  }
+
   protected void deleteArtifact(Id.Artifact artifact, int expectedResponseCode) throws Exception {
     String path = String.format("artifacts/%s/versions/%s", artifact.getName(), artifact.getVersion().getVersion());
     HttpResponse response = doDelete(getVersionedAPIPath(path, artifact.getNamespace().getId()));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -58,6 +58,7 @@ import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.DefaultId;
 import co.cask.cdap.internal.app.Specifications;
+import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
@@ -100,16 +101,20 @@ public class DefaultStoreTest {
   private static final Gson GSON = new Gson();
   private static DefaultStore store;
   private static DefaultNamespaceStore nsStore;
+  private static Scheduler scheduler;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Injector injector = AppFabricTestHelper.getInjector();
     store = injector.getInstance(DefaultStore.class);
     nsStore = injector.getInstance(DefaultNamespaceStore.class);
+    scheduler = injector.getInstance(Scheduler.class);
   }
 
   @Before
   public void before() throws Exception {
+    // Delete any schedules that may have been registered with Quartz during app deployment
+    scheduler.deleteAllSchedules(Id.Namespace.DEFAULT);
     store.clear();
     NamespacedLocationFactory namespacedLocationFactory =
       AppFabricTestHelper.getInjector().getInstance(NamespacedLocationFactory.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -32,6 +32,7 @@ import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.base.Predicate;
@@ -78,34 +79,34 @@ public class LineageTest extends MetadataTestBase {
       // Add metadata to applicaton
       ImmutableMap<String, String> appProperties = ImmutableMap.of("app-key1", "app-value1");
       addProperties(app, appProperties);
-      Assert.assertEquals(appProperties, getProperties(app));
+      Assert.assertEquals(appProperties, getProperties(app, MetadataScope.USER));
       ImmutableSet<String> appTags = ImmutableSet.of("app-tag1");
       addTags(app, appTags);
-      Assert.assertEquals(appTags, getTags(app));
+      Assert.assertEquals(appTags, getTags(app, MetadataScope.USER));
 
       // Add metadata to flow
       ImmutableMap<String, String> flowProperties = ImmutableMap.of("flow-key1", "flow-value1");
       addProperties(flow, flowProperties);
-      Assert.assertEquals(flowProperties, getProperties(flow));
+      Assert.assertEquals(flowProperties, getProperties(flow, MetadataScope.USER));
       ImmutableSet<String> flowTags = ImmutableSet.of("flow-tag1", "flow-tag2");
       addTags(flow, flowTags);
-      Assert.assertEquals(flowTags, getTags(flow));
+      Assert.assertEquals(flowTags, getTags(flow, MetadataScope.USER));
 
       // Add metadata to dataset
       ImmutableMap<String, String> dataProperties = ImmutableMap.of("data-key1", "data-value1");
       addProperties(dataset, dataProperties);
-      Assert.assertEquals(dataProperties, getProperties(dataset));
+      Assert.assertEquals(dataProperties, getProperties(dataset, MetadataScope.USER));
       ImmutableSet<String> dataTags = ImmutableSet.of("data-tag1", "data-tag2");
       addTags(dataset, dataTags);
-      Assert.assertEquals(dataTags, getTags(dataset));
+      Assert.assertEquals(dataTags, getTags(dataset, MetadataScope.USER));
 
       // Add metadata to stream
       ImmutableMap<String, String> streamProperties = ImmutableMap.of("stream-key1", "stream-value1");
       addProperties(stream, streamProperties);
-      Assert.assertEquals(streamProperties, getProperties(stream));
+      Assert.assertEquals(streamProperties, getProperties(stream, MetadataScope.USER));
       ImmutableSet<String> streamTags = ImmutableSet.of("stream-tag1", "stream-tag2");
       addTags(stream, streamTags);
-      Assert.assertEquals(streamTags, getTags(stream));
+      Assert.assertEquals(streamTags, getTags(stream, MetadataScope.USER));
 
       long startTime = TimeMathParser.nowInSeconds();
       RunId flowRunId = runAndWait(flow);
@@ -210,15 +211,15 @@ public class LineageTest extends MetadataTestBase {
       // Add metadata
       ImmutableSet<String> sparkTags = ImmutableSet.of("spark-tag1", "spark-tag2");
       addTags(spark, sparkTags);
-      Assert.assertEquals(sparkTags, getTags(spark));
+      Assert.assertEquals(sparkTags, getTags(spark, MetadataScope.USER));
 
       ImmutableSet<String> workerTags = ImmutableSet.of("worker-tag1");
       addTags(worker, workerTags);
-      Assert.assertEquals(workerTags, getTags(worker));
+      Assert.assertEquals(workerTags, getTags(worker, MetadataScope.USER));
 
       ImmutableMap<String, String> datasetProperties = ImmutableMap.of("data-key1", "data-value1");
       addProperties(dataset, datasetProperties);
-      Assert.assertEquals(datasetProperties, getProperties(dataset));
+      Assert.assertEquals(datasetProperties, getProperties(dataset, MetadataScope.USER));
 
       // Start all programs
       RunId flowRunId = runAndWait(flow);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,18 +16,28 @@
 
 package co.cask.cdap.metadata;
 
+import co.cask.cdap.AllProgramsApp;
 import co.cask.cdap.AppWithDataset;
 import co.cask.cdap.WordCountApp;
 import co.cask.cdap.WordCountMinusFlowApp;
 import co.cask.cdap.api.Config;
+import co.cask.cdap.api.data.batch.BatchReadable;
+import co.cask.cdap.api.data.batch.BatchWritable;
+import co.cask.cdap.api.data.batch.RecordScannable;
+import co.cask.cdap.api.data.batch.RecordWritable;
 import co.cask.cdap.api.data.format.FormatSpecification;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.ViewSpecification;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
@@ -35,14 +45,18 @@ import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.jar.Manifest;
+import javax.annotation.Nullable;
 
 /**
  * Tests for {@link MetadataHttpHandler}
@@ -108,17 +122,17 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Map<String, String> artifactProperties = ImmutableMap.of("rKey", "rValue", "rK", "rV");
     addProperties(artifactId, artifactProperties);
     // retrieve properties and verify
-    Map<String, String> properties = getProperties(application);
+    Map<String, String> properties = getProperties(application, MetadataScope.USER);
     Assert.assertEquals(appProperties, properties);
-    properties = getProperties(pingService);
+    properties = getProperties(pingService, MetadataScope.USER);
     Assert.assertEquals(serviceProperties, properties);
-    properties = getProperties(myds);
+    properties = getProperties(myds, MetadataScope.USER);
     Assert.assertEquals(datasetProperties, properties);
-    properties = getProperties(mystream);
+    properties = getProperties(mystream, MetadataScope.USER);
     Assert.assertEquals(streamProperties, properties);
-    properties = getProperties(myview);
+    properties = getProperties(myview, MetadataScope.USER);
     Assert.assertEquals(viewProperties, properties);
-    properties = getProperties(artifactId);
+    properties = getProperties(artifactId, MetadataScope.USER);
     Assert.assertEquals(artifactProperties, properties);
 
     // test search for application
@@ -212,17 +226,17 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
 
     // test removal
     removeProperties(application);
-    Assert.assertTrue(getProperties(application).isEmpty());
+    Assert.assertTrue(getProperties(application, MetadataScope.USER).isEmpty());
     removeProperty(pingService, "sKey");
     removeProperty(pingService, "sK");
-    Assert.assertTrue(getProperties(pingService).isEmpty());
+    Assert.assertTrue(getProperties(pingService, MetadataScope.USER).isEmpty());
     removeProperty(myds, "dKey");
-    Assert.assertEquals(ImmutableMap.of("dK", "dV"), getProperties(myds));
+    Assert.assertEquals(ImmutableMap.of("dK", "dV"), getProperties(myds, MetadataScope.USER));
     removeProperty(mystream, "stK");
     removeProperty(mystream, "stKey");
-    Assert.assertEquals(ImmutableMap.of("multiword", multiWordValue), getProperties(mystream));
+    Assert.assertEquals(ImmutableMap.of("multiword", multiWordValue), getProperties(mystream, MetadataScope.USER));
     removeProperty(myview, "viewK");
-    Assert.assertEquals(ImmutableMap.of("viewKey", "viewValue"), getProperties(myview));
+    Assert.assertEquals(ImmutableMap.of("viewKey", "viewValue"), getProperties(myview, MetadataScope.USER));
     // cleanup
     removeProperties(myview);
     removeProperties(application);
@@ -230,12 +244,12 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     removeProperties(myds);
     removeProperties(mystream);
     removeProperties(artifactId);
-    Assert.assertTrue(getProperties(application).isEmpty());
-    Assert.assertTrue(getProperties(pingService).isEmpty());
-    Assert.assertTrue(getProperties(myds).isEmpty());
-    Assert.assertTrue(getProperties(mystream).isEmpty());
-    Assert.assertTrue(getProperties(myview).isEmpty());
-    Assert.assertTrue(getProperties(artifactId).isEmpty());
+    Assert.assertTrue(getProperties(application, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getProperties(pingService, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getProperties(myds, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getProperties(mystream, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getProperties(myview, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getProperties(artifactId, MetadataScope.USER).isEmpty());
 
     // non-existing namespace
     addProperties(nonExistingApp, appProperties, NotFoundException.class);
@@ -268,22 +282,22 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Set<String> artifactTags = ImmutableSet.of("rTag", "rT");
     addTags(artifactId, artifactTags);
     // retrieve tags and verify
-    Set<String> tags = getTags(application);
+    Set<String> tags = getTags(application, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(appTags));
     Assert.assertTrue(appTags.containsAll(tags));
-    tags = getTags(pingService);
+    tags = getTags(pingService, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(serviceTags));
     Assert.assertTrue(serviceTags.containsAll(tags));
-    tags = getTags(myds);
+    tags = getTags(myds, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(datasetTags));
     Assert.assertTrue(datasetTags.containsAll(tags));
-    tags = getTags(mystream);
+    tags = getTags(mystream, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(streamTags));
     Assert.assertTrue(streamTags.containsAll(tags));
-    tags = getTags(myview);
+    tags = getTags(myview, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(viewTags));
     Assert.assertTrue(viewTags.containsAll(tags));
-    tags = getTags(artifactId);
+    tags = getTags(artifactId, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(artifactTags));
     Assert.assertTrue(artifactTags.containsAll(tags));
     // test search for stream
@@ -308,7 +322,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     );
     Assert.assertEquals(expected, searchTags);
     // test prefix search, should match stream and application
-    searchTags = searchMetadata(Id.Namespace.DEFAULT, "Wo*", MetadataSearchTargetType.ALL);
+    searchTags = searchMetadata(Id.Namespace.DEFAULT, "Wow*", MetadataSearchTargetType.ALL);
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(application),
       new MetadataSearchResultRecord(mystream)
@@ -316,7 +330,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(expected, searchTags);
 
     // search without any target param
-    searchTags = searchMetadata(Id.Namespace.DEFAULT, "Wo*", null);
+    searchTags = searchMetadata(Id.Namespace.DEFAULT, "Wow*", null);
     Assert.assertEquals(expected, searchTags);
 
     // search non-existent tags should return empty set
@@ -325,23 +339,23 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
 
     // test removal
     removeTag(application, "aTag");
-    Assert.assertEquals(ImmutableSet.of("aT", "Wow-WOW1", "WOW_WOW2"), getTags(application));
+    Assert.assertEquals(ImmutableSet.of("aT", "Wow-WOW1", "WOW_WOW2"), getTags(application, MetadataScope.USER));
     removeTags(pingService);
-    Assert.assertTrue(getTags(pingService).isEmpty());
+    Assert.assertTrue(getTags(pingService, MetadataScope.USER).isEmpty());
     removeTags(pingService);
-    Assert.assertTrue(getTags(pingService).isEmpty());
+    Assert.assertTrue(getTags(pingService, MetadataScope.USER).isEmpty());
     removeTag(myds, "dT");
-    Assert.assertEquals(ImmutableSet.of("dTag"), getTags(myds));
+    Assert.assertEquals(ImmutableSet.of("dTag"), getTags(myds, MetadataScope.USER));
     removeTag(mystream, "stT");
     removeTag(mystream, "stTag");
     removeTag(mystream, "Wow-WOW1");
     removeTag(mystream, "WOW_WOW2");
     removeTag(myview, "viewT");
     removeTag(myview, "viewTag");
-    Assert.assertTrue(getTags(mystream).isEmpty());
+    Assert.assertTrue(getTags(mystream, MetadataScope.USER).isEmpty());
     removeTag(artifactId, "rTag");
     removeTag(artifactId, "rT");
-    Assert.assertTrue(getTags(artifactId).isEmpty());
+    Assert.assertTrue(getTags(artifactId, MetadataScope.USER).isEmpty());
     // cleanup
     removeTags(application);
     removeTags(pingService);
@@ -349,11 +363,11 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     removeTags(mystream);
     removeTags(myview);
     removeTags(artifactId);
-    Assert.assertTrue(getTags(application).isEmpty());
-    Assert.assertTrue(getTags(pingService).isEmpty());
-    Assert.assertTrue(getTags(myds).isEmpty());
-    Assert.assertTrue(getTags(mystream).isEmpty());
-    Assert.assertTrue(getTags(artifactId).isEmpty());
+    Assert.assertTrue(getTags(application, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getTags(pingService, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getTags(myds, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getTags(mystream, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getTags(artifactId, MetadataScope.USER).isEmpty());
     // non-existing namespace
     addTags(nonExistingApp, appTags, NotFoundException.class);
     addTags(nonExistingService, serviceTags, NotFoundException.class);
@@ -365,10 +379,10 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
 
   @Test
   public void testMetadata() throws Exception {
-    assertCleanState();
+    assertCleanState(MetadataScope.USER);
     // Remove when nothing exists
     removeAllMetadata();
-    assertCleanState();
+    assertCleanState(MetadataScope.USER);
     // Add some properties and tags
     Map<String, String> appProperties = ImmutableMap.of("aKey", "aValue");
     Map<String, String> serviceProperties = ImmutableMap.of("sKey", "sValue");
@@ -395,7 +409,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     addTags(myview, viewTags);
     addTags(artifactId, artifactTags);
     // verify app
-    Set<MetadataRecord> metadataRecords = getMetadata(application);
+    Set<MetadataRecord> metadataRecords = getMetadata(application, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     MetadataRecord metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -403,7 +417,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(appProperties, metadata.getProperties());
     Assert.assertEquals(appTags, metadata.getTags());
     // verify service
-    metadataRecords = getMetadata(pingService);
+    metadataRecords = getMetadata(pingService, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -411,7 +425,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(serviceProperties, metadata.getProperties());
     Assert.assertEquals(serviceTags, metadata.getTags());
     // verify dataset
-    metadataRecords = getMetadata(myds);
+    metadataRecords = getMetadata(myds, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -419,7 +433,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(datasetProperties, metadata.getProperties());
     Assert.assertEquals(datasetTags, metadata.getTags());
     // verify stream
-    metadataRecords = getMetadata(mystream);
+    metadataRecords = getMetadata(mystream, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -427,7 +441,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(streamProperties, metadata.getProperties());
     Assert.assertEquals(streamTags, metadata.getTags());
     // verify view
-    metadataRecords = getMetadata(myview);
+    metadataRecords = getMetadata(myview, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -435,7 +449,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(viewProperties, metadata.getProperties());
     Assert.assertEquals(viewTags, metadata.getTags());
     // verify artifact
-    metadataRecords = getMetadata(artifactId);
+    metadataRecords = getMetadata(artifactId, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
     metadata = metadataRecords.iterator().next();
     Assert.assertEquals(MetadataScope.USER, metadata.getScope());
@@ -444,7 +458,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(artifactTags, metadata.getTags());
     // cleanup
     removeAllMetadata();
-    assertCleanState();
+    assertCleanState(MetadataScope.USER);
   }
 
   @Test
@@ -457,7 +471,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     addProperties(program, flowProperties);
 
     // Get properties
-    Map<String, String> properties = getProperties(program);
+    Map<String, String> properties = getProperties(program, MetadataScope.USER);
     Assert.assertEquals(2, properties.size());
 
     //Delete the App after stopping the flow
@@ -538,7 +552,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     addProperties(program, flowProperties);
 
     // Get properties
-    Map<String, String> properties = getProperties(program);
+    Map<String, String> properties = getProperties(program, MetadataScope.USER);
     Assert.assertEquals(2, properties.size());
 
     // Deploy WordCount App without Flow program. No need to start/stop the flow.
@@ -552,6 +566,362 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     deleteApp(wordCountApp, 200);
   }
 
+  @Test
+  public void testSystemMetadataRetrieval() throws Exception {
+    deploy(AllProgramsApp.class);
+    // verify stream system metadata
+    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, AllProgramsApp.STREAM_NAME);
+    Set<String> streamSystemTags = getTags(streamId, MetadataScope.SYSTEM);
+    Assert.assertEquals(ImmutableSet.of(AllProgramsApp.STREAM_NAME), streamSystemTags);
+    Map<String, String> streamSystemProperties = getProperties(streamId, MetadataScope.SYSTEM);
+    Assert.assertEquals(ImmutableMap.of("schema:body", "body:" + Schema.Type.STRING.toString(),
+                                        "ttl", String.valueOf(Long.MAX_VALUE)), streamSystemProperties);
+    Set<MetadataRecord> streamSystemMetadata = getMetadata(streamId, MetadataScope.SYSTEM);
+    Assert.assertEquals(
+      ImmutableSet.of(new MetadataRecord(streamId, MetadataScope.SYSTEM, streamSystemProperties, streamSystemTags)),
+      streamSystemMetadata);
+    // create view and verify view system metadata
+    Id.Stream.View view = Id.Stream.View.from(streamId, "view");
+    Schema viewSchema = Schema.recordOf("record",
+                                        Schema.Field.of("viewBody", Schema.nullableOf(Schema.of(Schema.Type.BYTES))));
+    createOrUpdateView(view, new ViewSpecification(new FormatSpecification("format", viewSchema)));
+    Set<String> viewSystemTags = getTags(view, MetadataScope.SYSTEM);
+    Assert.assertEquals(ImmutableSet.of("view", AllProgramsApp.STREAM_NAME), viewSystemTags);
+    Map<String, String> viewSystemProperties = getProperties(view, MetadataScope.SYSTEM);
+    Assert.assertEquals("viewBody:" + Schema.Type.BYTES.toString(), viewSystemProperties.get("schema:viewBody"));
+    ImmutableSet<String> viewUserTags = ImmutableSet.of("viewTag");
+    addTags(view, viewUserTags);
+    Assert.assertEquals(
+      ImmutableSet.of(new MetadataRecord(view, ImmutableMap.<String, String>of(), viewUserTags),
+                      new MetadataRecord(view, MetadataScope.SYSTEM, viewSystemProperties, viewSystemTags)),
+      getMetadata(view)
+    );
+    // verify dataset system metadata
+    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DATASET_NAME);
+    Set<String> dsSystemTags = getTags(datasetInstance, MetadataScope.SYSTEM);
+    Assert.assertEquals(
+      ImmutableSet.of(AllProgramsApp.DATASET_NAME,
+                      BatchReadable.class.getSimpleName(),
+                      BatchWritable.class.getSimpleName(),
+                      RecordScannable.class.getSimpleName(),
+                      RecordWritable.class.getSimpleName()),
+      dsSystemTags);
+    Map<String, String> dsSystemProperties = getProperties(datasetInstance, MetadataScope.SYSTEM);
+    Assert.assertEquals(KeyValueTable.class.getName(), dsSystemProperties.get("type"));
+    // verify app system metadata
+    Id.Application app = Id.Application.from(Id.Namespace.DEFAULT, AllProgramsApp.NAME);
+    Assert.assertEquals(
+      ImmutableMap.builder()
+        .put(ProgramType.FLOW.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + AllProgramsApp.NoOpFlow.NAME,
+             AllProgramsApp.NoOpFlow.NAME)
+        .put(ProgramType.MAPREDUCE.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + AllProgramsApp.NoOpMR.NAME,
+             AllProgramsApp.NoOpMR.NAME)
+        .put(ProgramType.SERVICE.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR +
+               AllProgramsApp.NoOpService.NAME, AllProgramsApp.NoOpService.NAME)
+        .put(ProgramType.SPARK.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + AllProgramsApp.NoOpSpark.NAME,
+             AllProgramsApp.NoOpSpark.NAME)
+        .put(ProgramType.WORKER.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + AllProgramsApp.NoOpWorker.NAME,
+             AllProgramsApp.NoOpWorker.NAME)
+        .put(ProgramType.WORKFLOW.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR
+               + AllProgramsApp.NoOpWorkflow.NAME, AllProgramsApp.NoOpWorkflow.NAME)
+        .put("schedule" + MetadataDataset.KEYVALUE_SEPARATOR + AllProgramsApp.SCHEDULE_NAME,
+             AllProgramsApp.SCHEDULE_NAME + MetadataDataset.KEYVALUE_SEPARATOR + AllProgramsApp.SCHEDULE_DESCRIPTION)
+        .build(),
+      getProperties(app, MetadataScope.SYSTEM));
+    Assert.assertEquals(ImmutableSet.of(AllProgramsApp.class.getSimpleName(), AllProgramsApp.NAME),
+                        getTags(app, MetadataScope.SYSTEM));
+    // verify program system metadata
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.FLOW, AllProgramsApp.NoOpFlow.NAME), "Realtime");
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.WORKER, AllProgramsApp.NoOpWorker.NAME), "Realtime");
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.SERVICE, AllProgramsApp.NoOpService.NAME), "Realtime");
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR.NAME), "Batch");
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.SPARK, AllProgramsApp.NoOpSpark.NAME), "Batch");
+    assertProgramSystemMetadata(Id.Program.from(app, ProgramType.WORKFLOW, AllProgramsApp.NoOpWorkflow.NAME), "Batch");
+  }
+
+  @Test
+  public void testSearchUsingSystemMetadata() throws Exception {
+    deploy(AllProgramsApp.class);
+    // search artifacts
+    assertArtifactSearch();
+    // search app
+    Id.Application app = Id.Application.from(Id.Namespace.DEFAULT, AllProgramsApp.NAME);
+    assertAppSearch(app);
+    // search programs
+    assertProgramSearch(app);
+    // search data entities
+    assertDataEntitySearch();
+  }
+
+  private void assertProgramSystemMetadata(Id.Program programId, String mode) throws Exception {
+    Assert.assertTrue(getProperties(programId, MetadataScope.SYSTEM).isEmpty());
+    Set<String> expected = ImmutableSet.of(programId.getId(), programId.getType().getPrettyName(), mode);
+    if (ProgramType.WORKFLOW == programId.getType()) {
+      expected = ImmutableSet.of(programId.getId(), programId.getType().getPrettyName(), mode,
+                                 AllProgramsApp.NoOpAction.class.getSimpleName(), AllProgramsApp.NoOpMR.NAME);
+    }
+    Assert.assertEquals(expected, getTags(programId, MetadataScope.SYSTEM));
+  }
+
+  private void assertArtifactSearch() throws Exception {
+    // add a plugin artifact.
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE,
+                                     AllProgramsApp.AppPlugin.class.getPackage().getName());
+    Id.Artifact pluginArtifact = Id.Artifact.from(Id.Namespace.DEFAULT, "plugins", "1.0.0");
+    Assert.assertEquals(HttpResponseStatus.OK.getCode(),
+                        addPluginArtifact(pluginArtifact, AllProgramsApp.AppPlugin.class, manifest,
+                                          new HashSet<ArtifactRange>()).getStatusLine().getStatusCode());
+    // search using artifact name
+    Set<MetadataSearchResultRecord> expected = ImmutableSet.of(new MetadataSearchResultRecord(pluginArtifact));
+    Set<MetadataSearchResultRecord> results = searchMetadata(Id.Namespace.DEFAULT, "plugins", null);
+    Assert.assertEquals(expected, results);
+    // search the artifact given a plugin
+    results = searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.PLUGIN_TYPE, null);
+    Assert.assertEquals(expected, results);
+    results = searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.PLUGIN_NAME + ":" + AllProgramsApp.PLUGIN_TYPE, null);
+    Assert.assertEquals(expected, results);
+    results = searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.PLUGIN_NAME, MetadataSearchTargetType.ARTIFACT);
+    Assert.assertEquals(expected, results);
+    // add a user tag to the application with the same name as the plugin
+    addTags(application, ImmutableSet.of(AllProgramsApp.PLUGIN_NAME));
+    // search for all entities with plugin name. Should return both artifact and application
+    results = searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.PLUGIN_NAME, null);
+    Assert.assertEquals(
+      ImmutableSet.of(new MetadataSearchResultRecord(application), new MetadataSearchResultRecord(pluginArtifact)),
+      results);
+    // search for all entities for a plugin with the plugin name. Should return only the artifact, since for the
+    // application, its just a tag, not a plugin
+    results = searchMetadata(Id.Namespace.DEFAULT, "plugin:" + AllProgramsApp.PLUGIN_NAME + ":*", null);
+    Assert.assertEquals(expected, results);
+  }
+
+  private void assertAppSearch(Id.Application app) throws Exception {
+    // using app name
+    ImmutableSet<MetadataSearchResultRecord> expected = ImmutableSet.of(new MetadataSearchResultRecord(app));
+    Assert.assertEquals(expected, searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NAME, null));
+    // using artifact name
+    Assert.assertEquals(expected, searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.class.getSimpleName(), null));
+    // using program names
+    Assert.assertEquals(expected, searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpFlow.NAME,
+                                                 MetadataSearchTargetType.APP));
+    Assert.assertEquals(expected, searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpMR.NAME,
+                                                 MetadataSearchTargetType.APP));
+    Assert.assertEquals(expected, searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpService.NAME,
+                                                 MetadataSearchTargetType.APP));
+    Assert.assertEquals(expected, searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpSpark.NAME,
+                                                 MetadataSearchTargetType.APP));
+    Assert.assertEquals(expected, searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpWorker.NAME,
+                                                 MetadataSearchTargetType.APP));
+    Assert.assertEquals(expected, searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpWorkflow.NAME,
+                                                 MetadataSearchTargetType.APP));
+    // using program types
+    Assert.assertEquals(
+      expected, searchMetadata(Id.Namespace.DEFAULT,
+                               ProgramType.FLOW.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
+                               MetadataSearchTargetType.APP));
+    Assert.assertEquals(
+      expected, searchMetadata(Id.Namespace.DEFAULT,
+                               ProgramType.MAPREDUCE.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
+                               MetadataSearchTargetType.APP));
+    Assert.assertEquals(
+      ImmutableSet.builder().addAll(expected).add(new MetadataSearchResultRecord(application)).build(),
+      searchMetadata(Id.Namespace.DEFAULT,
+                     ProgramType.SERVICE.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
+                     MetadataSearchTargetType.APP));
+    Assert.assertEquals(
+      expected, searchMetadata(Id.Namespace.DEFAULT,
+                               ProgramType.SPARK.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
+                               MetadataSearchTargetType.APP));
+    Assert.assertEquals(
+      expected, searchMetadata(Id.Namespace.DEFAULT,
+                               ProgramType.WORKER.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
+                               MetadataSearchTargetType.APP));
+    Assert.assertEquals(
+      expected, searchMetadata(Id.Namespace.DEFAULT,
+                               ProgramType.WORKFLOW.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
+                               MetadataSearchTargetType.APP));
+
+    // using schedule
+    Assert.assertEquals(expected, searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.SCHEDULE_NAME, null));
+    Assert.assertEquals(expected, searchMetadata(Id.Namespace.DEFAULT, "EveryMinute", null));
+  }
+
+  private void assertProgramSearch(Id.Application app) throws Exception {
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR.NAME)),
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.WORKFLOW, AllProgramsApp.NoOpWorkflow.NAME)),
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.SPARK, AllProgramsApp.NoOpSpark.NAME))
+      ),
+      searchMetadata(Id.Namespace.DEFAULT, "Batch", null));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.FLOW, AllProgramsApp.NoOpFlow.NAME)),
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.SERVICE, AllProgramsApp.NoOpService.NAME)),
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.WORKER, AllProgramsApp.NoOpWorker.NAME)),
+        new MetadataSearchResultRecord(
+          Id.Program.from(Id.Application.from(Id.Namespace.DEFAULT, AppWithDataset.class.getSimpleName()),
+                          ProgramType.SERVICE, "PingService"))
+      ),
+      searchMetadata(Id.Namespace.DEFAULT, "Realtime", null));
+
+    // Using program names
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.FLOW, AllProgramsApp.NoOpFlow.NAME))),
+      searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpFlow.NAME, MetadataSearchTargetType.PROGRAM));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR.NAME)),
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.WORKFLOW, AllProgramsApp.NoOpWorkflow.NAME))),
+      searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpMR.NAME, MetadataSearchTargetType.PROGRAM));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.SERVICE, AllProgramsApp.NoOpService.NAME))),
+      searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpService.NAME, MetadataSearchTargetType.PROGRAM));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.SPARK, AllProgramsApp.NoOpSpark.NAME))),
+      searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpSpark.NAME, MetadataSearchTargetType.PROGRAM));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.WORKER, AllProgramsApp.NoOpWorker.NAME))),
+      searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpWorker.NAME, MetadataSearchTargetType.PROGRAM));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.WORKFLOW, AllProgramsApp.NoOpWorkflow.NAME))),
+      searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.NoOpWorkflow.NAME, MetadataSearchTargetType.PROGRAM));
+
+    // using program types
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.FLOW, AllProgramsApp.NoOpFlow.NAME))),
+      searchMetadata(Id.Namespace.DEFAULT, ProgramType.FLOW.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR.NAME))),
+      searchMetadata(Id.Namespace.DEFAULT, ProgramType.MAPREDUCE.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.SERVICE, AllProgramsApp.NoOpService.NAME)),
+        new MetadataSearchResultRecord(pingService)),
+      searchMetadata(Id.Namespace.DEFAULT, ProgramType.SERVICE.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.SPARK, AllProgramsApp.NoOpSpark.NAME))),
+      searchMetadata(Id.Namespace.DEFAULT, ProgramType.SPARK.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.WORKER, AllProgramsApp.NoOpWorker.NAME))),
+      searchMetadata(Id.Namespace.DEFAULT, ProgramType.WORKER.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.WORKFLOW, AllProgramsApp.NoOpWorkflow.NAME))),
+      searchMetadata(Id.Namespace.DEFAULT, ProgramType.WORKFLOW.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+  }
+
+  private void assertDataEntitySearch() throws Exception {
+    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DATASET_NAME);
+    Id.DatasetInstance dsWithSchema = Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DS_WITH_SCHEMA_NAME);
+    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, AllProgramsApp.STREAM_NAME);
+    Id.Stream.View view = Id.Stream.View.from(streamId, "view");
+
+    Set<MetadataSearchResultRecord> expected = ImmutableSet.of(
+      new MetadataSearchResultRecord(streamId),
+      new MetadataSearchResultRecord(mystream)
+    );
+
+    // schema search with fieldname
+    Set<MetadataSearchResultRecord> metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, "body", null);
+    Assert.assertEquals(expected, metadataSearchResultRecords);
+
+    // schema search with fieldname and fieldtype
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, "body:" + Schema.Type.STRING.toString(), null);
+    Assert.assertEquals(expected, metadataSearchResultRecords);
+
+    // schema search for partial fieldname
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, "bo*", null);
+    Assert.assertEquals(expected, metadataSearchResultRecords);
+
+    // schema search with fieldname and all/partial fieldtype
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, "body:STR*", null);
+    Assert.assertEquals(expected, metadataSearchResultRecords);
+
+    // schema search for a field with the given fieldtype
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, "STRING", null);
+    Assert.assertEquals(ImmutableSet.<MetadataSearchResultRecord>builder()
+                          .addAll(expected)
+                          .add(new MetadataSearchResultRecord(dsWithSchema))
+                          .build(),
+                        metadataSearchResultRecords);
+
+    // create a view
+    Schema viewSchema = Schema.recordOf("record",
+                                        Schema.Field.of("viewBody", Schema.nullableOf(Schema.of(Schema.Type.BYTES))));
+    createOrUpdateView(view, new ViewSpecification(new FormatSpecification("format", viewSchema)));
+
+    // search all entities that have a defined schema
+    // add a user property with "schema" as key
+    Map<String, String> datasetProperties = ImmutableMap.of("schema", "schemaValue");
+    addProperties(datasetInstance, datasetProperties);
+
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, "schema:*", null);
+    Assert.assertEquals(ImmutableSet.<MetadataSearchResultRecord>builder()
+                          .addAll(expected)
+                          .add(new MetadataSearchResultRecord(datasetInstance))
+                          .add(new MetadataSearchResultRecord(dsWithSchema))
+                          .add(new MetadataSearchResultRecord(view))
+                          .build(),
+                        metadataSearchResultRecords);
+
+    // search dataset
+    ImmutableSet<MetadataSearchResultRecord> expectedKvTables = ImmutableSet.of(
+      new MetadataSearchResultRecord(datasetInstance), new MetadataSearchResultRecord(myds)
+    );
+    ImmutableSet<MetadataSearchResultRecord> expectedAllDatasets = ImmutableSet.<MetadataSearchResultRecord>builder()
+      .addAll(expectedKvTables)
+      .add(new MetadataSearchResultRecord(dsWithSchema))
+      .build();
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, BatchReadable.class.getSimpleName(), null);
+    Assert.assertEquals(expectedAllDatasets, metadataSearchResultRecords);
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, BatchWritable.class.getSimpleName(),
+                                                 MetadataSearchTargetType.DATASET);
+    Assert.assertEquals(expectedAllDatasets, metadataSearchResultRecords);
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, RecordScannable.class.getSimpleName(), null);
+    Assert.assertEquals(expectedAllDatasets, metadataSearchResultRecords);
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, RecordWritable.class.getSimpleName(), null);
+    Assert.assertEquals(expectedKvTables, metadataSearchResultRecords);
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, KeyValueTable.class.getName(), null);
+    Assert.assertEquals(expectedKvTables, metadataSearchResultRecords);
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, "type:*", null);
+    Assert.assertEquals(expectedAllDatasets, metadataSearchResultRecords);
+
+    // search using ttl
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, "ttl:*", null);
+    Assert.assertEquals(expected, metadataSearchResultRecords);
+
+    // search using names
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.STREAM_NAME, null);
+    Assert.assertEquals(
+      ImmutableSet.of(new MetadataSearchResultRecord(streamId), new MetadataSearchResultRecord(view)),
+      metadataSearchResultRecords);
+
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.STREAM_NAME,
+                                                 MetadataSearchTargetType.STREAM);
+    Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(streamId)), metadataSearchResultRecords);
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.STREAM_NAME,
+                                                 MetadataSearchTargetType.VIEW);
+    Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(view)), metadataSearchResultRecords);
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, "view",
+                                                 MetadataSearchTargetType.VIEW);
+    Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(view)), metadataSearchResultRecords);
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.DATASET_NAME, null);
+    Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(datasetInstance)), metadataSearchResultRecords);
+    metadataSearchResultRecords = searchMetadata(Id.Namespace.DEFAULT, AllProgramsApp.DS_WITH_SCHEMA_NAME, null);
+    Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(dsWithSchema)), metadataSearchResultRecords);
+  }
+
   private void removeAllMetadata() throws Exception {
     removeMetadata(application);
     removeMetadata(pingService);
@@ -561,43 +931,22 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     removeMetadata(artifactId);
   }
 
-  private void assertCleanState() throws Exception {
-    // Assert clean state
-    Set<MetadataRecord> appMetadatas = getMetadata(application);
-    // only user metadata right now.
-    Assert.assertEquals(1, appMetadatas.size());
-    MetadataRecord appMetadata = appMetadatas.iterator().next();
-    Assert.assertTrue(appMetadata.getProperties().isEmpty());
-    Assert.assertTrue(appMetadata.getTags().isEmpty());
-    Set<MetadataRecord> serviceMetadatas = getMetadata(pingService);
-    // only user metadata right now.
-    Assert.assertEquals(1, serviceMetadatas.size());
-    MetadataRecord serviceMetadata = serviceMetadatas.iterator().next();
-    Assert.assertTrue(serviceMetadata.getProperties().isEmpty());
-    Assert.assertTrue(serviceMetadata.getTags().isEmpty());
-    Set<MetadataRecord> datasetMetadatas = getMetadata(myds);
-    // only user metadata right now.
-    Assert.assertEquals(1, datasetMetadatas.size());
-    MetadataRecord datasetMetadata = datasetMetadatas.iterator().next();
-    Assert.assertTrue(datasetMetadata.getProperties().isEmpty());
-    Assert.assertTrue(datasetMetadata.getTags().isEmpty());
-    Set<MetadataRecord> streamMetadatas = getMetadata(mystream);
-    // only user metadata right now.
-    Assert.assertEquals(1, streamMetadatas.size());
-    MetadataRecord streamMetadata = streamMetadatas.iterator().next();
-    Assert.assertTrue(streamMetadata.getProperties().isEmpty());
-    Assert.assertTrue(streamMetadata.getTags().isEmpty());
-    Set<MetadataRecord> viewMetadatas = getMetadata(myview);
-    // only user metadata right now.
-    Assert.assertEquals(1, viewMetadatas.size());
-    MetadataRecord viewMetadata = viewMetadatas.iterator().next();
-    Assert.assertTrue(viewMetadata.getProperties().isEmpty());
-    Assert.assertTrue(viewMetadata.getTags().isEmpty());
-    Set<MetadataRecord> artifactMetadatas = getMetadata(artifactId);
-    // only user metadata right now.
-    Assert.assertEquals(1, artifactMetadatas.size());
-    MetadataRecord artifactMetadata = artifactMetadatas.iterator().next();
-    Assert.assertTrue(artifactMetadata.getProperties().isEmpty());
-    Assert.assertTrue(artifactMetadata.getTags().isEmpty());
+  private void assertCleanState(@Nullable MetadataScope scope) throws Exception {
+    assertEmptyMetadata(getMetadata(application, scope), scope);
+    assertEmptyMetadata(getMetadata(pingService, scope), scope);
+    assertEmptyMetadata(getMetadata(myds, scope), scope);
+    assertEmptyMetadata(getMetadata(mystream, scope), scope);
+    assertEmptyMetadata(getMetadata(myview, scope), scope);
+    assertEmptyMetadata(getMetadata(artifactId, scope), scope);
+  }
+
+  private void assertEmptyMetadata(Set<MetadataRecord> entityMetadata, @Nullable MetadataScope scope) {
+    // should have two metadata records - one for each scope, both should have empty properties and tags
+    int expectedRecords = (scope == null) ? 2 : 1;
+    Assert.assertEquals(expectedRecords, entityMetadata.size());
+    for (MetadataRecord metadataRecord : entityMetadata) {
+      Assert.assertTrue(metadataRecord.getProperties().isEmpty());
+      Assert.assertTrue(metadataRecord.getTags().isEmpty());
+    }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,6 +27,7 @@ import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
@@ -160,57 +161,81 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
   }
 
   protected Set<MetadataRecord> getMetadata(Id.Application app) throws Exception {
-    return metadataClient.getMetadata(app);
+    return getMetadata(app, null);
   }
 
   protected Set<MetadataRecord> getMetadata(Id.Artifact artifact) throws Exception {
-    return metadataClient.getMetadata(artifact);
+    return getMetadata(artifact, null);
   }
 
   protected Set<MetadataRecord> getMetadata(Id.Program program) throws Exception {
-    return metadataClient.getMetadata(program);
+    return getMetadata(program, null);
   }
 
   protected Set<MetadataRecord> getMetadata(Id.DatasetInstance dataset) throws Exception {
-    return metadataClient.getMetadata(dataset);
+    return getMetadata(dataset, null);
   }
 
   protected Set<MetadataRecord> getMetadata(Id.Stream stream) throws Exception {
-    return metadataClient.getMetadata(stream);
+    return getMetadata(stream, null);
   }
 
   protected Set<MetadataRecord> getMetadata(Id.Stream.View view) throws Exception {
-    return metadataClient.getMetadata(view);
+    return getMetadata(view, null);
   }
 
-  // Currently, getMetadata(entity) returns a single-element set, so we can get the properties from there
-  protected Map<String, String> getProperties(Id.Application app) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(app).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.Application app, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(app, scope);
   }
 
-  protected Map<String, String> getProperties(Id.Artifact artifact) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(artifact).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.Artifact artifact, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(artifact, scope);
   }
 
-  protected Map<String, String> getProperties(Id.Program program) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(program).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.Program program, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(program, scope);
   }
 
-  protected Map<String, String> getProperties(Id.DatasetInstance dataset) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(dataset).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.DatasetInstance dataset,
+                                            @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(dataset, scope);
   }
 
-  protected Map<String, String> getProperties(Id.Stream stream) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(stream).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.Stream stream, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(stream, scope);
   }
 
-  protected Map<String, String> getProperties(Id.Stream.View view) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(view).iterator()).getProperties();
+  protected Set<MetadataRecord> getMetadata(Id.Stream.View view, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(view, scope);
+  }
+
+  protected Map<String, String> getProperties(Id.Application app, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(app, scope).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.Artifact artifact, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(artifact, scope).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.Program program, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(program, scope).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.DatasetInstance dataset, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(dataset, scope).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.Stream stream, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(stream, scope).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.Stream.View view, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(view, scope).iterator()).getProperties();
   }
 
   protected void getPropertiesFromInvalidEntity(Id.Application app) throws Exception {
     try {
-      getProperties(app);
+      getProperties(app, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + app);
     } catch (NotFoundException expected) {
       // expected
@@ -219,7 +244,7 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
 
   protected void getPropertiesFromInvalidEntity(Id.Program program) throws Exception {
     try {
-      getProperties(program);
+      getProperties(program, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + program);
     } catch (NotFoundException expected) {
       // expected
@@ -228,7 +253,7 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
 
   protected void getPropertiesFromInvalidEntity(Id.DatasetInstance dataset) throws Exception {
     try {
-      getProperties(dataset);
+      getProperties(dataset, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + dataset);
     } catch (NotFoundException expected) {
       // expected
@@ -237,7 +262,7 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
 
   protected void getPropertiesFromInvalidEntity(Id.Stream stream) throws Exception {
     try {
-      getProperties(stream);
+      getProperties(stream, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + stream);
     } catch (NotFoundException expected) {
       // expected
@@ -245,7 +270,7 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
   }
   protected void getPropertiesFromInvalidEntity(Id.Stream.View view) throws Exception {
     try {
-      getProperties(view);
+      getProperties(view, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + view);
     } catch (NotFoundException expected) {
       // expected
@@ -416,33 +441,32 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
   }
 
   protected Set<MetadataSearchResultRecord> searchMetadata(Id.Namespace namespaceId, String query,
-                                                           MetadataSearchTargetType target) throws Exception {
+                                                           @Nullable MetadataSearchTargetType target) throws Exception {
     return metadataClient.searchMetadata(namespaceId, query, target);
   }
 
-  // Currently, getMetadata(entity) returns a single-element set, so we can get the tags from there
-  protected Set<String> getTags(Id.Application app) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(app).iterator()).getTags();
+  protected Set<String> getTags(Id.Application app, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(app, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Artifact artifact) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(artifact).iterator()).getTags();
+  protected Set<String> getTags(Id.Artifact artifact, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(artifact, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Program program) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(program).iterator()).getTags();
+  protected Set<String> getTags(Id.Program program, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(program, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.DatasetInstance dataset) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(dataset).iterator()).getTags();
+  protected Set<String> getTags(Id.DatasetInstance dataset, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(dataset, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Stream stream) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(stream).iterator()).getTags();
+  protected Set<String> getTags(Id.Stream stream, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(stream, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Stream.View view) throws Exception {
-    return Iterators.getOnlyElement(getMetadata(view).iterator()).getTags();
+  protected Set<String> getTags(Id.Stream.View view, MetadataScope scope) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(view, scope).iterator()).getTags();
   }
 
   protected void removeTags(Id.Application app) throws Exception {

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,6 +24,7 @@ import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
 import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.common.http.HttpMethod;
@@ -353,7 +354,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Application appId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(appId, constructPath(appId));
+    return getMetadata(appId, null);
   }
 
   /**
@@ -362,7 +363,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Artifact artifactId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(artifactId, constructPath(artifactId));
+    return getMetadata(artifactId, null);
   }
 
   /**
@@ -371,7 +372,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.DatasetInstance datasetInstance)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(datasetInstance, constructPath(datasetInstance));
+    return getMetadata(datasetInstance, null);
   }
 
   /**
@@ -380,7 +381,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Stream streamId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(streamId, constructPath(streamId));
+    return getMetadata(streamId, null);
   }
 
   /**
@@ -389,7 +390,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Stream.View viewId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(viewId, constructPath(viewId));
+    return getMetadata(viewId, null);
   }
 
   /**
@@ -398,7 +399,61 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Program programId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(programId, constructPath(programId));
+    return getMetadata(programId, null);
+  }
+
+  /**
+   * @param appId the app for which to retrieve metadata
+   * @return The metadata for the application.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Application appId, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(appId, constructPath(appId), scope);
+  }
+
+  /**
+   * @param artifactId the artifact for which to retrieve metadata
+   * @return The metadata for the artifact.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Artifact artifactId, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(artifactId, constructPath(artifactId), scope);
+  }
+
+  /**
+   * @param datasetInstance the dataset for which to retrieve metadata
+   * @return The metadata for the dataset.
+   */
+  public Set<MetadataRecord> getMetadata(Id.DatasetInstance datasetInstance, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(datasetInstance, constructPath(datasetInstance), scope);
+  }
+
+  /**
+   * @param streamId the stream for which to retrieve metadata
+   * @return The metadata for the stream.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Stream streamId, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(streamId, constructPath(streamId), scope);
+  }
+
+  /**
+   * @param viewId the view for which to retrieve metadata
+   * @return The metadata for the view.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Stream.View viewId, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(viewId, constructPath(viewId), scope);
+  }
+
+  /**
+   * @param programId the program for which to retrieve metadata
+   * @return The metadata for the program.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Program programId, @Nullable MetadataScope scope)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return doGetMetadata(programId, constructPath(programId), scope);
   }
 
   /**
@@ -407,12 +462,19 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Run runId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(runId, constructPath(runId));
+    return doGetMetadata(runId, constructPath(runId));
   }
 
-  private Set<MetadataRecord> getMetadata(Id.NamespacedId namespacedId, String entityPath)
+  private Set<MetadataRecord> doGetMetadata(Id.NamespacedId namespacedId, String entityPath)
+    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    return doGetMetadata(namespacedId, entityPath, null);
+  }
+
+  private Set<MetadataRecord> doGetMetadata(Id.NamespacedId namespacedId, String entityPath,
+                                            @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata", entityPath);
+    path = scope == null ? path : String.format("%s?scope=%s", path, scope);
     HttpResponse response = makeRequest(namespacedId, path, HttpMethod.GET);
     return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_RECORD_TYPE);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/view/ViewAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/view/ViewAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,8 @@
 package co.cask.cdap.data.view;
 
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.data2.metadata.system.ViewSystemMetadataWriter;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.explore.utils.ExploreTableNaming;
 import co.cask.cdap.proto.Id;
@@ -33,12 +35,15 @@ public class ViewAdmin {
   private final ViewStore store;
   private final ExploreFacade explore;
   private final ExploreTableNaming naming;
+  private final MetadataStore metadataStore;
 
   @Inject
-  public ViewAdmin(ViewStore store, ExploreFacade explore, ExploreTableNaming naming) {
+  public ViewAdmin(ViewStore store, ExploreFacade explore, ExploreTableNaming naming,
+                   MetadataStore metadataStore) {
     this.store = store;
     this.explore = explore;
     this.naming = naming;
+    this.metadataStore = metadataStore;
   }
 
   public boolean createOrUpdate(Id.Stream.View viewId, ViewSpecification spec) throws Exception {
@@ -59,13 +64,17 @@ public class ViewAdmin {
       spec = new ViewSpecification(spec.getFormat(), naming.getTableName(viewId));
     }
     explore.enableExploreStream(viewId.getStream(), spec.getTableName(), spec.getFormat());
-    return store.createOrUpdate(viewId, spec);
+    boolean result = store.createOrUpdate(viewId, spec);
+    ViewSystemMetadataWriter systemMetadataWriter = new ViewSystemMetadataWriter(metadataStore, viewId, spec);
+    systemMetadataWriter.write();
+    return result;
   }
 
   public void delete(Id.Stream.View viewId) throws Exception {
     ViewSpecification spec = store.get(viewId);
     explore.disableExploreStream(viewId.getStream(), spec.getTableName());
     store.delete(viewId);
+    metadataStore.removeMetadata(viewId);
   }
 
   public List<Id.Stream.View> list(Id.Stream streamId) {
@@ -76,7 +85,7 @@ public class ViewAdmin {
     return store.get(viewId);
   }
 
-  public boolean exists (Id.Stream.View viewId) {
+  public boolean exists(Id.Stream.View viewId) {
     return store.exists(viewId);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -36,6 +36,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.commons.math3.analysis.function.Add;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -55,9 +56,8 @@ public class MetadataDataset extends AbstractDataset {
     .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
     .create();
 
-  private static final Pattern VALUE_SPLIT_PATTERN = Pattern.compile("[-_\\s]+");
+  private static final Pattern VALUE_SPLIT_PATTERN = Pattern.compile("[-_:\\s]+");
   private static final Pattern TAGS_SEPARATOR_PATTERN = Pattern.compile("[,\\s]+");
-
   private static final String HISTORY_COLUMN = "h"; // column for metadata history
   private static final String VALUE_COLUMN = "v";  // column for metadata value
   private static final String TAGS_SEPARATOR = ",";

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Cask Data, Inc.
+ * Copyright 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -176,7 +176,7 @@ public class DefaultMetadataStore implements MetadataStore {
       public MetadataRecord apply(MetadataDataset input) throws Exception {
         Map<String, String> properties = input.getProperties(entityId);
         Set<String> tags = input.getTags(entityId);
-        return new MetadataRecord(entityId, properties, tags);
+        return new MetadataRecord(entityId, scope, properties, tags);
       }
     }, scope);
   }
@@ -186,7 +186,7 @@ public class DefaultMetadataStore implements MetadataStore {
    * for the specified set of {@link Id.NamespacedId}s.
    */
   @Override
-  public Set<MetadataRecord> getMetadata(MetadataScope scope, final Set<Id.NamespacedId> entityIds) {
+  public Set<MetadataRecord> getMetadata(final MetadataScope scope, final Set<Id.NamespacedId> entityIds) {
     return execute(new TransactionExecutor.Function<MetadataDataset, Set<MetadataRecord>>() {
       @Override
       public Set<MetadataRecord> apply(MetadataDataset input) throws Exception {
@@ -194,7 +194,7 @@ public class DefaultMetadataStore implements MetadataStore {
         for (Id.NamespacedId entityId : entityIds) {
           Map<String, String> properties = input.getProperties(entityId);
           Set<String> tags = input.getTags(entityId);
-          metadataRecords.add(new MetadataRecord(entityId, properties, tags));
+          metadataRecords.add(new MetadataRecord(entityId, scope, properties, tags));
         }
         return metadataRecords;
       }
@@ -432,7 +432,7 @@ public class DefaultMetadataStore implements MetadataStore {
   }
 
   @Override
-  public Set<MetadataSearchResultRecord> searchMetadataOnType(MetadataScope scope, final String namespaceId,
+  public Set<MetadataSearchResultRecord> searchMetadataOnType(final MetadataScope scope, final String namespaceId,
                                                               final String searchQuery,
                                                               final MetadataSearchTargetType type) {
     Iterable<MetadataEntry> metadataEntries = execute(new TransactionExecutor.Function<MetadataDataset,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.metadata.MetadataScope;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * A class to write {@link MetadataScope#SYSTEM} metadata for an {@link Id.NamespacedId entity}.
+ */
+public abstract class AbstractSystemMetadataWriter {
+
+  private static final String SCHEMA_FIELD_PROPERTY_PREFIX = "schema";
+  private static final String PLUGIN_KEY_PREFIX = "plugin";
+  private static final String PLUGIN_VERSION_KEY_PREFIX = "pluginversion";
+  protected static final String TTL_KEY = "ttl";
+
+  private final MetadataStore metadataStore;
+  private final Id.NamespacedId entityId;
+
+  public AbstractSystemMetadataWriter(MetadataStore metadataStore, Id.NamespacedId entityId) {
+    this.metadataStore = metadataStore;
+    this.entityId = entityId;
+  }
+
+  /**
+   * Define the {@link MetadataScope#SYSTEM system} metadata properties to add for this entity.
+   *
+   * @return A {@link Map} of properties to add to this {@link Id.NamespacedId entity} in {@link MetadataScope#SYSTEM}
+   */
+  abstract Map<String, String> getSystemPropertiesToAdd();
+
+  /**
+   * Define the {@link MetadataScope#SYSTEM system} tags to add for this entity.
+   *
+   * @return an array of tags to add to this {@link Id.NamespacedId entity} in {@link MetadataScope#SYSTEM}
+   */
+  abstract String[] getSystemTagsToAdd();
+
+  /**
+   * Updates the {@link MetadataScope#SYSTEM} metadata for this {@link Id.NamespacedId entity}.
+   */
+  public void write() {
+    Map<String, String> properties = getSystemPropertiesToAdd();
+    if (properties.size() > 0) {
+      metadataStore.setProperties(MetadataScope.SYSTEM, entityId, properties);
+    }
+    String[] tags = getSystemTagsToAdd();
+    if (tags.length > 0) {
+      metadataStore.addTags(MetadataScope.SYSTEM, entityId, tags);
+    }
+  }
+
+  protected void addSchema(ImmutableMap.Builder<String, String> propertiesToUpdate, @Nullable Schema schema) {
+    if (schema == null) {
+      return;
+    }
+
+    if (schema.isSimpleOrNullableSimple()) {
+      Schema.Type type = getSimpleType(schema);
+      propertiesToUpdate.put(SCHEMA_FIELD_PROPERTY_PREFIX, type.toString());
+    } else {
+      for (Schema.Field field : schema.getFields()) {
+        String fieldName = field.getName();
+        // TODO: What if field.getSchema() is not simple or nullable simple?
+        String fieldType = getSimpleType(field.getSchema()).toString();
+        propertiesToUpdate.put(SCHEMA_FIELD_PROPERTY_PREFIX + MetadataDataset.KEYVALUE_SEPARATOR + fieldName,
+                               fieldName + MetadataDataset.KEYVALUE_SEPARATOR + fieldType);
+      }
+    }
+  }
+
+  protected void addPlugin(PluginClass pluginClass, @Nullable String version,
+                         ImmutableMap.Builder<String, String> properties) {
+    String name = pluginClass.getName();
+    String type = pluginClass.getType();
+    // Need both name and type in the key because two plugins of different types could have the same name.
+    // However, the composite of name + type is guaranteed to be unique
+    properties.put(
+      PLUGIN_KEY_PREFIX + MetadataDataset.KEYVALUE_SEPARATOR + name + MetadataDataset.KEYVALUE_SEPARATOR + type,
+      name + MetadataDataset.KEYVALUE_SEPARATOR + type
+    );
+    if (version != null) {
+      properties.put(
+        PLUGIN_VERSION_KEY_PREFIX + MetadataDataset.KEYVALUE_SEPARATOR + name +
+          MetadataDataset.KEYVALUE_SEPARATOR + type,
+        name + MetadataDataset.KEYVALUE_SEPARATOR + version
+      );
+    }
+  }
+
+  private Schema.Type getSimpleType(Schema schema) {
+    if (schema.isNullable()) {
+      schema = schema.getNonNullable();
+    }
+    return schema.getType();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AppSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AppSystemMetadataWriter.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.api.schedule.ScheduleSpecification;
+import co.cask.cdap.api.service.ServiceSpecification;
+import co.cask.cdap.api.spark.SparkSpecification;
+import co.cask.cdap.api.worker.WorkerSpecification;
+import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.internal.schedule.StreamSizeSchedule;
+import co.cask.cdap.internal.schedule.TimeSchedule;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A {@link AbstractSystemMetadataWriter} for an {@link Id.Application application}.
+ */
+public class AppSystemMetadataWriter extends AbstractSystemMetadataWriter {
+
+  private final ApplicationSpecification appSpec;
+
+  public AppSystemMetadataWriter(MetadataStore metadataStore, Id.Application entityId,
+                                 ApplicationSpecification appSpec) {
+    super(metadataStore, entityId);
+    this.appSpec = appSpec;
+  }
+
+  @Override
+  Map<String, String> getSystemPropertiesToAdd() {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    addPrograms(properties);
+    addSchedules(properties);
+    // appSpec.getPlugins() returns all instances of all plugins, so there may be duplicates.
+    // we only store unique plugins right now
+    Set<PluginClass> existing = new HashSet<>();
+    for (Plugin plugin : appSpec.getPlugins().values()) {
+      if (!existing.contains(plugin.getPluginClass())) {
+        addPlugin(plugin.getPluginClass(), null, properties);
+        existing.add(plugin.getPluginClass());
+      }
+    }
+    return properties.build();
+  }
+
+  @Override
+  String[] getSystemTagsToAdd() {
+    return new String[] {
+      appSpec.getName(),
+      appSpec.getArtifactId().getName()
+    };
+  }
+
+  private void addPrograms(ImmutableMap.Builder<String, String> properties) {
+    addPrograms(ProgramType.FLOW, appSpec.getFlows().values(), properties);
+    addPrograms(ProgramType.MAPREDUCE, appSpec.getMapReduce().values(), properties);
+    addPrograms(ProgramType.SERVICE, appSpec.getServices().values(), properties);
+    addPrograms(ProgramType.SPARK, appSpec.getSpark().values(), properties);
+    addPrograms(ProgramType.WORKER, appSpec.getWorkers().values(), properties);
+    addPrograms(ProgramType.WORKFLOW, appSpec.getWorkflows().values(), properties);
+  }
+
+  private void addPrograms(ProgramType programType, Iterable<? extends ProgramSpecification> specs,
+                           ImmutableMap.Builder<String, String> properties) {
+    for (ProgramSpecification spec : specs) {
+      properties.put(programType.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + spec.getName(),
+                     spec.getName());
+    }
+  }
+
+  private void addSchedules(ImmutableMap.Builder<String, String> properties) {
+    for (ScheduleSpecification scheduleSpec : appSpec.getSchedules().values()) {
+      Schedule schedule = scheduleSpec.getSchedule();
+      properties.put("schedule" + MetadataDataset.KEYVALUE_SEPARATOR + schedule.getName(),
+                     schedule.getName() + MetadataDataset.KEYVALUE_SEPARATOR + schedule.getDescription());
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ArtifactSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ArtifactSystemMetadataWriter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.api.artifact.ArtifactClasses;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ArtifactInfo;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * A {@link AbstractSystemMetadataWriter} for an {@link Id.Artifact artifact}.
+ */
+public class ArtifactSystemMetadataWriter extends AbstractSystemMetadataWriter {
+
+  private final ArtifactInfo artifactInfo;
+
+  public ArtifactSystemMetadataWriter(MetadataStore metadataStore, Id.Artifact artifactId,
+                                      ArtifactInfo artifactInfo) {
+    super(metadataStore, artifactId);
+    this.artifactInfo = artifactInfo;
+  }
+
+  @Override
+  Map<String, String> getSystemPropertiesToAdd() {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    ArtifactClasses classes = artifactInfo.getClasses();
+    for (PluginClass pluginClass : classes.getPlugins()) {
+      addPlugin(pluginClass, artifactInfo.getVersion(), properties);
+    }
+    return properties.build();
+  }
+
+  @Override
+  String[] getSystemTagsToAdd() {
+    return new String[] {
+      artifactInfo.getName()
+    };
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriter.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.api.data.batch.BatchReadable;
+import co.cask.cdap.api.data.batch.BatchWritable;
+import co.cask.cdap.api.data.batch.RecordScannable;
+import co.cask.cdap.api.data.batch.RecordWritable;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.ObjectMappedTable;
+import co.cask.cdap.api.dataset.lib.ObjectMappedTableProperties;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link AbstractSystemMetadataWriter} for a {@link Id.DatasetInstance dataset}.
+ */
+public class DatasetSystemMetadataWriter extends AbstractSystemMetadataWriter {
+  private final Id.DatasetInstance dsInstance;
+  private final String dsType;
+  private final DatasetProperties dsProperties;
+  private final SystemDatasetInstantiatorFactory dsInstantiatorFactory;
+
+  public DatasetSystemMetadataWriter(MetadataStore metadataStore,
+                                     SystemDatasetInstantiatorFactory dsInstantiatorFactory,
+                                     Id.DatasetInstance dsInstance, DatasetProperties dsProperties,
+                                     @Nullable String dsType) {
+    super(metadataStore, dsInstance);
+    this.dsInstance = dsInstance;
+    this.dsType = dsType;
+    this.dsProperties = dsProperties;
+    this.dsInstantiatorFactory = dsInstantiatorFactory;
+  }
+
+  @Override
+  Map<String, String> getSystemPropertiesToAdd() {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    Map<String, String> datasetProperties = dsProperties.getProperties();
+    String schemaStr = null;
+    if (datasetProperties.containsKey(DatasetProperties.SCHEMA)) {
+      schemaStr = datasetProperties.get(DatasetProperties.SCHEMA);
+    } else if (datasetProperties.containsKey(ObjectMappedTableProperties.OBJECT_SCHEMA)) {
+      // If it is an ObjectMappedTable, the schema is in a property called 'object.schema'
+      schemaStr = datasetProperties.get(ObjectMappedTableProperties.OBJECT_SCHEMA);
+    }
+    if (schemaStr != null) {
+      Schema schema = getSchema(schemaStr);
+      addSchema(properties, schema);
+    }
+    if (dsType != null) {
+      properties.put("type", dsType);
+    }
+    if (datasetProperties.containsKey(Table.PROPERTY_TTL)) {
+      properties.put(TTL_KEY, datasetProperties.get(Table.PROPERTY_TTL));
+    }
+    return properties.build();
+  }
+
+  @Override
+  String[] getSystemTagsToAdd() {
+    List<String> tags = new ArrayList<>();
+    tags.add(dsInstance.getId());
+    try (SystemDatasetInstantiator dsInstantiator = dsInstantiatorFactory.create();
+         Dataset dataset = dsInstantiator.getDataset(dsInstance)) {
+      if (dataset instanceof RecordScannable) {
+        tags.add(RecordScannable.class.getSimpleName());
+      }
+      if (dataset instanceof RecordWritable) {
+        tags.add(RecordWritable.class.getSimpleName());
+      }
+      if (dataset instanceof BatchReadable) {
+        tags.add(BatchReadable.class.getSimpleName());
+      }
+      if (dataset instanceof BatchWritable) {
+        tags.add(BatchWritable.class.getSimpleName());
+      }
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    return tags.toArray(new String[tags.size()]);
+  }
+
+  private Schema getSchema(String schemaStr) {
+    if (schemaStr.startsWith("\"") && schemaStr.endsWith("\"")) {
+      // simple type in lower case
+      schemaStr = schemaStr.substring(1, schemaStr.length() - 1);
+      return Schema.of(Schema.Type.valueOf(schemaStr.toUpperCase()));
+    }
+    // otherwise its a json
+    try {
+      return Schema.parseJson(schemaStr);
+    } catch (IOException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ProgramSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ProgramSystemMetadataWriter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link AbstractSystemMetadataWriter} for a {@link Id.Program program}.
+ */
+public class ProgramSystemMetadataWriter extends AbstractSystemMetadataWriter {
+  private final Id.Program programId;
+  private final ProgramSpecification programSpec;
+
+  public ProgramSystemMetadataWriter(MetadataStore metadataStore, Id.Program programId,
+                                     ProgramSpecification programSpec) {
+    super(metadataStore, programId);
+    this.programId = programId;
+    this.programSpec = programSpec;
+  }
+
+  @Override
+  Map<String, String> getSystemPropertiesToAdd() {
+    return ImmutableMap.of();
+  }
+
+  @Override
+  String[] getSystemTagsToAdd() {
+    List<String> tags = ImmutableList.<String>builder()
+      .add(programId.getId())
+      .add(programId.getType().getPrettyName())
+      .add(getMode())
+      .addAll(getWorkflowNodes())
+      .build();
+    return tags.toArray(new String[tags.size()]);
+  }
+
+  private String getMode() {
+    switch (programId.getType()) {
+      case MAPREDUCE:
+      case SPARK:
+      case WORKFLOW:
+      case CUSTOM_ACTION:
+        return "Batch";
+      case FLOW:
+      case WORKER:
+      case SERVICE:
+        return "Realtime";
+      default:
+        throw new IllegalArgumentException("Unknown program type " + programId.getType());
+    }
+  }
+
+  private Iterable<String> getWorkflowNodes() {
+    if (ProgramType.WORKFLOW != programId.getType()) {
+      return ImmutableSet.of();
+    }
+    Preconditions.checkArgument(programSpec instanceof WorkflowSpecification,
+                                "Expected programSpec %s to be of type WorkflowSpecification", programSpec);
+    return ((WorkflowSpecification) programSpec).getNodeIdMap().keySet();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.data2.transaction.stream.StreamConfig;
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * A {@link AbstractSystemMetadataWriter} for a {@link Id.Stream stream}.
+ */
+public class StreamSystemMetadataWriter extends AbstractSystemMetadataWriter {
+
+  private final StreamConfig config;
+
+  public StreamSystemMetadataWriter(MetadataStore metadataStore, Id.Stream streamId, StreamConfig config) {
+    super(metadataStore, streamId);
+    this.config = config;
+  }
+
+  @Override
+  Map<String, String> getSystemPropertiesToAdd() {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    addSchema(properties, config.getFormat().getSchema());
+    properties.put(TTL_KEY, String.valueOf(config.getTTL()));
+    return properties.build();
+  }
+
+  @Override
+  String[] getSystemTagsToAdd() {
+    return new String[] {
+      config.getStreamId().getId()
+    };
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.system;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ViewSpecification;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * A {@link AbstractSystemMetadataWriter} for an {@link Id.Stream.View view}.
+ */
+public class ViewSystemMetadataWriter extends AbstractSystemMetadataWriter {
+
+  private final Id.Stream.View viewId;
+  private final ViewSpecification viewSpec;
+
+  public ViewSystemMetadataWriter(MetadataStore metadataStore, Id.Stream.View viewId, ViewSpecification viewSpec) {
+    super(metadataStore, viewId);
+    this.viewId = viewId;
+    this.viewSpec = viewSpec;
+  }
+
+  @Override
+  Map<String, String> getSystemPropertiesToAdd() {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    addSchema(properties, viewSpec.getFormat().getSchema());
+    return properties.build();
+  }
+
+  @Override
+  String[] getSystemTagsToAdd() {
+    return new String[] {
+      viewId.getId(),
+      viewId.getStreamId()
+    };
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,18 +21,23 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
+import co.cask.cdap.data2.metadata.system.DatasetSystemMetadataWriter;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -47,13 +52,16 @@ public class LineageWriterDatasetFramework implements DatasetFramework, ProgramC
   private final LineageWriter lineageWriter;
   private final ProgramContext programContext = new ProgramContext();
   private final MetadataStore metadataStore;
+  private final SystemDatasetInstantiatorFactory dsInstantiatorFactory;
 
   @Inject
   LineageWriterDatasetFramework(@Named(DataSetsModules.BASIC_DATASET_FRAMEWORK) DatasetFramework datasetFramework,
-                                LineageWriter lineageWriter, MetadataStore metadataStore) {
+                                LineageWriter lineageWriter, MetadataStore metadataStore,
+                                LocationFactory locationFactory, CConfiguration cConf) {
     this.delegate = datasetFramework;
     this.lineageWriter = lineageWriter;
     this.metadataStore = metadataStore;
+    this.dsInstantiatorFactory = new SystemDatasetInstantiatorFactory(locationFactory, datasetFramework, cConf);
   }
 
   @Override
@@ -91,12 +99,35 @@ public class LineageWriterDatasetFramework implements DatasetFramework, ProgramC
   public void addInstance(String datasetTypeName, Id.DatasetInstance datasetInstanceId, DatasetProperties props)
     throws DatasetManagementException, IOException {
     delegate.addInstance(datasetTypeName, datasetInstanceId, props);
+    // add system metadata for user datasets only
+    if (!isUserDataset(datasetInstanceId)) {
+      return;
+    }
+    AbstractSystemMetadataWriter systemMetadataWriter =
+      new DatasetSystemMetadataWriter(metadataStore, dsInstantiatorFactory, datasetInstanceId, props, datasetTypeName);
+    systemMetadataWriter.write();
+  }
+
+  //TODO: CDAP-4627 - Figure out a better way to identify system datasets in user namespaces
+  private boolean isUserDataset(Id.DatasetInstance datasetInstanceId) {
+    return !Id.Namespace.SYSTEM.equals(datasetInstanceId.getNamespace()) &&
+      !"system.queue.config".equals(datasetInstanceId.getId()) &&
+      !datasetInstanceId.getId().startsWith("system.sharded.queue") &&
+      !datasetInstanceId.getId().startsWith("system.queue") &&
+      !datasetInstanceId.getId().startsWith("system.stream");
   }
 
   @Override
   public void updateInstance(Id.DatasetInstance datasetInstanceId, DatasetProperties props)
     throws DatasetManagementException, IOException {
     delegate.updateInstance(datasetInstanceId, props);
+    // add system metadata for user datasets only
+    if (!isUserDataset(datasetInstanceId)) {
+      return;
+    }
+    AbstractSystemMetadataWriter systemMetadataWriter =
+      new DatasetSystemMetadataWriter(metadataStore, dsInstantiatorFactory, datasetInstanceId, props, null);
+    systemMetadataWriter.write();
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchTargetType.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchTargetType.java
@@ -19,7 +19,7 @@ package co.cask.cdap.proto.metadata;
  * Supported types for metadata search.
  */
 public enum MetadataSearchTargetType {
-  // the custom values are required because these value match the entitiy-type stored as
+  // the custom values are required because these value match the entity-type stored as
   // a part of MDS key.
   ALL("All"),
   ARTIFACT("Artifact"),


### PR DESCRIPTION
(CDAP-4264) Add system metadata for all CDAP entities. 

(CDAP-4269) Added REST REST APIs to query system metadata by setting the 'scope' query parameter to 'system'.

(CDAP-4265) (CDAP-4266) (CDAP-4267) (CDAP-4268) Added the ability to add/update/delete system metadata for artifacts, apps, programs, datasets, streams and views.

Build: http://builds.cask.co/browse/CDAP-RBT592
Jiras:
[CDAP-4264](https://issues.cask.co/browse/CDAP-4264)
[CDAP-4265](https://issues.cask.co/browse/CDAP-4265)
[CDAP-4266](https://issues.cask.co/browse/CDAP-4266)
[CDAP-4267](https://issues.cask.co/browse/CDAP-4267)
[CDAP-4268](https://issues.cask.co/browse/CDAP-4268)
[CDAP-4269](https://issues.cask.co/browse/CDAP-4269)

This PR is based off of #4884, which has already been reviewed. Please only review the second commit.