### PR TITLE
(CDAP-4720) Remove defaulting MetadataRecord to MetadataScope.USER. P…

### DIFF
--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -70,6 +70,13 @@
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-authorization-dataset-plugin</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-fabric</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>co.cask.tephra</groupId>

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -108,7 +108,9 @@ public class ArtifactRepository {
    * @throws IOException if there was an error making changes in the meta store
    */
   public void clear(Id.Namespace namespace) throws IOException {
-    artifactStore.clear(namespace);
+    for (ArtifactDetail artifactDetail : artifactStore.getArtifacts(namespace)) {
+      deleteArtifact(Id.Artifact.from(namespace, artifactDetail.getDescriptor().getArtifactId()));
+    }
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -86,10 +86,14 @@ public class LineageAdminTest extends MetadataTestBase {
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityValidator());
 
     // Define metadata
-    MetadataRecord run1AppMeta = new MetadataRecord(program1.getApplication(), toMap("pk1", "pk1"), toSet("pt1"));
-    MetadataRecord run1ProgramMeta = new MetadataRecord(program1, toMap("pk1", "pk1"), toSet("pt1"));
-    MetadataRecord run1Data1Meta = new MetadataRecord(dataset1, toMap("dk1", "dk1"), toSet("dt1"));
-    MetadataRecord run1Data2Meta = new MetadataRecord(dataset2, toMap("dk2", "dk2"), toSet("dt2"));
+    MetadataRecord run1AppMeta = new MetadataRecord(program1.getApplication(), MetadataScope.USER,
+                                                    toMap("pk1", "pk1"), toSet("pt1"));
+    MetadataRecord run1ProgramMeta = new MetadataRecord(program1, MetadataScope.USER,
+                                                        toMap("pk1", "pk1"), toSet("pt1"));
+    MetadataRecord run1Data1Meta = new MetadataRecord(dataset1, MetadataScope.USER,
+                                                      toMap("dk1", "dk1"), toSet("dt1"));
+    MetadataRecord run1Data2Meta = new MetadataRecord(dataset2, MetadataScope.USER,
+                                                      toMap("dk2", "dk2"), toSet("dt2"));
 
     // Add metadata
     metadataStore.setProperties(MetadataScope.USER, program1.getApplication(), run1AppMeta.getProperties());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
@@ -149,10 +149,10 @@ public class LineageTest extends MetadataTestBase {
       // Assert metadata
       // Id.Flow needs conversion to Id.Program JIRA - CDAP-3658
       Id.Program programForFlow = Id.Program.from(flow.getApplication(), flow.getType(), flow.getId());
-      Assert.assertEquals(toSet(new MetadataRecord(app, appProperties, appTags),
-                                new MetadataRecord(programForFlow, flowProperties, flowTags),
-                                new MetadataRecord(dataset, dataProperties, dataTags),
-                                new MetadataRecord(stream, streamProperties, streamTags)),
+      Assert.assertEquals(toSet(new MetadataRecord(app, MetadataScope.USER, appProperties, appTags),
+                                new MetadataRecord(programForFlow, MetadataScope.USER, flowProperties, flowTags),
+                                new MetadataRecord(dataset, MetadataScope.USER, dataProperties, dataTags),
+                                new MetadataRecord(stream, MetadataScope.USER, streamProperties, streamTags)),
                           fetchRunMetadata(new Id.Run(flow, flowRunId.getId())));
 
       // Assert with a time range after the flow run should return no results
@@ -280,26 +280,26 @@ public class LineageTest extends MetadataTestBase {
       // Assert metadata
       // Id.Flow needs conversion to Id.Program JIRA - CDAP-3658
       Id.Program programForFlow = Id.Program.from(flow.getApplication(), flow.getType(), flow.getId());
-      Assert.assertEquals(toSet(new MetadataRecord(app, emptyMap(), emptySet()),
-                                new MetadataRecord(programForFlow, emptyMap(), emptySet()),
-                                new MetadataRecord(dataset, datasetProperties, emptySet()),
-                                new MetadataRecord(stream, emptyMap(), emptySet())),
+      Assert.assertEquals(toSet(new MetadataRecord(app, MetadataScope.USER, emptyMap(), emptySet()),
+                                new MetadataRecord(programForFlow, MetadataScope.USER, emptyMap(), emptySet()),
+                                new MetadataRecord(dataset, MetadataScope.USER, datasetProperties, emptySet()),
+                                new MetadataRecord(stream, MetadataScope.USER, emptyMap(), emptySet())),
                           fetchRunMetadata(new Id.Run(flow, flowRunId.getId())));
 
       // Id.Worker needs conversion to Id.Program JIRA - CDAP-3658
       Id.Program programForWorker = Id.Program.from(worker.getApplication(), worker.getType(), worker.getId());
-      Assert.assertEquals(toSet(new MetadataRecord(app, emptyMap(), emptySet()),
-                                new MetadataRecord(programForWorker, emptyMap(), workerTags),
-                                new MetadataRecord(dataset, datasetProperties, emptySet()),
-                                new MetadataRecord(stream, emptyMap(), emptySet())),
+      Assert.assertEquals(toSet(new MetadataRecord(app, MetadataScope.USER, emptyMap(), emptySet()),
+                                new MetadataRecord(programForWorker, MetadataScope.USER, emptyMap(), workerTags),
+                                new MetadataRecord(dataset, MetadataScope.USER, datasetProperties, emptySet()),
+                                new MetadataRecord(stream, MetadataScope.USER, emptyMap(), emptySet())),
                           fetchRunMetadata(new Id.Run(worker, workerRunId.getId())));
 
       // Id.Spark needs conversion to Id.Program JIRA - CDAP-3658
       Id.Program programForSpark = Id.Program.from(spark.getApplication(), spark.getType(), spark.getId());
-      Assert.assertEquals(toSet(new MetadataRecord(app, emptyMap(), emptySet()),
-                                new MetadataRecord(programForSpark, emptyMap(), sparkTags),
-                                new MetadataRecord(dataset, datasetProperties, emptySet()),
-                                new MetadataRecord(stream, emptyMap(), emptySet())),
+      Assert.assertEquals(toSet(new MetadataRecord(app, MetadataScope.USER, emptyMap(), emptySet()),
+                                new MetadataRecord(programForSpark, MetadataScope.USER, emptyMap(), sparkTags),
+                                new MetadataRecord(dataset, MetadataScope.USER, datasetProperties, emptySet()),
+                                new MetadataRecord(stream, MetadataScope.USER, emptyMap(), emptySet())),
                           fetchRunMetadata(new Id.Run(spark, sparkRunId.getId())));
     } finally {
       try {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -602,7 +602,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     ImmutableSet<String> viewUserTags = ImmutableSet.of("viewTag");
     addTags(view, viewUserTags);
     Assert.assertEquals(
-      ImmutableSet.of(new MetadataRecord(view, ImmutableMap.<String, String>of(), viewUserTags),
+      ImmutableSet.of(new MetadataRecord(view, MetadataScope.USER, ImmutableMap.<String, String>of(), viewUserTags),
                       new MetadataRecord(view, MetadataScope.SYSTEM, viewSystemProperties, viewSystemTags)),
       getMetadata(view)
     );

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataKafkaPublishTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataKafkaPublishTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.AllProgramsApp;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
+import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.internal.AppFabricClient;
+import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.kafka.KafkaTester;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.codec.NamespacedIdCodec;
+import co.cask.cdap.proto.metadata.MetadataChangeRecord;
+import co.cask.tephra.runtime.TransactionInMemoryModule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.AbstractModule;
+import com.google.inject.util.Modules;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * Tests for verifying that system metadata gets published to Kafka when publishing is enabled
+ */
+public class SystemMetadataKafkaPublishTest {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
+    .create();
+
+  @ClassRule
+  public static final KafkaTester KAFKA_TESTER = new KafkaTester(
+    ImmutableMap.of(Constants.Metadata.UPDATES_PUBLISH_ENABLED, "true"),
+    ImmutableList.of(
+      Modules.override(
+        new DataSetsModules().getInMemoryModules()).with(new AbstractModule() {
+        @Override
+        protected void configure() {
+          // Need the distributed metadata store.
+          bind(MetadataStore.class).to(DefaultMetadataStore.class);
+        }
+      }),
+      new LocationRuntimeModule().getInMemoryModules(),
+      new TransactionInMemoryModule(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new NamespaceClientRuntimeModule().getInMemoryModules()
+    ),
+    1,
+    Constants.Metadata.UPDATES_KAFKA_BROKER_LIST
+  );
+
+  @Test
+  public void testPublishing() throws Exception {
+    CConfiguration cConf = KAFKA_TESTER.getCConf();
+    AppFabricTestHelper.deployApplication(AllProgramsApp.class, cConf);
+    String topic = cConf.get(Constants.Metadata.UPDATES_KAFKA_TOPIC);
+    Type metadataChangeRecordType = new TypeToken<MetadataChangeRecord>() { }.getType();
+    // Expect 17 messages to be generated for system metadata additions:
+    // 1 = for adding tags to artifact
+    // 2 = for adding properties and tags to app
+    // 6 = 1 each for adding properties to flow, mr, service, spark, workflow, worker
+    // 3 = for adding properties, tags and schema for stream
+    // 2 = for adding properties and tags to kvt dataset
+    // 3 = for adding properties, tags and schema to dsWithSchema dataset
+    KAFKA_TESTER.getPublishedMessages(topic, 17, metadataChangeRecordType, GSON);
+    AppFabricClient appFabricClient = AppFabricTestHelper.getInjector(cConf).getInstance(AppFabricClient.class);
+    appFabricClient.reset();
+    // Expect 24 more messages to be generated for metadata deletions:
+    // 22 = 2 (1 for USER scope and 1 for SYSTEM scope) each for artifact, app, flow, mr, service, spark, workflow,
+    // worker, stream, kvt, dsWithSchema
+    // 2 extra for the stream because during namespace delete, stream delete gets called twice - once via
+    // StreamAdmin.removeAllInNamespace and once via Store.removeAll
+    KAFKA_TESTER.getPublishedMessages(topic, 24, metadataChangeRecordType, GSON, 17);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/publisher/NoOpMetadataChangePublisher.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/publisher/NoOpMetadataChangePublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@ package co.cask.cdap.data2.metadata.publisher;
 import co.cask.cdap.proto.metadata.MetadataChangeRecord;
 
 /**
- * A no-op {@link MetadataChangePublisher} for use in tests and standalone.
+ * A no-op {@link MetadataChangePublisher} for use when publishing is disabled.
  */
 public class NoOpMetadataChangePublisher implements MetadataChangePublisher {
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Cask Data, Inc.
+ * Copyright 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -56,7 +56,7 @@ public class NoOpMetadataStore implements MetadataStore {
 
   @Override
   public MetadataRecord getMetadata(MetadataScope scope, Id.NamespacedId entityId) {
-    return new MetadataRecord(entityId);
+    return new MetadataRecord(entityId, scope);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/publisher/KafkaMetadataChangePublisherTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/publisher/KafkaMetadataChangePublisherTest.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
 import co.cask.cdap.proto.metadata.MetadataChangeRecord;
 import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.tephra.runtime.TransactionInMemoryModule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -98,57 +99,61 @@ public class KafkaMetadataChangePublisherTest {
     ImmutableList.Builder<MetadataChangeRecord> changesBuilder = ImmutableList.builder();
     Id.DatasetInstance dataset = Id.DatasetInstance.from("ns1", "ds1");
     // Initial state: empty
-    MetadataRecord previous = new MetadataRecord(dataset, ImmutableMap.<String, String>of(),
+    MetadataRecord previous = new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.<String, String>of(),
                                                  ImmutableSet.<String>of());
     // Change 1: add one property and 1 tag
     MetadataChangeRecord.MetadataDiffRecord initialAddition = new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(dataset, ImmutableMap.of("key1", "value1"), ImmutableSet.of("tag1")),
-      new MetadataRecord(dataset, ImmutableMap.<String, String>of(), ImmutableSet.<String>of())
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.of("key1", "value1"), ImmutableSet.of("tag1")),
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.<String, String>of(), ImmutableSet.<String>of())
     );
     long updateTime = currentTime - 1000;
     changesBuilder.add(new MetadataChangeRecord(previous, initialAddition, updateTime));
     // Metadata after initial addition
-    previous = new MetadataRecord(dataset, ImmutableMap.of("key1", "value1"), ImmutableSet.of("tag1"));
+    previous = new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.of("key1", "value1"),
+                                  ImmutableSet.of("tag1"));
     // Change 1: update a property - translates to one addition and one deletion
     MetadataChangeRecord.MetadataDiffRecord propUpdated = new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(dataset, ImmutableMap.of("key1", "v1"), ImmutableSet.<String>of()),
-      new MetadataRecord(dataset, ImmutableMap.of("key1", "value1"), ImmutableSet.<String>of())
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.of("key1", "v1"), ImmutableSet.<String>of()),
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.of("key1", "value1"), ImmutableSet.<String>of())
     );
     updateTime = currentTime - 800;
     changesBuilder.add(new MetadataChangeRecord(previous, propUpdated, updateTime));
     // Metadata after property update
-    previous = new MetadataRecord(dataset, ImmutableMap.of("key1", "v1"), ImmutableSet.of("tag1"));
+    previous = new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.of("key1", "v1"), ImmutableSet.of("tag1"));
     // Change 2: add a new property - translates to one addition
     MetadataChangeRecord.MetadataDiffRecord propAdded = new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(dataset, ImmutableMap.of("key2", "value2"), ImmutableSet.<String>of()),
-      new MetadataRecord(dataset, ImmutableMap.<String, String>of(), ImmutableSet.<String>of())
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.of("key2", "value2"), ImmutableSet.<String>of()),
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.<String, String>of(), ImmutableSet.<String>of())
     );
     updateTime = currentTime - 600;
     changesBuilder.add(new MetadataChangeRecord(previous, propAdded, updateTime));
     // Metadata after property addition
-    previous = new MetadataRecord(dataset, ImmutableMap.of("key1", "v1", "key2", "value2"), ImmutableSet.of("tag1"));
+    previous = new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.of("key1", "v1", "key2", "value2"),
+                                  ImmutableSet.of("tag1"));
     // Change 3: remove a property - translates to 1 deletion
     MetadataChangeRecord.MetadataDiffRecord propRemoved = new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(dataset, ImmutableMap.<String, String>of(), ImmutableSet.<String>of()),
-      new MetadataRecord(dataset, ImmutableMap.of("key1", "v1"), ImmutableSet.<String>of())
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.<String, String>of(), ImmutableSet.<String>of()),
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.of("key1", "v1"), ImmutableSet.<String>of())
     );
     updateTime = currentTime - 400;
     changesBuilder.add(new MetadataChangeRecord(previous, propRemoved, updateTime));
     // Metadata after property deletion
-    previous = new MetadataRecord(dataset, ImmutableMap.of("key2", "value2"), ImmutableSet.of("tag1"));
+    previous = new MetadataRecord(dataset, MetadataScope.USER,
+                                  ImmutableMap.of("key2", "value2"), ImmutableSet.of("tag1"));
     // Change 4: remove a tag - translates to 1 deletion
     MetadataChangeRecord.MetadataDiffRecord tagRemoved = new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(dataset, ImmutableMap.<String, String>of(), ImmutableSet.<String>of()),
-      new MetadataRecord(dataset, ImmutableMap.<String, String>of(), ImmutableSet.of("tag1"))
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.<String, String>of(), ImmutableSet.<String>of()),
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.<String, String>of(), ImmutableSet.of("tag1"))
     );
     updateTime = currentTime - 200;
     changesBuilder.add(new MetadataChangeRecord(previous, tagRemoved, updateTime));
     // Metadata after tag removal
