### PR TITLE
Fixes to cdap-defaults.xml

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2014-2015 Cask Data, Inc.
+  Copyright © 2014-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -66,7 +66,7 @@
     <value>2</value>
     <description>
       Indicates the maximum number of retries JobClient will make to
-      establish a server connection when retrieving job status and history
+      establish a service connection when retrieving job status and history
     </description>
   </property>
 
@@ -124,7 +124,7 @@
     <value>16777216</value>
     <description>
       Specifies the maximum read buffer size in bytes used by the Thrift
-      server; value should be set to greater than the maximum frame sent on
+      service; value should be set to greater than the maximum frame sent on
       the RPC channel
     </description>
   </property>
@@ -169,7 +169,8 @@
     <name>zookeeper.quorum</name>
     <value>127.0.0.1:2181/${root.namespace}</value>
     <description>
-      ZooKeeper quorum string
+      ZooKeeper quorum string; specifies the ZooKeeper host:port; substitute the quorum
+      (FQDN1:2181,FQDN2:2181,...) for the components shown here
     </description>
   </property>
 
@@ -211,7 +212,8 @@
     <name>app.artifact.dir</name>
     <value>/opt/cdap/master/artifacts</value>
     <description>
-      Semicolon-separated list of directories where all system artifacts and their corresponding config files are stored
+      Semicolon-separated list of local directories scanned for system artifacts
+      to add to the artifact repository
     </description>
   </property>
 
@@ -219,7 +221,7 @@
     <name>app.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Host address on which the app fabric server is started
+      App Fabric service bind address
     </description>
   </property>
 
@@ -313,7 +315,7 @@
     <name>data.tx.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Transaction service inet address
+      Transaction service bind address
     </description>
   </property>
 
@@ -467,7 +469,7 @@
     <name>data.tx.thrift.max.read.buffer</name>
     <value>${thrift.max.read.buffer}</value>
     <description>
-      Maximum read buffer size (in bytes) used by the transaction server;
+      Maximum read buffer size (in bytes) used by the transaction service;
       the value should be set to something greater than the maximum frame
       sent on the RPC channel
     </description>
@@ -534,7 +536,7 @@
     <name>dataset.service.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Dataset service hostname
+      Dataset service bind address
     </description>
   </property>
 
@@ -658,7 +660,7 @@
     <name>app.boss.threads</name>
     <value>1</value>
     <description>
-      Number of Netty server boss threads
+      Number of Netty service boss threads
     </description>
   </property>
 
@@ -674,7 +676,7 @@
     <name>app.exec.threads</name>
     <value>20</value>
     <description>
-      Number of Netty server executor threads
+      Number of Netty service executor threads
     </description>
   </property>
 
@@ -682,7 +684,7 @@
     <name>app.worker.threads</name>
     <value>10</value>
     <description>
-      Number of Netty server worker threads
+      Number of Netty service worker threads
     </description>
   </property>
 
@@ -693,7 +695,7 @@
     <name>kafka.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Kafka server hostname address
+      CDAP Kafka service bind address
     </description>
   </property>
 
@@ -701,7 +703,7 @@
     <name>kafka.bind.port</name>
     <value>9092</value>
     <description>
-      Kafka server bind port
+      CDAP Kafka service bind port
     </description>
   </property>
 
@@ -709,9 +711,9 @@
     <name>kafka.default.replication.factor</name>
     <value>1</value>
     <description>
-      Kafka replication factor; used to replicate Kafka messages across
+      CDAP Kafka replication factor; used to replicate Kafka messages across
       multiple machines to prevent data loss in the event of a hardware
-      failure. The recommended setting is to run at least two Kafka servers.
+      failure. The recommended setting is to run at least two CDAP Kafka servers.
       If you are running two Kafka servers, set this value to 2; otherwise,
       set it to the number of Kafka servers.
     </description>
@@ -721,7 +723,7 @@
     <name>kafka.log.dir</name>
     <value>/tmp/kafka-logs</value>
     <description>
-      Kafka log storage directory
+      CDAP Kafka service log storage directory
     </description>
   </property>
 
@@ -734,23 +736,24 @@
   </property>
 
   <property>
