### PR TITLE
Allow node versions 0.10.x

### DIFF
--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -120,7 +120,7 @@ for /f "tokens=* delims= " %%f in ('node -v') do @(
 set line=%line:v=!!%
 
 for /F "delims=.,v tokens=1,2,3" %%a in ('echo %line%') do (
-  if %%a LEQ 1 if %%b LEQ 10 (
+  if %%a LEQ 1 if %%b LSS 10 (
     echo Node.js version is not supported. We recommend any version of Node.js greater than v0.10.0.
     GOTO :FINALLY
   )


### PR DESCRIPTION
The current bat script had a bug which did not allow node versions 0.10.x, though the error message says it is allowed.
Related: https://github.com/caskdata/cdap/pull/4492