### PR TITLE
Fixes the use-case to show two different messages when cdap-master & cdap-router services goes down

### DIFF
--- a/cdap-ui/app/directives/app-level-loading-icon/loading.js
+++ b/cdap-ui/app/directives/app-level-loading-icon/loading.js
@@ -28,23 +28,23 @@ angular.module(PKG.name + '.commons')
           scope: $scope,
           windowClass: 'custom-loading-modal'
         }, modal, isBackendDown = false;
-
+        var genericServiceErrorMsg = 'CDAP Services are not available';
+        var genericSubtitle = 'Trying to connect...';
         EventPipe.on('backendDown', function(message, subtitle) {
           if (!isBackendDown) {
             if (modal) {
               modal.close();
             }
             isBackendDown = true;
-            if (!message) {
-              $scope.message = 'Service(s) are offline';
-            } else {
-              $scope.message = message;
-              $scope.subtitle = subtitle;
-            }
+            $scope.message = message || genericServiceErrorMsg;
+            $scope.subtitle = subtitle || genericSubtitle;
             modal = $bootstrapModal.open(modalObj);
             modal.result.finally(function() {
               $state.go('overview', {}, {reload: true});
             });
+          } else {
+            $scope.message = message || genericServiceErrorMsg;
+            $scope.subtitle = subtitle || genericSubtitle;
           }
         }.bind($scope));
 

--- a/cdap-ui/app/services/service-status-factory.js
+++ b/cdap-ui/app/services/service-status-factory.js
@@ -48,8 +48,11 @@ angular.module(PKG.name + '.services')
           EventPipe.emit('backendUp');
           myAuth.logout();
         });
-      } else {
-        EventPipe.emit('backendDown');
+      } else if(err && err.code === 'ECONNREFUSED') {
+        EventPipe.emit('backendDown', 'Unable to connect to CDAP Router', 'Attempting to connect…');
+      } else if (!err) {
+        // Ideally we won't reach here. 
+        EventPipe.emit('backendUp');
       }
     }
     );

--- a/cdap-ui/app/services/status-factory.js
+++ b/cdap-ui/app/services/status-factory.js
@@ -56,16 +56,17 @@ angular.module(PKG.name + '.services')
     function error(err, statusCode) {
       if (err && err.code === 'ECONNREFUSED') {
         this.startPolling();
-        EventPipe.emit('backendDown', 'Unable to connect to CDAP Router', 'Attempting to connect…');
+        EventPipe.emit('backendDown', 'Unable to connect to CDAP Router', 'Attempting to connect...');
         return;
-      } else if (statusCode === 503) {
+      } else if (statusCode === 503 || statusCode === 500) {
+        this.startPolling();
         EventPipe.emit('backendDown');
       }
       reAuthenticate(statusCode);
     }
 
     function reAuthenticate(statusCode) {
-      if (statusCode === 401) {
+      if (statusCode === 401 || statusCode === 200) {
         $timeout(function() {
           EventPipe.emit('backendUp');
           myAuth.logout();


### PR DESCRIPTION
Steps to reproduce the original issue,
- Stop cdap-master
- Stop cdap-router

The UI always shows 'Service(s) are offline' message and would never update the UI even when the services back online.
The current fix checks for services and show appropriate messages when master or router services go down & constantly polls for the status of services & when back updates the UI appropriately.

Tested in both secure & un-secure. Works the same.
![unsecure-status](https://cloud.githubusercontent.com/assets/1452845/12415776/5cb32f3c-be52-11e5-803b-59ec4f30714e.gif)
