### PR TITLE
UIFeature/ui admin error handling fix

### DIFF
--- a/cdap-ui/app/directives/instance-control/instance-control.js
+++ b/cdap-ui/app/directives/instance-control/instance-control.js
@@ -26,7 +26,7 @@ angular.module(PKG.name + '.commons')
       templateUrl: 'instance-control/instance-control.html',
     };
   })
-  .controller('instanceControlController', function ($scope, MyCDAPDataSource) {
+  .controller('instanceControlController', function ($scope, MyCDAPDataSource, myAlertOnValium) {
     var myDataSrc = new MyCDAPDataSource($scope);
 
     myDataSrc.request({
@@ -40,9 +40,19 @@ angular.module(PKG.name + '.commons')
         method: 'PUT',
         _cdapPath: $scope.basePath + '/instances',
         body: {'instances': $scope.instance.requested}
-      }).then(function success () {
-        $scope.instance.provisioned = $scope.instance.requested;
-      });
+      }).then(
+        function success () {
+          $scope.instance.provisioned = $scope.instance.requested;
+        },
+        function error(err) {
+          myAlertOnValium.show({
+            type: 'danger',
+            title: 'Error',
+            content: err,
+            duration: false
+          });
+        }
+      );
     };
 
   });

--- a/cdap-ui/app/directives/instance-control/instance-control.js
+++ b/cdap-ui/app/directives/instance-control/instance-control.js
@@ -39,7 +39,8 @@ angular.module(PKG.name + '.commons')
       myDataSrc.request({
         method: 'PUT',
         _cdapPath: $scope.basePath + '/instances',
-        body: {'instances': $scope.instance.requested}
+        body: {'instances': $scope.instance.requested},
+        suppressErrors: true
       }).then(
         function success () {
           $scope.instance.provisioned = $scope.instance.requested;
@@ -48,7 +49,7 @@ angular.module(PKG.name + '.commons')
           myAlertOnValium.show({
             type: 'danger',
             title: 'Error',
-            content: err,
+            content: angular.isObject(err) ? err.data : err,
             duration: false
           });
         }

--- a/cdap-ui/app/directives/schedules-view/schedules-view.html
+++ b/cdap-ui/app/directives/schedules-view/schedules-view.html
@@ -18,7 +18,7 @@
   <div class="alerts">
     <div class="alert alert-danger" ng-if="error.content">
       <button type="button" class="close" ng-click="error.content=false">×</button>
-      {{error.content}}
+      <span>{{error.content}}</span>
     </div>
   </div>
   <div class="schedule-heading row">

--- a/cdap-ui/app/directives/schedules-view/schedules-view.less
+++ b/cdap-ui/app/directives/schedules-view/schedules-view.less
@@ -68,18 +68,5 @@ body.state-workflows {
     .container {
       width: 100%;
     }
-    div.alerts {
-      top: 60px;
-    }
-    div.alert-danger {
-      color: white;
-      .close {
-        text-shadow: none;
-        .opacity(0.4);
-        &:focus {
-          outline: none;
-        }
-      }
-    }
   }
 }

--- a/cdap-ui/app/directives/start-stop-button/start-stop-button.js
+++ b/cdap-ui/app/directives/start-stop-button/start-stop-button.js
@@ -71,7 +71,7 @@ angular.module(PKG.name + '.commons')
                 myAlertOnValium.show({
                   type: 'danger',
                   title: 'Error',
-                  content: err,
+                  content: angular.isObject(err) ? err.data : err,
                   duration: false
                 });
               }