-    previous = new MetadataRecord(dataset, ImmutableMap.of("key2", "value2"), ImmutableSet.<String>of());
+    previous = new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.of("key2", "value2"),
+                                  ImmutableSet.<String>of());
     // Change 5: add a tag - translates to 1 addition
     MetadataChangeRecord.MetadataDiffRecord tagAdded = new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(dataset, ImmutableMap.<String, String>of(), ImmutableSet.of("tag1")),
-      new MetadataRecord(dataset, ImmutableMap.<String, String>of(), ImmutableSet.<String>of())
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.<String, String>of(), ImmutableSet.of("tag1")),
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.<String, String>of(), ImmutableSet.<String>of())
     );
     updateTime = currentTime;
     changesBuilder.add(new MetadataChangeRecord(previous, tagAdded, updateTime));

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
@@ -97,90 +97,90 @@ public class MetadataStoreTest {
   private final Set<String> flowTags = ImmutableSet.of("fTag");
 
   private final MetadataChangeRecord change1 = new MetadataChangeRecord(
-    new MetadataRecord(dataset),
+    new MetadataRecord(dataset, MetadataScope.USER),
     new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(dataset, ImmutableMap.<String, String>of(), datasetTags),
-      new MetadataRecord(dataset)
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.<String, String>of(), datasetTags),
+      new MetadataRecord(dataset, MetadataScope.USER)
     ),
     System.currentTimeMillis()
   );
   private final MetadataChangeRecord change2 = new MetadataChangeRecord(
-    new MetadataRecord(app),
+    new MetadataRecord(app, MetadataScope.USER),
     new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(app, appProperties, ImmutableSet.<String>of()),
-      new MetadataRecord(app)
+      new MetadataRecord(app, MetadataScope.USER, appProperties, ImmutableSet.<String>of()),
+      new MetadataRecord(app, MetadataScope.USER)
     ),
     System.currentTimeMillis()
   );
   private final MetadataChangeRecord change3 = new MetadataChangeRecord(
-    new MetadataRecord(app, appProperties, ImmutableSet.<String>of()),
+    new MetadataRecord(app, MetadataScope.USER, appProperties, ImmutableSet.<String>of()),
     new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(app, ImmutableMap.<String, String>of(), appTags),
-      new MetadataRecord(app)
+      new MetadataRecord(app, MetadataScope.USER, ImmutableMap.<String, String>of(), appTags),
+      new MetadataRecord(app, MetadataScope.USER)
     ),
     System.currentTimeMillis()
   );
   private final MetadataChangeRecord change4 = new MetadataChangeRecord(
-    new MetadataRecord(stream),
+    new MetadataRecord(stream, MetadataScope.USER),
     new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(stream, streamProperties, ImmutableSet.<String>of()),
-      new MetadataRecord(stream)
+      new MetadataRecord(stream, MetadataScope.USER, streamProperties, ImmutableSet.<String>of()),
+      new MetadataRecord(stream, MetadataScope.USER)
     ),
     System.currentTimeMillis()
   );
   private final MetadataChangeRecord change5 = new MetadataChangeRecord(
-    new MetadataRecord(stream, streamProperties, ImmutableSet.<String>of()),
+    new MetadataRecord(stream, MetadataScope.USER, streamProperties, ImmutableSet.<String>of()),
     new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(stream),
-      new MetadataRecord(stream)
+      new MetadataRecord(stream, MetadataScope.USER),
+      new MetadataRecord(stream, MetadataScope.USER)
     ),
     System.currentTimeMillis()
   );
   private final MetadataChangeRecord change6 = new MetadataChangeRecord(
-    new MetadataRecord(stream, streamProperties, ImmutableSet.<String>of()),
+    new MetadataRecord(stream, MetadataScope.USER, streamProperties, ImmutableSet.<String>of()),
     new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(stream, updatedStreamProperties, ImmutableSet.<String>of()),
-      new MetadataRecord(stream, streamProperties, ImmutableSet.<String>of())
+      new MetadataRecord(stream, MetadataScope.USER, updatedStreamProperties, ImmutableSet.<String>of()),
+      new MetadataRecord(stream, MetadataScope.USER, streamProperties, ImmutableSet.<String>of())
     ),
     System.currentTimeMillis()
   );
   private final MetadataChangeRecord change7 = new MetadataChangeRecord(
-    new MetadataRecord(flow),
+    new MetadataRecord(flow, MetadataScope.USER),
     new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(flow, ImmutableMap.<String, String>of(), flowTags),
-      new MetadataRecord(flow)
+      new MetadataRecord(flow, MetadataScope.USER, ImmutableMap.<String, String>of(), flowTags),
+      new MetadataRecord(flow, MetadataScope.USER)
     ),
     System.currentTimeMillis()
   );
   private final MetadataChangeRecord change8 = new MetadataChangeRecord(
-    new MetadataRecord(flow, ImmutableMap.<String, String>of(), flowTags),
+    new MetadataRecord(flow, MetadataScope.USER, ImmutableMap.<String, String>of(), flowTags),
     new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(flow),
-      new MetadataRecord(flow, ImmutableMap.<String, String>of(), flowTags)
+      new MetadataRecord(flow, MetadataScope.USER),
+      new MetadataRecord(flow, MetadataScope.USER, ImmutableMap.<String, String>of(), flowTags)
     ),
     System.currentTimeMillis()
   );
   private final MetadataChangeRecord change9 = new MetadataChangeRecord(
-    new MetadataRecord(dataset, ImmutableMap.<String, String>of(), datasetTags),
+    new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.<String, String>of(), datasetTags),
     new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(dataset),