+    <name>kafka.seed.brokers</name>
+    <value>127.0.0.1:9092</value>
+    <description>
+      Comma-separated list of CDAP Kafka service brokers; for distributed CDAP, 
+      replace with list of FQDN:port brokers
+    </description>
+  </property>
+
+  <property>
     <name>kafka.zookeeper.namespace</name>
     <value>kafka</value>
     <description>
-      Kafka ZooKeeper namespace
+      CDAP Kafka service ZooKeeper namespace
     </description>
   </property>
 
 
   <!-- Logging Configuration -->
-
-  <property>
-    <name>kafka.seed.brokers</name>
-    <value>127.0.0.1:9092</value>
-    <description>
-      List of Kafka brokers (comma separated)
-    </description>
-  </property>
 
   <property>
     <name>log.base.dir</name>
@@ -780,7 +783,7 @@
     <name>log.publish.num.partitions</name>
     <value>10</value>
     <description>
-      Number of Kafka partitions to publish the logs to
+      Number of CDAP Kafka service partitions to publish the logs to
     </description>
   </property>
 
@@ -828,7 +831,7 @@
     <name>log.saver.status.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Default inet address for binding log saver HTTP service
+      Log Saver HTTP service bind address
     </description>
   </property>
 
@@ -839,7 +842,7 @@
     <name>http.service.boss.threads</name>
     <value>1</value>
     <description>
-      Number of Netty server boss threads for master HTTP services
+      Number of Netty service boss threads for master HTTP services
     </description>
   </property>
 
@@ -855,7 +858,7 @@
     <name>http.service.exec.threads</name>
     <value>20</value>
     <description>
-      Number of Netty server executor threads for master HTTP services
+      Number of Netty service executor threads for master HTTP services
     </description>
   </property>
 
@@ -863,7 +866,7 @@
     <name>http.service.worker.threads</name>
     <value>10</value>
     <description>
-      Number of Netty server worker threads for master HTTP services
+      Number of Netty service worker threads for master HTTP services
     </description>
   </property>
 
@@ -934,7 +937,7 @@
     <name>metadata.service.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Default inet address for binding metadata HTTP service
+      Metadata HTTP service bind address
     </description>
   </property>
 
@@ -942,7 +945,7 @@
     <name>metadata.service.exec.threads</name>
     <value>${http.service.exec.threads}</value>
     <description>
-      Number of Netty server executor threads for metadata HTTP service
+      Number of Netty service executor threads for metadata HTTP service
     </description>
   </property>
 
@@ -950,7 +953,7 @@
     <name>metadata.service.worker.threads</name>
     <value>${http.service.worker.threads}</value>
     <description>
-      Number of Netty server IO worker threads for metadata HTTP service
+      Number of Netty service IO worker threads for metadata HTTP service
     </description>
   </property>
 
@@ -958,7 +961,7 @@
     <name>metadata.updates.kafka.broker.list</name>
     <value>127.0.0.1:${kafka.bind.port}</value>
     <description>
-      Kafka broker list to which metadata update notifications are published
+      CDAP Kafka service broker list to which metadata update notifications are published
     </description>
   </property>
 
@@ -966,7 +969,7 @@
     <name>metadata.updates.kafka.topic</name>
     <value>cdap-metadata-updates</value>
     <description>
-      Kafka topic to which metadata update notifications are published
+      CDAP Kafka service topic to which metadata update notifications are published
     </description>
   </property>
 
@@ -988,7 +991,7 @@
     <name>metrics.boss.threads</name>
     <value>${http.service.boss.threads}</value>
     <description>
-      Number of Netty server boss threads for metrics HTTP services
+      Number of Netty service boss threads for metrics HTTP services
     </description>
   </property>
 
@@ -1047,7 +1050,7 @@
     <name>metrics.dataset.hbase.stats.report.interval</name>
     <value>60</value>
     <description>
-      Report interval for hbase stats, in seconds
+      Report interval for HBase stats, in seconds
     </description>
   </property>
 
@@ -1055,7 +1058,7 @@
     <name>metrics.dataset.leveldb.stats.report.interval</name>
     <value>60</value>
     <description>
-      Report interval for leveldb stats, in seconds
+      Report interval for LevelDB stats, in seconds
     </description>
   </property>
 
@@ -1063,7 +1066,7 @@
     <name>metrics.exec.threads</name>
     <value>${http.service.exec.threads}</value>
     <description>
