### PR TITLE
Check for RPM files in target directory

### DIFF
--- a/cdap-distributions/bin/build_yum_repo.sh
+++ b/cdap-distributions/bin/build_yum_repo.sh
@@ -47,7 +47,7 @@ STAGE_DIR=${TARGET_DIR}/yumrepo
 
 S3_BUCKET=${S3_BUCKET:-repository.cask.co}
 S3_REPO_PATH=${S3_REPO_PATH:-centos/6/x86_64/cdap} # No leading or trailing slashes
-VERSION=${VERSION:-$(ls -1 *.rpm | head -n 1 | xargs rpm --queryformat "%{VERSION}" -qp)} # query package file
+VERSION=${VERSION:-$(ls -1 ${TARGET_DIR}/*.rpm | head -n 1 | xargs rpm --queryformat "%{VERSION}" -qp)} # query package file
 GPG_KEY_NAME=${GPG_KEY_NAME:-${1}}
 GPG_PASSPHRASE=${GPG_PASSPHRASE:-${2}}
 __version=${VERSION/-SNAPSHOT/}


### PR DESCRIPTION
Fixes:
```
22-Jan-2016 21:48:56	ls: cannot access *.rpm: No such file or directory
22-Jan-2016 21:48:56	rpm: no arguments given for query
22-Jan-2016 21:48:56	Usage: grep [OPTION]... PATTERN [FILE]...
22-Jan-2016 21:48:56	Try `grep --help' for more information.
22-Jan-2016 21:48:56	ERROR: [Errno 32] Broken pipe
```