### PR TITLE
CDAP-4723 add build improvements to plugin archetypes

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -29,6 +29,24 @@
         <include>**/*.java</include>
       </includes>
     </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory>docs</directory>
+      <includes>
+        <include>*.md</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory>widgets</directory>
+      <includes>
+        <include>*.json</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory></directory>
+      <includes>
+        <include>README.md</include>
+      </includes>
+    </fileSet>
   </fileSets>
 </archetype-descriptor>
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/README.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/README.md
@@ -1,0 +1,32 @@
+Build
+-----
+To build your plugins::
+
+  mvn clean package -DskipTests
+
+The build will create a .jar and .json file under the ``target`` directory.
+These files can be used to deploy your plugins.
+
+UI Integration
+--------------
+The Cask Hydrator UI displays each plugin property as a simple textbox. To customize how the plugin properties
+are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
+The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/cdap-apps/hydrator/custom.html#plugin-configuration-json)
+for details on the configuration file.
+The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
+that follows the convention of ``[plugin-name]-[plugin-type].md``.
+
+When the build runs, it will scan the ``widgets`` and ``docs`` directories in order to build an appropriately
+formatted .json file under the ``target`` directory. This file is deployed along with your .jar file to add your
+plugins to CDAP.
+
+Deployment
+----------
+You can deploy your plugins using the CDAP CLI::
+
+  > load artifact <target/plugin.jar> config-file <target/plugin.json>
+
+For example, if your artifact is named 'my-plugins-1.0.0'::
+
+  > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/docs/Sink-batchsink.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/docs/Sink-batchsink.md
@@ -1,0 +1,9 @@
+# Sink Batch Sink
+
+Insert documentation about your plugin in this file.
+The UI will display the contents in the reference section of your plugin,
+assuming this file is named following a convention of ``[plugin-name]-batchsink.md``.
+The plugin name is case sensitive.
+
+For examples of plugin documentation, see the
+[Hydrator documentation](https://github.com/caskdata/hydrator-plugins/tree/develop/core-plugins/docs).

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/pom.xml
@@ -29,6 +29,12 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>3.3.1-SNAPSHOT</cdap.version>
     <hadoop.version>2.3.0</hadoop.version>
+    <!-- properties for script build step that creates the config files for the artifacts -->
+    <widgets.dir>widgets</widgets.dir>
+    <docs.dir>docs</docs.dir>
+    <etl.versionRange>[3.3.0,10.0.0-SNAPSHOT)</etl.versionRange>
+    <!-- this is here because project.basedir evaluates to null in the script build step -->
+    <main.basedir>${project.basedir}</main.basedir>
   </properties>
 
   <repositories>
@@ -170,6 +176,92 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.7</version>
+          <executions>
+            <!-- Create the config file for artifact which can be used to deploy the artifact.
+                 Sets the parents field to system:cdap-etl-batch and system:cdap-etl-realtime with whatever
+                 version range is set in the etl.versionRange property.
+                 also sets a widget and doc property for each file contained in the widgets and docs directories. -->
+            <execution>
+              <id>create-artifact-config</id>
+              <phase>prepare-package</phase>
+              <configuration>
+                <target>
+                  <script language="javascript"> <![CDATA[
+
+                  // for some reason, project.basedir evaluates to null if we just get the property here.
+                  // so we set main.basedir to project.basedir in the pom properties, then main.basedir is used here
+                  // where it evaluates correctly for whatever reason
+                  var baseDir = project.getProperty("main.basedir");
+                  var targetDir = project.getProperty("project.build.directory");
+                  var artifactId = project.getProperty("project.artifactId");
+                  var version = project.getProperty("project.version");
+
+                  var cfgFile = new java.io.File(targetDir, artifactId + "-" + version + ".json");
+                  if (!cfgFile.exists()) {
+                    cfgFile.createNewFile();
+                  }
+
+                  var etlRange = project.getProperty("etl.versionRange");
+                  var config = {
+                    "parents": [ "system:cdap-etl-batch" + etlRange, "system:cdap-etl-realtime" + etlRange ],
+                    "properties": {}
+                  }
+
+                  // look in widgets directory for widget config for each plugin
+                  var widgetsDir = new java.io.File(baseDir, project.getProperty("widgets.dir"));
+                  if (widgetsDir.isDirectory()) {
+                    var widgetsFiles = widgetsDir.listFiles();
+                    for (i = 0; i < widgetsFiles.length; i++) {
+                      var widgetsFile = widgetsFiles[i];
+                      if (widgetsFile.isFile()) {
+                        var propertyName = "widgets." + widgetsFile.getName();
+                        // if the filename ends with .json
+                        if (propertyName.indexOf(".json", propertyName.length - 5) !== -1) {
+                          // strip the .json
+                          propertyName = propertyName.slice(0, -5);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(widgetsFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          var contentsAsJson = JSON.parse(contents);
+                          config.properties[propertyName] = JSON.stringify(contentsAsJson);
+                        }
+                      }
+                    }
+                  }
+
+                  // look in the docs directory for docs for each plugin
+                  var docsDir = new java.io.File(baseDir, project.getProperty("docs.dir"));
+                  if (docsDir.isDirectory()) {
+                    var docFiles = docsDir.listFiles();
+                    for (i = 0; i < docFiles.length; i++) {
+                      var docFile = docFiles[i];
+                      if (docFile.isFile()) {
+                        var propertyName = "doc." + docFile.getName();
+                        // if the filename ends with .md
+                        if (propertyName.indexOf(".md", propertyName.length - 3) !== -1) {
+                          // strip the extension
+                          propertyName = propertyName.slice(0, -3);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(docFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          config.properties[propertyName] = contents + "";
+                        }
+                      }
+                    }
+                  }
+
+                  var fw = new java.io.BufferedWriter(new java.io.FileWriter(cfgFile.getAbsoluteFile()));
+                  fw.write(JSON.stringify(config, null, 2));
+                  fw.close();
+                ]]></script>
+                </target>
+              </configuration>
+              <goals>
+                <goal>run</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -182,7 +274,10 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/widgets/Sink-batchsink.json
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/widgets/Sink-batchsink.json
@@ -1,0 +1,13 @@
+{
+  "metadata": {
+    "spec-version": "1.0"
+  },
+  "configuration-groups": [
+    {
+      "label": "Sink Configuration",
+      "properties": [
+      ]
+    }
+  ],
+  "outputs": []
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -29,6 +29,24 @@
         <include>**/*.java</include>
       </includes>
     </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory>docs</directory>
