### PR TITLE
CDAP-3262 Adding a Windows warning message.

### DIFF
--- a/cdap-docs/developers-manual/source/_includes/building-apps.txt
+++ b/cdap-docs/developers-manual/source/_includes/building-apps.txt
@@ -1,7 +1,7 @@
-.. include:: ../building-apps.rst
+.. include:: /getting-started/building-apps.rst
    :start-line: 7
    :end-line:   10
 
 See :ref:`Building and Running CDAP Applications <cdap-building-running>` for information
 on accessing the CDAP CLI and CDAP SDK bin utilities, building examples, starting CDAP,
-and deploying, starting, and stopping applications. 
+and deploying, starting, and stopping applications.

--- a/cdap-docs/developers-manual/source/_includes/windows-note.txt
+++ b/cdap-docs/developers-manual/source/_includes/windows-note.txt
@@ -1,0 +1,3 @@
+**Note:** There is an issue with running Microsoft Windows and using the CDAP Standalone scripts
+when ``JAVA_HOME`` is defined as a path with spaces in it. A workaround is to use a
+definition of ``JAVA_HOME`` that does not include spaces.

--- a/cdap-docs/developers-manual/source/getting-started/building-apps.rst
+++ b/cdap-docs/developers-manual/source/getting-started/building-apps.rst
@@ -60,6 +60,10 @@ Accessing CLI, curl and the SDK bin
   Note that under Windows, you'll need to create a new command line window in order to see
   this change to the path variable. The Windows path has been augmented with a directory where
   the SDK includes Windows-versions of commands such as ``curl``.
+  
+- There is an issue with running Microsoft Windows and using the CDAP Standalone scripts
+  when ``JAVA_HOME`` is defined as a path with spaces in it. A workaround is to use a
+  definition of ``JAVA_HOME`` that does not include spaces.
 
 .. _cdap-building-running-example:
 

--- a/cdap-docs/developers-manual/source/getting-started/building-apps.rst
+++ b/cdap-docs/developers-manual/source/getting-started/building-apps.rst
@@ -61,9 +61,7 @@ Accessing CLI, curl and the SDK bin
   this change to the path variable. The Windows path has been augmented with a directory where
   the SDK includes Windows-versions of commands such as ``curl``.
   
-- There is an issue with running Microsoft Windows and using the CDAP Standalone scripts
-  when ``JAVA_HOME`` is defined as a path with spaces in it. A workaround is to use a
-  definition of ``JAVA_HOME`` that does not include spaces.
+.. include:: /_includes/windows-note.txt
 
 .. _cdap-building-running-example:
 

--- a/cdap-docs/developers-manual/source/getting-started/standalone/docker.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/docker.rst
@@ -152,4 +152,4 @@ Docker and CDAP Applications
 .. include:: ../start-stop-cdap.rst  
    :start-line: 4
 
-.. include:: building-apps.txt
+.. include:: /_includes/building-apps.txt

--- a/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
@@ -35,7 +35,11 @@ If you are **running under Microsoft Windows**, you will need to have installed 
 `Microsoft Visual C++ 2010 Redistributable Package
 <http://www.microsoft.com/en-us/download/details.aspx?id=14632>`__ in order to have the
 required DLLs to run Hadoop and CDAP; currently, CDAP is supported only on 64-bit Windows
-platforms.
+platforms. 
+
+There is an issue with running Microsoft Windows and using the CDAP Standalone scripts
+when ``JAVA_HOME`` is defined as a path with spaces in it. A workaround is to use a
+definition of ``JAVA_HOME`` that does not include spaces.
 
 .. _recommend-using-an-ide:
 

--- a/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
@@ -37,9 +37,7 @@ If you are **running under Microsoft Windows**, you will need to have installed 
 required DLLs to run Hadoop and CDAP; currently, CDAP is supported only on 64-bit Windows
 platforms. 
 
-There is an issue with running Microsoft Windows and using the CDAP Standalone scripts
-when ``JAVA_HOME`` is defined as a path with spaces in it. A workaround is to use a
-definition of ``JAVA_HOME`` that does not include spaces.
+.. include:: /_includes/windows-note.txt
 
 .. _recommend-using-an-ide:
 