-      Number of Netty server executor threads for metrics HTTP services
+      Number of Netty service executor threads for metrics HTTP services
     </description>
   </property>
 
@@ -1146,7 +1149,7 @@
     <name>metrics.processor.status.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Default iNet address for binding metrics processor HTTP service
+      Metrics Processor HTTP service bind address
     </description>
   </property>
 
@@ -1154,7 +1157,7 @@
     <name>metrics.query.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Metrics query server host address
+      Metrics Query service bind address
     </description>
   </property>
 
@@ -1162,7 +1165,7 @@
     <name>metrics.query.bind.port</name>
     <value>45005</value>
     <description>
-      Metrics query server bind port
+      Metrics Query service bind port
     </description>
   </property>
 
@@ -1170,7 +1173,7 @@
     <name>metrics.worker.threads</name>
     <value>${http.service.worker.threads}</value>
     <description>
-      Number of Netty server worker threads for metrics HTTP services
+      Number of Netty service worker threads for metrics HTTP services
     </description>
   </property>
 
@@ -1193,7 +1196,7 @@
     <name>notification.transport.system</name>
     <value>kafka</value>
     <description>
-      Transport system used by the notification system; can be either kafka or stream
+      Transport system used by the notification system; can be either 'kafka' or 'stream'
     </description>
   </property>
 
@@ -1233,7 +1236,7 @@
     <name>router.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Router server address
+      CDAP Router service bind address
     </description>
   </property>
 
@@ -1241,26 +1244,26 @@
     <name>router.bind.port</name>
     <value>10000</value>
     <description>
-      Port number that the CDAP Router should bind to for HTTP connections
+      CDAP Router service bind port
     </description>
   </property>
 
   <property>
     <name>router.client.boss.threads</name>
     <value>1</value>
-    <description>The number of boss threads in the router client</description>
+    <description>The number of boss threads in the CDAP Router service client</description>
   </property>
 
   <property>
     <name>router.client.worker.threads</name>
     <value>10</value>
-    <description>The number of worker threads in the router client</description>
+    <description>The number of worker threads in the CDAP Router service client</description>
   </property>
 
   <property>
     <name>router.connection.backlog</name>
     <value>20000</value>
-    <description>The connection backlog in the CDAP Router</description>
+    <description>The connection backlog in the CDAP Router service</description>
   </property>
 
   <property>
@@ -1272,30 +1275,38 @@
   </property>
 
   <property>
+    <name>router.server.address</name>
+    <value>127.0.0.1</value>
+    <description>
+      CDAP Router service address to which CDAP UI connects
+    </description>
+  </property>
+
+  <property>
     <name>router.server.boss.threads</name>
     <value>1</value>
-    <description>The number of boss threads in the CDAP Router</description>
+    <description>The number of boss threads in the CDAP Router service</description>
   </property>
 
   <property>
     <name>router.server.port</name>
     <value>${router.bind.port}</value>
     <description>
-      Router port to which CDAP UI connects
+      CDAP Router service port to which CDAP UI connects
     </description>
   </property>
 
   <property>
     <name>router.server.worker.threads</name>
     <value>10</value>
-    <description>The number of worker threads in the CDAP Router</description>
+    <description>The number of worker threads in the CDAP Router service</description>
   </property>
 
   <property>
     <name>router.ssl.bind.port</name>
     <value>10443</value>
     <description>
-      Port number that the CDAP Router should bind to for HTTPS connections
+      CDAP Router service bind port for HTTPS
     </description>
   </property>
 
@@ -1310,7 +1321,7 @@
     <name>router.ssl.webapp.bind.port</name>
     <value>20443</value>
     <description>
-      Secure router listening port for webapp
+      CDAP Router service bind port for webapp for HTTPS (deprecated)
     </description>
   </property>
 
@@ -1318,7 +1329,7 @@
     <name>router.webapp.bind.port</name>
     <value>20000</value>
     <description>
-      Router listening port for webapp
+      CDAP Router service bind port for webapp (deprecated)
     </description>
   </property>
 
@@ -1326,7 +1337,7 @@
     <name>router.webapp.enabled</name>
     <value>false</value>
     <description>
-      Determines if the webapp listening service should be started at the CDAP Router
+      Determines if the webapp listening service should be started (deprecated)
     </description>
   </property>
 
