### PR TITLE
fixes issue where column content was bottom-aligned

### DIFF
--- a/cdap-ui/app/features/hydrator/bottompanel.less
+++ b/cdap-ui/app/features/hydrator/bottompanel.less
@@ -412,6 +412,7 @@ body.theme-cdap.state-hydrator {
           > div {
             display: table-cell;
             padding: 20px 10px;
+            vertical-align: top;
           }
         }
         div.source-table {


### PR DESCRIPTION
*  Vertical aligns Node Config tab columns to the top to prevent bottom panel alignment of schema columns

Before:
![vm](https://cloud.githubusercontent.com/assets/5335210/12430164/f69349e8-bea2-11e5-8c6f-8ba424ecee0b.gif)

After:
![vm-fixed](https://cloud.githubusercontent.com/assets/5335210/12430173/fd87e966-bea2-11e5-84fd-b25b0d4ba720.gif)

