### PR TITLE
Log the exception's message, instead of the entire thing.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -429,7 +429,7 @@ public class ETLMapReduce extends AbstractMapReduce {
         }
         transformExecutor.resetEmitter();
       } catch (Exception e) {
-        LOG.error("Exception thrown in BatchDriver Mapper: {}", e);
+        LOG.error("Exception thrown in BatchDriver Mapper.", e);
         Throwables.propagate(e);
       }
     }


### PR DESCRIPTION
There's an invalid log message being printed - the literal `{}` is being printed, since the second parameter is a Throwable, instead of an object that is to be interpolated into the string.

Here's what it looked like:
![image](https://cloud.githubusercontent.com/assets/2440977/12826192/b5544552-cb2e-11e5-8e82-b35ba4a2da42.png)
