### PR TITLE
(CDAP-4654) Fixed search API for UI. Shouldn't use tags: prefix and s…

### DIFF
--- a/cdap-ui/app/features/search/controllers/search-object-with-tags-controller.js
+++ b/cdap-ui/app/features/search/controllers/search-object-with-tags-controller.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,7 +27,7 @@ class SearchObjectWithTagsController {
   fetchAssociatedObjects() {
     let params = {
       namespaceId: this.$stateParams.namespace,
-      query: `tags:${this.tag}*`
+      query: `${this.tag}`
     };
     this.myTagsApi
       .searchTags(params)
@@ -76,7 +76,6 @@ class SearchObjectWithTagsController {
         });
         break;
       case 'program':
-
         angular.extend(modifiedTObject, {
           namespaceId: entityObj.application.namespace.id,
           appId: entityObj.application.applicationId,
@@ -86,6 +85,8 @@ class SearchObjectWithTagsController {
           icon: (entityObj.type.toLowerCase() === 'flow'? 'icon-tigon': 'icon-' + entityObj.type.toLowerCase())
         });
         break;
+      default:
+        return;
     }
     this.taggedObjects.push(modifiedTObject);
   }

--- a/cdap-ui/app/features/search/templates/search-objects-with-tags.html
+++ b/cdap-ui/app/features/search/templates/search-objects-with-tags.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2015-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -101,6 +101,29 @@
             <p class="tobject-type">
               <span class="{{tObject.icon}} pull-left"></span>
               <span> Service </span>
+            </p>
+          </div>
+        </div>
+        <div ng-if="tObject.programType === 'Spark'">
+          <div class="tobject">
+            <a ui-sref="spark.detail({namespace: tObject.namespaceId, appId: tObject.appId, programId: tObject.programId})">
+            <span class="{{tObject.icon}}"></span>
+            <span ng-bind="tObject.programId"></span>
+            </a>
+            <p class="tobject-type">
+              <span class="{{tObject.icon}} pull-left"></span>
+              <span> Spark </span>
+            </p>
+          </div>
+        </div>
+        <div ng-if="tObject.programType === 'Worker'">
+          <div class="tobject">
+            <a ui-sref="worker.detail({namespace: tObject.namespaceId, appId: tObject.appId, programId: tObject.programId})">
+              <span ng-bind="tObject.programId"></span>
+            </a>
+            <p class="tobject-type">
+              <span class="{{tObject.icon}} pull-left"></span>
+              <span> Worker </span>
             </p>
           </div>
         </div>


### PR DESCRIPTION
…houldn't add a * in the end of the search query. Also added missing rendering for spark and workers on the search results page.

Also fixed a bug so that search results for objects that cannot be rendered in the CDAP UI (e.g. views, artifacts) are not counted in the total, thereby removing inconsistency