### PR TITLE
Turn on anchors.

### DIFF
--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -212,11 +212,12 @@ div.body h5 { background-color: #F2F2F2; margin: 30px 0px 10px 0px; }
 div.body h6 { background-color: #F2F2F2; }
 
 a.headerlink {
-    color: #c60f0f;
+    color: #ff6600 !important;
     font-size: 0.8em;
     padding: 0 4px 0 4px;
-    text-decoration: none;
-    display: none;
+    margin-left: 6px;
+    text-decoration: none !important;
+    float: right;
 }
 
 a.headerlink:hover {

--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -217,7 +217,6 @@ a.headerlink {
     padding: 0 4px 0 4px;
     margin-left: 6px;
     text-decoration: none !important;
-    float: right;
 }
 
 a.headerlink:hover {

--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -219,11 +219,6 @@ a.headerlink {
     text-decoration: none !important;
 }
 
-a.headerlink:hover {
-    background-color: #c60f0f;
-    color: white;
-}
-
 a.toc-backref {
     color: black;
 }

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -447,6 +447,8 @@ html_static_path = ['../../_common/_static']
 # typographically correct entities.
 #html_use_smartypants = True
 
+html_add_permalinks = u'\U0001F517' # HTML '&#128279;' # Link symbol: see http://www.fileformat.info/info/unicode/char/1f517/index.htm
+
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {'**': [
     'manuals.html',

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -447,8 +447,6 @@ html_static_path = ['../../_common/_static']
 # typographically correct entities.
 #html_use_smartypants = True
 
-html_add_permalinks = u'\U0001F517' # HTML '&#128279;' # Link symbol: see http://www.fileformat.info/info/unicode/char/1f517/index.htm
-
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {'**': [
     'manuals.html',


### PR DESCRIPTION
Adds "on-hover" anchors to text headlines. Makes finding links much easier.

Fixes https://issues.cask.co/browse/CDAP-4883

Passes [Quick Build 3](http://builds.cask.co/browse/CDAP-DOB105-2)

See an example at: http://builds.cask.co/artifact/CDAP-DOB105/shared/build-3/Docs-HTML/3.3.1-SNAPSHOT/en/index.html

Hover over text: "CDAP Documentation v3.3.1". Anchor appears just after the text.

**"On-hold"** as there are revisions to be made, including re-doing this against develop if it is not completed by release/3.3.

