### PR TITLE
Bump cdap and plugin versions

### DIFF
--- a/cdap-examples/resources/weblog-analytics-config.json
+++ b/cdap-examples/resources/weblog-analytics-config.json
@@ -2,7 +2,7 @@
     "artifact": {
         "name": "cdap-etl-batch",
         "scope": "SYSTEM",
-        "version": "3.3.0"
+        "version": "3.4.0-SNAPSHOT"
     },
     "config": {
         "source": {

--- a/cdap-examples/resources/weblog-analytics.txt
+++ b/cdap-examples/resources/weblog-analytics.txt
@@ -1,3 +1,3 @@
-create app test cdap-etl-batch 3.3.0 system \$CDAP_HOME/examples/resources/weblog-analytics-config.json 
+create app test cdap-etl-batch 3.4.0-SNAPSHOT system \$CDAP_HOME/examples/resources/weblog-analytics-config.json
 load stream logEventStream \$CDAP_HOME/examples/resources/accesslog.txt
 start mapreduce test.ETLMapReduce

--- a/cdap-examples/resources/weblog-service.txt
+++ b/cdap-examples/resources/weblog-service.txt
@@ -1,2 +1,2 @@
-deploy app \$CDAP_HOME/examples/CubeService/target/CubeServiceApp-3.3.0.jar
+deploy app \$CDAP_HOME/examples/CubeService/target/CubeServiceApp-3.4.0-SNAPSHOT.jar
 start service CubeServiceApp.CubeService 

--- a/cdap-ui/app/features/hydrator/controllers/create-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -92,7 +92,7 @@ angular.module(PKG.name + '.feature.hydrator')
       if (result.error) {
         $alert({
           type: 'danger',
-          content: 'Imported pre-defined app has issues. Please check the JSON of the imported pre-defined app'
+          content: 'Imported pre-defined app has issues. Please check the JSON of the imported pre-defined app.'
         });
       } else {
         $state.go('hydrator.create.studio', {

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdap-ui",
-  "version": "3.3.0",
+  "version": "3.4.0-SNAPSHOT",
   "description": "Front-end for CDAP",
   "scripts": {
     "start": "node ./server.js",

--- a/cdap-ui/templates/apps/predefined/AmazonSQSToHBase.json
+++ b/cdap-ui/templates/apps/predefined/AmazonSQSToHBase.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.0"
+    "version": "3.4.0-SNAPSHOT"
   },
   "config": {
     "source": {
@@ -19,7 +19,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.0"
+          "version": "1.3.0-SNAPSHOT"
         }
       }
     },
@@ -36,7 +36,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.0"
+            "version": "1.3.0-SNAPSHOT"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/KafkaToHBase.json
+++ b/cdap-ui/templates/apps/predefined/KafkaToHBase.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.0"
+    "version": "3.4.0-SNAPSHOT"
   },
   "config": {
     "source": {
@@ -21,7 +21,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.0"
+          "version": "1.3.0-SNAPSHOT"
         }
       }
     },
@@ -39,7 +39,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.0"
+            "version": "1.3.0-SNAPSHOT"
           }
         }
       }
@@ -57,7 +57,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.0"
+            "version": "1.3.0-SNAPSHOT"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/KafkaToOLAPCube.json
+++ b/cdap-ui/templates/apps/predefined/KafkaToOLAPCube.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.0"
+    "version": "3.4.0-SNAPSHOT"
   },
   "config": {
     "source": {
@@ -21,7 +21,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.0"
+          "version": "1.3.0-SNAPSHOT"
         }
       }
     },
@@ -40,7 +40,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.0"
+            "version": "1.3.0-SNAPSHOT"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/KafkaToStream.json
+++ b/cdap-ui/templates/apps/predefined/KafkaToStream.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.0"
+    "version": "3.4.0-SNAPSHOT"
   },
   "config": {
     "source": {
@@ -17,7 +17,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.0"
+          "version": "1.3.0-SNAPSHOT"
         }
       }
     },
@@ -35,7 +35,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.0"
+            "version": "1.3.0-SNAPSHOT"
           }
         }
       }
@@ -53,7 +53,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.0"
+            "version": "1.3.0-SNAPSHOT"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/StreamToHBase.json
+++ b/cdap-ui/templates/apps/predefined/StreamToHBase.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-batch",
     "scope": "SYSTEM",
-    "version": "3.3.0"
+    "version": "3.4.0-SNAPSHOT"
   },
   "config": {
     "source": {
@@ -19,7 +19,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.0"
+          "version": "1.3.0-SNAPSHOT"
         }
       }
     },
@@ -37,7 +37,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.0"
+            "version": "1.3.0-SNAPSHOT"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/TwitterToHBase.json
+++ b/cdap-ui/templates/apps/predefined/TwitterToHBase.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.0"
+    "version": "3.4.0-SNAPSHOT"
   },
   "config": {
     "source": {
@@ -19,7 +19,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.0"
+          "version": "1.3.0-SNAPSHOT"
         }
       }
     },
@@ -37,7 +37,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.0"
+            "version": "1.3.0-SNAPSHOT"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/TwitterToStream.json
+++ b/cdap-ui/templates/apps/predefined/TwitterToStream.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.0"
+    "version": "3.4.0-SNAPSHOT"
   },
   "config": {
     "source": {
@@ -19,7 +19,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.0"
+          "version": "1.3.0-SNAPSHOT"
         }
       }
     },
@@ -37,7 +37,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.0"
+            "version": "1.3.0-SNAPSHOT"
           }
         }
       }
@@ -55,7 +55,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.0"
+            "version": "1.3.0-SNAPSHOT"
           }
         }
       }


### PR DESCRIPTION
Merging release into develop made '3.3.0' appear in some places.
This addresses that and bumps the version also, as appropriate.