--- a/cdap-ui/app/features/admin/controllers/namespace/app-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/app-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin').controller('NamespaceAppController',
-function ($scope, $state, myAppUploader, MyCDAPDataSource, myNamespace, $alert, GLOBALS, myHydratorFactory) {
+function ($scope, $state, myAppUploader, MyCDAPDataSource, myNamespace, myAlertOnValium, GLOBALS, myHydratorFactory) {
 
   $scope.apps = [];
   $scope.GLOBALS = GLOBALS;
@@ -36,7 +36,7 @@ function ($scope, $state, myAppUploader, MyCDAPDataSource, myNamespace, $alert, 
       _cdapPath: path + '/' + id,
       method: 'DELETE'
     }, function() {
-      $alert({
+      myAlertOnValium.show({
         type: 'success',
         title: id,
         content: 'Application deleted successfully'

--- a/cdap-ui/app/features/admin/controllers/namespace/app-metadata-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/app-metadata-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin').controller('NamespaceAppMetadataController',
-function ($scope, $state, $alert, $timeout, MyCDAPDataSource, myHydratorFactory) {
+function ($scope, $state, myAlertOnValium, $timeout, MyCDAPDataSource, myHydratorFactory) {
 
   var data = new MyCDAPDataSource($scope);
   var path = '/namespaces/' + $state.params.nsadmin + '/apps/' + $state.params.appId;
@@ -33,7 +33,7 @@ function ($scope, $state, $alert, $timeout, MyCDAPDataSource, myHydratorFactory)
       _cdapPath: path,
       method: 'DELETE'
     }, function() {
-      $alert({
+      myAlertOnValium.show({
         type: 'success',
         title: app,
         content: 'Application deleted successfully'

--- a/cdap-ui/app/features/admin/controllers/namespace/create-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/create-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin')
-  .controller('NamespaceCreateController', function ($scope, myAlert, $modalInstance, MyCDAPDataSource, myNamespace, EventPipe) {
+  .controller('NamespaceCreateController', function ($scope, myAlert, $modalInstance, MyCDAPDataSource, myNamespace, EventPipe, myAlertOnValium) {
     $scope.model = {
       name: '',
       description: ''
@@ -35,30 +35,26 @@ angular.module(PKG.name + '.feature.admin')
         body: {
           name: $scope.model.name,
           description: $scope.model.description
-        }
+        },
+        suppressErrors: true
       })
         .then(
           function success(res) {
             $scope.isSaving = false;
-            myAlert({
+            myAlertOnValium.show({
               type: 'success',
               content: res
             });
 
             myNamespace.getList(true).then(function() {
               EventPipe.emit('namespace.update');
-               $modalInstance.close();
+              $modalInstance.close();
             });
 
           },
           function error(err) {
             $scope.isSaving = false;
             $scope.error = err.data;
-            myAlert({
-              type: 'danger',
-              content: $scope.error,
-              duration: false
-            });
           }
         );
     };

--- a/cdap-ui/app/features/admin/controllers/namespace/create-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/create-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin')
-  .controller('NamespaceCreateController', function ($scope, $alert, $modalInstance, MyCDAPDataSource, myNamespace, EventPipe) {
+  .controller('NamespaceCreateController', function ($scope, myAlert, $modalInstance, MyCDAPDataSource, myNamespace, EventPipe) {
     $scope.model = {
       name: '',
       description: ''
@@ -40,9 +40,9 @@ angular.module(PKG.name + '.feature.admin')
         .then(
           function success(res) {
             $scope.isSaving = false;
-            $alert({
-              content: res,
-              type: 'success'
+            myAlert({
+              type: 'success',
+              content: res
             });
 
             myNamespace.getList(true).then(function() {
@@ -54,6 +54,11 @@ angular.module(PKG.name + '.feature.admin')
           function error(err) {
             $scope.isSaving = false;
             $scope.error = err.data;
+            myAlert({
+              type: 'danger',
+              content: $scope.error,
+              duration: false
+            });
           }
         );
     };

--- a/cdap-ui/app/features/admin/controllers/namespace/dataset-metadata-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/dataset-metadata-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin').controller('NamespaceDatasetMetadataController',
-function ($scope, $state, $alert, $filter, myDatasetApi, myExploreApi, EventPipe) {
+function ($scope, $state, myAlertOnValium, $filter, myDatasetApi, myExploreApi, EventPipe) {
 
   var params = {
     namespace: $state.params.nsadmin,
@@ -57,7 +57,7 @@ function ($scope, $state, $alert, $filter, myDatasetApi, myExploreApi, EventPipe
       EventPipe.emit('hideLoadingIcon.immediate');
 
       $state.go('admin.namespace.detail.data', {}, {reload: true});
-      $alert({
+      myAlertOnValium.show({
         type: 'success',
         content: 'Successfully deleted dataset'
       });

--- a/cdap-ui/app/features/admin/controllers/namespace/metadata-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/metadata-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin').controller('NamespaceMetadataController',
-function ($scope, $state, myAlert, MyCDAPDataSource, myNamespace) {
+function ($scope, $state, myAlertOnValium, MyCDAPDataSource, myNamespace) {
 
   $scope.nsname = myNamespace.getDisplayName($state.params.nsadmin);
   var data = new MyCDAPDataSource($scope);
@@ -29,10 +29,11 @@ function ($scope, $state, myAlert, MyCDAPDataSource, myNamespace) {
     });
 
   $scope.doSave = function () {
-    myAlert({
+    myAlertOnValium.show({
       title: 'It doesn\'t work yet',
       content: 'There is no content yet',
-      type: 'warning'
+      type: 'warning',
+      duration: false
     });
   };
 

--- a/cdap-ui/app/features/admin/controllers/namespace/settings-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/settings-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin')
-  .controller('NamespaceSettingsController', function ($scope, MyCDAPDataSource, $state, $alert, $timeout, myNamespace, EventPipe) {
+  .controller('NamespaceSettingsController', function ($scope, MyCDAPDataSource, $state, myAlertOnValium, $timeout, myNamespace, EventPipe) {
 
     var dataSrc = new MyCDAPDataSource($scope);
     $scope.loading = false;
@@ -37,7 +37,7 @@ angular.module(PKG.name + '.feature.admin')
         }
       })
       .then(function () {
-        $alert({
+        myAlertOnValium.show({
           type: 'success',
           content: 'Namespace successfully updated'
         });
@@ -62,7 +62,7 @@ angular.module(PKG.name + '.feature.admin')
           EventPipe.emit('hideLoadingIcon.immediate');
 
           $state.go('admin.overview', {}, {reload: true});
-          $alert({
+          myAlertOnValium.show({
             type: 'success',
             content: 'You have successfully deleted a namespace'
           });

--- a/cdap-ui/app/features/admin/controllers/namespace/stream-metadata-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/stream-metadata-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin')
-  .controller('NamespaceStreamMetadataController', function($scope, $stateParams, myHelpers, $alert, myStreamApi, $state, EventPipe, myAlertOnValium) {
+  .controller('NamespaceStreamMetadataController', function($scope, $stateParams, myHelpers, myStreamApi, $state, EventPipe, myAlertOnValium) {
 
     $scope.avro = {};
 
@@ -192,7 +192,7 @@ angular.module(PKG.name + '.feature.admin')
         EventPipe.emit('hideLoadingIcon.immediate');
 
         $state.go('admin.namespace.detail.data', {}, {reload: true});
-        $alert({
+        myAlertOnValium.show({
           type: 'success',
           content: 'Successfully deleted stream'
         });

--- a/cdap-ui/app/features/admin/controllers/namespace/templates-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/templates-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin')
-  .controller('NamespaceTemplatesController', function ($scope, myPipelineApi, PluginConfigFactory, myHelpers, mySettings, $stateParams, $alert, $state, GLOBALS, $rootScope, myAlertOnValium) {
+  .controller('NamespaceTemplatesController', function ($scope, myPipelineApi, PluginConfigFactory, myHelpers, mySettings, $stateParams, $state, GLOBALS, $rootScope, myAlertOnValium) {
 
     var vm = this;
     var oldTemplateName;
@@ -225,7 +225,8 @@ angular.module(PKG.name + '.feature.admin')
         myAlertOnValium.show({
           type: 'danger',
           title: 'Error!',
-          content: GLOBALS.en.admin.templateNameMissingError
+          content: GLOBALS.en.admin.templateNameMissingError,
+          duration: false
         });
 
         return;
@@ -236,7 +237,8 @@ angular.module(PKG.name + '.feature.admin')
         myAlertOnValium.show({
           type: 'danger',
           title: 'Error!',
-          content: GLOBALS.en.admin.pluginSameNameError
+          content: GLOBALS.en.admin.pluginSameNameError,
+          duration: false
         });
 
         return;
@@ -274,9 +276,10 @@ angular.module(PKG.name + '.feature.admin')
           var config = myHelpers.objectQuery(res, namespace, properties.templateType, properties.pluginType, properties.pluginTemplate);
 
           if (config && !vm.isEdit) {
-            $alert({
+            myAlertOnValium.show({
               type: 'danger',
-              content: GLOBALS.en.admin.templateNameExistsError
+              content: GLOBALS.en.admin.templateNameExistsError,
+              duration: false
             });
             vm.loading = false;
 
@@ -285,9 +288,10 @@ angular.module(PKG.name + '.feature.admin')
 
           if (vm.isEdit && oldTemplateName !== vm.pluginConfig.pluginTemplate) {
             if (config) {
-              $alert({
+              myAlertOnValium.show({
                 type: 'danger',
-                content: GLOBALS.en.admin.templateNameExistsError
+                content: GLOBALS.en.admin.templateNameExistsError,
+                duration: false
               });
               vm.loading = false;
 
@@ -308,7 +312,7 @@ angular.module(PKG.name + '.feature.admin')
 
           mySettings.set('pluginTemplates', res)
             .then(function () {
-              $alert({
+              myAlertOnValium.show({
                 type: 'success',
                 content: 'Success saving template'
               });

--- a/cdap-ui/app/features/admin/controllers/namespace/templates-list-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/templates-list-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.admin')
-  .controller('NamespaceTemplatesListController', function ($scope, mySettings, $stateParams, $alert, myHelpers, GLOBALS) {
+  .controller('NamespaceTemplatesListController', function ($scope, mySettings, $stateParams, myAlertOnValium, myHelpers, GLOBALS) {
 
     var vm = this;
     vm.list = [];
@@ -66,7 +66,7 @@ angular.module(PKG.name + '.feature.admin')
 
           mySettings.set('pluginTemplates', res)
             .then(function () {
-              $alert({
+              myAlertOnValium.show({
                 type: 'success',
                 content: 'Successfully deleted template'
               });

--- a/cdap-ui/app/features/admin/templates/namespace/create.html
+++ b/cdap-ui/app/features/admin/templates/namespace/create.html
@@ -22,6 +22,17 @@
   </a>
 </div>
 <div class="modal-body">
+  <div class="alerts">
+    <div class="alert alert-danger"
+         ng-show="error"
+         role="alert">
+      <button type="button"
+              class="close"
+              ng-click="error=null"
+              aria-label="Close">×</button>
+      <span>{{error}}</span>
+    </div>
+  </div>
   <form class="form-horizontal"
         role="form"
         name="namespaceCreateForm"
@@ -39,17 +50,6 @@
                ng-keypress="enter($event)"
                autofocus
                required>
-        <div class="alert alert-danger alert-dismissible"
-             ng-show="error"
-             role="alert">
-          <button type="button"
-                  class="close"
-                  ng-click="error=null"
-                  aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-          <p><i class="fa fa-exclamation-circle"></i>  {{error}}</p>
-        </div>
       </div>
     </div>
 

--- a/cdap-ui/app/features/admin/templates/namespace/streamscreate.html
+++ b/cdap-ui/app/features/admin/templates/namespace/streamscreate.html
@@ -22,6 +22,17 @@
     </a>
 </div>
 <div class="modal-body">
+  <div class="alerts">
+    <div class="alert alert-danger"
+         ng-show="error"
+         role="alert">
+      <button type="button"
+              class="close"
+              ng-click="error=null"
+              aria-label="Close">x</button>
+      <span>{{error}}</span>
+    </div>
+  </div>
   <form class="form-horizontal">
     <label class="col-sm-2 control-label">
       <span>Stream ID</span>
@@ -35,17 +46,6 @@
         placeholder="Stream ID"
         name="streamId"
         cask-focus="streamId">
-      <div class="alert alert-danger alert-dismissible"
-           ng-show="error"
-           role="alert">
-        <button type="button"
-                class="close"
-                ng-click="error=null"
-                aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-        <p><i class="fa fa-exclamation-circle"></i>  {{error}}</p>
-      </div>
     </div>
   </form>
 </div>

--- a/cdap-ui/app/services/streams/my-stream-api.js
+++ b/cdap-ui/app/services/streams/my-stream-api.js
@@ -30,7 +30,7 @@ angular.module(PKG.name + '.services')
     {
       list: myHelpers.getConfig('GET', 'REQUEST', listPath, true),
       get: myHelpers.getConfig('GET', 'REQUEST', basepath),
-      create: myHelpers.getConfig('PUT', 'REQUEST', basepath),
+      create: myHelpers.getConfig('PUT', 'REQUEST', basepath, false, {suppressErrors: true}),
       setProperties: myHelpers.getConfig('PUT', 'REQUEST', basepath + '/properties'),
       truncate: myHelpers.getConfig('POST', 'REQUEST', basepath + '/truncate'),
       programsList: myHelpers.getConfig('GET', 'REQUEST', basepath + '/programs', true),

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -39,17 +39,22 @@ body.theme-cdap {
   // --------------------------------------------------
 
   > div.alerts {
-    div.alert-danger {
-      color: white;
-      margin-bottom: 0;
-      width: 100%;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
-      .border-radius(0);
-    }
     button.close {
       font-size: 34px;
+    }
+  }
+  // Common styles
+  .alert {
+    text-shadow: 0 1px 0 rgba(255,255,255,.2);
+    width: 100%;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    margin-bottom: 0;
+    .border-radius(0);
+    @shadow: inset 0 1px 0 rgba(255,255,255,.25), 0 1px 2px rgba(0,0,0,.05);
+    .box-shadow(@shadow);
+    button.close {
       font-weight: 400;
       line-height: 12px;
       margin-left: 10px;
@@ -59,12 +64,6 @@ body.theme-cdap {
         outline: 0;
       }
     }
-  }
-  // Common styles
-  .alert {
-    text-shadow: 0 1px 0 rgba(255,255,255,.2);
-    @shadow: inset 0 1px 0 rgba(255,255,255,.25), 0 1px 2px rgba(0,0,0,.05);
-    .box-shadow(@shadow);
   }
 
   // Mixin for generating new styles
@@ -77,7 +76,10 @@ body.theme-cdap {
   .alert-success    { .alert-styles(@alert-success-bg); }
   .alert-info       { .alert-styles(@alert-info-bg); }
   .alert-warning    { .alert-styles(@alert-warning-bg); }
-  .alert-danger     { .alert-styles(@alert-danger-bg); }
+  .alert-danger     {
+    color: white;
+    .alert-styles(@alert-danger-bg);
+  }
 
   //
   // Status text
@@ -474,6 +476,9 @@ body.theme-cdap {
     .modal-body {
       padding: 10px;
       width: 100%;
+      div.alerts {
+        top: 60px;
+      }
     }
     .modal-footer {
       border-top: 0;

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -77,8 +77,9 @@ body.theme-cdap {
   .alert-info       { .alert-styles(@alert-info-bg); }
   .alert-warning    { .alert-styles(@alert-warning-bg); }
   .alert-danger     {
-    color: white;
     .alert-styles(@alert-danger-bg);
+    color: white;
+    border: 0;
   }
 
   //


### PR DESCRIPTION
*  Adds new alert styling to admin states (including modals)
*  Consolidates alert styling

TO DO:
-  [x] Resolve issue where error in create namespace modal displays both as a ribbon and in the global notification popover

![app](https://cloud.githubusercontent.com/assets/5335210/12399816/0a435d20-bdd1-11e5-9875-025986d6d1ab.gif)

![namespace](https://cloud.githubusercontent.com/assets/5335210/12399817/0e73c448-bdd1-11e5-8bbc-56296241e8b4.gif)



