### PR TITLE
CDAP-4754 Lazily instantiate the datumReader in ObjectStoreDataset, s…

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -87,19 +87,15 @@ public class SystemDatasetInstantiator implements Closeable {
     public <T extends Dataset> T getDataset(Id.DatasetInstance datasetId, Map<String, String> arguments)
     throws DatasetInstantiationException {
 
-    T dataset;
     try {
-
-      dataset = datasetFramework.getDataset(datasetId, arguments, parentClassLoader, classLoaderProvider, owners);
+      T dataset = datasetFramework.getDataset(datasetId, arguments, parentClassLoader, classLoaderProvider, owners);
       if (dataset == null) {
         throw new DatasetInstantiationException("Trying to access dataset that does not exist: " + datasetId);
       }
-
+      return dataset;
     } catch (Exception e) {
       throw new DatasetInstantiationException("Failed to access dataset: " + datasetId, e);
     }
-
-    return dataset;
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -82,7 +82,7 @@ public class ObjectMappedTableDataset<T> extends AbstractDataset implements Obje
       try {
         // this can throw a runtime exception from a ClassNotFoundException
         Type type = typeRepresentation.toType();
-        this.rowReader = new ReflectionRowReader<>(objectSchema, (TypeToken<T>) TypeToken.of(type));
+        rowReader = new ReflectionRowReader<>(objectSchema, (TypeToken<T>) TypeToken.of(type));
       } catch (RuntimeException e) {
         String missingClass = isClassNotFoundException(e);
         if (missingClass != null) {
@@ -93,7 +93,7 @@ public class ObjectMappedTableDataset<T> extends AbstractDataset implements Obje
         throw e;
       }
     }
-    return this.rowReader;
+    return rowReader;
   }
 
   private String isClassNotFoundException(Throwable e) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
@@ -233,6 +233,10 @@ public class ObjectStoreDatasetTest {
     Schema schema = new ReflectionSchemaGenerator().generate(type);
 
     ObjectStoreDataset<Custom> objectStore = new ObjectStoreDataset<>("kv", kvTable, typeRep, schema, loader);
+
+    // need to call this to actually load the Custom class, because the Custom class is no longer used in the
+    // ObjectStoreDataset's constructor, but rather lazily when its actually needed.
+    objectStore.getRecordType();
     objectStore.write("dummy", new Custom(382, Lists.newArrayList("blah")));
     // verify the class name was recorded (the dummy class loader was used).
     Assert.assertEquals(Custom.class.getName(), lastClassLoaded.get());


### PR DESCRIPTION
In some places, we need to instantiate ObjectStoreDataset, but we don't need to actually use it.
In these places, we may not have the user-defined class accessible (the one that parameterizes the ObjectStore). So, moving the usage of the user-defined class Type to a lazy-style usage, rather than using it in the constructor, so that ObjectStoreDataset can be instantiated without a ClassNotFoundException.

Two places where we need to instantiate like this are when enabling explore on it and when tagging datasets with metadata.

https://issues.cask.co/browse/CDAP-4754
http://builds.cask.co/browse/CDAP-RBT623-2