### PR TITLE
CDAP-4800 handle edge case for version range

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRangeTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRangeTest.java
@@ -92,7 +92,13 @@ public class ArtifactRangeTest {
 
     for (String invalidRange : invalidRanges) {
       try {
-        ArtifactRange.parse(invalidRange);
+        ArtifactRange.parse(Id.Namespace.DEFAULT, invalidRange);
+        Assert.fail();
+      } catch (InvalidArtifactRangeException e) {
+        // expected
+      }
+      try {
+        ArtifactRange.parse("system:" + invalidRange);
         Assert.fail();
       } catch (InvalidArtifactRangeException e) {
         // expected
@@ -122,7 +128,13 @@ public class ArtifactRangeTest {
 
     for (String invalidRange : invalidRanges) {
       try {
-        ArtifactRange.parse(invalidRange);
+        ArtifactRange.parse(Id.Namespace.DEFAULT, invalidRange);
+        Assert.fail();
+      } catch (InvalidArtifactRangeException e) {
+        // expected
+      }
+      try {
+        ArtifactRange.parse("system:" + invalidRange);
         Assert.fail();
       } catch (InvalidArtifactRangeException e) {
         // expected

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/ArtifactConfigReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/ArtifactConfigReader.java
@@ -117,13 +117,13 @@ public class ArtifactConfigReader {
 
       String rangeStr = json.getAsString();
       try {
-        return ArtifactRange.parse(rangeStr);
-      } catch (InvalidArtifactRangeException e1) {
-        try {
-          return ArtifactRange.parse(namespace, json.getAsString());
-        } catch (InvalidArtifactRangeException e2) {
-          throw new JsonParseException("Invalid artifact range " + rangeStr);
+        if (rangeStr.indexOf(':') > 0) {
+          return ArtifactRange.parse(rangeStr);
+        } else {
+          return ArtifactRange.parse(namespace, rangeStr);
         }
+      } catch (InvalidArtifactRangeException e) {
+        throw new JsonParseException(e.getMessage());
       }
     }
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactRange.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactRange.java
@@ -169,13 +169,14 @@ public class ArtifactRange {
     // search for the '[' or '(' between the artifact name and lower version
     int versionStartIndex = indexOf(artifactRangeStr, '[', '(', 0);
     if (versionStartIndex < 0) {
-      throw new InvalidArtifactRangeException(String.format("Invalid artifact range %s. " +
-        "Could not find '[' or '(' indicating start of artifact lower version.", artifactRangeStr));
+      throw new InvalidArtifactRangeException(
+        String.format("Invalid artifact range %s. " +
+                        "Could not find '[' or '(' indicating start of artifact lower version.", artifactRangeStr));
     }
     String name = artifactRangeStr.substring(0, versionStartIndex);
     if (!Id.Artifact.isValidName(name)) {
-      throw new InvalidArtifactRangeException(String.format("Invalid artifact range %s. " +
-        "Artifact name '%s' is invalid.", artifactRangeStr, name));
+      throw new InvalidArtifactRangeException(
+        String.format("Invalid artifact range %s. Artifact name '%s' is invalid.", artifactRangeStr, name));
     }
 
     boolean isLowerInclusive = artifactRangeStr.charAt(versionStartIndex) == '[';
@@ -183,8 +184,9 @@ public class ArtifactRange {
     // search for the comma separating versions
     int commaIndex = artifactRangeStr.indexOf(',', versionStartIndex + 1);
     if (commaIndex < 0) {
-      throw new InvalidArtifactRangeException(String.format("Invalid artifact range %s. " +
-        "Could not find ',' separating lower and upper verions.", artifactRangeStr));
+      throw new InvalidArtifactRangeException(
+        String.format("Invalid artifact range %s. Could not find ',' separating lower and upper verions.",
+                      artifactRangeStr));
     }
     String lowerStr = artifactRangeStr.substring(versionStartIndex + 1, commaIndex).trim();
     ArtifactVersion lower = new ArtifactVersion(lowerStr);
@@ -207,10 +209,18 @@ public class ArtifactRange {
     }
     boolean isUpperInclusive = artifactRangeStr.charAt(versionEndIndex) == ']';
 
-    if (lower.compareTo(upper) > 0) {
+    // check that lower is not greater than upper
+    int comp = lower.compareTo(upper);
+    if (comp > 0) {
       throw new InvalidArtifactRangeException(String.format(
         "Invalid artifact range %s. Lower version %s is greater than upper version %s.",
         artifactRangeStr, lowerStr, upperStr));
+    } else if (comp == 0 && isLowerInclusive && !isUpperInclusive) {
+      // if lower and upper are equal, but lower is inclusive and upper is exclusive, this is also invalid
+      throw new InvalidArtifactRangeException(String.format(
+        "Invalid artifact range %s. Lower and upper versions %s are equal, " +
+          "but lower is inclusive and upper is exclusive.",
+        artifactRangeStr, lowerStr));
     }
 
     return new ArtifactRange(namespace, name, lower, isLowerInclusive, upper, isUpperInclusive);


### PR DESCRIPTION
Error when a version range has a lower version that is equal to
the upper version, but the lower version is inclusive and the
upper is exclusive. Also fixing a unit test that was trying to
test for this scenario, but calling the wrong method.

Also a small change to the artifact config parser so that the
right error message is used in the above scenario.