### PR TITLE
Fix CDAP SDK, when there are space(s) in the path.

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -203,16 +203,7 @@ cdap_set_classpath() {
 
   # In order to ensure that we can do hacks, need to make sure classpath is sorted
   # so that cdap jars are placed earlier in the classpath than twill or hadoop jars
-  COMP_LIB=""
-  i=0
-  for jar in `ls -1 ${COMP_HOME}/lib/* | sort` ; do
-    ((i++))
-    if [ $i -eq 1 ] ; then
-        COMP_LIB=${jar}
-    else
-        COMP_LIB=${COMP_LIB}:${jar}
-    fi
-  done
+  COMP_LIB=$(find "${COMP_HOME}/lib" -type f | sort | tr '\n' ':')
 
   if [ -n "${HBASE_CP}" ]; then
     CP="${COMP_LIB}:${HBASE_CP}:${CCONF}/:${COMP_HOME}/conf/:${EXTRA_CLASSPATH}"

--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014-2015 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -68,20 +68,13 @@ while [ -h "$PRG" ] ; do
         PRG=`dirname "$PRG"`"/$link"
     fi
 done
-SAVED="`pwd`"
 cd "`dirname \"$PRG\"`/.." >&-
 APP_HOME="`pwd -P`"
 
-i=0
-for jar in `ls -1 $APP_HOME/lib/* | sort` ; do
-    ((i++))
-    if [ $i -eq 1 ] ; then
-        CLASSPATH=${jar}
-    else
-        CLASSPATH=${CLASSPATH}:${jar}
-    fi
-done
-CLASSPATH="${CLASSPATH}:$APP_HOME/conf/"
+# In order to ensure that we can do hacks, need to make sure classpath is sorted
+# so that cdap jars are placed earlier in the classpath than twill or hadoop jars
+CLASSPATH=$(find "${APP_HOME}/lib" -type f | sort | tr '\n' ':')
+CLASSPATH="${CLASSPATH}:${APP_HOME}/conf/"
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then


### PR DESCRIPTION
The `*` was making it so that the paths were being iterated over by bash, and by default, space character is a delimiter which splits it, so any path with a space in it was being interpreted as two separate paths.
Using the `find` command and then joining the paths by `:` works better for this.

Tested:
![image](https://cloud.githubusercontent.com/assets/2440977/12830093/6c86f298-cb42-11e5-83db-49a3059afca6.png)
