### PR TITLE
updates styling and duration of error alert banners

### DIFF
--- a/cdap-ui/app/directives/error/error-popover.html
+++ b/cdap-ui/app/directives/error/error-popover.html
@@ -36,7 +36,7 @@
           <span class="badge" ng-if="alert.count > 1">{{alert.count}}</span>
           <strong>{{ alert.title }}</strong>  {{ alert.content }}
           <p>
-            <small class="text-muted">{{ alert.time | amCalendar }}</small>
+            <small>{{ alert.time | amCalendar }}</small>
           </p>
         </div>
         <div class="col-xs-2">

--- a/cdap-ui/app/directives/error/error.less
+++ b/cdap-ui/app/directives/error/error.less
@@ -82,7 +82,7 @@ my-error {
     }
     .alert-danger {
       background-image: none;
-      color: @brand-danger;
+      color: white;
     }
     .alert-muted {
       background-color: #dcdce4;

--- a/cdap-ui/app/directives/error/error.less
+++ b/cdap-ui/app/directives/error/error.less
@@ -15,6 +15,8 @@
  */
 
 @import "../../styles/variables.less";
+@import "../../styles/themes/cdap/mixins.less";
+@import "../../../bower_components/bootstrap/less/mixins.less";
 
 my-error {
   .error-button {
@@ -86,8 +88,12 @@ my-error {
       background-color: #dcdce4;
       border-color: darken(@well-bg, 10%);
     }
-    .fa-times:hover {
-      cursor: pointer;
+    .fa-times {
+      color: black;
+      .opacity(0.4);
+      &:hover {
+        cursor: pointer;
+      }
     }
   }
 

--- a/cdap-ui/app/directives/schedules-view/schedules-view.html
+++ b/cdap-ui/app/directives/schedules-view/schedules-view.html
@@ -1,20 +1,26 @@
 <!--
   Copyright © 2015 Cask Data, Inc.
- 
+
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
   the License at
- 
+
   http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
   License for the specific language governing permissions and limitations under
   the License.
---> 
+-->
 
 <div class="container">
+  <div class="alerts">
+    <div class="alert alert-danger" ng-if="error.content">
+      <button type="button" class="close" ng-click="error.content=false">×</button>
+      {{error}}
+    </div>
+  </div>
   <div class="schedule-heading row">
 
     <div class="col-xs-offset-1 col-xs-3">

--- a/cdap-ui/app/directives/schedules-view/schedules-view.html
+++ b/cdap-ui/app/directives/schedules-view/schedules-view.html
@@ -18,7 +18,7 @@
   <div class="alerts">
     <div class="alert alert-danger" ng-if="error.content">
       <button type="button" class="close" ng-click="error.content=false">×</button>
-      {{error}}
+      {{error.content}}
     </div>
   </div>
   <div class="schedule-heading row">

--- a/cdap-ui/app/directives/schedules-view/schedules-view.js
+++ b/cdap-ui/app/directives/schedules-view/schedules-view.js
@@ -22,7 +22,8 @@ angular.module(PKG.name + '.commons')
         schedules: '=',
         isSchedulesDisabled: '@',
         onScheduleAction: '&',
-        scheduleContext: '='
+        scheduleContext: '=',
+        error: '='
       },
       templateUrl: 'schedules-view/schedules-view.html',
       controller: function($scope) {

--- a/cdap-ui/app/directives/schedules-view/schedules-view.less
+++ b/cdap-ui/app/directives/schedules-view/schedules-view.less
@@ -15,6 +15,9 @@
  */
 
 @import "../../styles/variables.less";
+@import "../../styles/themes/cdap/mixins.less";
+@import "../../../bower_components/bootstrap/less/mixins.less";
+
 @border-color: #d0d0dd;
 my-schedules-view {
   .schedule-heading {
@@ -64,6 +67,19 @@ body.state-workflows {
   my-schedules-view {
     .container {
       width: 100%;
+    }
+    div.alerts {
+      top: 60px;
+    }
+    div.alert-danger {
+      color: white;
+      .close {
+        text-shadow: none;
+        .opacity(0.4);
+        &:focus {
+          outline: none;
+        }
+      }
     }
   }
 }

--- a/cdap-ui/app/directives/start-stop-button/start-stop-button.js
+++ b/cdap-ui/app/directives/start-stop-button/start-stop-button.js
@@ -26,7 +26,7 @@ angular.module(PKG.name + '.commons')
         runtimeHandler: '&'
       },
       templateUrl: 'start-stop-button/start-stop-button.html',
-      controller: function($scope, $state, MyCDAPDataSource, myRuntimeService, myProgramPreferencesService) {
+      controller: function($scope, $state, MyCDAPDataSource, myRuntimeService, myProgramPreferencesService, myAlertOnValium) {
         $scope.isStoppable = ($scope.isStoppable === 'true');
         $scope.isRestartable = ($scope.isRestartable === 'true');
 
@@ -58,14 +58,24 @@ angular.module(PKG.name + '.commons')
             $scope.status = 'STOPPING';
           }
           dataSrc.request(requestObj)
-            .then(function() {
-              if ($state.includes('**.run')) {
-                // go to the most current run, /runs
-                $state.go('^', $state.params, {reload: true});
-              } else {
-                $state.go($state.current, $state.params, {reload: true});
+            .then(
+              function success() {
+                if ($state.includes('**.run')) {
+                  // go to the most current run, /runs
+                  $state.go('^', $state.params, {reload: true});
+                } else {
+                  $state.go($state.current, $state.params, {reload: true});
+                }
+              },
+              function error(err) {
+                myAlertOnValium.show({
+                  type: 'danger',
+                  title: 'Error',
+                  content: err,
+                  duration: false
+                });
               }
-            });
+            );
         };
 
         // Delegate runtime & preferences handler

--- a/cdap-ui/app/features/hydrator/adapters.less
+++ b/cdap-ui/app/features/hydrator/adapters.less
@@ -259,6 +259,9 @@ body.theme-cdap {
         h4 { color: white; }
       }
     }
+    &.alert-open .alerts {
+      top: 60px;
+    }
   }
 
   &.state-hydrator-list {

--- a/cdap-ui/app/features/hydrator/controllers/create-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create-ctrl.js
@@ -116,7 +116,8 @@ angular.module(PKG.name + '.feature.hydrator')
          } catch(e) {
            $alert({
              type: 'danger',
-             content: 'Error in the JSON imported.'
+             content: 'Error in the JSON imported.',
+             duration: false
            });
            console.log('ERROR in imported json: ', e);
            return;

--- a/cdap-ui/app/features/hydrator/controllers/detail/top-panel-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/detail/top-panel-ctrl.js
@@ -14,8 +14,9 @@
  * the License.
  */
 angular.module(PKG.name + '.feature.hydrator')
-  .controller('HydratorDetailTopPanelController', function(DetailRunsStore, DetailNonRunsStore, PipelineDetailActionFactory, GLOBALS, $state, $alert, myLoadingService, $timeout, $scope, moment) {
+  .controller('HydratorDetailTopPanelController', function(DetailRunsStore, DetailNonRunsStore, PipelineDetailActionFactory, GLOBALS, $state, $alert, myLoadingService, $timeout, $scope, moment, myAlertOnValium) {
     this.GLOBALS = GLOBALS;
+    this.myAlertOnValium = myAlertOnValium;
     this.config = DetailNonRunsStore.getCloneConfig();
     this.app = {
       name: this.config.name,
@@ -95,6 +96,16 @@ angular.module(PKG.name + '.feature.hydrator')
           PipelineDetailActionFactory.startPipeline(
             DetailRunsStore.getApi(),
             DetailRunsStore.getParams()
+          ).then(
+            () => {},
+            (err) => {
+              this.myAlertOnValium.show({
+                type: 'danger',
+                title: 'Unable to start a new run',
+                content: angular.isObject(err)? err.data: err,
+                duration: false
+              });
+            }
           );
           break;
         case 'Schedule':
@@ -103,12 +114,22 @@ angular.module(PKG.name + '.feature.hydrator')
             DetailRunsStore.getApi(),
             DetailRunsStore.getScheduleParams()
           )
-            .then(function() {
-              PipelineDetailActionFactory.fetchScheduleStatus(
-                DetailRunsStore.getApi(),
-                DetailRunsStore.getScheduleParams()
-              );
-            });
+            .then(
+              () => {
+                PipelineDetailActionFactory.fetchScheduleStatus(
+                  DetailRunsStore.getApi(),
+                  DetailRunsStore.getScheduleParams()
+                );
+              },
+              (err) => {
+                this.myAlertOnValium.show({
+                  type: 'danger',
+                  title: 'Unable to schedule the pipeline',
+                  content: angular.isObject(err)? err.data: err,
+                  duration: false
+                });
+              }
+            );
           break;
         case 'Suspend':
           this.scheduleStatus = 'SUSPENDING';
@@ -116,18 +137,38 @@ angular.module(PKG.name + '.feature.hydrator')
             DetailRunsStore.getApi(),
             DetailRunsStore.getScheduleParams()
           )
-            .then(function() {
-              PipelineDetailActionFactory.fetchScheduleStatus(
-                DetailRunsStore.getApi(),
-                DetailRunsStore.getScheduleParams()
-              );
-            });
+            .then(
+              () => {
+                PipelineDetailActionFactory.fetchScheduleStatus(
+                  DetailRunsStore.getApi(),
+                  DetailRunsStore.getScheduleParams()
+                );
+              },
+              (err) => {
+                this.myAlertOnValium.show({
+                  type: 'danger',
+                  title: 'Unable to suspend the pipeline',
+                  content: angular.isObject(err)? err.data: err,
+                  duration: false
+                });
+              }
+            );
           break;
         case 'Stop':
           this.appStatus = 'STOPPING';
           PipelineDetailActionFactory.stopPipeline(
             DetailRunsStore.getApi(),
             DetailRunsStore.getParams()
+          ).then(
+            () => {},
+            (err) => {
+              this.myAlertOnValium.show({
+                type: 'danger',
+                title: 'Unable to stop the current run',
+                content: angular.isObject(err)? err.data: err,
+                duration: false
+              });
+            }
           );
           break;
         case 'Delete':
@@ -146,11 +187,12 @@ angular.module(PKG.name + '.feature.hydrator')
               },
               function error(err) {
                 myLoadingService.hideLoadingIcon();
-                $timeout(function() {
-                  $alert({
+                $timeout(() => {
+                  this.myAlertOnValium.show({
                     type: 'danger',
                     title: 'Unable to delete Pipeline',
-                    content: err.data
+                    content: err.data,
+                    duration: false
                   });
                 });
               }

--- a/cdap-ui/app/features/workflows/controllers/tabs/schedule-ctrl.js
+++ b/cdap-ui/app/features/workflows/controllers/tabs/schedule-ctrl.js
@@ -21,6 +21,7 @@ class ScheduleController {
     this.$scope = $scope;
     this.$q = $q;
     this.myAlert = myAlert;
+    this.error = {};
 
     let params = {
       namespace: this.$state.params.namespace,
@@ -110,10 +111,7 @@ class ScheduleController {
     }, {},
     function success() {},
     function error(err) {
-      this.myAlert({
-        title: 'Cannot Suspend Schedule',
-        content: err
-      });
+      this.error.content = err;
     }.bind(this));
   }
 

--- a/cdap-ui/app/features/workflows/templates/tabs/schedules.html
+++ b/cdap-ui/app/features/workflows/templates/tabs/schedules.html
@@ -1,18 +1,18 @@
 <!--
   Copyright © 2015 Cask Data, Inc.
- 
+
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
   the License at
- 
+
   http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
   License for the specific language governing permissions and limitations under
   the License.
---> 
+-->
 
 <div class="modal-header clearfix">
   <h3 class="pull-left">Schedules</h3>
@@ -27,7 +27,8 @@
     <my-schedules-view
       data-schedules="SchedulesController.schedules"
       data-on-schedule-action="SchedulesController.scheduleActionsMediator"
-      data-schedule-context="SchedulesController">
+      data-schedule-context="SchedulesController"
+      data-error="SchedulesController.error">
     </my-schedules-view>
   </div>
 

--- a/cdap-ui/app/index.html
+++ b/cdap-ui/app/index.html
@@ -43,9 +43,7 @@
       <div ui-view></div>
     </main>
 
-    <div id="alerts">
-      <div class="container"></div>
-    </div>
+    <div class="alerts" id="alerts"></div>
 
     <loading-icon></loading-icon>
 

--- a/cdap-ui/app/main.js
+++ b/cdap-ui/app/main.js
@@ -193,7 +193,7 @@ angular
   .config(function ($alertProvider) {
     angular.extend($alertProvider.defaults, {
       animation: 'am-fade-and-scale',
-      container: '#alerts > .container',
+      container: '#alerts',
       duration: 3
     });
   })

--- a/cdap-ui/app/services/app-uploader.js
+++ b/cdap-ui/app/services/app-uploader.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.services')
-  .factory('myAppUploader', function(myFileUploader, $state, $alert, myAlert) {
+  .factory('myAppUploader', function(myFileUploader, $state, myAlertOnValium) {
     function upload(files, namespace) {
 
       for (var i = 0; i < files.length; i++) {
@@ -28,7 +28,7 @@ angular.module(PKG.name + '.services')
       }
 
       function success() {
-        $alert({
+        myAlertOnValium.show({
           type: 'success',
           title: 'Upload success',
           content: 'The application has been uploaded successfully'
@@ -38,10 +38,11 @@ angular.module(PKG.name + '.services')
 
       // Independent xhr request. Failure case will not be handled by $rootScope.
       function error(err) {
-        myAlert({
+        myAlertOnValium.show({
           type: 'danger',
           title: 'Upload failed',
-          content: err || ''
+          content: err || '',
+          duration: false
         });
       }
     }

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -64,10 +64,10 @@ body {
   margin-bottom: 1px;
 }
 
-#alerts {
+.alerts {
   position: fixed;
-  z-index: 2001;
-  top: 85px;
+  z-index: 1029;
+  top: 114px;
   left: 0;
   right: 0;
 }

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -38,6 +38,28 @@ body.theme-cdap {
   // Alerts
   // --------------------------------------------------
 
+  > div.alerts {
+    div.alert-danger {
+      color: white;
+      margin-bottom: 0;
+      width: 100%;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+      .border-radius(0);
+    }
+    button.close {
+      font-size: 34px;
+      font-weight: 400;
+      line-height: 12px;
+      margin-left: 10px;
+      text-shadow: none;
+      .opacity(0.4);
+      &:focus {
+        outline: 0;
+      }
+    }
+  }
   // Common styles
   .alert {
     text-shadow: 0 1px 0 rgba(255,255,255,.2);

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -37,6 +37,7 @@
 @brand-info:            rgb(102, 110, 131); // #666e83
 @brand-warning:         rgb(244, 180, 0);   // #f4b400
 @brand-danger:          rgb(209, 86, 104);  // #d15668
+@alert-danger-bg:       rgb(250, 67, 71);   // #FA4347
 
 @body-bg:               rgb(235, 236, 241); // #ebecf1
 @jumbotron-bg:          white;              // #fff, white


### PR DESCRIPTION
*  Removes 3 sec duration for program operation errors (alert message now persists until user dismisses it by clicking "X")
*  Adds new styling and positioning of these alerts (including workflow schedules modal)
*  Adjusts styling of "x" in the alert notification center to be consistent with the new alert styles

TO DO:
-  [x] Add new error ribbon styling to import pipeline 
-  [x] Add new error ribbon styling to custom app uploaded (currently, errors are sent to global notification popover)

Custom app upload error:
![error](https://cloud.githubusercontent.com/assets/5335210/12381481/88c00596-bd3f-11e5-9685-512e39ba7e28.gif)

import pipeline error:
![error](https://cloud.githubusercontent.com/assets/5335210/12380744/41b7face-bd2f-11e5-852e-032849a178b8.gif)

error in CDAP:
![workflows](https://cloud.githubusercontent.com/assets/5335210/12369281/7f327f0a-bba9-11e5-834e-3a4e492626ee.gif)

error within modal:
![schedules](https://cloud.githubusercontent.com/assets/5335210/12369286/90392984-bba9-11e5-9965-389cf17e75b3.gif)
