### PR TITLE
(CDAP-4671) Added a command to search CDAP entities based on their me…

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,8 @@
 package co.cask.cdap.cli;
 
 import co.cask.cdap.StandaloneTester;
+import co.cask.cdap.api.data.batch.BatchReadable;
+import co.cask.cdap.api.data.batch.RecordScannable;
 import co.cask.cdap.cli.util.InstanceURIParser;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.CsvTableRenderer;
@@ -28,7 +30,9 @@ import co.cask.cdap.client.app.ConfigTestApp;
 import co.cask.cdap.client.app.FakeApp;
 import co.cask.cdap.client.app.FakeDataset;
 import co.cask.cdap.client.app.FakeFlow;
+import co.cask.cdap.client.app.FakeSpark;
 import co.cask.cdap.client.app.FakeWorkflow;
+import co.cask.cdap.client.app.PingService;
 import co.cask.cdap.client.app.PrefixedEchoHandler;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.config.ConnectionConfig;
@@ -47,6 +51,7 @@ import co.cask.common.cli.CLI;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -71,6 +76,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -92,6 +98,16 @@ public class CLIMainTest {
   private static final Gson GSON = new Gson();
 
   private static final String PREFIX = "123ff1_";
+  // TODO: Uncomment after CDAP-4687 is fixed
+  private final Id.Artifact fakeArtifactId = Id.Artifact.from(Id.Namespace.DEFAULT, FakeApp.NAME, "1.0");
+  private final Id.Application fakeAppId = Id.Application.from(Id.Namespace.DEFAULT, FakeApp.NAME);
+  private final Id.Workflow fakeWorkflowId = Id.Workflow.from(fakeAppId, FakeWorkflow.NAME);
+  private final Id.Flow fakeFlowId = Id.Flow.from(fakeAppId, FakeFlow.NAME);
+  private final Id.Program fakeSparkId = Id.Program.from(fakeAppId, ProgramType.SPARK, FakeSpark.NAME);
+  private final Id.Service pingServiceId = Id.Service.from(fakeAppId, PingService.NAME);
+  private final Id.Service prefixedEchoHandlerId = Id.Service.from(fakeAppId, PrefixedEchoHandler.NAME);
+  private final Id.DatasetInstance fakeDsId = Id.DatasetInstance.from(Id.Namespace.DEFAULT, FakeApp.DS_NAME);
+  private final Id.Stream fakeStreamId = Id.Stream.from(Id.Namespace.DEFAULT, FakeApp.STREAM_NAME);
 
   private static ProgramClient programClient;
   private static CLIConfig cliConfig;
@@ -481,8 +497,6 @@ public class CLIMainTest {
 
   @Test
   public void testWorkflowToken() throws Exception {
-    Id.Application fakeAppId = Id.Application.from(Id.Namespace.DEFAULT, FakeApp.NAME);
-    Id.Workflow fakeWorkflowId = Id.Workflow.from(fakeAppId, FakeWorkflow.NAME);
     String workflow = String.format("%s.%s", FakeApp.NAME, FakeWorkflow.NAME);
     File doneFile = TMP_FOLDER.newFile("fake.done");
     Map<String, String> runtimeArgs = ImmutableMap.of("done.file", doneFile.getAbsolutePath());
@@ -528,6 +542,75 @@ public class CLIMainTest {
     // stop workflow
     testCommandOutputContains(cli, "stop workflow " + workflow,
                               String.format("400: Program '%s' is not running", fakeWorkflowId));
+  }
+
+  @Test
+  public void testMetadata() throws Exception {
+    testCommandOutputContains(cli, "cli render as csv", "Now rendering as CSV");
+    // verify system metadata
+    testCommandOutputContains(cli, String.format("get metadata %s scope system", fakeAppId),
+                              FakeApp.class.getSimpleName());
+    testCommandOutputContains(cli, String.format("get metadata-tags %s scope system", fakeWorkflowId),
+                              FakeWorkflow.FakeAction.class.getSimpleName());
+    testCommandOutputContains(cli, String.format("get metadata-tags %s scope system", fakeWorkflowId),
+                              FakeWorkflow.FakeAction.ANOTHER_FAKE_NAME);
+    testCommandOutputContains(cli, String.format("get metadata-tags %s scope system", fakeDsId),
+                              BatchReadable.class.getSimpleName());
+    testCommandOutputContains(cli, String.format("get metadata-tags %s scope system", fakeDsId),
+                              RecordScannable.class.getSimpleName());
+    testCommandOutputContains(cli, String.format("get metadata-tags %s scope system", fakeStreamId),
+                              FakeApp.STREAM_NAME);
+    testCommandOutputContains(cli, String.format("add metadata-properties %s appKey=appValue", fakeAppId),
+                              "Successfully added metadata properties");
+    testCommandOutputContains(cli, String.format("get metadata-properties %s", fakeAppId), "appKey,appValue");
+    testCommandOutputContains(cli, String.format("add metadata-tags %s 'wfTag1 wfTag2'", fakeWorkflowId),
+                              "Successfully added metadata tags");
+    String output = getCommandOutput(cli, String.format("get metadata-tags %s", fakeWorkflowId));
+    List<String> lines = Arrays.asList(output.split("\\r?\\n"));
+    Assert.assertTrue(lines.contains("wfTag1") && lines.contains("wfTag2"));
+    testCommandOutputContains(cli, String.format("add metadata-properties %s dsKey=dsValue", fakeDsId),
+                              "Successfully added metadata properties");
+    testCommandOutputContains(cli, String.format("get metadata-properties %s", fakeDsId), "dsKey,dsValue");
+    testCommandOutputContains(cli, String.format("add metadata-tags %s 'streamTag1 streamTag2'", fakeStreamId),
+                              "Successfully added metadata tags");
+    output = getCommandOutput(cli, String.format("get metadata-tags %s", fakeStreamId));
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    Assert.assertTrue(lines.contains("streamTag1") && lines.contains("streamTag2"));
+    // test search
+    // TODO: CDAP-4687: Uncomment when fixed
+    // testCommandOutputContains(cli, String.format("search metadata %s filtered by target-type artifact",
+    //                                             FakeApp.class.getSimpleName()), fakeArtifactId.toString());
+    testCommandOutputContains(cli, "search metadata appKey:appValue", fakeAppId.toString());
+    testCommandOutputContains(cli, "search metadata fake* filtered by target-type app", fakeAppId.toString());
+    output = getCommandOutput(cli, "search metadata fake* filtered by target-type program");
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    List<String> expected = ImmutableList.of("Entity", fakeWorkflowId.toString(), fakeSparkId.toString(),
+                                             fakeFlowId.toString());
+    Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
+    testCommandOutputContains(cli, "search metadata fake* filtered by target-type dataset", fakeDsId.toString());
+    testCommandOutputContains(cli, "search metadata fake* filtered by target-type stream", fakeStreamId.toString());
+    testCommandOutputContains(cli, String.format("search metadata %s", FakeApp.SCHEDULE_NAME), fakeAppId.toString());
+    testCommandOutputContains(cli, String.format("search metadata %s", FakeApp.STREAM_SCHEDULE_NAME),
+                              fakeAppId.toString());
+    testCommandOutputContains(cli, String.format("search metadata %s filtered by target-type app", PingService.NAME),
+                              fakeAppId.toString());
+    testCommandOutputContains(cli, String.format("search metadata %s filtered by target-type program",
+                                                 PrefixedEchoHandler.NAME), prefixedEchoHandlerId.toString());
+    testCommandOutputContains(cli, "search metadata batch* filtered by target-type dataset", fakeDsId.toString());
+    testCommandOutputNotContains(cli, "search metadata batchwritable filtered by target-type dataset",
+                                 fakeDsId.toString());
+    testCommandOutputContains(cli, "search metadata recordS* filtered by target-type dataset", fakeDsId.toString());
+    testCommandOutputNotContains(cli, "search metadata recordWritable filtered by target-type dataset",
+                                 fakeDsId.toString());
+    output = getCommandOutput(cli, "search metadata batch filtered by target-type program");
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    expected = ImmutableList.of("Entity", fakeSparkId.toString(), fakeWorkflowId.toString());
+    Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
+    output = getCommandOutput(cli, "search metadata realtime filtered by target-type program");
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    expected = ImmutableList.of("Entity", fakeFlowId.toString(), pingServiceId.toString(),
+                                prefixedEchoHandlerId.toString());
+    Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
   }
 
   private static File createAppJarFile(Class<?> cls) throws IOException {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2015 Cask Data, Inc.
+ * Copyright © 2012-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -99,7 +99,14 @@ public enum ArgumentName {
 
   INSTANCE_URI("cdap-instance-uri"),
   VERIFY_SSL_CERT("verify-ssl-cert"),
-  ENTITY("entity-id");
+  ENTITY("entity-id"),
+
+  /**
+   * Metadata
+   */
+  SEARCH_QUERY("search-query"),
+  TARGET_TYPE("target-type"),
+  METADATA_SCOPE("scope");
 
   private final String name;
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/DefaultCompleters.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/DefaultCompleters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -31,6 +31,8 @@ import co.cask.cdap.cli.completer.element.ProgramIdCompleter;
 import co.cask.cdap.cli.completer.element.StreamIdCompleter;
 import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.metadata.MetadataScope;
+import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
@@ -69,6 +71,8 @@ public class DefaultCompleters implements Supplier<Map<String, Completer>> {
         .put(ArgumentName.COMMAND_CATEGORY.getName(), new EnumCompleter(CommandCategory.class))
         .put(ArgumentName.TABLE_RENDERER.getName(), new EnumCompleter(RenderAsCommand.Type.class))
         .put(ArgumentName.WORKFLOW_TOKEN_SCOPE.getName(), new EnumCompleter(WorkflowToken.Scope.class))
+        .put(ArgumentName.TARGET_TYPE.getName(), new EnumCompleter(MetadataSearchTargetType.class))
+        .put(ArgumentName.METADATA_SCOPE.getName(), new EnumCompleter(MetadataScope.class))
         .put(ArgumentName.FORMAT.getName(), new StringsCompleter(Formats.ALL))
         .putAll(generateProgramIdCompleters(injector)).build();
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,6 +23,7 @@ import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -51,7 +52,9 @@ public class GetMetadataCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
-    Set<MetadataRecord> metadata = client.getMetadata(entity.toId());
+    String scope = arguments.getOptional(ArgumentName.METADATA_SCOPE.toString());
+    Set<MetadataRecord> metadata = scope == null ? client.getMetadata(entity.toId()) :
+      client.getMetadata(entity.toId(), MetadataScope.valueOf(scope.toUpperCase()));
 
     Table table = Table.builder()
       .setHeader("entity", "tags", "properties", "scope")
@@ -74,7 +77,8 @@ public class GetMetadataCommand extends AbstractCommand {
 
   @Override
   public String getPattern() {
-    return String.format("get metadata <%s>", ArgumentName.ENTITY);
+    return String.format("get metadata <%s> [scope <%s>]",
+                         ArgumentName.ENTITY, ArgumentName.METADATA_SCOPE);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataPropertiesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,6 +23,7 @@ import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -52,7 +53,9 @@ public class GetMetadataPropertiesCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
-    Map<String, String> properties = client.getProperties(entity.toId());
+    String scope = arguments.getOptional(ArgumentName.METADATA_SCOPE.toString());
+    Map<String, String> properties = scope == null ? client.getProperties(entity.toId()) :
+      client.getProperties(entity.toId(), MetadataScope.valueOf(scope.toUpperCase()));
 
     Table table = Table.builder()
       .setHeader("key", "value")
@@ -71,7 +74,8 @@ public class GetMetadataPropertiesCommand extends AbstractCommand {
 
   @Override
   public String getPattern() {
-    return String.format("get metadata-properties <%s>", ArgumentName.ENTITY);
+    return String.format("get metadata-properties <%s> [scope <%s>]",
+                         ArgumentName.ENTITY, ArgumentName.METADATA_SCOPE);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataTagsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,6 +22,7 @@ import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
@@ -50,7 +51,9 @@ public class GetMetadataTagsCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
-    Set<String> tags = client.getTags(entity.toId());
+    String scope = arguments.getOptional(ArgumentName.METADATA_SCOPE.toString());
+    Set<String> tags = scope == null ? client.getTags(entity.toId()) :
+      client.getTags(entity.toId(), MetadataScope.valueOf(scope.toUpperCase()));
 
     Table table = Table.builder()
       .setHeader("tags")
@@ -69,7 +72,8 @@ public class GetMetadataTagsCommand extends AbstractCommand {
 
   @Override
   public String getPattern() {
-    return String.format("get metadata-tags <%s>", ArgumentName.ENTITY);
+    return String.format("get metadata-tags <%s> [scope <%s>]",
+                         ArgumentName.ENTITY, ArgumentName.METADATA_SCOPE);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command.metadata;
+
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.util.AbstractCommand;
+import co.cask.cdap.cli.util.RowMaker;
+import co.cask.cdap.cli.util.table.Table;
+import co.cask.cdap.client.MetadataClient;
+import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
+import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
+import co.cask.common.cli.Arguments;
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Command for metadata search in CLI.
+ */
+public class SearchMetadataCommand extends AbstractCommand {
+
+  private final MetadataClient metadataClient;
+
+  @Inject
+  public SearchMetadataCommand(CLIConfig cliConfig, MetadataClient metadataClient) {
+    super(cliConfig);
+    this.metadataClient = metadataClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream output) throws Exception {
+    String searchQuery = arguments.get(ArgumentName.SEARCH_QUERY.toString());
+    String type = arguments.getOptional(ArgumentName.TARGET_TYPE.toString());
+    MetadataSearchTargetType targetType = type == null ? MetadataSearchTargetType.ALL :
+      MetadataSearchTargetType.valueOf(type.toUpperCase());
+    Set<MetadataSearchResultRecord> searchResults = metadataClient.searchMetadata(cliConfig.getCurrentNamespace(),
+                                                                                  searchQuery, targetType);
+    Table table = Table.builder()
+      .setHeader("Entity")
+      .setRows(Lists.newArrayList(searchResults), new RowMaker<MetadataSearchResultRecord>() {
+        @Override
+        public List<?> makeRow(MetadataSearchResultRecord searchResult) {
+          return Lists.newArrayList(searchResult.getEntityId().toString());
+        }
+      }).build();
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("search metadata <%s> [filtered by target-type <%s>]", ArgumentName.SEARCH_QUERY,
+                         ArgumentName.TARGET_TYPE);
+  }
+
+  @Override
+  public String getDescription() {
+    return "Allows users to search CDAP entities based on the metadata annotated on them.";
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/MetadataCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/MetadataCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,16 +18,6 @@ package co.cask.cdap.cli.commandset;
 
 import co.cask.cdap.cli.Categorized;
 import co.cask.cdap.cli.CommandCategory;
-import co.cask.cdap.cli.command.app.CreateAppCommand;
-import co.cask.cdap.cli.command.app.DeleteAppCommand;
-import co.cask.cdap.cli.command.app.DeployAppCommand;
-import co.cask.cdap.cli.command.app.DescribeAppCommand;
-import co.cask.cdap.cli.command.app.ListAppsCommand;
-import co.cask.cdap.cli.command.app.RestartProgramsCommand;
-import co.cask.cdap.cli.command.app.StartProgramsCommand;
-import co.cask.cdap.cli.command.app.StatusProgramsCommand;
-import co.cask.cdap.cli.command.app.StopProgramsCommand;
-import co.cask.cdap.cli.command.app.UpdateAppCommand;
 import co.cask.cdap.cli.command.metadata.AddMetadataPropertiesCommand;
 import co.cask.cdap.cli.command.metadata.AddMetadataTagsCommand;
 import co.cask.cdap.cli.command.metadata.GetMetadataCommand;
@@ -38,6 +28,7 @@ import co.cask.cdap.cli.command.metadata.RemoveMetadataPropertiesCommand;
 import co.cask.cdap.cli.command.metadata.RemoveMetadataPropertyCommand;
 import co.cask.cdap.cli.command.metadata.RemoveMetadataTagCommand;
 import co.cask.cdap.cli.command.metadata.RemoveMetadataTagsCommand;
+import co.cask.cdap.cli.command.metadata.SearchMetadataCommand;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
 import com.google.common.collect.ImmutableList;
@@ -63,6 +54,7 @@ public class MetadataCommands extends CommandSet<Command> implements Categorized
         .add(injector.getInstance(RemoveMetadataPropertyCommand.class))
         .add(injector.getInstance(RemoveMetadataTagCommand.class))
         .add(injector.getInstance(RemoveMetadataTagsCommand.class))
+        .add(injector.getInstance(SearchMetadataCommand.class))
         .build());
   }
 

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
@@ -92,24 +92,36 @@ public class MetadataClient {
   }
 
   /**
-   * @param id the entity for which to retrieve metadata
+   * @param id the entity for which to retrieve metadata across {@link MetadataScope#SYSTEM} and
+   * {@link MetadataScope#USER}
    * @return The metadata for the entity.
    */
   public Set<MetadataRecord> getMetadata(Id id)
+    throws UnauthorizedException, BadRequestException, NotFoundException, IOException {
+    return getMetadata(id, null);
+  }
+
+  /**
+   * @param id the entity for which to retrieve metadata
+   * @param scope the {@link MetadataScope} to retrieve the metadata from. If null, this method retrieves
+   *              metadata from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
+   * @return The metadata for the entity.
+   */
+  public Set<MetadataRecord> getMetadata(Id id, @Nullable MetadataScope scope)
     throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
 
     if (id instanceof Id.Application) {
-      return getMetadata((Id.Application) id);
+      return getMetadata((Id.Application) id, scope);
     } else if (id instanceof Id.Artifact) {
-      return getMetadata((Id.Artifact) id);
+      return getMetadata((Id.Artifact) id, scope);
     } else if (id instanceof Id.DatasetInstance) {
-      return getMetadata((Id.DatasetInstance) id);
+      return getMetadata((Id.DatasetInstance) id, scope);
     } else if (id instanceof Id.Stream) {
-      return getMetadata((Id.Stream) id);
+      return getMetadata((Id.Stream) id, scope);
     } else if (id instanceof Id.Stream.View) {
-      return getMetadata((Id.Stream.View) id);
+      return getMetadata((Id.Stream.View) id, scope);
     } else if (id instanceof Id.Program) {
-      return getMetadata((Id.Program) id);
+      return getMetadata((Id.Program) id, scope);
     } else if (id instanceof Id.Run) {
       return getMetadata((Id.Run) id);
     }
@@ -118,52 +130,71 @@ public class MetadataClient {
   }
 
   /**
-   * @param id the entity for which to retrieve metadata properties
+   * @param id the entity for which to retrieve metadata properties across {@link MetadataScope#SYSTEM} and
+   * {@link MetadataScope#USER}
    * @return The metadata properties for the entity.
    */
   public Map<String, String> getProperties(Id id)
+    throws UnauthorizedException, BadRequestException, NotFoundException, IOException {
+    return getProperties(id, null);
+  }
+
+  /**
+   * @param id the entity for which to retrieve metadata properties
+   * @param scope the {@link MetadataScope} to retrieve the properties from. If null, this method retrieves
+   *              properties from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
+   * @return The metadata properties for the entity.
+   */
+  public Map<String, String> getProperties(Id id, @Nullable MetadataScope scope)
     throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
 
     if (id instanceof Id.Application) {
-      return getProperties((Id.Application) id);
+      return getProperties((Id.Application) id, scope);
     } else if (id instanceof Id.Artifact) {
-      return getProperties((Id.Artifact) id);
+      return getProperties((Id.Artifact) id, scope);
     } else if (id instanceof Id.DatasetInstance) {
-      return getProperties((Id.DatasetInstance) id);
+      return getProperties((Id.DatasetInstance) id, scope);
     } else if (id instanceof Id.Stream) {
-      return getProperties((Id.Stream) id);
+      return getProperties((Id.Stream) id, scope);
     } else if (id instanceof Id.Stream.View) {
-      return getProperties((Id.Stream.View) id);
+      return getProperties((Id.Stream.View) id, scope);
     } else if (id instanceof Id.Program) {
-      return getProperties((Id.Program) id);
-    } else if (id instanceof Id.Run) {
-      return getProperties((Id.Run) id);
+      return getProperties((Id.Program) id, scope);
     }
 
     throw new IllegalArgumentException("Unsupported Id type: " + id.getClass().getName());
   }
 
   /**
-   * @param id the entity for which to retrieve metadata tags
+   * @param id the entity for which to retrieve metadata tags across {@link MetadataScope#SYSTEM} and
+   * {@link MetadataScope#USER}
    * @return The metadata tags for the entity.
    */
-  public Set<String> getTags(Id id)
+  public Set<String> getTags(Id id) throws UnauthorizedException, BadRequestException, NotFoundException, IOException {
+    return getTags(id, null);
+  }
+
+  /**
+   * @param id the entity for which to retrieve metadata tags
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If null, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
+   * @return The metadata tags for the entity.
+   */
+  public Set<String> getTags(Id id, @Nullable MetadataScope scope)
     throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
 
     if (id instanceof Id.Application) {
-      return getTags((Id.Application) id);
+      return getTags((Id.Application) id, scope);
     } else if (id instanceof Id.Artifact) {
-      return getTags((Id.Artifact) id);
+      return getTags((Id.Artifact) id, scope);
     } else if (id instanceof Id.DatasetInstance) {
-      return getTags((Id.DatasetInstance) id);
+      return getTags((Id.DatasetInstance) id, scope);
     } else if (id instanceof Id.Stream) {
-      return getTags((Id.Stream) id);
+      return getTags((Id.Stream) id, scope);
     } else if (id instanceof Id.Stream.View) {
-      return getTags((Id.Stream.View) id);
+      return getTags((Id.Stream.View) id, scope);
     } else if (id instanceof Id.Program) {
-      return getTags((Id.Program) id);
-    } else if (id instanceof Id.Run) {
-      return getTags((Id.Run) id);
+      return getTags((Id.Program) id, scope);
     }
 
     throw new IllegalArgumentException("Unsupported Id type: " + id.getClass().getName());
@@ -188,8 +219,6 @@ public class MetadataClient {
       addProperties((Id.Stream.View) id, properties);
     } else if (id instanceof Id.Program) {
       addProperties((Id.Program) id, properties);
-    } else if (id instanceof Id.Run) {
-      addProperties((Id.Run) id, properties);
     } else {
       throw new IllegalArgumentException("Unsupported Id type: " + id.getClass().getName());
     }
@@ -214,8 +243,6 @@ public class MetadataClient {
       addTags((Id.Stream.View) id, tags);
     } else if (id instanceof Id.Program) {
       addTags((Id.Program) id, tags);
-    } else if (id instanceof Id.Run) {
-      addTags((Id.Run) id, tags);
     } else {
       throw new IllegalArgumentException("Unsupported Id type: " + id.getClass().getName());
     }
@@ -239,8 +266,6 @@ public class MetadataClient {
       removeMetadata((Id.Stream.View) id);
     } else if (id instanceof Id.Program) {
       removeMetadata((Id.Program) id);
-    } else if (id instanceof Id.Run) {
-      removeMetadata((Id.Run) id);
     } else {
       throw new IllegalArgumentException("Unsupported Id type: " + id.getClass().getName());
     }
@@ -264,8 +289,6 @@ public class MetadataClient {
       removeProperties((Id.Stream.View) id);
     } else if (id instanceof Id.Program) {
       removeProperties((Id.Program) id);
-    } else if (id instanceof Id.Run) {
-      removeProperties((Id.Run) id);
     } else {
       throw new IllegalArgumentException("Unsupported Id type: " + id.getClass().getName());
     }
@@ -289,8 +312,6 @@ public class MetadataClient {
       removeTags((Id.Stream.View) id);
     } else if (id instanceof Id.Program) {
       removeTags((Id.Program) id);
-    } else if (id instanceof Id.Run) {
-      removeTags((Id.Run) id);
     } else {
       throw new IllegalArgumentException("Unsupported Id type: " + id.getClass().getName());
     }
@@ -315,8 +336,6 @@ public class MetadataClient {
       removeProperty((Id.Stream.View) id, property);
     } else if (id instanceof Id.Program) {
       removeProperty((Id.Program) id, property);
-    } else if (id instanceof Id.Run) {
-      removeProperty((Id.Run) id, property);
     } else {
       throw new IllegalArgumentException("Unsupported Id type: " + id.getClass().getName());
     }
@@ -346,60 +365,6 @@ public class MetadataClient {
     } else {
       throw new IllegalArgumentException("Unsupported Id type: " + id.getClass().getName());
     }
-  }
-
-  /**
-   * @param appId the app for which to retrieve metadata
-   * @return The metadata for the application.
-   */
-  public Set<MetadataRecord> getMetadata(Id.Application appId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(appId, null);
-  }
-
-  /**
-   * @param artifactId the artifact for which to retrieve metadata
-   * @return The metadata for the artifact.
-   */
-  public Set<MetadataRecord> getMetadata(Id.Artifact artifactId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(artifactId, null);
-  }
-
-  /**
-   * @param datasetInstance the dataset for which to retrieve metadata
-   * @return The metadata for the dataset.
-   */
-  public Set<MetadataRecord> getMetadata(Id.DatasetInstance datasetInstance)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(datasetInstance, null);
-  }
-
-  /**
-   * @param streamId the stream for which to retrieve metadata
-   * @return The metadata for the stream.
-   */
-  public Set<MetadataRecord> getMetadata(Id.Stream streamId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(streamId, null);
-  }
-
-  /**
-   * @param viewId the view for which to retrieve metadata
-   * @return The metadata for the view.
-   */
-  public Set<MetadataRecord> getMetadata(Id.Stream.View viewId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(viewId, null);
-  }
-
-  /**
-   * @param programId the program for which to retrieve metadata
-   * @return The metadata for the program.
-   */
-  public Set<MetadataRecord> getMetadata(Id.Program programId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getMetadata(programId, null);
   }
 
   /**
@@ -481,140 +446,149 @@ public class MetadataClient {
 
   /**
    * @param appId the app for which to retrieve metadata properties
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata properties for the application.
    */
-  public Map<String, String> getProperties(Id.Application appId)
+  public Map<String, String> getProperties(Id.Application appId, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getProperties(appId, constructPath(appId));
+    return getProperties(appId, constructPath(appId), scope);
   }
 
   /**
    * @param artifactId the artifact for which to retrieve metadata properties
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata properties for the artifact.
    */
-  public Map<String, String> getProperties(Id.Artifact artifactId)
+  public Map<String, String> getProperties(Id.Artifact artifactId, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getProperties(artifactId, constructPath(artifactId));
+    return getProperties(artifactId, constructPath(artifactId), scope);
   }
 
   /**
    * @param datasetInstance the dataset for which to retrieve metadata properties
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata properties for the dataset.
    */
-  public Map<String, String> getProperties(Id.DatasetInstance datasetInstance)
+  public Map<String, String> getProperties(Id.DatasetInstance datasetInstance, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getProperties(datasetInstance, constructPath(datasetInstance));
+    return getProperties(datasetInstance, constructPath(datasetInstance), scope);
   }
 
   /**
    * @param streamId the stream for which to retrieve metadata properties
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata properties for the stream.
    */
-  public Map<String, String> getProperties(Id.Stream streamId)
+  public Map<String, String> getProperties(Id.Stream streamId, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getProperties(streamId, constructPath(streamId));
+    return getProperties(streamId, constructPath(streamId), scope);
   }
 
   /**
    * @param viewId the view for which to retrieve metadata properties
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata properties for the view.
    */
-  public Map<String, String> getProperties(Id.Stream.View viewId)
+  public Map<String, String> getProperties(Id.Stream.View viewId, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getProperties(viewId, constructPath(viewId));
+    return getProperties(viewId, constructPath(viewId), scope);
   }
 
   /**
    * @param programId the program for which to retrieve metadata properties
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata properties for the program.
    */
-  public Map<String, String> getProperties(Id.Program programId)
+  public Map<String, String> getProperties(Id.Program programId, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getProperties(programId, constructPath(programId));
+    return getProperties(programId, constructPath(programId), scope);
   }
 
-  /**
-   * @param runId the run for which to retrieve metadata properties
-   * @return The metadata properties for the run.
-   */
-  public Map<String, String> getProperties(Id.Run runId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getProperties(runId, constructPath(runId));
-  }
-
-  private Map<String, String> getProperties(Id.NamespacedId namespacedId, String entityPath)
+  private Map<String, String> getProperties(Id.NamespacedId namespacedId, String entityPath,
+                                            @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/properties", entityPath);
+    path = scope == null ? path : String.format("%s?scope=%s", path, scope);
     HttpResponse response = makeRequest(namespacedId, path, HttpMethod.GET);
     return GSON.fromJson(response.getResponseBodyAsString(), MAP_STRING_STRING_TYPE);
   }
 
   /**
    * @param appId the app for which to retrieve metadata tags
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata tags for the application.
    */
-  public Set<String> getTags(Id.Application appId)
+  public Set<String> getTags(Id.Application appId, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getTags(appId, constructPath(appId));
+    return getTags(appId, constructPath(appId), scope);
   }
 
   /**
    * @param artifactId the artifact for which to retrieve metadata tags
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata tags for the artifact.
    */
-  public Set<String> getTags(Id.Artifact artifactId)
+  public Set<String> getTags(Id.Artifact artifactId, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getTags(artifactId, constructPath(artifactId));
+    return getTags(artifactId, constructPath(artifactId), scope);
   }
 
   /**
    * @param datasetInstance the dataset for which to retrieve metadata tags
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata tags for the dataset.
    */
-  public Set<String> getTags(Id.DatasetInstance datasetInstance)
+  public Set<String> getTags(Id.DatasetInstance datasetInstance, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getTags(datasetInstance, constructPath(datasetInstance));
+    return getTags(datasetInstance, constructPath(datasetInstance), scope);
   }
 
   /**
    * @param streamId the stream for which to retrieve metadata tags
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata tags for the stream.
    */
-  public Set<String> getTags(Id.Stream streamId)
+  public Set<String> getTags(Id.Stream streamId, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getTags(streamId, constructPath(streamId));
+    return getTags(streamId, constructPath(streamId), scope);
   }
 
   /**
    * @param viewId the view for which to retrieve metadata tags
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata tags for the view.
    */
-  public Set<String> getTags(Id.Stream.View viewId)
+  public Set<String> getTags(Id.Stream.View viewId, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getTags(viewId, constructPath(viewId));
+    return getTags(viewId, constructPath(viewId), scope);
   }
 
   /**
    * @param programId the program for which to retrieve metadata tags
+   * @param scope the {@link MetadataScope} to retrieve the tags from. If unspecified, this method retrieves
+   *              tags from both {@link MetadataScope#SYSTEM} and {@link MetadataScope#USER}
    * @return The metadata tags for the program.
    */
-  public Set<String> getTags(Id.Program programId)
+  public Set<String> getTags(Id.Program programId, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getTags(programId, constructPath(programId));
+    return getTags(programId, constructPath(programId), scope);
   }
 
-  /**
-   * @param runId the run for which to retrieve metadata tags
-   * @return The metadata tags for the run.
-   */
-  public Set<String> getTags(Id.Run runId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    return getTags(runId, constructPath(runId));
-  }
-
-  private Set<String> getTags(Id.NamespacedId namespacedId, String entityPath)
+  private Set<String> getTags(Id.NamespacedId namespacedId, String entityPath, @Nullable MetadataScope scope)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/tags", entityPath);
+    path = scope == null ? path : String.format("%s?scope=%s", path, scope);
     HttpResponse response = makeRequest(namespacedId, path, HttpMethod.GET);
     return GSON.fromJson(response.getResponseBodyAsString(), SET_STRING_TYPE);
   }


### PR DESCRIPTION
…tadata

Fixed a couple of issues in the CLI
- (CDAP-4673) Added some unit tests for metadata CLI commands, however more thorough unit tests need to be added for lineage, etc.
- Added an optional 'scope' parameter for all 'get' metadata commands.

Fixed a couple of issues in the MetadataClient
- Removed methods that allowed to add and delete metadata/properties/tags for program runs. Also removed methods that allowed to retrieve properties and tags for program runs. These operations are not supported. You can only retrieve the entire metadata associated with a run.
- Added a missing MetadataScope parameter to some MetadataClient APIs that were being used by the CLI.

Jira: [CDAP-4671](https://issues.cask.co/browse/CDAP-4671)
Build: http://builds.cask.co/browse/CDAP-RBT609