### PR TITLE
CDAP-4629 add setting for driver resources to etl batch

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -138,10 +138,10 @@ public class ETLMapReduce extends AbstractMapReduce {
     Resources resources = config.getResources();
     Resources driverResources = config.getDriverResources() == null ? resources : config.getDriverResources();
     if (resources != null) {
-      setMapperResources(config.getResources());
+      setMapperResources(resources);
     }
     if (driverResources != null) {
-      setDriverResources(config.getDriverResources());
+      setDriverResources(driverResources);
     }
 
     // add source, sink, transform ids to the properties. These are needed at runtime to instantiate the plugins

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -143,6 +143,7 @@ public class ETLMapReduce extends AbstractMapReduce {
     properties.put(Constants.PIPELINEID, GSON.toJson(pipeline));
     properties.put(Constants.STAGE_LOGGING_ENABLED, String.valueOf(config.isStageLoggingEnabled()));
     setProperties(properties);
+    setDriverResources(config.getDriverResources());
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.batch.mapreduce;
 
 import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValue;
@@ -134,8 +135,13 @@ public class ETLMapReduce extends AbstractMapReduce {
           .setTableProperty("avro.schema.literal", Constants.ERROR_SCHEMA.toString())
           .build(), true);
 
-    if (config.getResources() != null) {
+    Resources resources = config.getResources();
+    Resources driverResources = config.getDriverResources() == null ? resources : config.getDriverResources();
+    if (resources != null) {
       setMapperResources(config.getResources());
+    }
+    if (driverResources != null) {
+      setDriverResources(config.getDriverResources());
     }
 
     // add source, sink, transform ids to the properties. These are needed at runtime to instantiate the plugins
@@ -143,7 +149,6 @@ public class ETLMapReduce extends AbstractMapReduce {
     properties.put(Constants.PIPELINEID, GSON.toJson(pipeline));
     properties.put(Constants.STAGE_LOGGING_ENABLED, String.valueOf(config.isStageLoggingEnabled()));
     setProperties(properties);
-    setDriverResources(config.getDriverResources());
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -136,10 +136,10 @@ public class ETLMapReduce extends AbstractMapReduce {
           .build(), true);
 
     Resources resources = config.getResources();
-    Resources driverResources = config.getDriverResources() == null ? resources : config.getDriverResources();
     if (resources != null) {
       setMapperResources(resources);
     }
+    Resources driverResources = config.getDriverResources();
     if (driverResources != null) {
       setDriverResources(driverResources);
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
@@ -85,10 +85,10 @@ public class ETLSpark extends AbstractSpark {
     Resources resources = config.getResources();
     Resources driverResources = config.getDriverResources() == null ? resources : config.getDriverResources();
     if (resources != null) {
-      setExecutorResources(config.getResources());
+      setExecutorResources(resources);
     }
     if (driverResources != null) {
-      setDriverResources(config.getDriverResources());
+      setDriverResources(driverResources);
     }
 
     // add source, sink, transform ids to the properties. These are needed at runtime to instantiate the plugins

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.batch.spark;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.plugin.PluginContext;
@@ -81,16 +82,19 @@ public class ETLSpark extends AbstractSpark {
           .setTableProperty("avro.schema.literal", Constants.ERROR_SCHEMA.toString())
           .build(), true);
 
-    if (config.getResources() != null) {
-      setDriverResources(config.getResources());
+    Resources resources = config.getResources();
+    Resources driverResources = config.getDriverResources() == null ? resources : config.getDriverResources();
+    if (resources != null) {
       setExecutorResources(config.getResources());
+    }
+    if (driverResources != null) {
+      setDriverResources(config.getDriverResources());
     }
 
     // add source, sink, transform ids to the properties. These are needed at runtime to instantiate the plugins
     Map<String, String> properties = new HashMap<>();
     properties.put(Constants.PIPELINEID, GSON.toJson(pipelineIds));
     setProperties(properties);
-    setDriverResources(config.getDriverResources());
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
@@ -83,10 +83,10 @@ public class ETLSpark extends AbstractSpark {
           .build(), true);
 
     Resources resources = config.getResources();
-    Resources driverResources = config.getDriverResources() == null ? resources : config.getDriverResources();
     if (resources != null) {
       setExecutorResources(resources);
     }
+    Resources driverResources = config.getDriverResources();
     if (driverResources != null) {
       setDriverResources(driverResources);
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
@@ -90,6 +90,7 @@ public class ETLSpark extends AbstractSpark {
     Map<String, String> properties = new HashMap<>();
     properties.put(Constants.PIPELINEID, GSON.toJson(pipelineIds));
     setProperties(properties);
+    setDriverResources(config.getDriverResources());
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLEmailActionTestRun.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLEmailActionTestRun.java
@@ -29,14 +29,11 @@ import co.cask.cdap.test.WorkflowManager;
 import com.dumbster.smtp.SimpleSmtpServer;
 import com.dumbster.smtp.SmtpMessage;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -56,19 +53,17 @@ public class ETLEmailActionTestRun extends ETLBatchTestBase {
   @Test
   public void testEmailAction() throws Exception {
 
-    ETLStage source = new ETLStage("source", MockSource.getPlugin("inputTable"));
-    ETLStage sink = new ETLStage("sink", MockSink.getPlugin("outputTable"));
-    List<ETLStage> transforms = new ArrayList<>();
-
     Plugin actionConfig = new Plugin("Email", ImmutableMap.of(EmailAction.RECIPIENT_EMAIL_ADDRESS, "to@test.com",
                                                               EmailAction.FROM_ADDRESS, "from@test.com",
                                                               EmailAction.MESSAGE, "testing body",
                                                               EmailAction.SUBJECT, "Test",
                                                               EmailAction.PORT, Integer.toString(port)));
 
-    ETLStage action = new ETLStage("action", actionConfig);
-    List<ETLStage> actionList = Lists.newArrayList(action);
-    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, transforms, actionList);
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .setSource(new ETLStage("source", MockSource.getPlugin("inputTable")))
+      .addSink(new ETLStage("sink", MockSink.getPlugin("outputTable")))
+      .addAction(new ETLStage("action", actionConfig))
+      .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "actionTest");

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/config/ETLBatchConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/config/ETLBatchConfig.java
@@ -24,12 +24,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
- * ETL Batch Configuration.
+ * ETL Batch Configuration. Public constructors are deprecated. Use the builder instead.
  */
 public final class ETLBatchConfig extends ETLConfig {
 
@@ -43,43 +44,59 @@ public final class ETLBatchConfig extends ETLConfig {
   private final Engine engine;
   private final String schedule;
   private final List<ETLStage> actions;
+  private final Resources driverResources;
 
-  public ETLBatchConfig(Engine engine, String schedule,
-                        ETLStage source, List<ETLStage> sinks, List<ETLStage> transforms,
-                        List<Connection> connections, @Nullable Resources resources, @Nullable List<ETLStage> actions) {
+  private ETLBatchConfig(Engine engine, String schedule,
+                         ETLStage source, List<ETLStage> sinks, List<ETLStage> transforms,
+                         List<Connection> connections, Resources resources,
+                         Resources driverResources,
+                         List<ETLStage> actions) {
     super(source, sinks, transforms, connections, resources);
     this.engine = engine;
     this.schedule = schedule;
     this.actions = actions;
+    this.driverResources = driverResources;
   }
 
+  @Deprecated
+  public ETLBatchConfig(Engine engine, String schedule,
+                        ETLStage source, List<ETLStage> sinks, List<ETLStage> transforms,
+                        List<Connection> connections, @Nullable Resources resources, @Nullable List<ETLStage> actions) {
+    this(engine, schedule, source, sinks, transforms, connections, resources, new Resources(), actions);
+  }
+
+  @Deprecated
   public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink, List<ETLStage> transforms,
                         List<Connection> connections, @Nullable Resources resources, @Nullable List<ETLStage> actions) {
     this(Engine.MAPREDUCE, schedule, source, ImmutableList.of(sink), transforms, connections, resources, actions);
   }
 
+  @Deprecated
   public ETLBatchConfig(String schedule, ETLStage source, List<ETLStage> sinks, List<ETLStage> transforms,
                         List<Connection> connections, @Nullable Resources resources, @Nullable List<ETLStage> actions) {
     this(Engine.MAPREDUCE, schedule, source, sinks, transforms, connections, resources, actions);
   }
 
-
+  @Deprecated
   public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink,
                         List<ETLStage> transforms, List<ETLStage> actions) {
     this(schedule, source, sink, transforms, new ArrayList<Connection>(), null, actions);
   }
 
   @VisibleForTesting
+  @Deprecated
   public ETLBatchConfig(Engine engine, String schedule, ETLStage source, ETLStage sink, List<ETLStage> transforms) {
     this(engine, schedule, source, ImmutableList.of(sink), transforms, new ArrayList<Connection>(), null, null);
   }
 
   @VisibleForTesting
+  @Deprecated
   public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink, List<ETLStage> transforms) {
     this(schedule, source, sink, transforms, new ArrayList<Connection>(), null, null);
   }
 
   @VisibleForTesting
+  @Deprecated
   public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink) {
     this(schedule, source, sink, null);
   }
@@ -94,6 +111,10 @@ public final class ETLBatchConfig extends ETLConfig {
 
   public List<ETLStage> getActions() {
     return actions;
+  }
+
+  public Resources getDriverResources() {
+    return driverResources;
   }
 
   @Override
@@ -117,5 +138,52 @@ public final class ETLBatchConfig extends ETLConfig {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), schedule, actions);
+  }
+
+
+  public static Builder builder(String schedule) {
+    return new Builder(schedule);
+  }
+
+  /**
+   * Builder for creating configs.
+   */
+  public static class Builder extends ETLConfig.Builder<Builder> {
+    private final String schedule;
+    private Engine engine;
+    private List<ETLStage> actions;
+    private Resources driverResources;
+
+    public Builder(String schedule) {
+      super();
+      this.schedule = schedule;
+      this.actions = new ArrayList<>();
+      this.engine = Engine.MAPREDUCE;
+    }
+
+    public Builder addAction(ETLStage action) {
+      this.actions.add(action);
+      return this;
+    }
+
+    public Builder addActions(Collection<ETLStage> actions) {
+      this.actions.addAll(actions);
+      return this;
+    }
+
+    public Builder setEngine(Engine engine) {
+      this.engine = engine;
+      return this;
+    }
+
+    public Builder setDriverResources(Resources driverResources) {
+      this.driverResources = driverResources;
+      return this;
+    }
+
+    public ETLBatchConfig build() {
+      return new ETLBatchConfig(engine, schedule, source, sinks, transforms,
+                                connections, resources, driverResources, actions);
+    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLConfig.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -36,14 +37,23 @@ public class ETLConfig extends Config {
   private final List<Connection> connections;
   private final Resources resources;
 
+  /**
+   * @deprecated use builders from subclasses instead.
+   */
+  @Deprecated
   public ETLConfig(ETLStage source, List<ETLStage> sinks, List<ETLStage> transforms,
                    List<Connection> connections, Resources resources) {
+    this(source, sinks, transforms, connections, resources, true);
+  }
+
+  protected ETLConfig(ETLStage source, List<ETLStage> sinks, List<ETLStage> transforms,
+                      List<Connection> connections, Resources resources, boolean stageLoggingEnabled) {
     this.source = source;
     this.sinks = sinks;
     this.transforms = transforms;
     this.connections = getValidConnections(connections);
     this.resources = resources;
-    this.stageLoggingEnabled = true;
+    this.stageLoggingEnabled = stageLoggingEnabled;
   }
 
   private List<Connection> getValidConnections(List<Connection> connections) {
@@ -156,5 +166,76 @@ public class ETLConfig extends Config {
   @Override
   public int hashCode() {
     return Objects.hash(source, sinks, transforms, connections, resources, isStageLoggingEnabled());
+  }
+
+  /**
+   * Builder for creating configs.
+   */
+  @SuppressWarnings("unchecked")
+  public abstract static class Builder<T extends Builder> {
+    protected ETLStage source;
+    protected List<ETLStage> sinks;
+    protected List<ETLStage> transforms;
+    protected List<Connection> connections;
+    protected Resources resources;
+    protected Boolean stageLoggingEnabled;
+
+    protected Builder() {
+      this.sinks = new ArrayList<>();
+      this.transforms = new ArrayList<>();
+      this.connections = new ArrayList<>();
+      this.resources = new Resources();
+      this.stageLoggingEnabled = true;
+    }
+
+    public T setSource(ETLStage source) {
+      this.source = source;
+      return (T) this;
+    }
+
+    public T addTransform(ETLStage transform) {
+      this.transforms.add(transform);
+      return (T) this;
+    }
+
+    public T addTransforms(Collection<ETLStage> transforms) {
+      this.transforms.addAll(transforms);
+      return (T) this;
+    }
+
+    public T addSink(ETLStage sink) {
+      this.sinks.add(sink);
+      return (T) this;
+    }
+
+    public T addSinks(Collection<ETLStage> sinks) {
+      this.sinks.addAll(sinks);
+      return (T) this;
+    }
+
+    public T addConnection(String from, String to) {
+      this.connections.add(new Connection(from, to));
+      return (T) this;
+    }
+
+    public T addConnection(Connection connection) {
+      this.connections.add(connection);
+      return (T) this;
+    }
+
+    public T addConnections(Collection<Connection> connections) {
+      this.connections.addAll(connections);
+      return (T) this;
+    }
+
+    public T setResources(Resources resources) {
+      this.resources = resources;
+      return (T) this;
+    }
+
+    public T disableStageLogging() {
+      this.stageLoggingEnabled = false;
+      return (T) this;
+    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLStage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLStage.java
@@ -28,7 +28,6 @@ public final class ETLStage {
   private final Plugin plugin;
   // TODO : can remove the following properties and clean up the constructor after UI support.
   private final Map<String, String> properties;
-  // TODO : remove errorDatasetName after CDAP-4232 is implemented
   private final String errorDatasetName;
 
   public ETLStage(String name, Plugin plugin, @Nullable String errorDatasetName) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/config/ETLRealtimeConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/config/ETLRealtimeConfig.java
@@ -27,42 +27,50 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * ETL Realtime Configuration.
+ * ETL Realtime Configuration. Public constructors are all deprecated in favor of the builder.
  */
 public final class ETLRealtimeConfig extends ETLConfig {
   private final Integer instances;
 
+  @Deprecated
   public ETLRealtimeConfig(Integer instances, ETLStage source, List<ETLStage> sinks,
                            List<ETLStage> transforms, List<Connection> connections, Resources resources) {
     super(source, sinks, transforms, connections, resources);
     this.instances = instances;
   }
 
+  @Deprecated
   public ETLRealtimeConfig(ETLStage source, List<ETLStage> sinks,
                            List<ETLStage> transforms, List<Connection> connections) {
     this(1, source, sinks, transforms, connections, null);
 
   }
+
+  @Deprecated
   public ETLRealtimeConfig(ETLStage source, ETLStage sinks,
                            List<ETLStage> transforms, List<Connection> connections) {
     this(1, source, sinks, transforms, connections, null);
   }
 
+  @Deprecated
   public ETLRealtimeConfig(Integer instances, ETLStage source, ETLStage sink, List<ETLStage> transforms,
                            List<Connection> connections, Resources resources) {
     super(source, sink, transforms, connections, resources);
     this.instances = instances;
   }
 
+  @Deprecated
   public ETLRealtimeConfig(int instances, ETLStage source, ETLStage sink, List<ETLStage> transforms) {
     this(instances, source, sink, transforms, new ArrayList<Connection>(), null);
   }
 
+  @Deprecated
   @VisibleForTesting
   public ETLRealtimeConfig(ETLStage source, ETLStage sink, List<ETLStage> transforms) {
     this(1, source, sink, transforms);
   }
 
+  @Deprecated
   @VisibleForTesting
   public ETLRealtimeConfig(ETLStage source, ETLStage sink) {
     this(source, sink, null);
@@ -92,5 +100,29 @@ public final class ETLRealtimeConfig extends ETLConfig {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), instances);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder to create realtime etl configs.
+   */
+  public static class Builder extends ETLConfig.Builder<Builder> {
+    private int instances;
+
+    public Builder() {
+      this.instances = 1;
+    }
+
+    public Builder setInstances(int instances) {
+      this.instances = instances;
+      return this;
+    }
+
+    public ETLRealtimeConfig build() {
+      return new ETLRealtimeConfig(instances, source, sinks, transforms, connections, resources);
+    }
   }
 }


### PR DESCRIPTION
Adds a configuration setting for the resources for the
mapreduce or spark driver for etl batch pipelines. Since this
requires adding yet another constructor, took this opportunity to
add builders for the configs.