### PR TITLE
Revert "[CDAP-4573] add an archetype for an app with MR; remove bin/ …

### DIFF
--- a/cdap-archetypes/cdap-app-archetype/README.rst
+++ b/cdap-archetypes/cdap-app-archetype/README.rst
@@ -17,18 +17,18 @@ Creating
 ========
 
 To create a project from the archetype, use this script as an example
-(substituting your version of CDAP for ${cdap.version} as appropriate)::
+(substituting for ${project.version} as appropriate)::
 
-  mvn archetype:generate
-    -DarchetypeGroupId=co.cask.cdap
-    -DarchetypeArtifactId=cdap-app-archetype
-    -DarchetypeVersion=${cdap.version}
+  mvn archetype:generate 					
+    -DarchetypeGroupId=co.cask.cdap 			
+    -DarchetypeArtifactId=cdap-app-archetype 	
+    -DarchetypeVersion=${project.version}
     -DgroupId=com.example
     -DartifactId=MyExample
-    -Dversion=1.0-SNAPSHOT
-
+    -Dversion=1.0						
 
 To confirm project creation, type Y and press ENTER.
+
 
 License and Trademarks
 ======================

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -18,6 +18,13 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
   name="cdap-app-archetype">
   <fileSets>
+    <fileSet encoding="UTF-8">
+      <directory>bin</directory>
+      <includes>
+        <include>*.sh</include>
+        <include>*.bat</include>
+      </includes>
+    </fileSet>
     <fileSet encoding="UTF-8" filtered="true" packaged="true">
       <directory>src/main/java</directory>
       <includes>

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/pom.xml
@@ -34,6 +34,17 @@
     <junit.version>4.11</junit.version>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+    </repository>
+    <repository>
+      <id>apache.snapshots</id>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>co.cask.cdap</groupId>

--- a/cdap-archetypes/cdap-spark-java-archetype/README.rst
+++ b/cdap-archetypes/cdap-spark-java-archetype/README.rst
@@ -17,12 +17,12 @@ Creating
 ========
 
 To create a project from the archetype, use this script as an example
-(substituting your version of CDAP for ${cdap.version} as appropriate)::
+(substituting for ${project.version} as appropriate)::
 
   mvn archetype:generate 					
     -DarchetypeGroupId=co.cask.cdap 			
     -DarchetypeArtifactId=cdap-spark-java-archetype 	
-    -DarchetypeVersion=${cdap.version}
+    -DarchetypeVersion=${project.version}
     -DgroupId=com.example
     -DartifactId=SparkPageRankExample
     -Dversion=1.0						

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -18,6 +18,13 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
   name="cdap-spark-java-archetype">
   <fileSets>
+    <fileSet encoding="UTF-8">
+      <directory>bin</directory>
+      <includes>
+        <include>*.sh</include>
+        <include>*.bat</include>
+      </includes>
+    </fileSet>
     <fileSet  encoding="UTF-8">
       <directory>libexec</directory>
       <includes>

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/pom.xml
@@ -37,6 +37,13 @@
     <hadoop.version>2.3.0</hadoop.version>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>apache.snapshots</id>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>co.cask.cdap</groupId>

--- a/cdap-archetypes/cdap-spark-scala-archetype/README.rst
+++ b/cdap-archetypes/cdap-spark-scala-archetype/README.rst
@@ -17,12 +17,12 @@ Creating
 ========
 
 To create a project from the archetype, use this script as an example
-(substituting your version of CDAP for ${cdap.version} as appropriate)::
+(substituting for ${project.version} as appropriate)::
 
   mvn archetype:generate 					
     -DarchetypeGroupId=co.cask.cdap 			
     -DarchetypeArtifactId=cdap-spark-scala-archetype 	
-    -DarchetypeVersion=${cdap.version}
+    -DarchetypeVersion=${project.version}
     -DgroupId=com.example 					
     -DartifactId=SparkKMeansExample
     -Dversion=1.0						

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -18,6 +18,13 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
   name="cdap-spark-scala-archetype">
   <fileSets>
+    <fileSet encoding="UTF-8">
+      <directory>bin</directory>
+      <includes>
+        <include>*.sh</include>
+        <include>*.bat</include>
+      </includes>
+    </fileSet>
     <fileSet  encoding="UTF-8">
       <directory>libexec</directory>
       <includes>

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/pom.xml
@@ -36,6 +36,18 @@
     <gson.version>2.2.4</gson.version>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>apache.snapshots</id>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+    </repository>
+    <repository>
+      <id>scala-tools.org</id>
+      <name>Scala-tools Maven2 Repository</name>
+      <url>http://scala-tools.org/repo-releases</url>
+    </repository>
+  </repositories>
+
   <pluginRepositories>
     <pluginRepository>
       <id>scala-tools.org</id>

--- a/cdap-archetypes/pom.xml
+++ b/cdap-archetypes/pom.xml
@@ -32,7 +32,6 @@
   <modules>
     <module>cdap-spark-java-archetype</module>
     <module>cdap-spark-scala-archetype</module>
-    <module>cdap-mapreduce-archetype</module>
     <module>cdap-app-archetype</module>
   </modules>
 

--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
@@ -81,9 +81,7 @@ implementation that does nothing::
   }
 
 CDAP ``Mapper`` and ``Reducer`` implement `the standard Hadoop APIs
-<http://hadoop.apache.org/docs/r2.3.0/api/org/apache/hadoop/mapreduce/package-summary.html>`__
-(note that CDAP only supports the "new" API in ``org.apache.hadoop.mapreduce``, and not the
-"old" API in ``org.apache.hadoop.mapred``)::
+<http://hadoop.apache.org/docs/r2.3.0/api/org/apache/hadoop/mapreduce/package-summary.html>`__::
 
   public static class PurchaseMapper 
       extends Mapper<byte[], Purchase, Text, Text> {

--- a/cdap-docs/developers-manual/source/getting-started/dev-env.rst
+++ b/cdap-docs/developers-manual/source/getting-started/dev-env.rst
@@ -31,12 +31,10 @@ The best way to start developing a CDAP application is by using the Maven archet
           -DarchetypeVersion=\ |release|
 
 This creates a Maven project with all required dependencies, Maven plugins, and a simple
-application template for the development of your application. You can import this Maven project
-into your preferred IDE |---| such as `IntelliJ <https://www.jetbrains.com/idea/>`__ or 
-`Eclipse <https://www.eclipse.org/>`__ |---| and start developing your first CDAP application.
-
-For an application that contains a MapReduce program, use ``-DarchetypeArtifactId=cdap-mapreduce-archetype``
-instead; for Spark, use either ``cdap-spark-java-archetype`` or ``cdap-spark-scala-archetype``.
+application template for the development of your application. You can import this Maven project into your preferred IDE—such as 
+`IntelliJ <https://www.jetbrains.com/idea/>`__ or 
+`Eclipse <https://www.eclipse.org/>`__—and start developing your first
+CDAP application.
 
 Using IntelliJ
 --------------


### PR DESCRIPTION
The PR https://github.com/caskdata/cdap/pull/4894 seems like it is incomplete. It is missing the actual mapreduce archetype module/code. It has broken the release build: http://builds.cask.co/browse/CDAP-RBT-JOB1-1046
Because of that, reverting it.

This reverts commit dacdb03cc2d93d9956065a30f15fcae7c0648770.

Build for this:
http://builds.cask.co/browse/CDAP-RBT594-1
