### PR TITLE
Fixes namespace dropdown to show only namespace

### DIFF
--- a/cdap-ui/app/directives/navbar-hydrator/namespace.html
+++ b/cdap-ui/app/directives/navbar-hydrator/namespace.html
@@ -15,13 +15,9 @@
 -->
 
 <ul class="dropdown-menu" role="menu" ng-show="currentUser">
-  <li ng-repeat="ns in namespaces | orderBy : 'name'" ng-show="namespaces.length > 1 && ns.name !== $state.params.namespace">
+  <li ng-repeat="ns in namespaces | orderBy : 'name'">
     <a role="menuitem" ui-sref="hydrator.list({namespace: ns.name})" tabindex="-1" title="{{ns.name}}">
       <span ng-bind="ns.name | myEllipsis: 32"></span>
     </a>
   </li>
-  <li role="menuitem" ng-show="namespaces.length === 1" class="disabled">
-    <a href="">No other namespaces</a>
-  </li>
 </ul>
-

--- a/cdap-ui/app/directives/navbar-hydrator/namespace.html
+++ b/cdap-ui/app/directives/navbar-hydrator/namespace.html
@@ -15,8 +15,13 @@
 -->
 
 <ul class="dropdown-menu" role="menu" ng-show="currentUser">
-  <li ng-repeat="ns in namespaces | orderBy : 'name'">
-    <a role="menuitem" ui-sref="hydrator.list({namespace: ns.name})" tabindex="-1" title="{{ns.name}}">
+  <li ng-repeat="ns in namespaces | orderBy : 'name'" >
+    <a role="menuitem"
+        ng-class="{'active': ns.name === namespace}"
+        ui-sref="hydrator.list({namespace: ns.name})"
+        tabindex="-1"
+        title="{{ns.name}}">
+      <i ng-class="{'fa fa-check': ns.name === namespace}"></i>
       <span ng-bind="ns.name | myEllipsis: 32"></span>
     </a>
   </li>

--- a/cdap-ui/app/directives/navbar-hydrator/navbar.html
+++ b/cdap-ui/app/directives/navbar-hydrator/navbar.html
@@ -38,7 +38,7 @@
 
   <ul class="navbar-namespace" id="navbar-namespace">
     <li class="dropdown">
-      <a href="" class="hy-dropdown-toggle clearfix" title="{{getDisplayName($state.params.namespace)}}">
+      <a href=" " class="hy-dropdown-toggle clearfix" title="{{getDisplayName($state.params.namespace)}}">
         <span class="pull-left" ng-bind="$state.params.namespace && getDisplayName($state.params.namespace) | myEllipsis: 12"></span>
         <span class="fa fa-angle-down pull-right"></span>
       </a>

--- a/cdap-ui/app/directives/navbar-hydrator/navbar.js
+++ b/cdap-ui/app/directives/navbar-hydrator/navbar.js
@@ -64,6 +64,14 @@ function myNavbarHydratorDirective (myAuth, MY_CONFIG, $dropdown) {
       $scope.$on (myAuth.logoutSuccess, function () {
         $scope.namespaces = [];
       });
+      // This is here because navbar-hydrator navbar is outside of <main-container/>
+      // So when we switch namesapce this controller is not reloaded. So the $scope.namespace
+      // is not updated. We need to watch until this $scope is alive and change the namespace
+      // This might be redundant right now when we just navigate in hydrator but this is something
+      // we should address this when we unify navbars.
+      $scope.$on('$stateChangeSuccess', function() {
+        $scope.namespace = $state.params.namespace;
+      });
     }
   };
 });

--- a/cdap-ui/app/directives/navbar-hydrator/navbar.less
+++ b/cdap-ui/app/directives/navbar-hydrator/navbar.less
@@ -94,9 +94,6 @@ body {
                 font-size: 11px;
               }
             }
-            &:hover, &:focus {
-              cursor: pointer;
-            }
           }
         }
       }
@@ -111,9 +108,7 @@ body {
         right: 100px;
         li.dropdown {
           list-style-type: none;
-          &:hover {
-            cursor: pointer;
-          }
+
           a.hy-dropdown-toggle {
             display: block;
             min-width: 125px;
@@ -207,6 +202,10 @@ body {
                 background-color: @cdap-header;
                 border: 1px solid @cdap-header;
                 color: white;
+              }
+              &.active {
+                color: #c4c4c4;
+                pointer-events: none;
               }
             }
           }


### PR DESCRIPTION
 Right now we show "No other namespaces" in Hydrator & just default namespace in the other. 

Related JIRA: https://issues.cask.co/browse/CDAP-4669