-      new MetadataRecord(dataset, ImmutableMap.<String, String>of(), datasetTags)
+      new MetadataRecord(dataset, MetadataScope.USER),
+      new MetadataRecord(dataset, MetadataScope.USER, ImmutableMap.<String, String>of(), datasetTags)
     ),
     System.currentTimeMillis()
   );
   private final MetadataChangeRecord change10 = new MetadataChangeRecord(
-    new MetadataRecord(stream, updatedStreamProperties, ImmutableSet.<String>of()),
+    new MetadataRecord(stream, MetadataScope.USER, updatedStreamProperties, ImmutableSet.<String>of()),
     new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(stream),
-      new MetadataRecord(stream, updatedStreamProperties, ImmutableSet.<String>of())
+      new MetadataRecord(stream, MetadataScope.USER),
+      new MetadataRecord(stream, MetadataScope.USER, updatedStreamProperties, ImmutableSet.<String>of())
     ),
     System.currentTimeMillis()
   );
   private final MetadataChangeRecord change11 = new MetadataChangeRecord(
-    new MetadataRecord(app, appProperties, appTags),
+    new MetadataRecord(app, MetadataScope.USER, appProperties, appTags),
     new MetadataChangeRecord.MetadataDiffRecord(
-      new MetadataRecord(app, ImmutableMap.<String, String>of(), ImmutableSet.<String>of()),
-      new MetadataRecord(app, appProperties, appTags)
+      new MetadataRecord(app, MetadataScope.USER, ImmutableMap.<String, String>of(), ImmutableSet.<String>of()),
+      new MetadataRecord(app, MetadataScope.USER, appProperties, appTags)
     ),
     System.currentTimeMillis()
   );

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/kafka/KafkaTester.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/kafka/KafkaTester.java
@@ -269,7 +269,8 @@ public class KafkaTester extends ExternalResource {
         }
       }
     );