@@ -1337,7 +1348,7 @@
     <name>cdap.master.kerberos.keytab</name>
     <value></value>
     <description>
-      The full path to the Kerberos keytab file containing the CDAP Master's
+      The full path to the Kerberos keytab file containing the CDAP Master service's
       credentials
     </description>
   </property>
@@ -1347,7 +1358,7 @@
     <value></value>
     <description>
       Example: "CDAP_PRINCIPAL/_HOST@EXAMPLE.COM". The Kerberos primary user
-      that should be used to login to the CDAP Master process. Substitute
+      that should be used to login to the CDAP Master service. Substitute
       the Kerberos primary (user) for CDAP_PRINCIPAL, and your domain for
       EXAMPLE.COM. The string "_HOST" will be substituted with the local
       hostname.
@@ -1366,7 +1377,7 @@
     <name>security.auth.server.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      IP address that the CDAP Authentication Server should bind to
+      CDAP Authentication service bind address
     </description>
   </property>
 
@@ -1374,7 +1385,7 @@
     <name>security.auth.server.bind.port</name>
     <value>10009</value>
     <description>
-      Port that the CDAP Authentication Server should bind to
+      CDAP Authentication service bind port
     </description>
   </property>
 
@@ -1382,7 +1393,7 @@
     <name>security.auth.server.ssl.bind.port</name>
     <value>10010</value>
     <description>
-      Port to bind to for HTTPS on the CDAP Authentication Server
+      CDAP Authentication service bind port for HTTPS
     </description>
   </property>
 
@@ -1461,7 +1472,7 @@
     <name>security.server.maxthreads</name>
     <value>100</value>
     <description>
-      Maximum number of threads that the CDAP Authentication Server should
+      Maximum number of threads that the CDAP Authentication service should
       use for handling HTTP requests
     </description>
   </property>
@@ -1539,7 +1550,7 @@
     <name>stream.async.queue.size</name>
     <value>100</value>
     <description>
-      Queue size per async worker thread for queuing up async write request
+      Queue size per async worker thread for queuing up async write requests
     </description>
   </property>
 
@@ -1547,7 +1558,7 @@
     <name>stream.async.worker.threads</name>
     <value>${stream.worker.threads}</value>
     <description>
-      Number of async worker threads for handling async write request
+      Number of async worker threads for handling async write requests
     </description>
   </property>
 
@@ -1572,7 +1583,7 @@
     <name>stream.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Default inet address for binding stream HTTP service
+      Stream HTTP service bind address
     </description>
   </property>
 
@@ -1588,8 +1599,8 @@
     <name>stream.container.instance.id</name>
     <value>0</value>
     <description>
-      Instance ID for stream service container. The actual value will be set
-      at runtime by the system automatically.
+      Instance ID for the stream service container; the actual value will be set
+      at runtime by the system automatically
     </description>
   </property>
 
@@ -1597,7 +1608,8 @@
     <name>stream.container.instances</name>
     <value>1</value>
     <description>
-      Number of YARN container instances for the stream handler
+      Number of YARN container instances for the stream handler; 
+      in standalone mode, it's always one
     </description>
   </property>
 
@@ -1632,7 +1644,7 @@
     <name>stream.file.cleanup.period</name>
     <value>300000</value>
     <description>
-      How often to run stream file cleanup process in milliseconds
+      Default time interval in milliseconds for running the stream file cleanup process
     </description>
   </property>
 
@@ -1719,8 +1731,8 @@
     <name>dashboard.router.check.timeout.secs</name>
     <value>0</value>
     <description>
-      Amount of time, in seconds, CDAP UI waits before exiting when unable to connect to CDAP Router on startup.
-      Use timeout as 0 to wait indefinitely.
+      Amount of time, in seconds, CDAP UI waits before exiting when unable to connect to
+      CDAP Router service on startup; use a timeout of 0 to wait indefinitely
     </description>
   </property>
 
@@ -1740,12 +1752,5 @@
     </description>
   </property>
 
-  <property>
-    <name>router.server.address</name>
-    <value>127.0.0.1</value>
-    <description>
-      Router address to which CDAP UI connects
-    </description>
-  </property>
 
 </configuration>

