### PR TITLE
Revert recent change which made 'explore.enabled' false in Standalone…

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
@@ -30,7 +30,6 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.test.SingletonExternalResource;
-import co.cask.cdap.test.TestConfiguration;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
@@ -56,9 +55,6 @@ public abstract class ClientTestBase {
 
   @ClassRule
   public static final SingletonExternalResource STANDALONE = new SingletonExternalResource(new StandaloneTester());
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", "true");
 
   @ClassRule
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -148,12 +148,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-unit-test</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
+++ b/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
@@ -20,7 +20,6 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.common.utils.Tasks;
-import co.cask.cdap.test.TestConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
@@ -60,17 +59,9 @@ public class StandaloneTester extends ExternalResource {
     cConf.set(Constants.Router.ADDRESS, getLocalHostname());
     cConf.setInt(Constants.Router.ROUTER_PORT, Networks.getRandomPort());
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
+    cConf.setBoolean(Constants.Explore.EXPLORE_ENABLED, true);
+    cConf.setBoolean(Constants.Explore.START_ON_DEMAND, true);
     cConf.setBoolean(StandaloneMain.DISABLE_UI, true);
-
-    // Setup test case specific configurations.
-    // The system properties are usually setup by TestConfiguration class using @ClassRule
-    for (String key : System.getProperties().stringPropertyNames()) {
-      if (key.startsWith(TestConfiguration.PROPERTY_PREFIX)) {
-        String value = System.getProperty(key);
-        cConf.set(key.substring(TestConfiguration.PROPERTY_PREFIX.length()), System.getProperty(key));
-        LOG.info("Custom configuration set: {} = {}", key, value);
-      }
-    }
 
     this.cConf = cConf;
 


### PR DESCRIPTION
Revert recent change which made 'explore.enabled' false in StandaloneTester

In the PR (https://github.com/caskdata/cdap/pull/4859/files#diff-4a1395b973f2f61a32216e6a41c5ddfb), the explicit default of 'explore.enabled' to true in StandaloneTester was removed.
The following PR is also related - https://github.com/caskdata/cdap/pull/4937.

This PR explicitly makes 'explore.enabled' default to true (existing test cases may depend on this, for instance: https://builds.cask.co/browse/CDAP-CIT-JOB1-747/).