### PR TITLE
Fix ITN failure

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
@@ -476,7 +476,7 @@ public class DistributedStreamService extends AbstractStreamService {
           for (Map.Entry<Id.Namespace, StreamSpecification> streamSpecEntry : streamMetaStore.listStreams().entries()) {
             Id.Stream streamId = Id.Stream.from(streamSpecEntry.getKey(), streamSpecEntry.getValue().getName());
             LOG.debug("Adding {} stream as a resource to the coordinator to manager streams leaders.", streamId);
-            builder.addPartition(new ResourceRequirement.Partition(streamId.getId(), 1));
+            builder.addPartition(new ResourceRequirement.Partition(streamId.toString(), 1));
           }
           return builder.build();
         } catch (Throwable e) {


### PR DESCRIPTION
Revert a change made in this PR : https://github.com/caskdata/cdap/pull/4762

Specifically, this line : https://github.com/caskdata/cdap/pull/4762/files#diff-f25334a1ec822e775c2aaf25f10ed04cR479

This change is causing failure in the integration tests since the streamId#getId returns just the streamName while streamId#toString returns stream:ns.streamname. This change was not made in other places where ``ResourceRequirement.Partition`` is created. Also ``DistributedStreamService#StreamsLeaderHandler`` is expecting PartitionReplica to be of the format : stream:ns.streamname.

Build : http://builds.cask.co/browse/CDAP-RBT610-2