--- a/cdap-docs/developers-manual/source/getting-started/standalone/virtual-machine.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/virtual-machine.rst
@@ -42,4 +42,4 @@ remove software, the admin user and password are both ``cdap``.
    :start-line: 4
    :end-line:   33
 
-.. include:: building-apps.txt
+.. include:: /_includes/building-apps.txt

--- a/cdap-docs/developers-manual/source/getting-started/standalone/zip.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/zip.rst
@@ -36,4 +36,4 @@ Once downloaded, unzip it to a directory on your machine:
    :start-line: 30
    :end-line:   33
 
-.. include:: building-apps.txt
+.. include:: /_includes/building-apps.txt

--- a/cdap-docs/developers-manual/source/getting-started/start-stop-cdap.rst
+++ b/cdap-docs/developers-manual/source/getting-started/start-stop-cdap.rst
@@ -24,6 +24,9 @@ Use the ``cdap.sh`` script to start and stop the Standalone CDAP
     |$| ./bin/cdap.sh stop
 
 Or, if you are using Windows, use the batch script ``cdap.bat`` to start and stop the SDK.
+(There is an issue with running Microsoft Windows and using the CDAP Standalone scripts
+when ``JAVA_HOME`` is defined as a path with spaces in it. A workaround is to use a
+definition of ``JAVA_HOME`` that does not include spaces.)
 
 Note that starting CDAP is not necessary if you use either the Virtual Machine or the
 Docker image, as they both start the Standalone CDAP automatically on startup.

--- a/cdap-docs/developers-manual/source/getting-started/start-stop-cdap.rst
+++ b/cdap-docs/developers-manual/source/getting-started/start-stop-cdap.rst
@@ -24,9 +24,8 @@ Use the ``cdap.sh`` script to start and stop the Standalone CDAP
     |$| ./bin/cdap.sh stop
 
 Or, if you are using Windows, use the batch script ``cdap.bat`` to start and stop the SDK.
-(There is an issue with running Microsoft Windows and using the CDAP Standalone scripts
-when ``JAVA_HOME`` is defined as a path with spaces in it. A workaround is to use a
-definition of ``JAVA_HOME`` that does not include spaces.)
+
+.. include:: /_includes/windows-note.txt
 
 Note that starting CDAP is not necessary if you use either the Virtual Machine or the
 Docker image, as they both start the Standalone CDAP automatically on startup.


### PR DESCRIPTION
Adds a warning about not using a Windows JAVA_HOME with spaces in it.

Fix for https://issues.cask.co/browse/CDAP-3262

Passes [Quick Build 2](http://builds.cask.co/browse/CDAP-DOB102-2)

Pages of Interest:
- [Getting Started: CDAP SDK](http://builds.cask.co/artifact/CDAP-DOB102/shared/build-2/Docs-HTML/3.3.1-SNAPSHOT/en/developers-manual/getting-started/standalone/index.html)
- [Getting Started: Starting and Stopping Standalone CDAP](http://builds.cask.co/artifact/CDAP-DOB102/shared/build-2/Docs-HTML/3.3.1-SNAPSHOT/en/developers-manual/getting-started/start-stop-cdap.html)
- [Getting Started: Building and Running CDAP Applications](http://builds.cask.co/artifact/CDAP-DOB102/shared/build-2/Docs-HTML/3.3.1-SNAPSHOT/en/developers-manual/getting-started/building-apps.html)

You can confirm that the moving of ``building-apps.txt`` didn't break by comparing the end of these two pages, and see that they have identical sections "Building and Running CDAP Applications":
- [Current "Binary Zip File"](http://docs.cask.co/cdap/current/en/developers-manual/getting-started/standalone/zip.html)
- [Revised "Binary Zip File"](http://builds.cask.co/artifact/CDAP-DOB102/shared/build-2/Docs-HTML/3.3.1-SNAPSHOT/en/developers-manual/getting-started/standalone/zip.html)