### PR TITLE
Reduce build time by disabling explore

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
@@ -63,7 +63,7 @@ public class MonitorHandlerTest extends AppFabricTestBase {
     List<SystemServiceMeta> actual = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
                                                        Charsets.UTF_8), token);
 
-    Assert.assertEquals(9, actual.size());
+    Assert.assertEquals(8, actual.size());
     urlConn.disconnect();
   }
 
@@ -78,7 +78,7 @@ public class MonitorHandlerTest extends AppFabricTestBase {
 
     Map<String, String> result = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
                                                Charsets.UTF_8), token);
-    Assert.assertEquals(9, result.size());
+    Assert.assertEquals(8, result.size());
     urlConn.disconnect();
     Assert.assertEquals("OK", result.get(Constants.Service.APP_FABRIC_HTTP));
   }

--- a/cdap-app-fabric/src/test/resources/cdap-site.xml
+++ b/cdap-app-fabric/src/test/resources/cdap-site.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  ~ Copyright © 2016 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<configuration>
+
+  <property>
+    <name>explore.enabled</name>
+    <value>false</value>
+    <description>Determines if the CDAP Explore Service (ad-hoc SQL queries) is enabled</description>
+  </property>
+
+</configuration>

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/QueryClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/QueryClientTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,16 +20,13 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.client.app.FakeApp;
 import co.cask.cdap.client.app.FakeFlow;
 import co.cask.cdap.client.common.ClientTestBase;
-import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.config.ConnectionConfig;
-import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.explore.client.FixedAddressExploreClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.QueryResult;
-import co.cask.cdap.security.authentication.client.AccessToken;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.collect.Lists;
 import org.junit.Assert;
@@ -39,7 +36,6 @@ import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.test.SingletonExternalResource;
+import co.cask.cdap.test.TestConfiguration;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
@@ -55,6 +56,9 @@ public abstract class ClientTestBase {
 
   @ClassRule
   public static final SingletonExternalResource STANDALONE = new SingletonExternalResource(new StandaloneTester());
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", "true");
 
   @ClassRule
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();

--- a/cdap-data-fabric-tests/src/test/resources/cdap-site.xml
+++ b/cdap-data-fabric-tests/src/test/resources/cdap-site.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  ~ Copyright © 2016 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<configuration>
+
+  <property>
+    <name>explore.enabled</name>
+    <value>false</value>
+    <description>Determines if the CDAP Explore Service (ad-hoc SQL queries) is enabled</description>
+  </property>
+
+</configuration>

--- a/cdap-data-fabric/src/test/resources/cdap-site.xml
+++ b/cdap-data-fabric/src/test/resources/cdap-site.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  ~ Copyright © 2016 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<configuration>
+
+  <property>
+    <name>explore.enabled</name>
+    <value>false</value>
+    <description>Determines if the CDAP Explore Service (ad-hoc SQL queries) is enabled</description>
+  </property>
+
+</configuration>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -148,6 +148,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-unit-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
+++ b/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,6 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.test.TestConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
@@ -60,6 +61,16 @@ public class StandaloneTester extends ExternalResource {
     cConf.setInt(Constants.Router.ROUTER_PORT, Networks.getRandomPort());
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
     cConf.setBoolean(StandaloneMain.DISABLE_UI, true);
+
+    // Setup test case specific configurations.
+    // The system properties are usually setup by TestConfiguration class using @ClassRule
+    for (String key : System.getProperties().stringPropertyNames()) {
+      if (key.startsWith(TestConfiguration.PROPERTY_PREFIX)) {
+        String value = System.getProperty(key);
+        cConf.set(key.substring(TestConfiguration.PROPERTY_PREFIX.length()), System.getProperty(key));
+        LOG.info("Custom configuration set: {} = {}", key, value);
+      }
+    }
 
     this.cConf = cConf;
 


### PR DESCRIPTION
The build time was significantly increased by this PR: https://github.com/caskdata/cdap/pull/4859
Disable explore in cdap-app-fabric, cdap-data-fabric, cdap-data-fabric-tests to reduce build time.

http://builds.cask.co/browse/CDAP-RBT605-4