--- a/cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml.example
+++ b/cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml.example
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2014-2015 Cask Data, Inc.
+  Copyright © 2014-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -50,43 +50,8 @@
     <name>zookeeper.quorum</name>
     <value>FQDN1:2181,FQDN2:2181/${root.namespace}</value>
     <description>
-      ZooKeeper quorum string; specifies the ZooKeeper host:port; 
-      substitute the quorum for the components shown here (FQDN1:2181,FQDN2:2181)
-    </description>
-  </property>
-
-
-  <!-- Router Configuration -->
-
-  <property>
-    <name>router.bind.address</name>
-    <value>0.0.0.0</value>
-    <description>
-      Router server address
-    </description>
-  </property>
-  
-  <property>
-    <name>router.bind.port</name>
-    <value>10000</value>
-    <description>
-      Port number that the CDAP router should bind to for HTTP connections
-    </description>
-  </property>
-
-  <property>
-    <name>router.server.address</name>
-    <value>{ROUTER-HOST-IP}</value>
-    <description>
-      Router address to which CDAP UI connects
-    </description>
-  </property>
-
-  <property>
-    <name>router.server.port</name>
-    <value>${router.bind.port}</value>
-    <description>
-      Router port to which CDAP UI connects
+      ZooKeeper quorum string; specifies the ZooKeeper host:port; substitute the quorum
+      (FQDN1:2181,FQDN2:2181,...) for the components shown here
     </description>
   </property>
 
@@ -97,7 +62,7 @@
     <name>app.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Host address on which the app fabric server is started
+      App Fabric service bind address
     </description>
   </property>
 
@@ -108,7 +73,7 @@
     <name>data.tx.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Transaction service inet address
+      Transaction service bind address
     </description>
   </property>
 
@@ -119,9 +84,9 @@
     <name>kafka.default.replication.factor</name>
     <value>1</value>
     <description>
-      Kafka replication factor; used to replicate Kafka messages across
+      CDAP Kafka replication factor; used to replicate Kafka messages across
       multiple machines to prevent data loss in the event of a hardware
-      failure. The recommended setting is to run at least two Kafka servers.
+      failure. The recommended setting is to run at least two CDAP Kafka servers.
       If you are running two Kafka servers, set this value to 2; otherwise,
       set it to the number of Kafka servers.
     </description>
@@ -131,7 +96,7 @@
     <name>kafka.log.dir</name>
     <value>/tmp/kafka-logs</value>
     <description>
-      Kafka log storage directory
+      CDAP Kafka service log storage directory
     </description>
   </property>
 
@@ -139,7 +104,8 @@
     <name>kafka.seed.brokers</name>
     <value>FQDN1:9092,FQDN2:9092</value>
     <description>
-      List of Kafka brokers (comma separated, replace with correct values)
+      Comma-separated list of CDAP Kafka service brokers; for distributed CDAP, 
+      replace with list of FQDN:port brokers
     </description>
   </property>
 
@@ -150,7 +116,42 @@
     <name>metrics.query.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Metrics query server host address
