### PR TITLE
Release 3.3.1: Fix broken links.

### DIFF
--- a/cdap-docs/admin-manual/source/operations/index.rst
+++ b/cdap-docs/admin-manual/source/operations/index.rst
@@ -79,12 +79,6 @@ Operations
 - |tx-maintenance|_ Periodic maintenance of the **Transaction Service.**
 
 
-.. |troubleshooting| replace:: **Troubleshooting:**
-.. _troubleshooting: troubleshooting.html
-
-- |troubleshooting|_ Selected examples of potential **problems and possible resolutions.**
-
-
 .. rubric:: Command Line Interface
 
 Most of the administrative operations are also available more conveniently through the

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -320,7 +320,6 @@ function build_docs_outer_level() {
   cp ${SCRIPT_PATH}/${COMMON_HIGHLEVEL_PY}  ${TARGET_PATH}/${SOURCE}/conf.py
   cp -R ${SCRIPT_PATH}/${COMMON_IMAGES}     ${TARGET_PATH}/${SOURCE}/
   cp ${SCRIPT_PATH}/${COMMON_SOURCE}/*.rst  ${TARGET_PATH}/${SOURCE}/
-  cp ${SCRIPT_PATH}/${COMMON_SOURCE}/*.md   ${TARGET_PATH}/${SOURCE}/
   
   local google_options
   if [ "x${google_code}" != "x" ]; then

--- a/cdap-docs/developers-manual/source/building-blocks/workflows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/workflows.rst
@@ -247,7 +247,7 @@ be used outside of a workflow. When run from within a workflow, the token is gua
 be non-null.
 
 The `WorkflowToken Java API 
-<../../reference-manual/javadocs/co/cask/cdap/api/workflow/WorkflowToken.html)>`__
+<../../reference-manual/javadocs/co/cask/cdap/api/workflow/WorkflowToken.html>`__
 includes methods for getting values for different keys, scopes, and nodes. The same
 key can be added to the workflow by different nodes, and there are methods to return a map of those
 key-value pairs. Convenience methods allow the putting and getting of non-string values

--- a/cdap-docs/examples-manual/source/apps-packs.rst
+++ b/cdap-docs/examples-manual/source/apps-packs.rst
@@ -23,7 +23,7 @@ The |cdap-apps-repository|_ contains data applications built using CDAP:
 - |wise|_ Web Insights Engine analyzes the behavior of users of a website by processing
   Apache web logs.
   This application is also the basis for the online tutorial of the same name,
-  `WISE: Web Analytics <http://docs.cask.co/tutorial/current/en/tutorial2.html>`__;
+  :ref:`WISE: Web Analytics <cdap-tutorial-wise>`;
   refer to it for step-by-step instructions on creating the application from scratch.
   Download or clone the app at `GitHub. <https://github.com/caskdata/cdap-apps>`__
 

--- a/cdap-docs/integrations/source/index.rst
+++ b/cdap-docs/integrations/source/index.rst
@@ -18,7 +18,7 @@ Integrations
 
 
 .. |cloudera-install| replace:: **Configuring and Installing:**
-.. _cloudera-install: ../admin-manual/installation/cloudera/index.html
+.. _cloudera-install: ../admin-manual/installation/cloudera.html
 
 - |cloudera-install|_ Configuring and installing CDAP using **Cloudera Manager** *(Administration Manual)*
 
@@ -30,7 +30,7 @@ Integrations
 
 
 .. |cloudera-faq| replace:: **FAQ:**
-.. _cloudera-faq: partners/cloudera/faq.html
+.. _cloudera-faq: ../faqs/cloudera-manager..html
 
 .. - |cloudera-faq|_ for Cloudera and Impala
 
@@ -38,7 +38,7 @@ Integrations
 .. rubric:: Ambari
 
 .. |ambari| replace:: **Configuring and Installing:**
-.. _ambari: ../admin-manual/installation/ambari/index.html
+.. _ambari: ../admin-manual/installation/ambari.html
 
 - |ambari|_ Configuring and installing CDAP using **Ambari** *(Administration Manual)*
 
@@ -46,7 +46,7 @@ Integrations
 .. rubric:: MapR
 
 .. |mapr| replace:: **Configuring and Installing:**
-.. _mapr: ../admin-manual/installation/mapr/index.html
+.. _mapr: ../admin-manual/installation/mapr.html
 
 - |mapr|_ Configuring and installing CDAP on **MapR** *(Administration Manual)*
 

--- a/cdap-docs/integrations/source/partners/cloudera/index.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/index.rst
@@ -47,7 +47,7 @@ results.
 
 
 .. |cloudera-install| replace:: **Configuring and Installing:**
-.. _cloudera-install: ../../../admin-manual/installation/cloudera/index.html
+.. _cloudera-install: ../../../admin-manual/installation/cloudera.html
 
 - |cloudera-install|_ Configuring and installing CDAP using **Cloudera Manager** *(Administration Manual)*
 
@@ -64,4 +64,3 @@ results.
    :width: 800px
    :align: center
    :class: bordered-image
-

--- a/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
@@ -15,10 +15,10 @@ Integrating CDAP with Impala
 
 When using CDAP with Impala:
 
-.. |included-applications| replace:: **Included Applications:**
-.. _included-applications: ../../../included-applications/index.html
+.. |cdap-apps| replace:: **CDAP Applications:**
+.. _cdap-apps: ../../../cdap-apps/hydrator/index.html
 
-- |included-applications|_ Using **ETL** and **custom ETL plugins**
+- |cdap-apps|_ Using **ETL** and **custom ETL plugins**
 
 
 .. |stream| replace:: **Stream Exploration:**


### PR DESCRIPTION
Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB94-2)

Fixes a number of broken links.

Removes an un-used line in the main build script that was generating an error message. We don't have any Markdown files in the main documentation build that we are copying (only in the cdap-apps manual), and attempting to copy any that weren't present causes an error...