### PR TITLE
CDAP-4786 Correct inclusion in the Spark Page Rank Example

### DIFF
--- a/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
@@ -62,7 +62,7 @@ When a Spark program is running inside a workflow, the memory requirements confi
 
 .. literalinclude:: /../../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
     :language: java
-    :lines: 123-124
+    :lines: 113-114
     :dedent: 6
 
 .. Building and Starting


### PR DESCRIPTION
Corrects the lines included from the example Java file showing the memory requirements and how to set them. It should be these two lines:
```
setDriverResources(new Resources(1024));
setExecutorResources(new Resources(1024));
```
Instead, by error, it was this one line:

```
ivate static final Gson GSON = new Gson();
```

Fixes https://issues.cask.co/browse/CDAP-4786

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB99-1)

Updated example page: [Spark Page Rank Example](http://builds.cask.co/artifact/CDAP-DOB99/shared/build-1/Docs-HTML/3.3.1-SNAPSHOT/en/examples-manual/examples/spark-page-rank.html#memory-requirements)

- [3.2.1 Version (correct)](http://docs.cask.co/cdap/3.2.1/en/examples-manual/examples/spark-page-rank.html#memory-requirements)
- [3.3.0 Version (with error)](http://docs.cask.co/cdap/3.3.0/en/examples-manual/examples/spark-page-rank.html#memory-requirements)