### PR TITLE
Delete rows from index table when deleting MetadataDataset entries

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -66,10 +66,12 @@ public class MetadataDataset extends AbstractDataset {
   private static final String VALUE_COLUMN = "v";  // column for metadata value
   private static final String TAGS_SEPARATOR = ",";
 
-  static final String INDEX_COLUMN = "i";          // column for metadata indexes
+  public static final String INDEX_COLUMN = "i";          // column for metadata indexes
 
-  // TODO: Remove this after 3.3. This is only for upgrade from 3.2 to 3.3
-  private static final String CASE_INSENSITIVE_VALUE_COLUMN = "civ";
+  //TODO: (UPG-3.3): Remove this after 3.3. This is only for upgrade from 3.2 to 3.3
+  // These are the columns which were indexed in 3.2
+  public static final String CASE_INSENSITIVE_VALUE_COLUMN = "civ";
+  public static final String KEYVALUE_COLUMN = "kv";
 
   public static final String TAGS_KEY = "tags";
   public static final String KEYVALUE_SEPARATOR = ":";

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -66,6 +66,7 @@ public class MetadataDataset extends AbstractDataset {
   private static final String VALUE_COLUMN = "v";  // column for metadata value
   private static final String TAGS_SEPARATOR = ",";
 
+  //TODO: (UPG-3.3): Make this public after 3.3
   public static final String INDEX_COLUMN = "i";          // column for metadata indexes
 
   //TODO: (UPG-3.3): Remove this after 3.3. This is only for upgrade from 3.2 to 3.3

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetDefinition.java
@@ -36,7 +36,6 @@ import java.util.Map;
  * Define the Dataset for metadata.
  */
 public class MetadataDatasetDefinition extends AbstractDatasetDefinition<MetadataDataset, DatasetAdmin> {
-  private static final Logger LOG = LoggerFactory.getLogger(MetadataDatasetDefinition.class);
 
   private static final String METADATA_INDEX_TABLE_NAME = "metadata_index";
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -17,6 +17,7 @@ package co.cask.cdap.data2.metadata.store;
 
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.IndexedTableDefinition;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -37,6 +38,8 @@ import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -552,16 +555,46 @@ public class DefaultMetadataStore implements MetadataStore {
    * @param framework Dataset framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework framework) throws IOException, DatasetManagementException {
-    framework.addInstance(MetadataDataset.class.getName(), BUSINESS_METADATA_INSTANCE_ID, DatasetProperties.EMPTY);
+    // In 3.2 we used MetadataDataset.KEYVALUE_COLUMN (kv) and MetadataDataset.CASE_INSENSITIVE_VALUE_COLUMN (civ) and
+    // in 3.3 we index new column MetadataDataset.CASE_INSENSITIVE_VALUE_COLUMN (i). During upgrade we want to
+    // have instance of BUSINESS_METADATA_INSTANCE_ID with columnToIndex with all these three column so that
+    // when we do a delete while upgrading MetadataDataset#upgrade the delete operation also delete the records
+    // for the old index column from index table.
+    DatasetProperties dsProperties = getOldColumnToIndex();
+    // the above is only needed for Business Metadata as in 3.2 we didn't have System Metadata table.
+    //TODO: (UPG-3.3): Remove this after 3.3
+    framework.addInstance(MetadataDataset.class.getName(), BUSINESS_METADATA_INSTANCE_ID, dsProperties);
     framework.addInstance(MetadataDataset.class.getName(), SYSTEM_METADATA_INSTANCE_ID, DatasetProperties.EMPTY);
   }
 
   public void upgrade() {
-    execute(new TransactionExecutor.Procedure<MetadataDataset>() {
+    DatasetProperties dsProperties = getOldColumnToIndex();
+    MetadataDataset businessMetadataDataset;
+    try {
+      businessMetadataDataset = DatasetsUtil.getOrCreateDataset(
+        dsFramework, BUSINESS_METADATA_INSTANCE_ID, MetadataDataset.class.getName(),
+        dsProperties, DatasetDefinition.NO_ARGUMENTS, null);
+    } catch (DatasetManagementException | IOException e) {
+      throw Throwables.propagate(e);
+    }
+    Preconditions.checkNotNull(businessMetadataDataset, "Failed to get Business Metadata Dataset.");
+    TransactionExecutor txExecutor = Transactions.createTransactionExecutor(txExecutorFactory, businessMetadataDataset);
+      txExecutor.executeUnchecked(new TransactionExecutor.Procedure<MetadataDataset>() {
       @Override
       public void apply(MetadataDataset input) throws Exception {
         input.upgrade();
       }
-    }, MetadataScope.USER); // in 3.2 we only had user metadata so upgrade only that
+    }, businessMetadataDataset);
+  }
+
+  /**
+   * @return {@link DatasetProperties} where {@link IndexedTableDefinition#INDEX_COLUMNS_CONF_KEY} is set to
+   * index columns from 3.2 and also 3.3
+   */
+  private static DatasetProperties getOldColumnToIndex() {
+    return DatasetProperties.builder()
+        .add(IndexedTableDefinition.INDEX_COLUMNS_CONF_KEY,
+             Joiner.on(",").join(MetadataDataset.KEYVALUE_COLUMN, MetadataDataset.CASE_INSENSITIVE_VALUE_COLUMN,
+                                 MetadataDataset.INDEX_COLUMN)).build();
   }
 }


### PR DESCRIPTION
[Andreas] The upgrade tool is too confusing. It is completely unclear why after creating the MetadataDataset instance with the oldColumnsToIndex properties in the in-memory dsFramework, we have to provide those same properties again when we call getOrCreateDataset(). It should already exist at that time and the properties should be ignored. Can't explain this. 

Other than that LGTM. If you test this and you can validate it is correct, all good. And we have to simplify the UpgradeTool in the next release. [end Andreas] 