+      <includes>
+        <include>*.md</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory>widgets</directory>
+      <includes>
+        <include>*.json</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory></directory>
+      <includes>
+        <include>README.md</include>
+      </includes>
+    </fileSet>
   </fileSets>
 </archetype-descriptor>
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/README.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/README.md
@@ -1,0 +1,32 @@
+Build
+-----
+To build your plugins::
+
+  mvn clean package -DskipTests
+
+The build will create a .jar and .json file under the ``target`` directory.
+These files can be used to deploy your plugins.
+
+UI Integration
+--------------
+The Cask Hydrator UI displays each plugin property as a simple textbox. To customize how the plugin properties
+are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
+The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/cdap-apps/hydrator/custom.html#plugin-configuration-json)
+for details on the configuration file.
+The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
+that follows the convention of ``[plugin-name]-[plugin-type].md``.
+
+When the build runs, it will scan the ``widgets`` and ``docs`` directories in order to build an appropriately
+formatted .json file under the ``target`` directory. This file is deployed along with your .jar file to add your
+plugins to CDAP.
+
+Deployment
+----------
+You can deploy your plugins using the CDAP CLI::
+
+  > load artifact <target/plugin.jar> config-file <target/plugin.json>
+
+For example, if your artifact is named 'my-plugins-1.0.0'::
+
+  > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/docs/Source-batchsource.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/docs/Source-batchsource.md
@@ -1,0 +1,9 @@
+# Source Batch Source
+
+Insert documentation about your plugin in this file.
+The UI will display the contents in the reference section of your plugin,
+assuming this file is named following a convention of ``[plugin-name]-batchsource.md``.
+The plugin name is case sensitive.
+
+For examples of plugin documentation, see the
+[Hydrator documentation](https://github.com/caskdata/hydrator-plugins/tree/develop/core-plugins/docs).

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/pom.xml
@@ -23,11 +23,17 @@
   <version>${version}</version>
   <packaging>jar</packaging>
 
-  <name>CDAP Application</name>
+  <name>ETL Batch Source</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <!-- properties for script build step that creates the config files for the artifacts -->
+    <widgets.dir>widgets</widgets.dir>
+    <docs.dir>docs</docs.dir>
+    <etl.versionRange>[3.3.0,10.0.0-SNAPSHOT)</etl.versionRange>
+    <!-- this is here because project.basedir evaluates to null in the script build step -->
+    <main.basedir>${project.basedir}</main.basedir>
   </properties>
 
   <repositories>
@@ -97,6 +103,92 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.7</version>
+          <executions>
+            <!-- Create the config file for artifact which can be used to deploy the artifact.
+                 Sets the parents field to system:cdap-etl-batch and system:cdap-etl-realtime with whatever
+                 version range is set in the etl.versionRange property.
+                 also sets a widget and doc property for each file contained in the widgets and docs directories. -->
+            <execution>
+              <id>create-artifact-config</id>
+              <phase>prepare-package</phase>
+              <configuration>
+                <target>
+                  <script language="javascript"> <![CDATA[
+
+                  // for some reason, project.basedir evaluates to null if we just get the property here.
+                  // so we set main.basedir to project.basedir in the pom properties, then main.basedir is used here
+                  // where it evaluates correctly for whatever reason
+                  var baseDir = project.getProperty("main.basedir");
+                  var targetDir = project.getProperty("project.build.directory");
+                  var artifactId = project.getProperty("project.artifactId");
+                  var version = project.getProperty("project.version");
+
+                  var cfgFile = new java.io.File(targetDir, artifactId + "-" + version + ".json");
+                  if (!cfgFile.exists()) {
+                    cfgFile.createNewFile();
+                  }
+
+                  var etlRange = project.getProperty("etl.versionRange");
+                  var config = {
+                    "parents": [ "system:cdap-etl-batch" + etlRange, "system:cdap-etl-realtime" + etlRange ],
+                    "properties": {}
+                  }
+
+                  // look in widgets directory for widget config for each plugin
+                  var widgetsDir = new java.io.File(baseDir, project.getProperty("widgets.dir"));
+                  if (widgetsDir.isDirectory()) {
+                    var widgetsFiles = widgetsDir.listFiles();
+                    for (i = 0; i < widgetsFiles.length; i++) {
+                      var widgetsFile = widgetsFiles[i];
+                      if (widgetsFile.isFile()) {
+                        var propertyName = "widgets." + widgetsFile.getName();
+                        // if the filename ends with .json
+                        if (propertyName.indexOf(".json", propertyName.length - 5) !== -1) {
+                          // strip the .json
+                          propertyName = propertyName.slice(0, -5);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(widgetsFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          var contentsAsJson = JSON.parse(contents);
+                          config.properties[propertyName] = JSON.stringify(contentsAsJson);
+                        }
+                      }
+                    }
+                  }
+
+                  // look in the docs directory for docs for each plugin
+                  var docsDir = new java.io.File(baseDir, project.getProperty("docs.dir"));
+                  if (docsDir.isDirectory()) {
+                    var docFiles = docsDir.listFiles();
+                    for (i = 0; i < docFiles.length; i++) {
+                      var docFile = docFiles[i];
+                      if (docFile.isFile()) {
+                        var propertyName = "doc." + docFile.getName();
+                        // if the filename ends with .md
+                        if (propertyName.indexOf(".md", propertyName.length - 3) !== -1) {
+                          // strip the extension
+                          propertyName = propertyName.slice(0, -3);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(docFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          config.properties[propertyName] = contents + "";
+                        }
+                      }
+                    }
+                  }
+
+                  var fw = new java.io.BufferedWriter(new java.io.FileWriter(cfgFile.getAbsoluteFile()));
+                  fw.write(JSON.stringify(config, null, 2));
+                  fw.close();
+                ]]></script>
+                </target>
+              </configuration>
+              <goals>
+                <goal>run</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -109,7 +201,10 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/widgets/Source-batchsource.json
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/widgets/Source-batchsource.json
@@ -1,0 +1,13 @@
+{
+  "metadata": {
+    "spec-version": "1.0"
+  },
+  "configuration-groups": [
+    {
+      "label": "Source Configuration",
+      "properties": [
+      ]
+    }
+  ],
+  "outputs": []
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2015 Cask Data, Inc.
-
-  Licensed under the Apache License, Version 2.0 (the "License"); you may not
-  use this file except in compliance with the License. You may obtain a copy of
-  the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-  License for the specific language governing permissions and limitations under
-  the License.
+  ~ Copyright © 2016 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
   -->
 <archetype-descriptor xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype/1.0.0"
                       name="cdap-etl-realtime-sink-archetype">
@@ -27,6 +27,24 @@
       <directory>src/test/java</directory>
       <includes>
         <include>**/*.java</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory>docs</directory>
+      <includes>
+        <include>*.md</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory>widgets</directory>
+      <includes>
+        <include>*.json</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory></directory>
+      <includes>
+        <include>README.md</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/README.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/README.md
@@ -1,0 +1,32 @@
+Build
+-----
+To build your plugins::
+
+  mvn clean package -DskipTests
+
+The build will create a .jar and .json file under the ``target`` directory.
+These files can be used to deploy your plugins.
+
+UI Integration
+--------------
+The Cask Hydrator UI displays each plugin property as a simple textbox. To customize how the plugin properties
+are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
+The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/cdap-apps/hydrator/custom.html#plugin-configuration-json)
+for details on the configuration file.
+The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
+that follows the convention of ``[plugin-name]-[plugin-type].md``.
+
+When the build runs, it will scan the ``widgets`` and ``docs`` directories in order to build an appropriately
+formatted .json file under the ``target`` directory. This file is deployed along with your .jar file to add your
+plugins to CDAP.
+
+Deployment
+----------
+You can deploy your plugins using the CDAP CLI::
+
+  > load artifact <target/plugin.jar> config-file <target/plugin.json>
+
+For example, if your artifact is named 'my-plugins-1.0.0'::
+
+  > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/docs/Sink-realtimesink.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/docs/Sink-realtimesink.md
@@ -1,0 +1,9 @@
+# Sink Real-time Sink
+
+Insert documentation about your plugin in this file.
+The UI will display the contents in the reference section of your plugin,
+assuming this file is named following a convention of ``[plugin-name]-realtimesink.md``.
+The plugin name is case sensitive.
+
+For examples of plugin documentation, see the
+[Hydrator documentation](https://github.com/caskdata/hydrator-plugins/tree/develop/core-plugins/docs).

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2015 Cask Data, Inc.
-
-  Licensed under the Apache License, Version 2.0 (the "License"); you may not
-  use this file except in compliance with the License. You may obtain a copy of
-  the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-  License for the specific language governing permissions and limitations under
-  the License.
+  ~ Copyright © 2016 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -23,11 +23,17 @@
   <version>${version}</version>
   <packaging>jar</packaging>
 
-  <name>ETL Realtime Sink </name>
+  <name>ETL Realtime Sink</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <!-- properties for script build step that creates the config files for the artifacts -->
+    <widgets.dir>widgets</widgets.dir>
+    <docs.dir>docs</docs.dir>
+    <etl.versionRange>[3.3.0,10.0.0-SNAPSHOT)</etl.versionRange>
+    <!-- this is here because project.basedir evaluates to null in the script build step -->
+    <main.basedir>${project.basedir}</main.basedir>
   </properties>
 
   <repositories>
@@ -97,6 +103,92 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.7</version>
+          <executions>
+            <!-- Create the config file for artifact which can be used to deploy the artifact.
+                 Sets the parents field to system:cdap-etl-batch and system:cdap-etl-realtime with whatever
+                 version range is set in the etl.versionRange property.
+                 also sets a widget and doc property for each file contained in the widgets and docs directories. -->
+            <execution>
+              <id>create-artifact-config</id>
+              <phase>prepare-package</phase>
+              <configuration>
+                <target>
+                  <script language="javascript"> <![CDATA[
+
+                  // for some reason, project.basedir evaluates to null if we just get the property here.
+                  // so we set main.basedir to project.basedir in the pom properties, then main.basedir is used here
+                  // where it evaluates correctly for whatever reason
+                  var baseDir = project.getProperty("main.basedir");
+                  var targetDir = project.getProperty("project.build.directory");
+                  var artifactId = project.getProperty("project.artifactId");
+                  var version = project.getProperty("project.version");
+
+                  var cfgFile = new java.io.File(targetDir, artifactId + "-" + version + ".json");
+                  if (!cfgFile.exists()) {
+                    cfgFile.createNewFile();
+                  }
+
+                  var etlRange = project.getProperty("etl.versionRange");
+                  var config = {
+                    "parents": [ "system:cdap-etl-batch" + etlRange, "system:cdap-etl-realtime" + etlRange ],
+                    "properties": {}
+                  }
+
+                  // look in widgets directory for widget config for each plugin
+                  var widgetsDir = new java.io.File(baseDir, project.getProperty("widgets.dir"));
+                  if (widgetsDir.isDirectory()) {
+                    var widgetsFiles = widgetsDir.listFiles();
+                    for (i = 0; i < widgetsFiles.length; i++) {
+                      var widgetsFile = widgetsFiles[i];
+                      if (widgetsFile.isFile()) {
+                        var propertyName = "widgets." + widgetsFile.getName();
+                        // if the filename ends with .json
+                        if (propertyName.indexOf(".json", propertyName.length - 5) !== -1) {
+                          // strip the .json
+                          propertyName = propertyName.slice(0, -5);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(widgetsFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          var contentsAsJson = JSON.parse(contents);
+                          config.properties[propertyName] = JSON.stringify(contentsAsJson);
+                        }
+                      }
+                    }
+                  }
+
+                  // look in the docs directory for docs for each plugin
+                  var docsDir = new java.io.File(baseDir, project.getProperty("docs.dir"));
+                  if (docsDir.isDirectory()) {
+                    var docFiles = docsDir.listFiles();
+                    for (i = 0; i < docFiles.length; i++) {
+                      var docFile = docFiles[i];
+                      if (docFile.isFile()) {
+                        var propertyName = "doc." + docFile.getName();
+                        // if the filename ends with .md
+                        if (propertyName.indexOf(".md", propertyName.length - 3) !== -1) {
+                          // strip the extension
+                          propertyName = propertyName.slice(0, -3);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(docFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          config.properties[propertyName] = contents + "";
+                        }
+                      }
+                    }
+                  }
+
+                  var fw = new java.io.BufferedWriter(new java.io.FileWriter(cfgFile.getAbsoluteFile()));
+                  fw.write(JSON.stringify(config, null, 2));
+                  fw.close();
+                ]]></script>
+                </target>
+              </configuration>
+              <goals>
+                <goal>run</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -109,7 +201,10 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/widgets/Sink-realtimesink.json
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/widgets/Sink-realtimesink.json
@@ -1,0 +1,13 @@
+{
+  "metadata": {
+    "spec-version": "1.0"
+  },
+  "configuration-groups": [
+    {
+      "label": "Sink Configuration",
+      "properties": [
+      ]
+    }
+  ],
+  "outputs": []
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2015 Cask Data, Inc.
-
-  Licensed under the Apache License, Version 2.0 (the "License"); you may not
-  use this file except in compliance with the License. You may obtain a copy of
-  the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-  License for the specific language governing permissions and limitations under
-  the License.
+  ~ Copyright © 2016 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
   -->
 <archetype-descriptor xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype/1.0.0"
                       name="cdap-etl-realtime-source-archetype">
@@ -27,6 +27,24 @@
       <directory>src/test/java</directory>
       <includes>
         <include>**/*.java</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory>docs</directory>
+      <includes>
+        <include>*.md</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory>widgets</directory>
+      <includes>
+        <include>*.json</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory></directory>
+      <includes>
+        <include>README.md</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/README.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/README.md
@@ -1,0 +1,32 @@
+Build
+-----
+To build your plugins::
+
+  mvn clean package -DskipTests
+
+The build will create a .jar and .json file under the ``target`` directory.
+These files can be used to deploy your plugins.
+
+UI Integration
+--------------
+The Cask Hydrator UI displays each plugin property as a simple textbox. To customize how the plugin properties
+are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
+The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/cdap-apps/hydrator/custom.html#plugin-configuration-json)
+for details on the configuration file.
+The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
+that follows the convention of ``[plugin-name]-[plugin-type].md``.
+
+When the build runs, it will scan the ``widgets`` and ``docs`` directories in order to build an appropriately
+formatted .json file under the ``target`` directory. This file is deployed along with your .jar file to add your
+plugins to CDAP.
+
+Deployment
+----------
+You can deploy your plugins using the CDAP CLI::
+
+  > load artifact <target/plugin.jar> config-file <target/plugin.json>
+
+For example, if your artifact is named 'my-plugins-1.0.0'::
+
+  > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/docs/Source-realtimesource.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/docs/Source-realtimesource.md
@@ -1,0 +1,9 @@
+# Source Real-time Source
+
+Insert documentation about your plugin in this file.
+The UI will display the contents in the reference section of your plugin,
+assuming this file is named following a convention of ``[plugin-name]-realtimesource.md``.
+The plugin name is case sensitive.
+
+For examples of plugin documentation, see the
+[Hydrator documentation](https://github.com/caskdata/hydrator-plugins/tree/develop/core-plugins/docs).

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2015 Cask Data, Inc.
-
-  Licensed under the Apache License, Version 2.0 (the "License"); you may not
-  use this file except in compliance with the License. You may obtain a copy of
-  the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-  License for the specific language governing permissions and limitations under
-  the License.
+  ~ Copyright © 2016 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -23,11 +23,17 @@
   <version>${version}</version>
   <packaging>jar</packaging>
 
-  <name>CDAP Application</name>
+  <name>ETL Realtime Source</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <!-- properties for script build step that creates the config files for the artifacts -->
+    <widgets.dir>widgets</widgets.dir>
+    <docs.dir>docs</docs.dir>
+    <etl.versionRange>[3.3.0,10.0.0-SNAPSHOT)</etl.versionRange>
+    <!-- this is here because project.basedir evaluates to null in the script build step -->
+    <main.basedir>${project.basedir}</main.basedir>
   </properties>
 
   <repositories>
@@ -97,6 +103,92 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.7</version>
+          <executions>
+            <!-- Create the config file for artifact which can be used to deploy the artifact.
+                 Sets the parents field to system:cdap-etl-batch and system:cdap-etl-realtime with whatever
+                 version range is set in the etl.versionRange property.
+                 also sets a widget and doc property for each file contained in the widgets and docs directories. -->
+            <execution>
+              <id>create-artifact-config</id>
+              <phase>prepare-package</phase>
+              <configuration>
+                <target>
+                  <script language="javascript"> <![CDATA[
+
+                  // for some reason, project.basedir evaluates to null if we just get the property here.
+                  // so we set main.basedir to project.basedir in the pom properties, then main.basedir is used here
+                  // where it evaluates correctly for whatever reason
+                  var baseDir = project.getProperty("main.basedir");
+                  var targetDir = project.getProperty("project.build.directory");
+                  var artifactId = project.getProperty("project.artifactId");
+                  var version = project.getProperty("project.version");
+
+                  var cfgFile = new java.io.File(targetDir, artifactId + "-" + version + ".json");
+                  if (!cfgFile.exists()) {
+                    cfgFile.createNewFile();
+                  }
+
+                  var etlRange = project.getProperty("etl.versionRange");
+                  var config = {
+                    "parents": [ "system:cdap-etl-batch" + etlRange, "system:cdap-etl-realtime" + etlRange ],
+                    "properties": {}
+                  }
+
+                  // look in widgets directory for widget config for each plugin
+                  var widgetsDir = new java.io.File(baseDir, project.getProperty("widgets.dir"));
+                  if (widgetsDir.isDirectory()) {
+                    var widgetsFiles = widgetsDir.listFiles();
+                    for (i = 0; i < widgetsFiles.length; i++) {
+                      var widgetsFile = widgetsFiles[i];
+                      if (widgetsFile.isFile()) {
+                        var propertyName = "widgets." + widgetsFile.getName();
+                        // if the filename ends with .json
+                        if (propertyName.indexOf(".json", propertyName.length - 5) !== -1) {
+                          // strip the .json
+                          propertyName = propertyName.slice(0, -5);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(widgetsFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          var contentsAsJson = JSON.parse(contents);
+                          config.properties[propertyName] = JSON.stringify(contentsAsJson);
+                        }
+                      }
+                    }
+                  }
+
+                  // look in the docs directory for docs for each plugin
+                  var docsDir = new java.io.File(baseDir, project.getProperty("docs.dir"));
+                  if (docsDir.isDirectory()) {
+                    var docFiles = docsDir.listFiles();
+                    for (i = 0; i < docFiles.length; i++) {
+                      var docFile = docFiles[i];
+                      if (docFile.isFile()) {
+                        var propertyName = "doc." + docFile.getName();
+                        // if the filename ends with .md
+                        if (propertyName.indexOf(".md", propertyName.length - 3) !== -1) {
+                          // strip the extension
+                          propertyName = propertyName.slice(0, -3);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(docFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          config.properties[propertyName] = contents + "";
+                        }
+                      }
+                    }
+                  }
+
+                  var fw = new java.io.BufferedWriter(new java.io.FileWriter(cfgFile.getAbsoluteFile()));
+                  fw.write(JSON.stringify(config, null, 2));
+                  fw.close();
+                ]]></script>
+                </target>
+              </configuration>
+              <goals>
+                <goal>run</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -109,7 +201,10 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/widgets/Source-realtimesource.json
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/widgets/Source-realtimesource.json
@@ -1,0 +1,13 @@
+{
+  "metadata": {
+    "spec-version": "1.0"
+  },
+  "configuration-groups": [
+    {
+      "label": "Source Configuration",
+      "properties": [
+      ]
+    }
+  ],
+  "outputs": []
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2015 Cask Data, Inc.
-
-  Licensed under the Apache License, Version 2.0 (the "License"); you may not
-  use this file except in compliance with the License. You may obtain a copy of
-  the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-  License for the specific language governing permissions and limitations under
-  the License.
+  ~ Copyright © 2016 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
   -->
 <archetype-descriptor xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype/1.0.0"
-                      name="cdap-etl-realtime-sink-archetype">
+                      name="cdap-etl-transform-archetype">
   <fileSets>
     <fileSet encoding="UTF-8" filtered="true" packaged="true">
       <directory>src/main/java</directory>
@@ -27,6 +27,24 @@
       <directory>src/test/java</directory>
       <includes>
         <include>**/*.java</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory>docs</directory>
+      <includes>
+        <include>*.md</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory>widgets</directory>
+      <includes>
+        <include>*.json</include>
+      </includes>
+    </fileSet>
+    <fileSet encoding="UTF-8" filtered="true" package="true">
+      <directory></directory>
+      <includes>
+        <include>README.md</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/README.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/README.md
@@ -1,0 +1,32 @@
+Build
+-----
+To build your plugins::
+
+  mvn clean package -DskipTests
+
+The build will create a .jar and .json file under the ``target`` directory.
+These files can be used to deploy your plugins.
+
+UI Integration
+--------------
+The Cask Hydrator UI displays each plugin property as a simple textbox. To customize how the plugin properties
+are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
+The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/cdap-apps/hydrator/custom.html#plugin-configuration-json)
+for details on the configuration file.
+The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
+that follows the convention of ``[plugin-name]-[plugin-type].md``.
+
+When the build runs, it will scan the ``widgets`` and ``docs`` directories in order to build an appropriately
+formatted .json file under the ``target`` directory. This file is deployed along with your .jar file to add your
+plugins to CDAP.
+
+Deployment
+----------
+You can deploy your plugins using the CDAP CLI::
+
+  > load artifact <target/plugin.jar> config-file <target/plugin.json>
+
+For example, if your artifact is named 'my-plugins-1.0.0'::
+
+  > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/docs/MyTransform-transform.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/docs/MyTransform-transform.md
@@ -1,0 +1,9 @@
+# MyTransform Transform
+
+Insert documentation about your plugin in this file.
+The UI will display the contents in the reference section of your plugin,
+assuming this file is named following a convention of ``[plugin-name]-transform.md``.
+The plugin name is case sensitive.
+
+For examples of plugin documentation, see the
+[Hydrator documentation](https://github.com/caskdata/hydrator-plugins/tree/develop/core-plugins/docs).

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2015 Cask Data, Inc.
-
-  Licensed under the Apache License, Version 2.0 (the "License"); you may not
-  use this file except in compliance with the License. You may obtain a copy of
-  the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-  License for the specific language governing permissions and limitations under
-  the License.
+  ~ Copyright © 2016 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -23,11 +23,17 @@
   <version>${version}</version>
   <packaging>jar</packaging>
 
-  <name>ETL Realtime Sink </name>
+  <name>ETL Transform</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <!-- properties for script build step that creates the config files for the artifacts -->
+    <widgets.dir>widgets</widgets.dir>
+    <docs.dir>docs</docs.dir>
+    <etl.versionRange>[3.3.0,10.0.0-SNAPSHOT)</etl.versionRange>
+    <!-- this is here because project.basedir evaluates to null in the script build step -->
+    <main.basedir>${project.basedir}</main.basedir>
   </properties>
 
   <repositories>
@@ -97,6 +103,92 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.7</version>
+          <executions>
+            <!-- Create the config file for artifact which can be used to deploy the artifact.
+                 Sets the parents field to system:cdap-etl-batch and system:cdap-etl-realtime with whatever
+                 version range is set in the etl.versionRange property.
+                 also sets a widget and doc property for each file contained in the widgets and docs directories. -->
+            <execution>
+              <id>create-artifact-config</id>
+              <phase>prepare-package</phase>
+              <configuration>
+                <target>
+                  <script language="javascript"> <![CDATA[
+
+                  // for some reason, project.basedir evaluates to null if we just get the property here.
+                  // so we set main.basedir to project.basedir in the pom properties, then main.basedir is used here
+                  // where it evaluates correctly for whatever reason
+                  var baseDir = project.getProperty("main.basedir");
+                  var targetDir = project.getProperty("project.build.directory");
+                  var artifactId = project.getProperty("project.artifactId");
+                  var version = project.getProperty("project.version");
+
+                  var cfgFile = new java.io.File(targetDir, artifactId + "-" + version + ".json");
+                  if (!cfgFile.exists()) {
+                    cfgFile.createNewFile();
+                  }
+
+                  var etlRange = project.getProperty("etl.versionRange");
+                  var config = {
+                    "parents": [ "system:cdap-etl-batch" + etlRange, "system:cdap-etl-realtime" + etlRange ],
+                    "properties": {}
+                  }
+
+                  // look in widgets directory for widget config for each plugin
+                  var widgetsDir = new java.io.File(baseDir, project.getProperty("widgets.dir"));
+                  if (widgetsDir.isDirectory()) {
+                    var widgetsFiles = widgetsDir.listFiles();
+                    for (i = 0; i < widgetsFiles.length; i++) {
+                      var widgetsFile = widgetsFiles[i];
+                      if (widgetsFile.isFile()) {
+                        var propertyName = "widgets." + widgetsFile.getName();
+                        // if the filename ends with .json
+                        if (propertyName.indexOf(".json", propertyName.length - 5) !== -1) {
+                          // strip the .json
+                          propertyName = propertyName.slice(0, -5);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(widgetsFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          var contentsAsJson = JSON.parse(contents);
+                          config.properties[propertyName] = JSON.stringify(contentsAsJson);
+                        }
+                      }
+                    }
+                  }
+
+                  // look in the docs directory for docs for each plugin
+                  var docsDir = new java.io.File(baseDir, project.getProperty("docs.dir"));
+                  if (docsDir.isDirectory()) {
+                    var docFiles = docsDir.listFiles();
+                    for (i = 0; i < docFiles.length; i++) {
+                      var docFile = docFiles[i];
+                      if (docFile.isFile()) {
+                        var propertyName = "doc." + docFile.getName();
+                        // if the filename ends with .md
+                        if (propertyName.indexOf(".md", propertyName.length - 3) !== -1) {
+                          // strip the extension
+                          propertyName = propertyName.slice(0, -3);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(docFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          config.properties[propertyName] = contents + "";
+                        }
+                      }
+                    }
+                  }
+
+                  var fw = new java.io.BufferedWriter(new java.io.FileWriter(cfgFile.getAbsoluteFile()));
+                  fw.write(JSON.stringify(config, null, 2));
+                  fw.close();
+                ]]></script>
+                </target>
+              </configuration>
+              <goals>
+                <goal>run</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -109,7 +201,10 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/src/main/java/TransformPlugin.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/src/main/java/TransformPlugin.java
@@ -17,12 +17,18 @@
 
 package $package;
 
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.Transform;
 
 /**
  * ETL Transform.
  */
+@Plugin(type = "transform")
+@Name("MyTransform")
+@Description("This is my transform")
 public class TransformPlugin<T> extends Transform<T, T> {
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/widgets/MyTransform-transform.json
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/widgets/MyTransform-transform.json
@@ -1,0 +1,13 @@
+{
+  "metadata": {
+    "spec-version": "1.0"
+  },
+  "configuration-groups": [
+    {
+      "label": "Transform Configuration",
+      "properties": [
+      ]
+    }
+  ],
+  "outputs": []
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/pom.xml
@@ -54,6 +54,8 @@
               <configuration>
                 <excludes>
                   <exclude>**/resources/**/*.txt</exclude>
+                  <exclude>**/resources/**/*.md</exclude>
+                  <exclude>**/resources/**/*.json</exclude>
                   <exclude>**/README.md</exclude>
                 </excludes>
               </configuration>


### PR DESCRIPTION
add the build script used to create the deployment json for etl
plugins. This change will create the json file in the target
directory instead of forcing users to create it themselves. It
also introduces the docs and widgets directories that integrate
with the Hydrator UI to format plugin fields and provide reference
documentation.