### PR TITLE
CDAP-4784 IndexedTable#put to avoid Table#get if colsToIndex is empty.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
@@ -257,20 +257,22 @@ public class IndexedTable extends AbstractDataset implements Table {
       }
     }
 
-    // first read the existing indexed values to find which have changed and need to be updated
-    Row existingRow = table.get(dataRow, colsToIndex.toArray(new byte[colsToIndex.size()][]));
-    for (Map.Entry<byte[], byte[]> entry : existingRow.getColumns().entrySet()) {
-      if (!Arrays.equals(entry.getValue(), putColumns.get(entry.getKey()))) {
-        index.delete(createIndexKey(dataRow, entry.getKey(), entry.getValue()), IDX_COL);
-      } else {
-        // value already indexed
-        colsToIndex.remove(entry.getKey());
+    if (!colsToIndex.isEmpty()) {
+      // first read the existing indexed values to find which have changed and need to be updated
+      Row existingRow = table.get(dataRow, colsToIndex.toArray(new byte[colsToIndex.size()][]));
+      for (Map.Entry<byte[], byte[]> entry : existingRow.getColumns().entrySet()) {
+        if (!Arrays.equals(entry.getValue(), putColumns.get(entry.getKey()))) {
+          index.delete(createIndexKey(dataRow, entry.getKey(), entry.getValue()), IDX_COL);
+        } else {
+          // value already indexed
+          colsToIndex.remove(entry.getKey());
+        }
       }
-    }
 
-    // add new index entries for all values that have changed or did not exist
-    for (byte[] col : colsToIndex) {
-      index.put(createIndexKey(dataRow, col, putColumns.get(col)), IDX_COL, dataRow);
+      // add new index entries for all values that have changed or did not exist
+      for (byte[] col : colsToIndex) {
+        index.put(createIndexKey(dataRow, col, putColumns.get(col)), IDX_COL, dataRow);
+      }
     }
 
     // store the data row


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-4784
The issue is that `Table#get(row, columns)` returns all columns in HBase if the second parameter is an empty list. This is due to some discrepancy in the Table APIs (https://issues.cask.co/browse/CDAP-4790), which is a larger (more impactful) change to fix/clean up.

For now, avoid deleting the all the index columns if `colsToIndex` is empty.

**Note:** This can be a temporary fix (and can be reverted), depending on the resolution to CDAP-4790.

Build: http://builds.cask.co/browse/CDAP-RBT622-2