### PR TITLE
CDAP-4710 pulling hydrator upgrade out to its own section

### DIFF
--- a/cdap-docs/cdap-apps/source/hydrator/index.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/index.rst
@@ -18,6 +18,7 @@ Cask Hydrator and ETL Pipelines
     Creating an ETL Application <creating>
     Creating Custom ETL Plugins <custom>
     ETL Plugins <plugins/index>
+    Upgrading ETL Applications <upgrade>
     
     
 .. _cdap-apps-intro-hydrator:
@@ -54,6 +55,10 @@ code; instead, you just configure CDAP appropriately and operate it.
 
 - **Lifecycle of ETL Applications:** This is managed using CDAP's :ref:`Lifecycle HTTP RESTful API <http-restful-api-lifecycle>`.
 
+.. |etl-upgrade| replace:: **Upgrading ETL Applications**
+.. _etl-upgrade: upgrade.html
+
+- |etl-upgrade|_ Instructions for upgrading old ETL applications.
 
 .. rubric:: Cask Hydrator
 

--- a/cdap-docs/cdap-apps/source/hydrator/overview.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/overview.rst
@@ -156,29 +156,3 @@ Application and Plugin Details
 
 - |etl-plugins|_ Details on ETL plugins and exploring available plugins using RESTful APIs.
 
-Upgrade Procedure
-=================
-
-If you wish to upgrade ETL applications created using the 3.2.x versions of ``cdap-etl-batch`` or ``cdap-etl-realtime``,
-you can use the ETL upgrade tool packaged with the distributed version of CDAP.
-The tool will connect to an instance of CDAP, look for any applications that use 3.2.x versions of the
-``cdap-etl-batch`` or ``cdap-etl-realtime`` artifacts, and then update application to use the |version| version of those artifacts.
-CDAP must be running when you run the command:
-
-.. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> upgrade
-
-You can also upgrade just the ETL applications within a specific namespace:
-
-.. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -n <namespace> upgrade
-
-Or just one application:
-
-.. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -n <namespace> -p <app-name> upgrade
-
-If you have authentication turned on, you also need to store an authentication token in a file and pass the file to the tool:
-
-.. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -a <tokenfile> upgrade

--- a/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
@@ -1,0 +1,34 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2016 Cask Data, Inc.
+
+.. _cdap-apps-etl-upgrade:
+
+=====================
+ETL Upgrade Procedure
+=====================
+
+If you wish to upgrade ETL applications created using the 3.2.x versions of ``cdap-etl-batch`` or ``cdap-etl-realtime``,
+you can use the ETL upgrade tool packaged with the distributed version of CDAP.
+The tool will connect to an instance of CDAP, look for any applications that use 3.2.x versions of the
+``cdap-etl-batch`` or ``cdap-etl-realtime`` artifacts, and then update the application to use the |version| version of those artifacts.
+CDAP must be running when you run the command:
+
+.. parsed-literal::
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> upgrade
+
+You can also upgrade just the ETL applications within a specific namespace:
+
+.. parsed-literal::
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -n <namespace> upgrade
+
+You can also upgrade just one ETL application:
+
+.. parsed-literal::
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -n <namespace> -p <app-name> upgrade
+
+If you have authentication turned on, you also need to store an authentication token in a file and pass the file to the tool:
+
+.. parsed-literal::
+  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u http://<host>:<port> -a <tokenfile> upgrade
+


### PR DESCRIPTION
This will let us link directly to it from the CDAP upgrade docs
instead of linking to part of an overview page.