### PR TITLE
fix widget-keyvalue properties

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-keyvalue/widget-keyvalue.js
+++ b/cdap-ui/app/directives/widget-container/widget-keyvalue/widget-keyvalue.js
@@ -35,13 +35,14 @@ angular.module(PKG.name + '.commons')
                            ',';
 
         $scope.showDelimiter = true;
-        if ($scope.config.properties && $scope.config.properties.showDelimiter === 'false') {
+        var showDelimiterProperty = myHelpers.objectQuery($scope.config, 'widget-attributes', 'showDelimiter');
+        if (($scope.config.properties && $scope.config.properties.showDelimiter === 'false') || showDelimiterProperty === 'false' ) {
           $scope.showDelimiter = false;
         }
 
         // Changing value field to dropdown based on config
         if ($scope.isDropdown) {
-          $scope.dropdownOptions = $scope.config.properties.dropdownOptions;
+          $scope.dropdownOptions = myHelpers.objectQuery($scope.config, 'widget-attributes', 'dropdownOptions');
         }
 
         // initializing


### PR DESCRIPTION
hide delimiters on keyvalue and also use the new pattern for dropdown