### PR TITLE
Speed up unit-test app deployment

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramResources.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramResources.java
@@ -199,11 +199,7 @@ public final class ProgramResources {
 
       if (include) {
         result.add(resultTransform.apply(classInfo));
-        URL url = classInfo.url();
-        // URL shouldn't be null for ".class" file. Since url() is @Nullable, hence the check
-        if (url != null) {
-          resourcesBaseURLs.add(getClassPathURL(classInfo.getResourceName(), url));
-        }
+        resourcesBaseURLs.add(classInfo.baseURL());
       }
     }
 
@@ -215,11 +211,7 @@ public final class ProgramResources {
       }
       // See if the resource base URL is already accepted through class filtering.
       // If it does, adds the resource name to the collection as well.
-      URL url = resourceInfo.url();
-      // The url returned might be null under Java8. Apparently some resources that are inside lib/ext jars
-      // are not loadable through the underlying ClassLoader (ExtClassLoader).
-      // Since those resources won't be loadable anyway, hence it's ok to be ignored from the include list.
-      if (url != null && resourcesBaseURLs.contains(getClassPathURL(resourceInfo.getResourceName(), url))) {
+      if (resourcesBaseURLs.contains(resourceInfo.baseURL())) {
         result.add(resultTransform.apply(resourceInfo));
       }
     }


### PR DESCRIPTION
- Loading the every resources from the class loader takes a lot of time
  We don’t actually need to load it since during the discovery of
  those resources, we already know the URLs