### PR TITLE
CDAP-4780 improve logging for namespace deletion

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/io/FileContextLocation.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/FileContextLocation.java
@@ -198,4 +198,8 @@ final class FileContextLocation implements Location {
   public int hashCode() {
     return Objects.hash(path);
   }
+
+  public String toString() {
+    return this.path.toString();
+  }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/StorageProviderNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/StorageProviderNamespaceAdmin.java
@@ -87,9 +87,11 @@ public class StorageProviderNamespaceAdmin {
   protected void delete(Id.Namespace namespaceId) throws IOException, ExploreException, SQLException {
     // TODO: CDAP-1581: Implement soft delete
     Location namespaceHome = namespacedLocationFactory.get(namespaceId);
-    if (namespaceHome.exists() && !namespaceHome.delete(true)) {
+    if (namespaceHome.exists()) {
+      if (!namespaceHome.delete(true)) {
         throw new IOException(String.format("Error while deleting home directory '%s' for namespace '%s'",
                                             namespaceHome, namespaceId.getId()));
+      }
     } else {
       // warn that namespace home was not found and skip delete step
       LOG.warn(String.format("Home directory '%s' for namespace '%s' does not exist.",


### PR DESCRIPTION
minor bug in if-else logic, as we were logging warning as namespace doesn't exists while namespace exists and deletion was successful. 
JIRA : https://issues.cask.co/browse/CDAP-4780