### PR TITLE
changes transition property for nodes

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag.less
+++ b/cdap-ui/app/directives/dag/my-dag.less
@@ -97,7 +97,8 @@ my-dag {
         width: 56px;
         .border-radius(6px);
         .box-shadow(0 10px 18px -9px fade(black, 50%));
-        .transition(all 50ms linear);
+        .transition(background-color 50ms linear);
+        .transition(color 50ms linear);
         background-clip: border-box;
         &:hover, &:focus {
           .fa.fa-close {
@@ -129,6 +130,7 @@ my-dag {
 
       .icon.fa, .fa.fa-close {
         cursor: pointer;
+
       }
       .icon.fa {
         line-height: 40px;


### PR DESCRIPTION
*  Modifies node transition property to fix flicking issue where node icons would go away for a fraction of time when clicking another node

Before:
![before](https://cloud.githubusercontent.com/assets/5335210/12564932/e19ecf3a-c366-11e5-80c6-771b05ef8a30.gif)

After:
![after](https://cloud.githubusercontent.com/assets/5335210/12564940/e790d424-c366-11e5-9188-8f63d128a7a7.gif)

Decreased alert height:
![screen shot 2016-01-27 at 12 37 32 pm](https://cloud.githubusercontent.com/assets/5335210/12627473/d8a789ac-c4f2-11e5-8341-cce344426c41.png)

