### PR TITLE
Fix cdap-defaults.xml

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -868,14 +868,6 @@
   </property>
 
   <property>
-    <name>master.collect.containers.log</name>
-    <value>true</value>
-    <description>
-      Determines if master service container logs are streamed back to the CDAP Master process log
-    </description>
-  </property>
-
-  <property>
     <name>master.collect.app.containers.log</name>
     <value>true</value>
     <description>
@@ -884,10 +876,18 @@
   </property>
 
   <property>
+    <name>master.collect.containers.log</name>
+    <value>true</value>
+    <description>
+      Determines if master service container logs are streamed back to the CDAP Master process log
+    </description>
+  </property>
+
+  <property>
     <name>master.service.max.instances</name>
     <value>5</value>
     <description>
-      Maximum Number of Master Service Instances
+      Maximum number of Master Service instances
     </description>
   </property>
 
@@ -895,7 +895,7 @@
     <name>master.service.memory.mb</name>
     <value>512</value>
     <description>
-      Size of Memory in megabytes for Master Service instance
+      Size of memory in megabytes for Master Service instance
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="aeaed69db81f2292b4c3ed8d1aafeb0a"
+DEFAULT_XML_MD5_HASH="2f5609665b8dbe5ed45bd58bd28b6eb1"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"


### PR DESCRIPTION
Re-ordered properties alphabetically, removed extra capital letters, updated MD5 hash.

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB86-1).