### PR TITLE
Feature/ui fix hydrator params resource

### DIFF
--- a/cdap-ui/app/features/admin/controllers/namespace/templates-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/templates-ctrl.js
@@ -147,10 +147,11 @@ angular.module(PKG.name + '.feature.admin')
       var artifact = {
         name: vm.plugin.artifact.name,
         version: vm.plugin.artifact.version,
+        scope: vm.plugin.artifact.scope,
         key: 'widgets.' + vm.plugin.name + '-' + vm.plugin.type
       };
 
-      PluginConfigFactory.fetchWidgetJson(artifact.name, artifact.version, artifact.key)
+      PluginConfigFactory.fetchWidgetJson(artifact.name, artifact.version, artifact.scope, artifact.key)
         .then(function success (res) {
 
           vm.configFetched = true;

--- a/cdap-ui/app/features/hydrator/controllers/create/canvas-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/canvas-ctrl.js
@@ -69,6 +69,7 @@ class HydratorCreateCanvasController {
       pluginNode = nodeFromNodesStore[0];
     }
     this.PipelineNodeConfigActionFactory.choosePlugin(pluginNode);
+    this.setStateAndUpdateConfigStore();
   }
 
   deleteNode() {

--- a/cdap-ui/app/features/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/leftpanel-ctrl.js
@@ -73,7 +73,7 @@ class LeftPanelController {
     event.stopPropagation();
     var item = this.LeftPanelStore.getSpecificPluginVersion(node);
     this.NodesActionsFactory.resetSelectedNode();
-    this.LeftPanelStore.updatePluginDefaultVersion(node);
+    this.LeftPanelStore.updatePluginDefaultVersion(item);
 
     let name = item.name || item.pluginTemplate;
 

--- a/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -98,9 +98,11 @@ class NodeConfigController {
     if (this.state.noproperty) {
       var artifactName = this.myHelpers.objectQuery(this.state.node, 'plugin', 'artifact', 'name');
       var artifactVersion = this.myHelpers.objectQuery(this.state.node, 'plugin', 'artifact', 'version');
+      var artifactScope = this.myHelpers.objectQuery(this.state.node, 'plugin', 'artifact', 'scope');
       this.PluginConfigFactory.fetchWidgetJson(
         artifactName,
         artifactVersion,
+        artifactScope,
         `widgets.${this.state.node.plugin.name}-${this.state.node.type}`
       )
         .then(

--- a/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
@@ -402,6 +402,9 @@ class ConfigStore {
           // the user should directly click on the last node and see what is the incoming schema
           // without having to open the subsequent nodes.
           nodesWOutBackendProps.forEach( n => {
+            // This could happen when the user doesn't provide an artifact information for a plugin & deploys it
+            // using CLI or REST and opens up in UI and clones it. Without this check it will throw a JS error.
+            if (!n.plugin.artifact) { return; }
             this.PluginConfigFactory.fetchWidgetJson(
               n.plugin.artifact.name,
               n.plugin.artifact.version,

--- a/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydrator/services/create/stores/config-store.js
@@ -405,6 +405,7 @@ class ConfigStore {
             this.PluginConfigFactory.fetchWidgetJson(
               n.plugin.artifact.name,
               n.plugin.artifact.version,
+              n.plugin.artifact.scope,
               `widgets.${n.plugin.name}-${n.type}`
             ).then(parseNodeConfig.bind(null, n));
           });

--- a/cdap-ui/app/features/hydrator/services/create/stores/left-panel-store.js
+++ b/cdap-ui/app/features/hydrator/services/create/stores/left-panel-store.js
@@ -32,8 +32,8 @@ var updateDefaultVersion = (pluginsList, defaultVersionMap = {}) => {
   }
   pluginsList.forEach((plugin) => {
     let key = `${plugin.name}-${plugin.type}-${plugin.artifact.name}`;
-    if(defaultVersionMap.hasOwnProperty(key)) {
-      plugin.defaultVersion = defaultVersionMap[key];
+    if(defaultVersionMap[plugin.artifact.scope].hasOwnProperty(key)) {
+      plugin.defaultVersion = defaultVersionMap[plugin.artifact.scope][key];
     }
   });
 };
@@ -44,7 +44,7 @@ var mapPluginsWithMoreInfo = (type, typeMap, MyDAGFactory, popoverTemplate) => {
     plugin.icon = MyDAGFactory.getIcon(plugin.name);
     plugin.template = popoverTemplate;
     plugin.defaultVersion = typeMap[plugin.name][0].artifact.version;
-    plugin.allVersions = typeMap[plugin.name].map( (plugin) => plugin.artifact.version);
+    plugin.allArtifacts = typeMap[plugin.name].map( (plugin) => plugin.artifact);
     return plugin;
   };
 };
@@ -174,7 +174,7 @@ class LeftPanelStore {
     }
   }
   updatePluginDefaultVersion(plugin) {
-    var key = `${plugin.name}-${plugin.type}-${plugin.artifact.name}`;
+    var key = `${plugin.name}-${plugin.type}-${plugin.artifact.name}-${plugin.artifact.scope}`;
     if (this.state.defaultVersionsMap.hasOwnProperty(key)) {
       if (this.state.defaultVersionsMap[key] !== plugin.defaultVersion) {
         this.state.defaultVersionsMap[key] = plugin.defaultVersion;

--- a/cdap-ui/app/features/hydrator/services/create/stores/left-panel-store.js
+++ b/cdap-ui/app/features/hydrator/services/create/stores/left-panel-store.js
@@ -239,10 +239,11 @@ class LeftPanelStore {
       angular.forEach(defaultVersionsMap, (pluginArtifact, pluginKey) => {
         delete this.state.defaultVersionsMap[pluginKey];
       });
+      let pipelineType = this.ConfigStore.getAppType();
       this.mySettings.set('plugin-default-version', this.state.defaultVersionsMap);
-      this.setSources(this.state.plugins.sources);
-      this.setSinks(this.state.plugins.sinks);
-      this.setTransforms(this.state.plugins.transforms);
+      this.setSources(this.state.plugins.sources, this.GLOBALS.pluginTypes[pipelineType]['source']);
+      this.setSinks(this.state.plugins.sinks, this.GLOBALS.pluginTypes[pipelineType]['sink']);
+      this.setTransforms(this.state.plugins.transforms, this.GLOBALS.pluginTypes[pipelineType]['transform']);
     }
   }
 

--- a/cdap-ui/app/features/hydrator/services/hydrator-service.js
+++ b/cdap-ui/app/features/hydrator/services/hydrator-service.js
@@ -84,12 +84,12 @@ class HydratorService {
       extensionType: node.type,
       pluginName: node.plugin.name
     };
-
+    let nodeArtifact = node.plugin.artifact;
     return this.myPipelineApi.fetchPluginProperties(params)
       .$promise
-      .then(function(res) {
-
-        var pluginProperties = (res.length? res[0].properties: {});
+      .then(function(res = []) {
+        let match = res.filter(plug => angular.equals(plug.artifact, nodeArtifact));
+        var pluginProperties = (match.length? match[0].properties: {});
         if (res.length && (!node.description || (node.description && !node.description.length))) {
           node.description = res[0].description;
         }

--- a/cdap-ui/app/features/hydrator/services/hydrator-service.js
+++ b/cdap-ui/app/features/hydrator/services/hydrator-service.js
@@ -80,7 +80,7 @@ class HydratorService {
     var params = {
       namespace: this.$state.params.namespace,
       pipelineType: appType,
-      version: (node.artifact && node.artifact.version ) || this.$rootScope.cdapVersion,
+      version: this.$rootScope.cdapVersion,
       extensionType: node.type,
       pluginName: node.plugin.name
     };

--- a/cdap-ui/app/features/hydrator/services/plugin-config-factory.js
+++ b/cdap-ui/app/features/hydrator/services/plugin-config-factory.js
@@ -21,8 +21,8 @@ class PluginConfigFactory {
     this.$state = $state;
     this.data = {};
   }
-  fetchWidgetJson(artifactName, artifactVersion, key) {
-    let cache = this.data[`${artifactName}-${artifactVersion}-${key}`];
+  fetchWidgetJson(artifactName, artifactVersion, artifactScope, key) {
+    let cache = this.data[`${artifactName}-${artifactVersion}-${artifactScope}-${key}`];
     if (cache) {
       return this.$q.when(cache);
     }
@@ -31,6 +31,7 @@ class PluginConfigFactory {
       namespace: this.$state.params.namespace || this.$state.params.nsadmin,
       artifactName,
       artifactVersion,
+      scope: artifactScope,
       keys: key
     })
       .$promise

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/leftpanel-plugin-popover.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/leftpanel-plugin-popover.html
@@ -32,7 +32,7 @@
     <li class="list-group-item">
       <h6>
         {{contentData.defaultVersion}}
-        <small ng-if="!contentData.showAllVersion && contentData.allVersions.length > 1">
+        <small ng-if="!contentData.showAllVersion && contentData.allArtifacts.length > 1">
           <a href="#" ng-click="contentData.showAllVersion = !contentData.showAllVersion">Change</a>
         </small>
       </h6>
@@ -44,10 +44,10 @@
     <a  ng-if="contentData.showAllVersion"
         href="#"
         class="list-group-item"
-        ng-repeat="version in contentData.allVersions track by $index"
+        ng-repeat="artifact in contentData.allArtifacts track by $index"
         ng-class="{'active': version === contentData.defaultVersion}"
-        ng-click="(contentData.defaultVersion = version) && delayClose(1) && popoverContext.onItemClicked($event, contentData)">
-      {{::version}}
+        ng-click="(contentData.defaultVersion = artifact.version) && delayClose(1) && popoverContext.onItemClicked($event, contentData)">
+      {{::artifact.version}}
     </a>
   </ul>
 </div>

--- a/cdap-ui/app/features/hydrator/templates/create/popovers/leftpanel-plugin-popover.html
+++ b/cdap-ui/app/features/hydrator/templates/create/popovers/leftpanel-plugin-popover.html
@@ -31,7 +31,7 @@
     </li>
     <li class="list-group-item">
       <h6>
-        {{contentData.defaultVersion}}
+        {{contentData.defaultArtifact['version']}}
         <small ng-if="!contentData.showAllVersion && contentData.allArtifacts.length > 1">
           <a href="#" ng-click="contentData.showAllVersion = !contentData.showAllVersion">Change</a>
         </small>
@@ -45,8 +45,8 @@
         href="#"
         class="list-group-item"
         ng-repeat="artifact in contentData.allArtifacts track by $index"
-        ng-class="{'active': version === contentData.defaultVersion}"
-        ng-click="(contentData.defaultVersion = artifact.version) && delayClose(1) && popoverContext.onItemClicked($event, contentData)">
+        ng-class="{'active': artifact.version === contentData.defaultArtifact.version}"
+        ng-click="(contentData.defaultArtifact = artifact) && delayClose(1) && popoverContext.onItemClicked($event, contentData)">
       {{::artifact.version}}
     </a>
   </ul>

--- a/cdap-ui/app/main.js
+++ b/cdap-ui/app/main.js
@@ -129,7 +129,7 @@ angular
         if (config.options) {
           // Can/Should make use of my<whatever>Api service in another service.
           // So in that case the service will not have a scope. Hence the check
-          if (config.params && config.params.scope) {
+          if (config.params && config.params.scope && angular.isObject(config.params.scope)) {
             myDataSrc = MyCDAPDataSource(config.params.scope);
             delete config.params.scope;
           } else {

--- a/cdap-ui/app/services/hydrator/my-pipeline-api.js
+++ b/cdap-ui/app/services/hydrator/my-pipeline-api.js
@@ -24,7 +24,7 @@ angular.module(PKG.name + '.services')
         pluginFetchBase = '/namespaces/:namespace/artifacts/:pipelineType/versions/:version/extensions/:extensionType',
         pluginsFetchPath = pluginFetchBase + '?scope=system',
         pluginDetailFetch = pluginFetchBase + '/plugins/:pluginName?scope=system',
-        artifactPropertiesPath = '/namespaces/:namespace/artifacts/:artifactName/versions/:artifactVersion/properties?scope=system';
+        artifactPropertiesPath = '/namespaces/:namespace/artifacts/:artifactName/versions/:artifactVersion/properties';
 
 
     return $resource(


### PR DESCRIPTION
- Fixes ```scope``` to be passed as a parameter in ```$resource``` API. Until today we pass in the ```$scope``` as part of the resource apis we have to automatically stop the polling when the controller is destroyed. The current fix is to check if the ```scope``` property is an object. If not create a new scope for the resource API. Might not be the best way, we should come up with a way to fix this in 3.4

- Fixes UI to show USER scoped artifact plugins and fixes the default version map maintained in ```perferencestore``` to store artifact object instead of just the version as string.

Related JIRA: https://issues.cask.co/browse/CDAP-4831