### PR TITLE
Speed up unit-tests by using local MR instead of forking new processes

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/RowKeyDistributorByHashPrefix.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/RowKeyDistributorByHashPrefix.java
@@ -79,7 +79,7 @@ public class RowKeyDistributorByHashPrefix extends AbstractRowKeyDistributor {
 
     @Override
     public byte[] getHashPrefix(byte[] originalKey) {
-      long hash = Math.abs(hashBytes(originalKey));
+      long hash = Math.abs(Arrays.hashCode(originalKey));
       return new byte[] {(byte) (hash % mod)};
     }
 
@@ -101,15 +101,6 @@ public class RowKeyDistributorByHashPrefix extends AbstractRowKeyDistributor {
     @Override
     public void init(String storedParams) {
       this.mod = Integer.valueOf(storedParams);
-    }
-
-    /** Compute hash for binary data. */
-    private static int hashBytes(byte[] bytes) {
-      int hash = 1;
-      for (int i = 0; i < bytes.length; i++) {
-        hash = (31 * hash) + (int) bytes[i];
-      }
-      return hash;
     }
   }
 


### PR DESCRIPTION
Tests get speed up from 300 seconds to 25 seconds.