### PR TITLE
Removes the assumption of an output schema for the stream plugin all the time

### DIFF
--- a/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
+++ b/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
@@ -146,7 +146,9 @@ angular.module(PKG.name + '.feature.hydrator')
               node.plugin.properties.schema = JSON.stringify({
                 type: 'record',
                 name: 'etlSchemaBody',
-                fields: pluginToSchemaMap[pluginName].concat(node.outputSchema.fields)
+                fields: angular.isObject(node.outputSchema)?
+                  pluginToSchemaMap[pluginName].concat(node.outputSchema.fields || []):
+                  pluginToSchemaMap[pluginName].concat([])
               });
             } else {
               try {

--- a/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
+++ b/cdap-ui/app/features/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
@@ -148,7 +148,7 @@ angular.module(PKG.name + '.feature.hydrator')
                 name: 'etlSchemaBody',
                 fields: angular.isObject(node.outputSchema)?
                   pluginToSchemaMap[pluginName].concat(node.outputSchema.fields || []):
-                  pluginToSchemaMap[pluginName].concat([])
+                  pluginToSchemaMap[pluginName]
               });
             } else {
               try {


### PR DESCRIPTION
- Removes the assumption of output schema for stream plugin. This could be useful if the user creates the JSON from scratch and deploy it through backend and use the UI to view the pipeline. 