### PR TITLE
CDAP-4460: Lineage test to test all programs lineage is failing

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
@@ -268,13 +268,13 @@ public class LineageTest extends MetadataTestBase {
             new Relation(stream, mapreduce, AccessType.READ, workflowMrRunId),
             new Relation(stream, worker, AccessType.WRITE, workerRunId)
           )));
-      Assert.assertEquals(expected, lineage);
+      Assert.assertEquals("Expected: " + expected + " but got " + lineage, expected, lineage);
 
       // Fetch stream lineage
       lineage = fetchLineage(stream, now - oneHour, now + oneHour, 10);
 
       // stream too is accessed by all programs
-      Assert.assertEquals(expected, lineage);
+      Assert.assertEquals("Expected: " + expected + " but got " + lineage, expected, lineage);
 
       // Assert metadata
       // Id.Flow needs conversion to Id.Program JIRA - CDAP-3658


### PR DESCRIPTION
- Add additional logging to the failed assertion