### PR TITLE
CDAP-4889 DatasetSpecUpgrade should only be called during upgrade 

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -377,6 +377,9 @@ public class UpgradeTool {
   private void performUpgrade() throws Exception {
     performCoprocessorUpgrade();
 
+    LOG.info("Upgrading Dataset Specification...");
+    dsSpecUpgrader.upgrade();
+
     LOG.info("Upgrading schedules...");
     datasetBasedTimeScheduleStore.upgrade();
 
@@ -402,9 +405,6 @@ public class UpgradeTool {
 
     LOG.info("Upgrading QueueAdmin ...");
     queueAdmin.upgrade();
-
-    LOG.info("Upgrading Dataset Specification...");
-    dsSpecUpgrader.upgrade();
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
Previously DataSpec upgrade was called during upgrade_hbase step as well. 
JIRA: https://issues.cask.co/browse/CDAP-4889
Build: http://builds.cask.co/browse/CDAP-RBT630-1