### PR TITLE
Move jersey dependency to unit test, for use by user spark programs.

### DIFF
--- a/cdap-examples/pom.xml
+++ b/cdap-examples/pom.xml
@@ -359,11 +359,6 @@
         <version>1.2</version>
       </dependency>
       <dependency>
-        <groupId>com.sun.jersey</groupId>
-        <artifactId>jersey-core</artifactId>
-        <version>1.18</version>
-      </dependency>
-      <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
         <version>1.2</version>

--- a/cdap-unit-test/pom.xml
+++ b/cdap-unit-test/pom.xml
@@ -113,6 +113,11 @@
       <artifactId>spark-sql_2.10</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-servlet</artifactId>
+      <version>1.18</version>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
This change is so that other Spark programs can be run from unit test cases.
This change replaces the following two PRs (and so I closed them):
https://github.com/cdap-guides/cdap-spark-guide/pull/49
https://github.com/caskdata/cdap-apps/pull/103

http://builds.cask.co/browse/CDAP-RBT616-1