### PR TITLE
Fix CDAP-4729: Remove "404" page from the index and returned results.

### DIFF
--- a/cdap-docs/_common/highlevel_conf.py
+++ b/cdap-docs/_common/highlevel_conf.py
@@ -96,6 +96,7 @@ def dump_search_index(builder, index):
     movefile(searchindexfn + '.tmp', searchindexfn)
     builder.info('done')
 
+
 FILENAMES = 'filenames'
 TERMS = 'terms'
 TITLES = 'titles'
@@ -105,16 +106,27 @@ TITLETERMS = 'titleterms'
 def clean(master):
     for ref in range(len(master[FILENAMES])):
         file = master[FILENAMES][ref]
-        if file.endswith("/index"):
+        if file_to_be_removed(file):
+#             print "File to be removed:%s ref:%s" % (file, ref)
+            terms_to_remove = []
             # Remove any file number references
             for term in master[TERMS]:
                 files = master[TERMS][term]
                 if isinstance(files, list) and ref in files:
-                    master[TERMS][term] = files.remove(ref)
-                    print "Deleted list reference: %s" % ref             
-                elif ref == files: # A single file reference
-                    del master[TERMS][term]
-                    print "Deleted single reference: %s" % ref             
+                    files.remove(ref)
+                    master[TERMS][term] = files
+#                     print "Deleted list reference: %s of term %s from %s" % (ref, term, files)
+                elif ref == files or [ref] == files: # A single file reference
+#                     print "Deleting single reference: %s of term %s" % (ref, term)
+                    terms_to_remove.append(term)
+            for term in terms_to_remove:
+                del master[TERMS][term]
+                               
+
+def file_to_be_removed(file):
+    # Rules for which files are to be removed from the index
+    return bool(file.endswith("/index") or 
+                file == "404")
 
 
 # Merge an index back into master, where the second index is located in a manual
@@ -133,9 +145,9 @@ def merge(master, new, manual):
     master[TITLES] = master[TITLES] + new[TITLES]
     
     # Merge to terms
-    master[TERMS] = merger(master[TERMS], new[TERMS], offset)
+    merger(master[TERMS], new[TERMS], offset)
     # Merge to titleterms
-    master[TITLETERMS] = merger(master[TITLETERMS], new[TITLETERMS], offset)
+    merger(master[TITLETERMS], new[TITLETERMS], offset)
     
     return master
 
@@ -144,6 +156,9 @@ def merger(dict1, dict2, offset):
     # merges dict2 into dict1, adjusting by offset
     # accounts for if existing items are lists or single objects
     # dict:{document:[0,3],cdap:[0,3],placeholder:[1,4,2,5],test:0}
+    # dict1 = {"document":[0,3],"cdap":[0,3],"placeholder":[1,4,2,5],"test":0,"test1":1}
+    # dict2 = {"document":[10,13],"cdap":[10,13],"placeholder":[11,14,22,25],"test":10,"test2":22}
+    # Returns dict1 modified-in-place, with all elements as lists
 
     terms = dict1.keys()
     for term in dict2.keys():
@@ -152,19 +167,22 @@ def merger(dict1, dict2, offset):
         if isinstance(add_files, list): 
             add_files = [(file + offset) for file in add_files]
         else:
-            add_files = add_files + offset
+            add_files = [add_files + offset]
         # Add to existing?
         if term in terms:
             # Add to existing
             files = dict1[term]
             if not isinstance(files, list):
                 files = [files]
-            if not isinstance(add_files, list):
-                add_files = [add_files]
             new_files = files + add_files
         else:
             new_files = add_files
         
         dict1[term]=new_files
+        
+    for term in terms:
+        files = dict1[term]
+        if not isinstance(files, list):
+            dict1[term]=[files]
+            
     return dict1