-    Assert.assertTrue(latch.await(15, TimeUnit.SECONDS));
+    Assert.assertTrue(String.format("Expected %d messages but found %d messages", expectedNumMsgs, actual.size()),
+                      latch.await(15, TimeUnit.SECONDS));
     cancellable.cancel();
     Assert.assertTrue(stopLatch.await(15, TimeUnit.SECONDS));
     return actual;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,26 +35,17 @@ public class MetadataRecord {
   private final Set<String> tags;
 
   /**
-   * Returns an empty {@link MetadataRecord}
-   */
-  public MetadataRecord(Id.NamespacedId entityId) {
-    this(entityId, ImmutableMap.<String, String>of(), ImmutableSet.<String>of());
-  }
-
-  /**
-   * Returns an empty {@link MetadataRecord} in the specified {@link MetadataScope}
+   * Returns an empty {@link MetadataRecord} in the specified {@link MetadataScope}.
    */
   public MetadataRecord(Id.NamespacedId entityId, MetadataScope scope) {
     this(entityId, scope, ImmutableMap.<String, String>of(), ImmutableSet.<String>of());
   }
 
+  /**
+   * Returns a new {@link MetadataRecord} from the specified existing {@link MetadataRecord}.
+   */
   public MetadataRecord(MetadataRecord other) {
-    this(other.getEntityId(), other.getProperties(), other.getTags());
-  }
-
-  // TODO: CDAP-4295 Remove defaulting to USER
-  public MetadataRecord(Id.NamespacedId entityId, Map<String, String> properties, Set<String> tags) {
-    this(entityId, MetadataScope.USER, properties, tags);
+    this(other.getEntityId(), other.getScope(), other.getProperties(), other.getTags());
   }
 
   public MetadataRecord(Id.NamespacedId entityId, MetadataScope scope, Map<String, String> properties,

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/codec/NamespacedIdCodecTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/codec/NamespacedIdCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,6 +19,7 @@ package co.cask.cdap.proto.codec;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
@@ -80,43 +81,43 @@ public class NamespacedIdCodecTest {
     Map<String, String> properties = ImmutableMap.of("key1", "value1", "k1", "v1");
     Set<String> tags = ImmutableSet.of("tag1", "t1");
     // verify with Id.Application
-    MetadataRecord appRecord = new MetadataRecord(app, properties, tags);
+    MetadataRecord appRecord = new MetadataRecord(app, MetadataScope.USER, properties, tags);
     String appRecordJson = GSON.toJson(appRecord);
     Assert.assertEquals(appRecord, GSON.fromJson(appRecordJson, MetadataRecord.class));
     // verify with Id.Program
-    MetadataRecord programRecord = new MetadataRecord(program, properties, tags);
+    MetadataRecord programRecord = new MetadataRecord(program, MetadataScope.USER, properties, tags);
     String programRecordJson = GSON.toJson(programRecord);
     Assert.assertEquals(programRecord, GSON.fromJson(programRecordJson, MetadataRecord.class));
     // verify with Id.Flow
-    MetadataRecord flowRecord = new MetadataRecord(flow, properties, tags);
+    MetadataRecord flowRecord = new MetadataRecord(flow, MetadataScope.USER, properties, tags);
     String flowRecordJson = GSON.toJson(flowRecord);
     Assert.assertEquals(flowRecord, GSON.fromJson(flowRecordJson, MetadataRecord.class));
     // verify with Id.Flow.Flowlet
-    MetadataRecord flowletRecord = new MetadataRecord(flowlet, properties, tags);
+    MetadataRecord flowletRecord = new MetadataRecord(flowlet, MetadataScope.USER, properties, tags);
     String flowletRecordJson = GSON.toJson(flowletRecord);
     Assert.assertEquals(flowletRecord, GSON.fromJson(flowletRecordJson, MetadataRecord.class));
     // verify with Id.Service
-    MetadataRecord serviceRecord = new MetadataRecord(service, properties, tags);
+    MetadataRecord serviceRecord = new MetadataRecord(service, MetadataScope.USER, properties, tags);
     String serviceRecordJson = GSON.toJson(serviceRecord);
     Assert.assertEquals(serviceRecord, GSON.fromJson(serviceRecordJson, MetadataRecord.class));
     // verify with Id.Schedule
-    MetadataRecord scheduleRecord = new MetadataRecord(schedule, properties, tags);
+    MetadataRecord scheduleRecord = new MetadataRecord(schedule, MetadataScope.USER, properties, tags);
     String scheduleRecordJson = GSON.toJson(scheduleRecord);
     Assert.assertEquals(scheduleRecord, GSON.fromJson(scheduleRecordJson, MetadataRecord.class));
     // verify with Id.Worker
-    MetadataRecord workerRecord = new MetadataRecord(worker, properties, tags);
+    MetadataRecord workerRecord = new MetadataRecord(worker, MetadataScope.USER, properties, tags);
     String workerRecordJson = GSON.toJson(workerRecord);
     Assert.assertEquals(workerRecord, GSON.fromJson(workerRecordJson, MetadataRecord.class));
     // verify with Id.Workflow
-    MetadataRecord workflowRecord = new MetadataRecord(workflow, properties, tags);
+    MetadataRecord workflowRecord = new MetadataRecord(workflow, MetadataScope.USER, properties, tags);
     String workflowRecordJson = GSON.toJson(workflowRecord);
     Assert.assertEquals(workflowRecord, GSON.fromJson(workflowRecordJson, MetadataRecord.class));
     // verify with Id.DatasetInstance
-    MetadataRecord datasetRecord = new MetadataRecord(dataset, properties, tags);
+    MetadataRecord datasetRecord = new MetadataRecord(dataset, MetadataScope.USER, properties, tags);
     String datasetRecordJson = GSON.toJson(datasetRecord);
     Assert.assertEquals(datasetRecord, GSON.fromJson(datasetRecordJson, MetadataRecord.class));
     // verify with Id.Stream
-    MetadataRecord streamRecord = new MetadataRecord(stream, properties, tags);
+    MetadataRecord streamRecord = new MetadataRecord(stream, MetadataScope.USER, properties, tags);
     String streamRecordJson = GSON.toJson(streamRecord);
     Assert.assertEquals(streamRecord, GSON.fromJson(streamRecordJson, MetadataRecord.class));
   }


### PR DESCRIPTION
…ass scope explicitly everytime a new MetadataRecord is required.

- Update AppFabricTestHelper to be able to pass in CConfiguration during deployment.
- Fix a bug in ArtifactRepository where ArtifactRepository.clear(Id.Namespace) was not deleting metadata of deleted artifacts.