### PR TITLE
CDAP-4117 Setting the user.name property to the value of hdfs.user before launching the twill application.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -230,6 +230,9 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
             twillPreparer.addSecureStore(secureStoreUpdater.update(null, null));
           }
 
+          // TODO CDAP-4776 Remove after TWILL-163 gets fixed.
+          // Setting the "user.name" property here with the value of "hdfs.user" configuration property.
+          // This user will be used by TWILL to do the cleanup of the HDFS program directories.
           System.setProperty("user.name", cConf.get(Constants.CFG_HDFS_USER));
           TwillController twillController = twillPreparer
             .withDependencies(HBaseTableUtilFactory.getHBaseTableUtilClass())

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -229,6 +229,8 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
             // TokenSecureStoreUpdater.update() ignores parameters
             twillPreparer.addSecureStore(secureStoreUpdater.update(null, null));
           }
+
+          System.setProperty("user.name", cConf.get(Constants.CFG_HDFS_USER));
           TwillController twillController = twillPreparer
             .withDependencies(HBaseTableUtilFactory.getHBaseTableUtilClass())
             .withClassPaths(Iterables.concat(extraClassPaths, Splitter.on(',').trimResults()

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -686,6 +686,9 @@ public class MasterServiceMain extends DaemonMain {
           prepareExploreContainer(preparer);
         }
 
+        // TODO CDAP-4776 Remove after TWILL-163 gets fixed.
+        // Setting the "user.name" property here with the value of "hdfs.user" configuration property.
+        // This user will be used by TWILL to do the cleanup of the HDFS program directories.
         System.setProperty("user.name", cConf.get(Constants.CFG_HDFS_USER));
         // Add a listener to delete temp files when application started/terminated.
         TwillController controller = preparer.start();

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -686,6 +686,7 @@ public class MasterServiceMain extends DaemonMain {
           prepareExploreContainer(preparer);
         }
 
+        System.setProperty("user.name", cConf.get(Constants.CFG_HDFS_USER));
         // Add a listener to delete temp files when application started/terminated.
         TwillController controller = preparer.start();
         Runnable cleanup = new Runnable() {


### PR DESCRIPTION
HDFS directories associated with the programs are created by user identified by `hdfs.user` configuration in the cdap-site.xml. The default value for the configuration is `yarn`. However because of the TWILL bug https://issues.apache.org/jira/browse/TWILL-163, the deletion of the directories on stopping of the program is attempted using `cdap` user. 

As a result we see following exception and directories are not cleaned up -
```java
19:17:30.645 [ApplicationMasterService] WARN  o.a.t.i.a.ApplicationMasterService - Exception while cleanup directory hdfs://xxx:8020/cdap/twill/flow.default.CountRandom.CountRandom/cc9dd40e-3189-45e5-89d2-93229f7246ab.
org.apache.hadoop.security.AccessControlException: Permission denied: user=cdap, access=WRITE, inode="/cdap/twill/flow.default.CountRandom.CountRandom":yarn:supergroup:drwxr-xr-x
        at 
```

Fix is to explicitly set the `user.name` system property to the `hdfs.user`, so that correct user will be used for directory deletion. 