-

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -40,6 +40,7 @@ function usage() {
   echo 
   echo "    docs-github-only  Clean build of HTML, zipped, with GitHub code, skipping Javadocs"
   echo "    docs-web-only     Clean build of HTML, zipped, with docs.cask.co code, skipping Javadocs"
+  echo "    docs-outer        Dirty build of HTML with docs.cask.co code, skipping re-building inner doc, zipping, and Javadocs"
   echo "    docs              Dirty build of HTML with docs.cask.co code, skipping zipping and Javadocs"
   echo 
   echo "    docs-github  Clean build of HTML and Javadocs, zipped, for placing on GitHub"
@@ -97,6 +98,7 @@ function run_command() {
   case ${1} in
     docs-all )          build_all;;
     docs )              build_docs ${DOCS};;
+    docs-outer )        build_docs ${DOCS_OUTER};;
     docs-github-only )  build_docs ${GITHUB_ONLY};;
     docs-web-only )     build_docs ${WEB_ONLY};;
     docs-github )       build_docs ${GITHUB};;
@@ -157,12 +159,16 @@ function build_docs() {
   echo "Building \"${doc_type}\" (${javadocs} Javadocs)"
   echo "--------------------------------------------------------"
   echo
-  if [ "${doc_type}" != "${DOCS}" ]; then
+  if [ "${doc_type}" != "${DOCS}" && "${doc_type}" != "${DOCS_OUTER}" ]; then
     clean_targets
   fi
   clear_messages_set_messages_file
-  run_command docs-first-pass ${source_path}
-  if [ "${doc_type}" == "${DOCS}" ]; then
+  
+  if [ "${doc_type}" != "${DOCS_OUTER}" ]; then
+    run_command docs-first-pass ${source_path}
+  fi
+  
+  if [ "${doc_type}" == "${DOCS}" -o "${doc_type}" == "${DOCS_OUTER}" ]; then
     build_docs_outer_level ${source_path}
     copy_docs_inner_level
   else
@@ -375,16 +381,18 @@ function zip_extras() {
 }
 
 function clean_targets() {
-  # Removes all outer- and inner-level build ${TARGET} directories
+  # Removes all outer- and (sometimes) inner-level build ${TARGET} directories
   rm -rf ${TARGET_PATH}
   mkdir ${TARGET_PATH}
   echo "Cleaned ${TARGET_PATH} directory"
   echo
-  for i in ${MANUALS}; do
-    rm -rf ${SCRIPT_PATH}/${i}/${TARGET}/*
-    echo "Cleaned ${SCRIPT_PATH}/${i}/${TARGET} directories"
-    echo
-  done
+  if [ "${doc_type}" != "${DOCS_OUTER}" ]; then
+    for i in ${MANUALS}; do
+      rm -rf ${SCRIPT_PATH}/${i}/${TARGET}/*
+      echo "Cleaned ${SCRIPT_PATH}/${i}/${TARGET} directories"
+      echo
+    done
+  fi
 }
 
 function clean_outer_level() {

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -8,6 +8,7 @@ COMMON_PLACEHOLDER="$COMMON/_source/placeholder_index._rst"
 HTACCESS="htaccess"
 
 DOCS="docs"
+DOCS_OUTER="docs-outer"
 GITHUB="github"
 GITHUB_ONLY="Github-only"
 WEB="web"


### PR DESCRIPTION
Added a "docs-outer" target that builds only the outer docs. Speeds up debugging.

Fixed the cleanup of the Master index to correctly remove a file.
Add a function which defines the files to be removed, and included the "404" file in the list
of files to be removed from the index.

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB96-1)

Compare:

- [Existing search for "release"](http://docs.cask.co/cdap/current/en/search.html?q=release&check_keywords=yes&area=default): second hit is the "404" page
- [New search for "release"](http://builds.cask.co/artifact/CDAP-DOB96/shared/build-1/Docs-HTML/3.3.1-SNAPSHOT/en/search.html?q=release&check_keywords=yes&area=default): "404" page is not in the results

