### PR TITLE
CDAP-4777 suspend/resume the flowlet only if it is running.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -777,8 +777,10 @@ public final class FlowletProgramRunner implements ProgramRunner {
         public void run() {
           suspendLock.lock();
           try {
-            controller.get().suspend().get();
-            controller.get().resume().get();
+            if (ProgramController.State.ALIVE == controller.get().getState()) {
+              controller.get().suspend().get();
+              controller.get().resume().get();
+            }
           } catch (Exception e) {
             LOG.error("Failed to suspend and resume flowlet.", e);
           } finally {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-4777

We suspend and resume the flowlet once the properties associated with the stream it consumes changes. Suspend and resume should only be done when the flowlet is running. When the flowlet is not in `ALIVE` state yet and the attempt to suspend/resume is made we see the exception in the log file 

```java
2016-01-27 21:32:25,735 - INFO  [FlowletRuntimeService STARTING:c.c.c.i.a.r.f.FlowletRuntimeService@112] - Initializing flowlet: flowlet=splitter, instance=0, groupsize=1, namespaceId=default, applicationId=PhoenixIntegration, program=WordCountFlow, runid=51f02e3f-c53d-11e5-b7dd-42010af00018
2016-01-27 21:32:25,829 - ERROR [flowlet-stream-update-0:c.c.c.i.a.r.f.FlowletProgramRunner@783] - Failed to suspend and resume flowlet.
java.util.concurrent.ExecutionException: java.lang.IllegalStateException: Suspension not allowed for program:default.PhoenixIntegration.flow.WordCountFlow in STARTING
        at com.google.common.util.concurrent.AbstractFuture$Sync.getValue(AbstractFuture.java:294) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.util.concurrent.AbstractFuture$Sync.get(AbstractFuture.java:281) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:116) ~[com.google.guava.guava-13.0.1.jar:na]
```

Note that this exception is harmless though and flow operations work fine. 