### PR TITLE
Bugfix/ui router check

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1715,6 +1715,15 @@
   </property>
 
   <property>
+    <name>dashboard.router.check.timeout.secs</name>
+    <value>0</value>
+    <description>
+      Amount of time, in seconds, CDAP UI waits before exiting when not able to connect to CDAP Router on startup.
+      Use timeout as 0 to wait indefinitely.
+    </description>
+  </property>
+
+  <property>
     <name>dashboard.ssl.bind.port</name>
     <value>9443</value>
     <description>

--- a/cdap-ui/app/features/home/home-ctrl.js
+++ b/cdap-ui/app/features/home/home-ctrl.js
@@ -15,8 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.home')
-  .controller('HomeController', function ($state, rNsList, mySessionStorage, myLoadingService, $filter, EventPipe, StatusFactory) {
-    StatusFactory.startPolling();
+  .controller('HomeController', function ($state, rNsList, mySessionStorage, myLoadingService, $filter, EventPipe) {
     // Needed to inject StatusFactory here for angular to instantiate the service and start polling.
     // check that $state.params.namespace is valid
     var n = rNsList.filter(function (one) {

--- a/cdap-ui/app/services/helpers.js
+++ b/cdap-ui/app/services/helpers.js
@@ -107,7 +107,7 @@ angular.module(PKG.name+'.services')
     for (var i = 1; i < arguments.length; i++) {
       obj = obj[arguments[i]];
       if (!angular.isObject(obj)) {
-        return obj;
+        return undefined;
       }
     }
     return obj;

--- a/cdap-ui/app/services/namespace.js
+++ b/cdap-ui/app/services/namespace.js
@@ -15,10 +15,10 @@
  */
 
 angular.module(PKG.name + '.services')
-  .service('myNamespace', function myNamespace($q, MyCDAPDataSource, EventPipe, $http, $rootScope, myAuth, MYAUTH_EVENT, myHelpers, $state) {
+  .service('myNamespace', function myNamespace($q, MyCDAPDataSource, EventPipe, $http, $rootScope, myAuth, MYAUTH_EVENT, myHelpers, $state, StatusFactory) {
 
     this.namespaceList = [];
-
+    StatusFactory.startPolling();
     var data = new MyCDAPDataSource(),
         prom,
         queryInProgress = null;
@@ -55,25 +55,8 @@ angular.module(PKG.name + '.services')
               function (err) {
                 prom.reject(err);
                 queryInProgress = null;
-                /*
-                  If security is enabled, we authenticate and validate token
-                   in 'home' state. However when we are in a nested state
-                   under namespace say, /ns/default/apps/PurchaseHistory/...
-                   the authentication and token validation is not done and we fetch the
-                   list of namespaces in 'ns' state in resolve with invalid token.
-
-                   This leads to a 'invalid_token' error but we don't properly re-direct
-                   to login. Hence this check.
-                */
-                if (myHelpers.objectQuery(err, 'data', 'auth_uri')) {
-                  $rootScope.$broadcast(MYAUTH_EVENT.sessionTimeout);
-                  $state.go('login');
-                } else {
-                  EventPipe.emit('backendDown', 'Problem accessing namespace.', 'Please refresh the page.');
-                }
               }
-        );
-
+            );
       }
 
       return prom.promise;

--- a/cdap-ui/app/services/status-factory.js
+++ b/cdap-ui/app/services/status-factory.js
@@ -61,11 +61,11 @@ angular.module(PKG.name + '.services')
       } else if (statusCode === 503) {
         EventPipe.emit('backendDown');
       }
-      reAuthenticate(err);
+      reAuthenticate(statusCode);
     }
 
-    function reAuthenticate(err) {
-      if (angular.isObject(err) && err.auth_uri) {
+    function reAuthenticate(statusCode) {
+      if (statusCode === 401) {
         $timeout(function() {
           EventPipe.emit('backendUp');
           myAuth.logout();

--- a/cdap-ui/server/config/log4js.json
+++ b/cdap-ui/server/config/log4js.json
@@ -1,11 +1,6 @@
 {
   "appenders": [
     {
-      "category" : "default",
-      "filename": "./logs/ui-node-proxy.log",
-      "type" : "file"
-    },
-    {
       "type": "console"
     }
   ],

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -264,7 +264,11 @@ function makeApp (authAddress, cdapConfig) {
         headers: req.headers
       }, function (err, response) {
         if (err) {
-          res.status(404).send();
+          if (err.code === 'ECONNREFUSED') {
+            res.status(404).send(err);
+            return;
+          }
+          res.status(500).send(err);
         } else {
           res.status(response.statusCode).send();
         }

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -19,7 +19,8 @@
 module.exports = {
   getApp: function () {
     return require('q').all([
-        require('./config/auth-address.js').ping(),
+        // router check also fetches the auth server address if security is enabled
+        require('./config/router-check.js').ping(),
         require('./config/parser.js').extractConfig('cdap')
       ])
       .spread(makeApp);


### PR DESCRIPTION
- Fixes node-proxy to handle when router and(or) master services are down.
- Fixes UI to show appropriate messages for different use cases.
- Poll backend until router is up. If there is a timeout set using ```dashboard.router.check.timeout.secs``` then poll until that time and then exit the node proxy if backend is not up until that point.