### PR TITLE
Hotfix/cdap 4790 make table apis consistent

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -300,13 +300,13 @@ public class IndexedTable extends AbstractDataset implements Table {
   }
 
   /**
-   * Perform a delete on the data table.  Any index entries referencing the deleted row will also be removed.
+   * Perform a delete on the data table. Any index entries referencing the deleted row will also be removed.
    * 
    * @param delete The delete operation identifying the row and optional columns to remove
    */
   @Override
   public void delete(Delete delete) {
-    if (delete.getColumns().isEmpty()) {
+    if (delete.getColumns() == null) {
       // full row delete
       delete(delete.getRow());
       return;

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Delete.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Delete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@ package co.cask.cdap.api.dataset.table;
 import java.util.Collection;
 
 /**
- * A Delete removes one or more or all columns from a row.
+ * A Delete removes one, multiple, or all columns from a row.
  */
 public class Delete extends RowColumns<Delete> {
   /**
@@ -66,6 +66,15 @@ public class Delete extends RowColumns<Delete> {
    */
   public Delete(String row, String... columns) {
     super(row, columns);
+  }
+
+  /**
+   * Delete a set of columns from a row.
+   * @param row Row to delete from.
+   * @param columns Columns to delete.
+   */
+  public Delete(String row, Collection<String> columns) {
+    super(row, columns.toArray(new String[columns.size()]));
   }
 }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/RowColumns.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/RowColumns.java
@@ -135,6 +135,18 @@ public abstract class RowColumns<T> {
   }
 
   /**
+   * @deprecated As of CDAP 3.3.1, no parameter {@code #add} method is deprecated. Use either {@link #add(String[])} or
+   * {@link #add(byte[][])}.
+   *
+   * @return the {@link RowColumns} object being defined
+   */
+  @SuppressWarnings("unchecked")
+  public T add() {
+    // here only for backwards compatibility in 3.3.1.
+    return (T) this;
+  }
+
+  /**
    * @return the row that was included
    */
   public byte[] getRow() {

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/RowColumns.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/RowColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,8 +19,10 @@ package co.cask.cdap.api.dataset.table;
 import co.cask.cdap.api.common.Bytes;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Base class for defining a row with set of columns.
@@ -29,50 +31,127 @@ import java.util.List;
 public abstract class RowColumns<T> {
   private final byte[] row;
 
-  private final List<byte[]> columns;
-
-  public byte[] getRow() {
-    return row;
-  }
-
-  public List<byte[]> getColumns() {
-    return columns;
-  }
+  private List<byte[]> columns;
 
   // key & column as byte[]
 
+  /**
+   * Defines a row with all columns included. If any of the {@code add} method is called, only columns specified through
+   * those {@code add} method calls are included.
+   * @param row the row to define.
+   */
   public RowColumns(byte[] row) {
     this.row = row;
-    this.columns = new ArrayList<>();
   }
 
+  /**
+   * Defines a row, with the specified set of columns.
+   * @param row the row to define
+   * @param columns the set of columns of the row to included
+   */
   public RowColumns(byte[] row, byte[]... columns) {
-    this(row);
-    add(columns);
-  }
-
-  @SuppressWarnings("unchecked")
-  public T add(byte[]... columns) {
-    Collections.addAll(this.columns, columns);
-    return (T) this;
+    this.row = row;
+    this.columns = Arrays.asList(columns);
   }
 
   // key and column as String
 
+  /**
+   * Defines a row with all columns included. If any of the {@code add} method is called, only columns specified through
+   * those {@code add} method calls are included.
+   * @param row the row to define. Note: It will be converted to {@code byte[]} with UTF-8 encoding.
+   */
   public RowColumns(String row) {
     this(Bytes.toBytes(row));
   }
 
+  /**
+   * Defines a row, including all columns, unless additional columns are specified.
+   * Note that the provided strings will be converted to {@code byte[]} with UTF-8 encoding.
+   *
+   * @param row the row to define
+   * @param columns the set of columns of the row to included
+   */
   public RowColumns(String row, String... columns) {
     this(row);
     add(columns);
   }
 
+  /**
+   * Specifies column(s) to be included.
+   * @param firstColumn the first column being included
+   * @param moreColumns a collection of additional columns being included
+   * @return the {@link RowColumns} object being defined
+   */
   @SuppressWarnings("unchecked")
-  public T add(String... columns) {
+  public T add(byte[] firstColumn, byte[]... moreColumns) {
+    initArray();
+    this.columns.add(firstColumn);
+    Collections.addAll(this.columns, moreColumns);
+    return (T) this;
+  }
+
+  /**
+   * Specifies column(s) to be included.
+   * @param columns a collection of columns being included
+   * @return the {@link RowColumns} object being defined
+   */
+  @SuppressWarnings("unchecked")
+  public T add(byte[][] columns) {
+    initArray();
+    Collections.addAll(this.columns, columns);
+    return (T) this;
+  }
+
+  /**
+   * Specifies column(s) to be included.
+   * Note that the provided strings will be converted to {@code byte[]} with UTF-8 encoding.
+   * @param firstColumn the first column being included
+   * @param moreColumns a collection of additional columns being included
+   * @return the {@link RowColumns} object being defined
+   */
+  @SuppressWarnings("unchecked")
+  public T add(String firstColumn, String... moreColumns) {
+    initArray();
+    this.columns.add(Bytes.toBytes(firstColumn));
+    for (String col : moreColumns) {
+      this.columns.add(Bytes.toBytes(col));
+    }
+    return (T) this;
+  }
+
+  /**
+   * Specifies column(s) to be included.
+   * @param columns a collection of columns being included
+   * @return the {@link RowColumns} object being defined
+   */
+  @SuppressWarnings("unchecked")
+  public T add(String[] columns) {
+    initArray();
     for (String col : columns) {
       this.columns.add(Bytes.toBytes(col));
     }
     return (T) this;
+  }
+
+  /**
+   * @return the row that was included
+   */
+  public byte[] getRow() {
+    return row;
+  }
+
+  /**
+   * @return a list of columns of this object. null indicates ALL columns.
+   */
+  @Nullable
+  public List<byte[]> getColumns() {
+    return columns;
+  }
+
+  private void initArray() {
+    if (this.columns == null) {
+      this.columns = new ArrayList<>();
+    }
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
@@ -107,6 +107,8 @@ public interface Table extends BatchReadable<byte[], Row>, BatchWritable<byte[],
    * NOTE: objects that are passed in parameters can be re-used by underlying implementation and present
    *       in returned data structures from this method.
    *
+   * @param row row to read from
+   * @param columns collection of columns to read; if empty, will return an empty Row.
    * @return instance of {@link Row}: never {@code null}; returns an empty Row if nothing read
    */
   @Nonnull
@@ -203,7 +205,7 @@ public interface Table extends BatchReadable<byte[], Row>, BatchWritable<byte[],
    * multiple times (especially in transactions that delete many columns of the same rows).
    *
    * @param row row to delete from
-   * @param columns names of columns to delete
+   * @param columns names of columns to delete; if empty, nothing will be deleted
    */
   void delete(byte[] row, byte[][] columns);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/AbstractTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/AbstractTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -83,7 +83,7 @@ public abstract class AbstractTable implements Table, TransactionAware {
 
   @Override
   public Row get(Get get) {
-    return get.getColumns().isEmpty() ?
+    return get.getColumns() == null ?
         get(get.getRow()) :
         get(get.getRow(), get.getColumns().toArray(new byte[get.getColumns().size()][]));
   }
@@ -162,7 +162,7 @@ public abstract class AbstractTable implements Table, TransactionAware {
 
   @Override
   public void delete(Delete delete) {
-    if (delete.getColumns().isEmpty()) {
+    if (delete.getColumns() == null) {
       delete(delete.getRow());
     } else {
       delete(delete.getRow(), delete.getColumns().toArray(new byte[delete.getColumns().size()][]));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -193,7 +193,7 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
    * Fetches column->value pairs for set of columns from persistent store.
    * NOTE: persisted store can also be in-memory, it is called "persisted" to distinguish from in-memory buffer.
    * @param row row key defines the row to fetch columns from
-   * @param columns set of columns to fetch, can be null which means fetch everything
+   * @param columns set of columns to fetch. null means fetch everything; empty array which means fetch nothing.
    * @return map of column->value pairs, never null.
    * @throws Exception
    */
@@ -240,7 +240,7 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
     List<Map<byte[], byte[]>> results = Lists.newArrayListWithCapacity(gets.size());
     for (Get get : gets) {
       List<byte[]> getColumns = get.getColumns();
-      byte[][] columns = getColumns.isEmpty() ? null : getColumns.toArray(new byte[getColumns.size()][]);
+      byte[][] columns = getColumns == null ? null : getColumns.toArray(new byte[getColumns.size()][]);
       results.add(getPersisted(get.getRow(), columns));
     }
     return results;
@@ -449,7 +449,7 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
         // merge what was in the buffer and what was persisted
         if (buffCols != null) {
           List<byte[]> getColumns = get.getColumns();
-          byte[][] columns = getColumns.isEmpty() ? null : getColumns.toArray(new byte[getColumns.size()][]);
+          byte[][] columns = getColumns == null ? null : getColumns.toArray(new byte[getColumns.size()][]);
           mergeToPersisted(rowColumns, buffCols, columns);
         }
 
@@ -496,9 +496,8 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
   }
 
   /**
-   * NOTE: Depending on the use-case, calling this method may be much less
-   *       efficient than calling same method with columns as parameters because it may always require round trip to
-   *       persistent store
+   * NOTE: Depending on the use-case, calling this method may be much less efficient than calling same method
+   *       with columns as parameters because it will require a round trip to persistent store.
    */
   @Override
   public void delete(byte[] row) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableService.java
@@ -243,7 +243,6 @@ public class InMemoryTableService {
     // todo: handle nulls
     ConcurrentNavigableMap<byte[], NavigableMap<byte[], NavigableMap<Long, Update>>> table = tables.get(tableName);
     Preconditions.checkArgument(table != null, "table not found: " + tableName);
-    assert table != null;
     NavigableMap<byte[], NavigableMap<Long, Update>> rowMap = table.get(row);
     return deepCopy(Updates.rowToBytes(getVisible(rowMap, version)));
   }


### PR DESCRIPTION
The makes any Table requests where an empty set of columns is specified to mean 'no columns'.
Previously, there was inconsistent behavior - this meant get all columns in some instances and meant get no columns in other instances.

https://issues.cask.co/browse/CDAP-4790
http://builds.cask.co/browse/CDAP-RBT633-11

https://wiki.cask.co/display/CE/Changes+to+Table+Interface