### PR TITLE
CDAP-4709 copy artifacts should be an earlier phase.

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -290,7 +290,7 @@
                    For example, if you want to include plugins from hydrator-plugins. -->
               <execution>
                 <id>copy-additional-system-artifacts</id>
-                <phase>prepare-package</phase>
+                <phase>process-resources</phase>
                 <configuration>
                   <target if="additional.artifacts.dir">
                     <copy todir="${stage.artifacts.dir}" flatten="true">


### PR DESCRIPTION
Copying of additional artifacts needs to be in a phase that occurs
before the copy-deb-staging execution in deb-prepare. Otherwise
those additional artifacts will not be in the staging directory
when the copy occurs, and they will be missing in the debian.


Note: This is the same PR as https://github.com/caskdata/cdap/pull/4986, but for some reason, the change was lost on develop.