### PR TITLE
Allow non-CDAP packages to use repo scripts

### DIFF
--- a/cdap-distributions/bin/build_apt_repo.sh
+++ b/cdap-distributions/bin/build_apt_repo.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -47,7 +47,7 @@ STAGE_DIR=${TARGET_DIR}/aptrepo
 
 S3_BUCKET=${S3_BUCKET:-repository.cask.co}
 S3_REPO_PATH=${S3_REPO_PATH:-ubuntu/precise/amd64/cdap} # No leading or trailing slashes
-VERSION=${VERSION:-$(basename ${TARGET_DIR}/cdap_*.deb | cut -d_ -f2 | cut -d- -f1)}
+VERSION=${VERSION:-$(basename ${TARGET_DIR}/*.deb | head -n 1 | cut -d_ -f2 | cut -d- -f1)}
 GPG_KEY_NAME=${GPG_KEY_NAME:-${1}}
 GPG_PASSPHRASE=${GPG_PASSPHRASE:-${2}}
 __version=${VERSION/-SNAPSHOT/}

--- a/cdap-distributions/bin/build_parcel_repo.sh
+++ b/cdap-distributions/bin/build_parcel_repo.sh
@@ -46,7 +46,7 @@ STAGE_DIR=${TARGET_DIR}/parcelrepo
 
 S3_BUCKET=${S3_BUCKET:-repository.cask.co}
 S3_REPO_PATH=${S3_REPO_PATH:-parcels/cdap} # No leading or trailing slashes
-VERSION=${VERSION:-$(basename ${TARGET_DIR}/CDAP-*.parcel | cut -d- -f2)}
+VERSION=${VERSION:-$(basename ${TARGET_DIR}/*.parcel | head -n 1 | cut -d- -f2)} # Assumes NAME-${VERSION}*
 __version=${VERSION/-SNAPSHOT/}
 __maj_min=$(echo ${__version} | cut -d. -f1,2)
 

--- a/cdap-distributions/bin/build_yum_repo.sh
+++ b/cdap-distributions/bin/build_yum_repo.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -47,7 +47,7 @@ STAGE_DIR=${TARGET_DIR}/yumrepo
 
 S3_BUCKET=${S3_BUCKET:-repository.cask.co}
 S3_REPO_PATH=${S3_REPO_PATH:-centos/6/x86_64/cdap} # No leading or trailing slashes
-VERSION=${VERSION:-$(basename ${TARGET_DIR}/cdap-*.rpm | cut -d- -f2)}
+VERSION=${VERSION:-$(ls -1 *.rpm | head -n 1 | rpm --queryformat "%{VERSION}" -qp)} # query package file
 GPG_KEY_NAME=${GPG_KEY_NAME:-${1}}
 GPG_PASSPHRASE=${GPG_PASSPHRASE:-${2}}
 __version=${VERSION/-SNAPSHOT/}

--- a/cdap-distributions/bin/build_yum_repo.sh
+++ b/cdap-distributions/bin/build_yum_repo.sh
@@ -47,7 +47,7 @@ STAGE_DIR=${TARGET_DIR}/yumrepo
 
 S3_BUCKET=${S3_BUCKET:-repository.cask.co}
 S3_REPO_PATH=${S3_REPO_PATH:-centos/6/x86_64/cdap} # No leading or trailing slashes
-VERSION=${VERSION:-$(ls -1 *.rpm | head -n 1 | rpm --queryformat "%{VERSION}" -qp)} # query package file
+VERSION=${VERSION:-$(ls -1 *.rpm | head -n 1 | xargs rpm --queryformat "%{VERSION}" -qp)} # query package file
 GPG_KEY_NAME=${GPG_KEY_NAME:-${1}}
 GPG_PASSPHRASE=${GPG_PASSPHRASE:-${2}}
 __version=${VERSION/-SNAPSHOT/}


### PR DESCRIPTION
This allows this script to be used with non-CDAP packages. The only requirement is that all versions match between all packages being processed.