+      Metrics Query service bind address
+    </description>
+  </property>
+
+
+  <!-- Router Configuration -->
+
+  <property>
+    <name>router.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      CDAP Router service bind address
+    </description>
+  </property>
+  
+  <property>
+    <name>router.bind.port</name>
+    <value>10000</value>
+    <description>
+      CDAP Router service bind port
+    </description>
+  </property>
+
+  <property>
+    <name>router.server.address</name>
+    <value>{ROUTER-HOST-IP}</value>
+    <description>
+      CDAP Router service address to which CDAP UI connects
+    </description>
+  </property>
+
+  <property>
+    <name>router.server.port</name>
+    <value>${router.bind.port}</value>
+    <description>
+      CDAP Router service port to which CDAP UI connects
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="71b21130534c3c1ee40fe5c5145cc96f"
+DEFAULT_XML_MD5_HASH="e78cb5584b744dede3e08d1464181183"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"
@@ -41,7 +41,7 @@ function download_includes() {
   test_an_include "${DEFAULT_XML_MD5_HASH}" "${DEFAULT_XML}"
 
   echo "Building rst file from cdap-default.xml..." 
-  python "${DEFAULT_TOOL}" -g -t "${target_includes_dir}/${DEFAULT_RST}"
+  python "${DEFAULT_TOOL}" --generate --target "${target_includes_dir}/${DEFAULT_RST}"
   
   echo "Copying files, changing references..."
   local source_rst="${target_includes_dir}/../../source/_includes/installation"

--- a/cdap-docs/tools/cdap-default-exclusions.txt
+++ b/cdap-docs/tools/cdap-default-exclusions.txt
@@ -1,2 +1,5 @@
 metrics.query.bind.address
 router.ssl.server.port
+router.ssl.webapp.bind.port
+router.webapp.bind.port
+router.webapp.enabled

--- a/cdap-docs/tools/cdap-xml-files.txt
+++ b/cdap-docs/tools/cdap-xml-files.txt
@@ -1,0 +1,8 @@
+# Line starting with a # or space are ignored
+
+cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml.example
+cdap-examples/Purchase/src/test/resources/cdap-site.xml
+cdap-standalone/src/main/resources/cdap-site.xml
+
+https://raw.githubusercontent.com/caskdata/cdap-ambari-service/develop/configuration/cdap-site.xml
+https://raw.githubusercontent.com/caskdata/cm_csd/develop/src/descriptor/service.sdl

--- a/cdap-examples/Purchase/src/test/resources/cdap-site.xml
+++ b/cdap-examples/Purchase/src/test/resources/cdap-site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  ~ Copyright © 2015 Cask Data, Inc.
+  ~ Copyright © 2015-2016 Cask Data, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
   ~ use this file except in compliance with the License. You may obtain a copy of
@@ -20,7 +20,10 @@
   <property>
     <name>stream.notification.threshold</name>
     <value>1</value>
-    <description>Default size of data, in MB, to be ingested by a Stream before a notification is published</description>
+    <description>
+      Size of data, in megabytes, to be ingested by a stream before a
+      notification is published
+    </description>
   </property>
 
 </configuration>

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -14,106 +14,127 @@
   the License.
   -->
 <configuration>
-    <!--
-       Metrics Configuration
-     -->
-    <property>
-        <name>metrics.data.table.retention.resolution.1.seconds</name>
-        <value>7200</value>
-        <description>Retention resolution 1 sec table (in seconds)</description>
-    </property>
 
-    <!--
-        Data Fabric configuration
-    -->
-    <property>
-        <name>data.local.storage.blocksize</name>
-        <value>1024</value>
-        <description>Specifies block size (in bytes)</description>
-    </property>
+  <!-- Global Configuration -->
 
-    <property>
-        <name>data.local.storage.cachesize</name>
-        <value>104857600</value>
-        <description>Specifies cache size (in bytes)</description>
-    </property>
+  <property>
+    <name>enable.unrecoverable.reset</name>
+    <value>true</value>
+    <description>
+      Determines if resetting CDAP should be enabled. **WARNING: Enabling
+      this option makes it possible to delete all applications and data; NO
+      RECOVERY IS POSSIBLE!**
+    </description>
+  </property>
 
-    <!--
-        Router configuration
-    -->
-    <property>
-        <name>router.address</name>
-        <value>127.0.0.1</value>
-        <description>Specifies a common address for both router and UI to bind to</description>
-    </property>
 
-    <property>
-        <name>router.bind.address</name>
-        <value>0.0.0.0</value>
-        <description>Specifies the address for router server to bind to</description>
-    </property>
+  <!-- Applications Configuration -->
+  
+  <property>
+    <name>app.artifact.dir</name>
+    <value>artifacts</value>
+    <description>
+      Semicolon-separated list of local directories scanned for system artifacts
+      to add to the artifact repository
+    </description>
+  </property>
 
-    <property>
-        <name>router.forward.rule</name>
-        <value>10000:gateway,20000:webapp/$HOST</value>
-        <description>Forward rules for router (port:service -> forward port to service)</description>
-    </property>
 
-    <property>
-        <name>router.server.address</name>
-        <value>${router.address}</value>
-        <description>Specifies the address of the router for the UI to bind to</description>
-    </property>
+  <!-- Datasets Configuration -->
+  
+  <property>
+    <name>data.local.storage.blocksize</name>
+    <value>1024</value>
+    <description>
+      Block size in bytes for data fabric when in standalone mode
+    </description>
+  </property>
 
-    <!--
-        Logging Configuration
-    -->
-    <property>
-        <name>log.publish.num.partitions</name>
-        <value>1</value>
-        <description>Number of Kafka partitions to publish the logs to</description>
-    </property>
+  <property>
+    <name>data.local.storage.cachesize</name>
+    <value>104857600</value>
+    <description>
+      Cache size in bytes for data fabric when in standalone mode
+    </description>
+  </property>
 
-    <property>
-        <name>log.base.dir</name>
-        <value>logs/avro</value>
-        <description>Base log directory</description>
-    </property>
 
-    <property>
-        <name>log.retention.duration.days</name>
-        <value>7</value>
-        <description>Log file retention duration (in days)</description>
-    </property>
+  <!-- Logging Configuration -->
+  
+  <property>
+    <name>log.base.dir</name>
+    <value>logs/avro</value>
+    <description>
+      Base log directory
+    </description>
+  </property>
 
-    <property>
-        <name>enable.unrecoverable.reset</name>
-        <value>true</value>
-        <description>
-            WARNING! - Enabling this option enables the deletion of all applications and data.
-            No recovery is possible!
-        </description>
-    </property>
+  <property>
+    <name>log.publish.num.partitions</name>
+    <value>1</value>
+    <description>
+      Number of CDAP Kafka service partitions to publish the logs to
+    </description>
+  </property>
 
-    <!--
-        Stream configuration
-    -->
-    <property>
-        <name>stream.container.instances</name>
-        <value>1</value>
-        <description>Number of stream writer instance. In local mode, it's always one</description>
-    </property>
+  <property>
+    <name>log.retention.duration.days</name>
+    <value>7</value>
+    <description>
+      Log file HDFS retention duration in days
+    </description>
+  </property>
 
-    <!--
-        Artifact configuration
-    -->
-    <property>
-        <name>app.artifact.dir</name>
-        <value>artifacts</value>
-        <description>
-            Semicolon-separated list of directories where all system artifacts and
-            their corresponding config files are stored
-        </description>
-    </property>
+
+  <!-- Metrics Configuration -->
+  
+  <property>
+    <name>metrics.data.table.retention.resolution.1.seconds</name>
+    <value>7200</value>
+    <description>
+      Retention resolution of the 1-second resolution table in seconds;
+      default retention period is 2 hours
+    </description>
+  </property>
+
+
+  <!-- Router Configuration -->
+  
+  <property>
+    <name>router.address</name>
+    <value>127.0.0.1</value>
+    <description>
+      CDAP Router service address to which CDAP UI connects (deprecated; use router.server.address directly)
+    </description>
+  </property>
+
+  <property>
+    <name>router.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      CDAP Router service bind address
+    </description>
+  </property>
+
+  <property>
+    <name>router.server.address</name>
+    <value>${router.address}</value>
+    <description>
+      CDAP Router service address to which CDAP UI connects
+    </description>
+  </property>
+
+
+  <!-- Stream Configuration -->
+  
+  <property>
+    <name>stream.container.instances</name>
+    <value>1</value>
+    <description>
+      Number of YARN container instances for the stream handler; 
+      in standalone mode, it's always one
+    </description>
+  </property>
+
 
 </configuration>


### PR DESCRIPTION
Addresses https://issues.cask.co/browse/CDAP-4803 (update description for app.artifact.dir)

Passes [Quick Build 6](http://builds.cask.co/browse/CDAP-DOB103-6)

Updates 
- cdap-common/src/main/resources/cdap-default.xml
- cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml.example
- cdap-examples/Purchase/src/test/resources/cdap-site.xml
- cdap-standalone/src/main/resources/cdap-site.xml

The Documentation Tool (cdap-docs/tools/doc-cdap-default.py) has a new option, "-a", that compares all the files or URLs listed in the file ``cdap-docs/tools/cdap-xml-files.txt`` against the default (cdap-default.xml) and publishes to standard out a report detailing any differences in the descriptions that it finds. It identified a number of properties that are only in the other sources, plus differences in the descriptions.

Fixed formatting issues and two spelling mistakes in the default file.

Added code to the formatter for the documentation to break long lines (if possible) after 40 characters so the table maintains a consistent width down the page. See the revised appendix, where properties and values are sometime split at a period:

Revised Appendices: http://builds.cask.co/artifact/CDAP-DOB103/shared/build-6/Docs-HTML/3.3.1-SNAPSHOT/en/admin-manual/appendices/cdap-site.html