### PR TITLE
Mark connection strings so they don't format as links in HTML.

### DIFF
--- a/cdap-docs/cdap-apps/source/hydrator/creating.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/creating.rst
@@ -499,7 +499,7 @@ Sample Application Configurations
             "properties": {
               "importQuery": "select id,name,age from my_table",
               "countQuery": "select count(id) from my_table",
-              "connectionString": "jdbc:mysql://localhost:3306/test",
+              "connectionString": "\jdbc:mysql://localhost:3306/test",
               "tableName": "src_table",
               "user": "my_user",
               "password": "my_password",
@@ -515,7 +515,7 @@ Sample Application Configurations
               "name": "Database",
               "properties": {
                 "columns": "id,name,age",
-                "connectionString": "jdbc:mysql://localhost:3306/test",
+                "connectionString": "\jdbc:mysql://localhost:3306/test",
                 "tableName": "dest_table",
                 "user": "my_user",
                 "password": "my_password",


### PR DESCRIPTION
Fixes two connection strings that were buried in literal text yet being formatted as links.

[Passes Quick Build](http://builds.cask.co/browse/CDAP-DOB104-1)

Original page: [CDAP Hydrator](http://docs.cask.co/cdap/current/en/cdap-apps/hydrator/creating.html)

Revised page: [CDAP Hydrator](http://builds.cask.co/artifact/CDAP-DOB104/shared/build-1/Docs-HTML/3.3.1-SNAPSHOT/en/cdap-apps/hydrator/creating.html#sample-application-configurations)