### PR TITLE
fixes plugin item widths to ensure 2 column layout

### DIFF
--- a/cdap-ui/app/features/hydrator/leftpanel.less
+++ b/cdap-ui/app/features/hydrator/leftpanel.less
@@ -49,10 +49,10 @@ body.theme-cdap.state-hydrator-create {
       width: 290px;
       .item .plugin-item {
         text-align: left;
-        width: 130px;
+        width: 48%;
         .name {
           display: inline-block;
-          max-width: 88px;
+          max-width: 81px;
         }
       }
       + .right-wrapper {
@@ -209,7 +209,7 @@ body.theme-cdap.state-hydrator-create {
         margin-bottom: 6px;
         padding: 0 8px;
         height: 40px;
-        width: 50px;
+        width: 48%;
         .border-radius(4px);
         .transition(all 0.2s ease);
         &:hover, &:focus {

--- a/cdap-ui/app/polyfill.js
+++ b/cdap-ui/app/polyfill.js
@@ -25,3 +25,10 @@
 SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformToElement || function(toElement) {
   return toElement.getScreenCTM().inverse().multiply(this.getScreenCTM());
 };
+
+// 'includes' function of String is not available in older version of chromium browsers.
+if (!String.prototype.includes) {
+  String.prototype.includes = function() {'use strict';
+    return String.prototype.indexOf.apply(this, arguments) !== -1;
+  };
+}


### PR DESCRIPTION
*  Adjusts widths of .plugin-item and child `<span>` containing label name to ensure proper 2 column width across all builds

SDK:
![mac](https://cloud.githubusercontent.com/assets/5335210/12407617/a2b6c826-be0d-11e5-99d4-f878f2e7c6ab.gif)

VM:
![vm](https://cloud.githubusercontent.com/assets/5335210/12407621/a9aaeed2-be0d-11e5-8f1f-51f41147a36a.gif)
