### PR TITLE
Feature/ui schema propagation revert 1

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.js
@@ -215,9 +215,6 @@ angular.module(PKG.name + '.commons')
         }
 
         initialize($scope.model);
-        EventPipe.on('plugin-outputschema.update', function() {
-          initialize($scope.model);
-        });
 
         EventPipe.on('plugin.reset', function () {
           $scope.model = angular.copy(modelCopy);
@@ -348,7 +345,6 @@ angular.module(PKG.name + '.commons')
           EventPipe.cancelEvent('schema.clear');
           EventPipe.cancelEvent('plugin.reset');
           EventPipe.cancelEvent('dataset.selected');
-          EventPipe.cancelEvent('plugin-outputschema.update');
         });
       }
     };

--- a/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.js
@@ -226,6 +226,9 @@ angular.module(PKG.name + '.commons')
         });
 
         EventPipe.on('dataset.selected', function (schema) {
+          if ($scope.model) {
+            return;
+          }
           initialize(schema);
         });
 

--- a/cdap-ui/app/features/hydrator/bottompanel.less
+++ b/cdap-ui/app/features/hydrator/bottompanel.less
@@ -250,6 +250,11 @@ body.theme-cdap.state-hydrator {
       .schema-propagation-confirm {
         padding-top: 10px;
       }
+      .btn-group {
+        .btn {
+          margin-right: 5px;
+        }
+      }
     }
     .input-schema {
       @media (max-width: @screen-md-max) {

--- a/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -87,22 +87,6 @@ class NodeConfigController {
       outputSchemaUpdate: 0
     };
   }
-  copyInputToOutputSchema() {
-     // If there is no information of output schema in the node config then just mantain an output schema for UI purposes.
-     this.state.groupsConfig.outputSchema.isOutputSchemaExists = true;
-     this.state.node.outputSchema = angular.toJson({fields: this.state.node.inputSchema});
-     // FIXME: This is stupid and it is here because of 2-way binding. We bind the model of schema editor to the output schema
-     // The schema editor updates the schema from within and it should expect changes from outside (in this case copy to Output button).
-     // To differntiate editing from within and changes from outside we have to do this.
-     // And we need to differentiate because while editing we don't want to lose focus on the current textbox ($watch on the same property loses it)
-     // One more reason we should have used Flux/Redux so that we could have eliminated these hacks.
-     // The side effects of 3-way-binding (user, external & copy to output) we have different event pipe events
-     // plugin.reset, schema.clear, dataset.selected, plugin-outputschema.update
-     this.$timeout(() => {
-       this.EventPipe.emit('plugin-outputschema.update');
-     });
-     this.ConfigActionsFactory.editPlugin(this.state.node.name, this.state.node);
-  }
   propagateSchemaDownStream() {
     this.ConfigActionsFactory.propagateSchemaDownStream(this.state.node.name);
   }
@@ -175,6 +159,9 @@ class NodeConfigController {
                   true
                 )
               );
+            }
+            if (!this.state.node.outputSchema) {
+              this.state.node.outputSchema = JSON.stringify({fields: this.state.node.inputSchema});
             }
             // Mark the configfetched to show that configurations have been received.
             this.state.configfetched = true;

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-input-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-input-schema.html
@@ -17,11 +17,6 @@
 <div class="input-schema">
     <div class="schema-inner" ng-if="NodeConfigController.state.node.inputSchema">
       <h4>Input Schema</h4>
-      <button class="btn btn-default"
-              ng-if="!NodeConfigController.configOutputSchema.implicitSchema && !isDisabled"
-              ng-click="NodeConfigController.copyInputToOutputSchema()">
-          Copy to Output
-      </button>
       <table class="table">
         <thead>
           <th>

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/plugin-edit-output-schema.html
@@ -26,22 +26,25 @@
     <span ng-if="NodeConfigController.state.isSink">Schema</span>
 
     <span class="fa fa-asterisk ng-scope" ng-if="NodeConfigController.state.groupsConfig.outputSchema.isOutputSchemaRequired"></span>
-    <button
-      class="btn btn-sm btn-default pull-right"
-      ng-click="NodeConfigController.schemaClear()"
-      ng-if="(!NodeConfigController.state.groupsConfig.outputSchema.implicitSchema && !isDisabled)"
-      ng-disabled="NodeConfigController.state.groupsConfig.outputSchema.implicitSchema || NodeConfigController.state.node.plugin.properties.format === 'clf' || NodeConfigController.state.node.plugin.properties.format === 'syslog'">
-      Clear
-    </button>
   </h4>
   <fieldset class="clearfix" ng-disabled="isDisabled">
-    <button class="btn btn-default"
-             tooltip="Propagates schema to all down-stream nodes."
-             tooltip-popup-delay="500"
-             ng-if="!isDisabled"
-             ng-click="NodeConfigController.showPropagateConfirm = true">
-      Propagate
-    </button>
+    <div class="btn-group">
+      <button class="btn btn-default"
+               tooltip="Propagates schema to all down-stream nodes."
+               tooltip-popup-delay="500"
+               tooltip-append-to-body="true"
+               ng-if="!isDisabled"
+               ng-click="NodeConfigController.showPropagateConfirm = true">
+        Propagate
+      </button>
+      <button
+        class="btn btn-default"
+        ng-click="NodeConfigController.schemaClear()"
+        ng-if="(!NodeConfigController.state.groupsConfig.outputSchema.implicitSchema && !isDisabled)"
+        ng-disabled="NodeConfigController.state.groupsConfig.outputSchema.implicitSchema || NodeConfigController.state.node.plugin.properties.format === 'clf' || NodeConfigController.state.node.plugin.properties.format === 'syslog'">
+        Clear
+      </button>
+    </div>
     <div class="schema-propagation-confirm">
       <div class="well well-xs" ng-if="NodeConfigController.showPropagateConfirm">
         Existing schema will be over-written. Continue?


### PR DESCRIPTION
- Removes ```CopytoOutput``` button in node config and implicitly copies input schema to output schema if empty.
- Prevents overwritting output schema when user chooses a stream in stream source (when output schema is already set by the user)