### PR TITLE
DynamicPartitioner with Avro OutputFormat

### DIFF
--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -161,6 +161,31 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-service</artifactId>
     </dependency>
+    <!-- For DynamicPartitionerWithAvroTest -->
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.7.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-mapred</artifactId>
+      <classifier>hadoop2</classifier>
+      <version>1.7.7</version>
+      <scope>test</scope>
+      <exclusions>
+        <!-- to avoid conflicts with provided netty version from cdap -->
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.DynamicPartitioner;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.mapred.AvroKey;
+import org.apache.avro.mapreduce.AvroJob;
+import org.apache.avro.mapreduce.AvroKeyInputFormat;
+import org.apache.avro.mapreduce.AvroKeyOutputFormat;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * App used to test whether M/R can use DynamicPartitioner with AvroKeyOutputFormat.
+ */
+public class AppWithMapReduceUsingAvroDynamicPartitioner extends AbstractApplication {
+
+  public static final String INPUT_DATASET = "INPUT_DATASET_NAME";
+  public static final String OUTPUT_DATASET = "OUTPUT_DATASET_NAME";
+
+  static final String OUTPUT_PARTITION_KEY = "output.partition.key";
+
+  static final String SCHEMA_STRING = Schema.recordOf(
+    "record",
+    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("zip", Schema.of(Schema.Type.INT))).toString();
+
+  static final org.apache.avro.Schema SCHEMA = new org.apache.avro.Schema.Parser().parse(SCHEMA_STRING);
+
+
+  @Override
+  public void configure() {
+    setName("AppWithMapReduceUsingAvroDynamicPartitioner");
+    setDescription("Application with MapReduce job using file as dataset");
+    createDataset(INPUT_DATASET, KeyValueTable.class);
+
+    createDataset(OUTPUT_DATASET, PartitionedFileSet.class, PartitionedFileSetProperties.builder()
+      // Properties for partitioning
+      .setPartitioning(Partitioning.builder().addLongField("time").addIntField("zip").build())
+        // Properties for file set
+      .setInputFormat(AvroKeyInputFormat.class)
+      .setOutputFormat(AvroKeyOutputFormat.class)
+      .setOutputProperty("schema", SCHEMA_STRING)
+        // Properties for Explore (to create a partitioned Hive table)
+      .setEnableExploreOnCreate(true)
+      .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
+      .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
+      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
+      .setTableProperty("avro.schema.literal", SCHEMA_STRING)
+      .build());
+
+    addMapReduce(new DynamicPartitioningMapReduce());
+  }
+
+  /**
+   * Partitions the records based upon a runtime argument (time) and a field extracted from the text being written (zip)
+   */
+  public static final class TimeAndZipPartitioner extends DynamicPartitioner<AvroKey<GenericRecord>, NullWritable> {
+
+    private Long outputPartitionKey;
+
+    @Override
+    public void initialize(MapReduceTaskContext<AvroKey<GenericRecord>, NullWritable> mapReduceTaskContext) {
+      this.outputPartitionKey = Long.valueOf(mapReduceTaskContext.getRuntimeArguments().get(OUTPUT_PARTITION_KEY));
+    }
+
+    @Override
+    public PartitionKey getPartitionKey(AvroKey<GenericRecord> record, NullWritable value) {
+      return PartitionKey.builder()
+        .addLongField("time", outputPartitionKey)
+        .addIntField("zip", (int) record.datum().get("zip"))
+        .build();
+    }
+  }
+
+  /**
+   * MapReduce job that dynamically partitions records based upon the 'zip' field in the record.
+   */
+  public static final class DynamicPartitioningMapReduce extends AbstractMapReduce {
+
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      context.setInput(INPUT_DATASET);
+
+      Map<String, String> cleanRecordsArgs = new HashMap<>();
+      PartitionedFileSetArguments.setDynamicPartitioner(cleanRecordsArgs, TimeAndZipPartitioner.class);
+      context.addOutput(OUTPUT_DATASET, cleanRecordsArgs);
+
+      Job job = context.getHadoopJob();
+      job.setMapperClass(FileMapper.class);
+      job.setNumReduceTasks(0);
+
+      AvroJob.setOutputKeySchema(job, SCHEMA);
+    }
+  }
+
+  public static class FileMapper extends Mapper<byte[], byte[], AvroKey<GenericRecord>, NullWritable> {
+
+    @Override
+    protected void setup(Context context) throws IOException, InterruptedException {
+      super.setup(context);
+    }
+
+    @Override
+    public void map(byte[] key, byte[] data, Context context) throws IOException, InterruptedException {
+      JsonObject jsonObject = new JsonParser().parse(Bytes.toString(data)).getAsJsonObject();
+      GenericRecordBuilder recordBuilder = new GenericRecordBuilder(SCHEMA)
+        .set("name", jsonObject.get("name").getAsString())
+        .set("zip", jsonObject.get("zip").getAsInt());
+      GenericRecord record = recordBuilder.build();
+      context.write(new AvroKey<>(record), NullWritable.get());
+    }
+  }
+
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/DynamicPartitionerWithAvroTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/DynamicPartitionerWithAvroTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch;
+
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
+import co.cask.cdap.test.XSlowTests;
+import co.cask.tephra.TransactionAware;
+import co.cask.tephra.TransactionExecutor;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.hadoop.fs.Path;
+import org.apache.twill.filesystem.Location;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static co.cask.cdap.internal.app.runtime.batch.AppWithMapReduceUsingAvroDynamicPartitioner.INPUT_DATASET;
+import static co.cask.cdap.internal.app.runtime.batch.AppWithMapReduceUsingAvroDynamicPartitioner.OUTPUT_DATASET;
+import static co.cask.cdap.internal.app.runtime.batch.AppWithMapReduceUsingAvroDynamicPartitioner.OUTPUT_PARTITION_KEY;
+import static co.cask.cdap.internal.app.runtime.batch.AppWithMapReduceUsingAvroDynamicPartitioner.SCHEMA;
+
+@Category(XSlowTests.class)
+/**
+ * This tests that we can use DynamicPartitioner with a PartitionedFileSet using
+ * AvroKeyOutputFormat/AvroKeyValueOutputFormat.
+ */
+public class DynamicPartitionerWithAvroTest extends MapReduceRunnerTestBase {
+
+  private GenericData.Record createRecord(String name, int zip) {
+    GenericData.Record record = new GenericData.Record(SCHEMA);
+    record.put("name", name);
+    record.put("zip", zip);
+    return record;
+  }
+
+  @Test
+  public void testDynamicPartitionerWithAvro() throws Exception {
+    final ApplicationWithPrograms app = deployApp(AppWithMapReduceUsingAvroDynamicPartitioner.class);
+
+    final GenericRecord record1 = createRecord("bob", 95111);
+    final GenericRecord record2 = createRecord("sally", 98123);
+    final GenericRecord record3 = createRecord("jane", 84125);
+    final GenericRecord record4 = createRecord("john", 84125);
+
+    final long now = System.currentTimeMillis();
+    // the four records above will fall into the partitions defined by the following three keys
+    // we have four records, but only 3 have unique zip codes (which is what we partition by)
+    final PartitionKey key1 = PartitionKey.builder().addLongField("time", now).addIntField("zip", 95111).build();
+    final PartitionKey key2 = PartitionKey.builder().addLongField("time", now).addIntField("zip", 98123).build();
+    final PartitionKey key3 = PartitionKey.builder().addLongField("time", now).addIntField("zip", 84125).build();
+    final Set<PartitionKey> expectedKeys = ImmutableSet.of(key1, key2, key3);
+
+    // write a value to the input kvTable
+    final KeyValueTable kvTable = datasetCache.getDataset(INPUT_DATASET);
+    Transactions.createTransactionExecutor(txExecutorFactory, kvTable).execute(
+      new TransactionExecutor.Subroutine() {
+        @Override
+        public void apply() {
+          // the keys are not used; it matters that they're unique though
+          kvTable.write("1", record1.toString());
+          kvTable.write("2", record2.toString());
+          kvTable.write("3", record3.toString());
+          kvTable.write("4", record4.toString());
+        }
+      });
+
+
+    // run the partition writer m/r with this output partition time
+    runProgram(app, AppWithMapReduceUsingAvroDynamicPartitioner.DynamicPartitioningMapReduce.class,
+               new BasicArguments(ImmutableMap.of(OUTPUT_PARTITION_KEY, Long.toString(now))));
+
+    // this should have created a partition in the pfs
+    final PartitionedFileSet pfs = datasetCache.getDataset(OUTPUT_DATASET);
+    final Location pfsBaseLocation = pfs.getEmbeddedFileSet().getBaseLocation();
+
+    Transactions.createTransactionExecutor(txExecutorFactory, (TransactionAware) pfs).execute(
+      new TransactionExecutor.Subroutine() {
+        @Override
+        public void apply() throws IOException {
+          Map<PartitionKey, PartitionDetail> partitions = new HashMap<>();
+          for (PartitionDetail partition : pfs.getPartitions(null)) {
+            partitions.put(partition.getPartitionKey(), partition);
+          }
+          Assert.assertEquals(3, partitions.size());
+
+          Assert.assertEquals(expectedKeys, partitions.keySet());
+
+          // Check the relative path of one partition. Also check that its location = pfs base location + relativePath
+          PartitionDetail partition1 = partitions.get(key1);
+          String relativePath = partition1.getRelativePath();
+          Assert.assertEquals(Long.toString(now) + Path.SEPARATOR + Integer.toString((int) key1.getField("zip")),
+                              relativePath);
+
+          Assert.assertEquals(pfsBaseLocation.append(relativePath), partition1.getLocation());
+
+          Assert.assertEquals(ImmutableList.of(record1), readOutput(partition1.getLocation()));
+          Assert.assertEquals(ImmutableList.of(record2), readOutput(partitions.get(key2).getLocation()));
+          Assert.assertEquals(ImmutableList.of(record3, record4), readOutput(partitions.get(key3).getLocation()));
+        }
+      });
+  }
+
+  private List<GenericRecord> readOutput(Location location) throws IOException {
+    DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(SCHEMA);
+    List<GenericRecord> records = new ArrayList<>();
+    for (Location file : location.list()) {
+      if (file.getName().endsWith(".avro")) {
+        DataFileStream<GenericRecord> fileStream = new DataFileStream<>(file.getInputStream(), datumReader);
+        Iterables.addAll(records, fileStream);
+        fileStream.close();
+      }
+    }
+    return records;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch;
+
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.runtime.Arguments;
+import co.cask.cdap.app.runtime.ProgramController;
+import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
+import co.cask.cdap.data2.dataset2.SingleThreadDatasetCache;
+import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.internal.DefaultId;
+import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
+import co.cask.cdap.internal.app.runtime.AbstractListener;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
+import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.proto.DatasetSpecificationSummary;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.test.XSlowTests;
+import co.cask.tephra.TransactionExecutorFactory;
+import co.cask.tephra.TransactionManager;
+import co.cask.tephra.TransactionSystemClient;
+import co.cask.tephra.TxConstants;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import org.apache.twill.common.Threads;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+@Category(XSlowTests.class)
+/**
+ * Base class for test cases that need to run MapReduce programs.
+ */
+public class MapReduceRunnerTestBase {
+
+  private static Injector injector;
+  private static TransactionManager txService;
+
+  protected static TransactionExecutorFactory txExecutorFactory;
+  protected static DatasetFramework dsFramework;
+  protected static DynamicDatasetCache datasetCache;
+  protected static MetricStore metricStore;
+
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  protected static final Supplier<File> TEMP_FOLDER_SUPPLIER = new Supplier<File>() {
+    @Override
+    public File get() {
+      try {
+        return tmpFolder.newFolder();
+      } catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  };
+
+  @BeforeClass
+  public static void beforeClass() {
+    // Set the tx timeout to a ridiculously low value that will test that the long-running transactions
+    // actually bypass that timeout.
+    CConfiguration conf = CConfiguration.create();
+    conf.setInt(TxConstants.Manager.CFG_TX_TIMEOUT, 1);
+    conf.setInt(TxConstants.Manager.CFG_TX_CLEANUP_INTERVAL, 2);
+    injector = AppFabricTestHelper.getInjector(conf);
+    txService = injector.getInstance(TransactionManager.class);
+    txExecutorFactory = injector.getInstance(TransactionExecutorFactory.class);
+    dsFramework = injector.getInstance(DatasetFramework.class);
+    datasetCache = new SingleThreadDatasetCache(
+      new SystemDatasetInstantiator(dsFramework, MapReduceRunnerTestBase.class.getClassLoader(), null),
+      injector.getInstance(TransactionSystemClient.class),
+      NamespaceId.DEFAULT, DatasetDefinition.NO_ARGUMENTS, null, null);
+
+    metricStore = injector.getInstance(MetricStore.class);
+    txService.startAndWait();
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    txService.stopAndWait();
+  }
+
+  @After
+  public void after() throws Exception {
+    // cleanup user data (only user datasets)
+    for (DatasetSpecificationSummary spec : dsFramework.getInstances(DefaultId.NAMESPACE)) {
+      dsFramework.deleteInstance(Id.DatasetInstance.from(DefaultId.NAMESPACE, spec.getName()));
+    }
+  }
+
+  protected ApplicationWithPrograms deployApp(Class<?> appClass) throws Exception {
+    return AppFabricTestHelper.deployApplicationWithManager(appClass, TEMP_FOLDER_SUPPLIER);
+  }
+
+  protected void runProgram(ApplicationWithPrograms app, Class<?> programClass, Arguments args) throws Exception {
+    waitForCompletion(submit(app, programClass, args));
+  }
+
+  private void waitForCompletion(ProgramController controller) throws InterruptedException {
+    final CountDownLatch completion = new CountDownLatch(1);
+    controller.addListener(new AbstractListener() {
+      @Override
+      public void completed() {
+        completion.countDown();
+      }
+
+      @Override
+      public void error(Throwable cause) {
+        completion.countDown();
+      }
+    }, Threads.SAME_THREAD_EXECUTOR);
+
+    // MR tests can run for long time.
+    completion.await(5, TimeUnit.MINUTES);
+  }
+
+  protected ProgramController submit(ApplicationWithPrograms app, Class<?> programClass, Arguments userArgs)
+    throws ClassNotFoundException {
+    ProgramRunnerFactory runnerFactory = injector.getInstance(ProgramRunnerFactory.class);
+    final Program program = getProgram(app, programClass);
+    Assert.assertNotNull(program);
+    ProgramRunner runner = runnerFactory.create(ProgramRunnerFactory.Type.valueOf(program.getType().name()));
+    BasicArguments systemArgs = new BasicArguments(ImmutableMap.of(ProgramOptionConstants.RUN_ID,
+                                                                   RunIds.generate().getId()));
+
+    return runner.run(program, new SimpleProgramOptions(program.getName(), systemArgs, userArgs));
+  }
+
+  @Nullable
+  private Program getProgram(ApplicationWithPrograms app, Class<?> programClass) throws ClassNotFoundException {
+    for (Program p : app.getPrograms()) {
+      if (programClass.getCanonicalName().equals(p.getMainClass().getCanonicalName())) {
+        return p;
+      }
+    }
+    return null;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,6 @@ package co.cask.cdap.internal.app.runtime.batch;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.common.Scope;
-import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.lib.Partition;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
@@ -30,54 +29,20 @@ import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.app.program.Program;
-import co.cask.cdap.app.runtime.Arguments;
-import co.cask.cdap.app.runtime.ProgramController;
-import co.cask.cdap.app.runtime.ProgramRunner;
-import co.cask.cdap.common.app.RunIds;
-import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
-import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
-import co.cask.cdap.data2.dataset2.SingleThreadDatasetCache;
 import co.cask.cdap.data2.transaction.Transactions;
-import co.cask.cdap.internal.AppFabricTestHelper;
-import co.cask.cdap.internal.DefaultId;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
-import co.cask.cdap.internal.app.runtime.AbstractListener;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
-import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
-import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
-import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
-import co.cask.cdap.proto.DatasetSpecificationSummary;
-import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
-import co.cask.tephra.TransactionExecutorFactory;
-import co.cask.tephra.TransactionManager;
-import co.cask.tephra.TransactionSystemClient;
-import co.cask.tephra.TxConstants;
-import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import com.google.inject.Injector;
-import org.apache.twill.common.Threads;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 
-import java.io.IOException;
 import java.text.DateFormat;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static co.cask.cdap.internal.app.runtime.batch.AppWithPartitionedFileSet.PARTITIONED;
@@ -90,65 +55,12 @@ import static co.cask.cdap.internal.app.runtime.batch.AppWithTimePartitionedFile
  * or that its partitions are registered correctly in the Hive meta store. That is because here in the
  * app-fabric tests, explore is disabled.
  */
-public class MapReduceWithPartitionedTest {
-
-  private static Injector injector;
-  private static TransactionExecutorFactory txExecutorFactory;
-
-  private static TransactionManager txService;
-  private static DatasetFramework dsFramework;
-  private static DynamicDatasetCache datasetCache;
-
-  @ClassRule
-  public static TemporaryFolder tmpFolder = new TemporaryFolder();
-
-  private static final Supplier<java.io.File> TEMP_FOLDER_SUPPLIER = new Supplier<java.io.File>() {
-    @Override
-    public java.io.File get() {
-      try {
-        return tmpFolder.newFolder();
-      } catch (IOException e) {
-        throw Throwables.propagate(e);
-      }
-    }
-  };
-
-  @BeforeClass
-  public static void beforeClass() {
-    // we are only gonna do long-running transactions here. Set the tx timeout to a ridiculously low value.
-    // that will test that the long-running transactions actually bypass that timeout.
-    CConfiguration conf = CConfiguration.create();
-    conf.setInt(TxConstants.Manager.CFG_TX_TIMEOUT, 1);
-    conf.setInt(TxConstants.Manager.CFG_TX_CLEANUP_INTERVAL, 2);
-    injector = AppFabricTestHelper.getInjector(conf);
-    txService = injector.getInstance(TransactionManager.class);
-    txExecutorFactory = injector.getInstance(TransactionExecutorFactory.class);
-    dsFramework = injector.getInstance(DatasetFramework.class);
-    datasetCache = new SingleThreadDatasetCache(
-      new SystemDatasetInstantiator(dsFramework, MapReduceWithPartitionedTest.class.getClassLoader(), null),
-      injector.getInstance(TransactionSystemClient.class),
-      NamespaceId.DEFAULT, DatasetDefinition.NO_ARGUMENTS, null, null);
-    txService.startAndWait();
-  }
-
-  @AfterClass
-  public static void afterClass() throws Exception {
-    txService.stopAndWait();
-  }
-
-  @After
-  public void after() throws Exception {
-    // cleanup user data (only user datasets)
-    for (DatasetSpecificationSummary spec : dsFramework.getInstances(DefaultId.NAMESPACE)) {
-      dsFramework.deleteInstance(Id.DatasetInstance.from(DefaultId.NAMESPACE, spec.getName()));
-    }
-  }
+public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
 
   @Test
   public void testTimePartitionedWithMR() throws Exception {
 
-    final ApplicationWithPrograms app =
-      AppFabricTestHelper.deployApplicationWithManager(AppWithTimePartitionedFileSet.class, TEMP_FOLDER_SUPPLIER);
+    final ApplicationWithPrograms app = deployApp(AppWithTimePartitionedFileSet.class);
 
     // write a value to the input table
     final Table table = datasetCache.getDataset(AppWithTimePartitionedFileSet.INPUT);
@@ -280,8 +192,7 @@ public class MapReduceWithPartitionedTest {
   @Test
   public void testPartitionedFileSetWithMR() throws Exception {
 
-    final ApplicationWithPrograms app =
-      AppFabricTestHelper.deployApplicationWithManager(AppWithPartitionedFileSet.class, TEMP_FOLDER_SUPPLIER);
+    final ApplicationWithPrograms app = deployApp(AppWithPartitionedFileSet.class);
 
     // write a value to the input table
     final Table table = datasetCache.getDataset(AppWithPartitionedFileSet.INPUT);
@@ -425,48 +336,5 @@ public class MapReduceWithPartitionedTest {
           Assert.assertTrue(row.isEmpty());
         }
       });
-  }
-
-  private void runProgram(ApplicationWithPrograms app, Class<?> programClass, Arguments args)
-    throws Exception {
-    waitForCompletion(submit(app, programClass, args));
-  }
-
-  private void waitForCompletion(ProgramController controller) throws InterruptedException {
-    final CountDownLatch completion = new CountDownLatch(1);
-    controller.addListener(new AbstractListener() {
-      @Override
-      public void completed() {
-        completion.countDown();
-      }
-
-      @Override
-      public void error(Throwable cause) {
-        completion.countDown();
-      }
-    }, Threads.SAME_THREAD_EXECUTOR);
-
-    // MR tests can run for long time.
-    completion.await(5, TimeUnit.MINUTES);
-  }
-
-  private ProgramController submit(ApplicationWithPrograms app, Class<?> programClass, Arguments userArgs)
-    throws ClassNotFoundException {
-    ProgramRunnerFactory runnerFactory = injector.getInstance(ProgramRunnerFactory.class);
-    final Program program = getProgram(app, programClass);
-    ProgramRunner runner = runnerFactory.create(ProgramRunnerFactory.Type.valueOf(program.getType().name()));
-    BasicArguments systemArgs = new BasicArguments(ImmutableMap.of(ProgramOptionConstants.RUN_ID,
-                                                                   RunIds.generate().getId()));
-
-    return runner.run(program, new SimpleProgramOptions(program.getName(), systemArgs, userArgs));
-  }
-
-  private Program getProgram(ApplicationWithPrograms app, Class<?> programClass) throws ClassNotFoundException {
-    for (Program p : app.getPrograms()) {
-      if (programClass.getCanonicalName().equals(p.getMainClass().getCanonicalName())) {
-        return p;
-      }
-    }
-    return null;
   }
 }


### PR DESCRIPTION
DynamicPartitioner did not work with avro output formats. See the JIRA for more details.

The fix is a few-line change in DynamicPartitioningOutputFormat.java, and the remainder of the PR is test code.
The second commit is refactoring of test cases to not have code duplication.

https://issues.cask.co/browse/CDAP-4806
http://builds.cask.co/browse/CDAP-RBT627-3