### PR TITLE
CDAP-3901 Remove depenency on namespace client from DatasetInstanceService

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -85,8 +85,6 @@ import co.cask.cdap.metrics.runtime.MetricsProcessorStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsServiceManager;
 import co.cask.cdap.pipeline.PipelineFactory;
 import co.cask.cdap.security.authorization.AuthorizationPlugin;
-import co.cask.cdap.store.DefaultNamespaceStore;
-import co.cask.cdap.store.NamespaceStore;
 import co.cask.http.HttpHandler;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
@@ -285,7 +283,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       );
 
       bind(Store.class).to(DefaultStore.class);
-      bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
       bind(ArtifactStore.class).in(Scopes.SINGLETON);
       bind(ProgramLifecycleService.class).in(Scopes.SINGLETON);
       bind(NamespaceAdmin.class).to(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,7 +22,6 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -33,6 +32,7 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.TempFolder;
 import co.cask.cdap.internal.app.scheduler.LogPrintingJob;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionManager;
@@ -93,7 +93,7 @@ public class DatasetBasedTimeScheduleStoreTest {
                                     new DataSetsModules().getStandaloneModules(),
                                     new DataSetServiceModules().getInMemoryModules(),
                                     new ExploreClientModule(),
-                                    new NamespaceClientRuntimeModule().getInMemoryModules());
+                                    new NamespaceStoreModule().getInMemoryModules());
     txService = injector.getInstance(TransactionManager.class);
     txService.startAndWait();
     dsOpsService = injector.getInstance(DatasetOpExecutor.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -47,6 +47,7 @@ import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModu
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ScheduledRuntime;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.PrivateModule;
@@ -108,6 +109,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new StreamAdminModules().getInMemoryModules());
     install(new StreamServiceRuntimeModule().getInMemoryModules());
     install(new NamespaceClientRuntimeModule().getStandaloneModules());
+    install(new NamespaceStoreModule().getStandaloneModules());
     install(new MetadataServiceModule());
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/stream/store/MDSStreamMetaStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/stream/store/MDSStreamMetaStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -38,6 +38,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.store.DefaultNamespaceStore;
 import co.cask.cdap.store.NamespaceStore;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.TransactionManager;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -68,13 +69,13 @@ public class MDSStreamMetaStoreTest extends StreamMetaStoreTestBase {
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new LocationRuntimeModule().getInMemoryModules(),
       new NamespaceClientRuntimeModule().getInMemoryModules(),
+      new NamespaceStoreModule().getStandaloneModules(),
       new AbstractModule() {
         @Override
         protected void configure() {
           bind(StreamMetaStore.class).to(MDSStreamMetaStore.class).in(Scopes.SINGLETON);
           bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
           bind(Store.class).to(DefaultStore.class);
-          bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
         }
       }
     );

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
@@ -31,6 +31,7 @@ import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data.stream.service.InMemoryStreamMetaStore;
 import co.cask.cdap.data.stream.service.StreamMetaStore;
 import co.cask.cdap.data.view.ViewAdminModules;
+import co.cask.cdap.data2.dataset2.InMemoryNamespaceStore;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -31,6 +31,7 @@ import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data.stream.service.InMemoryStreamMetaStore;
 import co.cask.cdap.data.stream.service.StreamMetaStore;
 import co.cask.cdap.data.view.ViewAdminModules;
+import co.cask.cdap.data2.dataset2.InMemoryNamespaceStore;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.explore.guice.ExploreClientModule;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -22,13 +22,13 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.ResolvingDiscoverable;
 import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.metrics.MetricsReporterHook;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.service.UncaughtExceptionIdleService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.MDSDatasetsRegistry;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
+import co.cask.cdap.store.NamespaceStore;
 import co.cask.http.NettyHttpService;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
@@ -83,11 +83,11 @@ public class DatasetService extends AbstractExecutionThreadService {
                         Set<DatasetMetricsReporter> metricReporters,
                         DatasetInstanceService datasetInstanceService,
                         StorageProviderNamespaceAdmin storageProviderNamespaceAdmin,
-                        AbstractNamespaceClient namespaceClient) throws Exception {
+                        NamespaceStore namespaceStore) throws Exception {
 
     this.typeManager = typeManager;
     DatasetTypeHandler datasetTypeHandler = new DatasetTypeHandler(typeManager, cConf, namespacedLocationFactory,
-                                                                   namespaceClient);
+                                                                   namespaceStore);
     DatasetInstanceHandler datasetInstanceHandler = new DatasetInstanceHandler(datasetInstanceService);
     StorageProviderNamespaceHandler storageProviderNamespaceHandler =
       new StorageProviderNamespaceHandler(storageProviderNamespaceAdmin);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryNamespaceStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryNamespaceStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.data.stream;
+package co.cask.cdap.data2.dataset2;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/guice/NamespaceStoreModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/guice/NamespaceStoreModule.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.store.guice;
+
+import co.cask.cdap.common.runtime.RuntimeModule;
+import co.cask.cdap.data2.dataset2.InMemoryNamespaceStore;
+import co.cask.cdap.store.DefaultNamespaceStore;
+import co.cask.cdap.store.NamespaceStore;
+import com.google.inject.Module;
+import com.google.inject.PrivateModule;
+import com.google.inject.Scope;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+
+
+/**
+ * Module to define Guice bindings for {@link NamespaceStore}
+ */
+public class NamespaceStoreModule extends RuntimeModule {
+
+  @Override
+  public Module getInMemoryModules() {
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        bind(NamespaceStore.class).to(InMemoryNamespaceStore.class).in(Scopes.SINGLETON);
+        expose(NamespaceStore.class);
+      }
+    };
+  }
+
+  @Override
+  public Module getStandaloneModules() {
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
+        expose(NamespaceStore.class);
+      }
+    };
+  }
+
+  @Override
+  public Module getDistributedModules() {
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
+        expose(NamespaceStore.class);
+      }
+    };
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/view/MDSViewStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/view/MDSViewStoreTest.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.MockExploreClient;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.TransactionManager;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -57,6 +58,7 @@ public class MDSViewStoreTest extends ViewStoreTestBase {
       new DataSetsModules().getStandaloneModules(),
       new DataFabricModules().getInMemoryModules(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
+      new NamespaceStoreModule().getInMemoryModules(),
       new LocationRuntimeModule().getInMemoryModules(),
       new AbstractModule() {
         @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -135,7 +135,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
       cConf,
       txExecutorFactory,
       registryFactory,
-      NAMESPACE_CLIENT);
+      NAMESPACE_STORE);
 
     service = new DatasetService(cConf,
                                  namespacedLocationFactory,
@@ -149,7 +149,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                  instanceService,
                                  new LocalStorageProviderNamespaceAdmin(cConf, namespacedLocationFactory,
                                                                         exploreFacade),
-                                 NAMESPACE_CLIENT
+                                 NAMESPACE_STORE
     );
     // Start dataset service, wait for it to be discoverable
     service.start();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -29,8 +29,6 @@ import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
-import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
 import co.cask.cdap.data2.dataset2.lib.file.FileSetModule;
 import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetModule;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
@@ -38,6 +36,7 @@ import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.store.NamespaceStore;
 import co.cask.tephra.DefaultTransactionExecutor;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
@@ -84,8 +83,7 @@ public abstract class AbstractDatasetFrameworkTest {
   private static final Id.DatasetType SIMPLE_KV_TYPE = Id.DatasetType.from(NAMESPACE_ID, SimpleKVTable.class.getName());
   private static final Id.DatasetType DOUBLE_KV_TYPE = Id.DatasetType.from(NAMESPACE_ID,
                                                                            DoubleWrappedKVTable.class.getName());
-
-  protected static final AbstractNamespaceClient NAMESPACE_CLIENT = new InMemoryNamespaceClient();
+  protected static final NamespaceStore NAMESPACE_STORE = new InMemoryNamespaceStore();
   protected static DatasetDefinitionRegistryFactory registryFactory;
   protected static CConfiguration cConf;
   protected static TransactionExecutorFactory txExecutorFactory;
@@ -108,7 +106,7 @@ public abstract class AbstractDatasetFrameworkTest {
         return registry;
       }
     };
-    NAMESPACE_CLIENT.create(new NamespaceMeta.Builder().setName(NAMESPACE_ID).build());
+    NAMESPACE_STORE.create(new NamespaceMeta.Builder().setName(NAMESPACE_ID).build());
   }
 
   @Test
@@ -370,8 +368,8 @@ public abstract class AbstractDatasetFrameworkTest {
     // create 2 namespaces
     Id.Namespace namespace1 = Id.Namespace.from("ns1");
     Id.Namespace namespace2 = Id.Namespace.from("ns2");
-    NAMESPACE_CLIENT.create(new NamespaceMeta.Builder().setName(namespace1).build());
-    NAMESPACE_CLIENT.create(new NamespaceMeta.Builder().setName(namespace2).build());
+    NAMESPACE_STORE.create(new NamespaceMeta.Builder().setName(namespace1).build());
+    NAMESPACE_STORE.create(new NamespaceMeta.Builder().setName(namespace2).build());
     framework.createNamespace(namespace1);
     framework.createNamespace(namespace2);
 
@@ -434,8 +432,8 @@ public abstract class AbstractDatasetFrameworkTest {
     // create 2 namespaces
     Id.Namespace namespace1 = Id.Namespace.from("ns1");
     Id.Namespace namespace2 = Id.Namespace.from("ns2");
-    NAMESPACE_CLIENT.create(new NamespaceMeta.Builder().setName(namespace1).build());
-    NAMESPACE_CLIENT.create(new NamespaceMeta.Builder().setName(namespace2).build());
+    NAMESPACE_STORE.create(new NamespaceMeta.Builder().setName(namespace1).build());
+    NAMESPACE_STORE.create(new NamespaceMeta.Builder().setName(namespace2).build());
     framework.createNamespace(namespace1);
     framework.createNamespace(namespace2);
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,8 +25,6 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -49,6 +47,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.store.DefaultNamespaceStore;
 import co.cask.cdap.store.NamespaceStore;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.ImmutableList;
@@ -77,7 +76,7 @@ public class ExploreDisabledTest {
   private static DatasetOpExecutor dsOpExecutor;
   private static DatasetService datasetService;
   private static ExploreClient exploreClient;
-  private static AbstractNamespaceClient namespaceClient;
+  private static NamespaceStore namespaceStore;
 
   @BeforeClass
   public static void start() throws Exception {
@@ -96,8 +95,8 @@ public class ExploreDisabledTest {
 
     datasetFramework = injector.getInstance(DatasetFramework.class);
 
-    namespaceClient = injector.getInstance(AbstractNamespaceClient.class);
-    namespaceClient.create(new NamespaceMeta.Builder().setName(namespaceId).build());
+    namespaceStore = injector.getInstance(NamespaceStore.class);
+    namespaceStore.create(new NamespaceMeta.Builder().setName(namespaceId).build());
     // This happens when you create a namespace via REST APIs. However, since we do not start AppFabricServer in
     // Explore tests, simulating that scenario by explicitly calling DatasetFramework APIs.
     datasetFramework.createNamespace(namespaceId);
@@ -106,7 +105,7 @@ public class ExploreDisabledTest {
   @AfterClass
   public static void stop() throws Exception {
     datasetFramework.deleteNamespace(namespaceId);
-    namespaceClient.delete(namespaceId);
+    namespaceStore.delete(namespaceId);
     exploreClient.close();
     datasetService.stopAndWait();
     dsOpExecutor.stopAndWait();
@@ -218,12 +217,11 @@ public class ExploreDisabledTest {
         new ViewAdminModules().getInMemoryModules(),
         new StreamAdminModules().getInMemoryModules(),
         new NotificationServiceRuntimeModule().getInMemoryModules(),
-        new NamespaceClientRuntimeModule().getInMemoryModules(),
+        new NamespaceStoreModule().getInMemoryModules(),
         new AbstractModule() {
           @Override
           protected void configure() {
             bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
-            bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
           }
         }
     );

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -42,6 +42,7 @@ import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.store.DefaultNamespaceStore;
 import co.cask.cdap.store.NamespaceStore;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.ImmutableList;
@@ -97,11 +98,11 @@ public class InMemoryExploreServiceTest {
         new ViewAdminModules().getInMemoryModules(),
         new StreamAdminModules().getInMemoryModules(),
         new NamespaceClientRuntimeModule().getInMemoryModules(),
+        new NamespaceStoreModule().getStandaloneModules(),
         new AbstractModule() {
           @Override
           protected void configure() {
             bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
-            bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
           }
         });
     transactionManager = injector.getInstance(TransactionManager.class);

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +26,6 @@ import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -39,6 +38,7 @@ import co.cask.cdap.logging.read.LogReader;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
 import co.cask.cdap.metrics.query.MetricsQueryService;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -168,7 +168,7 @@ public abstract class MetricsSuiteTestBase {
       new DataSetsModules().getStandaloneModules(),
       new DataSetServiceModules().getInMemoryModules(),
       new ExploreClientModule(),
-      new NamespaceClientRuntimeModule().getInMemoryModules()
+      new NamespaceStoreModule().getInMemoryModules()
     ).with(new AbstractModule() {
       @Override
       protected void configure() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -47,6 +47,7 @@ import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.store.DefaultNamespaceStore;
 import co.cask.cdap.store.NamespaceStore;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
@@ -108,6 +109,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new LoggingModules().getDistributedModules(),
       new ExploreClientModule(),
       new NamespaceClientRuntimeModule().getDistributedModules(),
+      new NamespaceStoreModule().getDistributedModules(),
       new MetadataServiceModule(),
       new ViewAdminModules().getDistributedModules(),
       new StreamAdminModules().getDistributedModules(),
@@ -116,7 +118,6 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
         @Override
         protected void configure() {
           bind(Store.class).to(DefaultStore.class);
-          bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
         }
       });
   }

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -58,6 +58,7 @@ import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModu
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -354,7 +355,8 @@ public class MasterServiceMain extends DaemonMain {
       new NotificationServiceRuntimeModule().getDistributedModules(),
       new ViewAdminModules().getDistributedModules(),
       new StreamAdminModules().getDistributedModules(),
-      new NamespaceClientRuntimeModule().getDistributedModules()
+      new NamespaceClientRuntimeModule().getDistributedModules(),
+      new NamespaceStoreModule().getDistributedModules()
     );
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -74,6 +74,7 @@ import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
@@ -477,6 +478,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
       new NotificationServiceRuntimeModule().getDistributedModules(),
       new MetricsClientRuntimeModule().getDistributedModules(),
       new KafkaClientModule(),
+      new NamespaceStoreModule().getDistributedModules(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -67,6 +67,7 @@ import co.cask.cdap.metrics.store.MetricDatasetFactory;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.distributed.TransactionService;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -205,6 +206,7 @@ public class UpgradeTool {
       // don't need real notifications for upgrade, so use the in-memory implementations
       new NotificationServiceRuntimeModule().getInMemoryModules(),
       new KafkaClientModule(),
+      new NamespaceStoreModule().getDistributedModules(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -67,6 +67,7 @@ import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
@@ -344,6 +345,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
       new NotificationServiceRuntimeModule().getDistributedModules(),
       new MetricsClientRuntimeModule().getDistributedModules(),
       new KafkaClientModule(),
+      new NamespaceStoreModule().getDistributedModules(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/UpgradeToolTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/UpgradeToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,7 +24,7 @@ import org.junit.Test;
 public class UpgradeToolTest {
   @Test
   public void testInjector() throws Exception {
-    UpgradeTool upgraderMain = new UpgradeTool();
+    new UpgradeTool();
     // should not throw exception
   }
 }

--- a/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
+++ b/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,8 +24,6 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -43,6 +41,8 @@ import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.notifications.service.TxRetryPolicy;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.store.NamespaceStore;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
@@ -87,7 +87,7 @@ public abstract class NotificationTest {
   private static TransactionManager txManager;
   private static DatasetOpExecutor dsOpService;
   private static DatasetService datasetService;
-  private static AbstractNamespaceClient namespaceClient;
+  private static NamespaceStore namespaceStore;
   private static NotificationService notificationService;
 
   private static final Id.Namespace namespace = Id.Namespace.from("namespace");
@@ -109,7 +109,7 @@ public abstract class NotificationTest {
       new MetricsClientRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new DataFabricModules().getInMemoryModules(),
-      new NamespaceClientRuntimeModule().getInMemoryModules()
+      new NamespaceStoreModule().getInMemoryModules()
     );
   }
 
@@ -128,7 +128,7 @@ public abstract class NotificationTest {
     datasetService.startAndWait();
 
     txClient = injector.getInstance(TransactionSystemClient.class);
-    namespaceClient = injector.getInstance(AbstractNamespaceClient.class);
+    namespaceStore = injector.getInstance(NamespaceStore.class);
   }
 
   public static void stopServices() throws Exception {
@@ -172,7 +172,7 @@ public abstract class NotificationTest {
     // clear the feeds
     feedManager.deleteFeed(FEED1);
     feedManager.deleteFeed(FEED2);
-    namespaceClient.delete(namespace);
+    namespaceStore.delete(namespace);
     Assert.assertEquals(0, feedManager.listFeeds(namespace).size());
   }
 
@@ -190,7 +190,7 @@ public abstract class NotificationTest {
   public void useTransactionTest() throws Exception {
     // Performing admin operations to create dataset instance
     // keyValueTable is a system dataset module
-    namespaceClient.create(new NamespaceMeta.Builder().setName(namespace).build());
+    namespaceStore.create(new NamespaceMeta.Builder().setName(namespace).build());
     Id.DatasetInstance myTableInstance = Id.DatasetInstance.from(namespace, "myTable");
     dsFramework.addInstance("keyValueTable", myTableInstance, DatasetProperties.EMPTY);
 
@@ -249,7 +249,7 @@ public abstract class NotificationTest {
     } finally {
       dsFramework.deleteInstance(myTableInstance);
       feedManager.deleteFeed(FEED1);
-      namespaceClient.delete(namespace);
+      namespaceStore.delete(namespace);
     }
   }
 

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -60,6 +60,7 @@ import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModu
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.security.guice.SecurityModules;
 import co.cask.cdap.security.server.ExternalAuthenticationServer;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.inmemory.InMemoryTransactionService;
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
@@ -382,6 +383,7 @@ public class StandaloneMain {
       new ViewAdminModules().getStandaloneModules(),
       new StreamAdminModules().getStandaloneModules(),
       new NamespaceClientRuntimeModule().getStandaloneModules(),
+      new NamespaceStoreModule().getStandaloneModules(),
       new MetadataServiceModule()
     );
   }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -33,9 +33,8 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
-import co.cask.cdap.common.namespace.LocalNamespaceClient;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.common.utils.OSDetector;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -78,6 +77,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.cdap.test.internal.ApplicationManagerFactory;
 import co.cask.cdap.test.internal.DefaultApplicationManager;
 import co.cask.cdap.test.internal.DefaultStreamManager;
@@ -200,7 +200,6 @@ public class TestBase {
           bind(StreamHandler.class).in(Scopes.SINGLETON);
           bind(StreamFetchHandler.class).in(Scopes.SINGLETON);
           bind(StreamViewHttpHandler.class).in(Scopes.SINGLETON);
-          bind(AbstractNamespaceClient.class).to(LocalNamespaceClient.class).in(Scopes.SINGLETON);
           bind(StreamFileJanitorService.class).to(LocalStreamFileJanitorService.class).in(Scopes.SINGLETON);
           bind(StreamWriterSizeCollector.class).to(BasicStreamWriterSizeCollector.class).in(Scopes.SINGLETON);
           bind(StreamCoordinatorClient.class).to(InMemoryStreamCoordinatorClient.class).in(Scopes.SINGLETON);
@@ -215,6 +214,8 @@ public class TestBase {
       new ExploreClientModule(),
       new NotificationFeedServiceRuntimeModule().getInMemoryModules(),
       new NotificationServiceRuntimeModule().getInMemoryModules(),
+      new NamespaceClientRuntimeModule().getStandaloneModules(),
+      new NamespaceStoreModule().getStandaloneModules(),
       new AbstractModule() {
         @Override
         @SuppressWarnings("deprecation")

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetUpgradeEnabledTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetUpgradeEnabledTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,7 +17,6 @@
 package co.cask.cdap.test.app;
 
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.SlowTests;
 import co.cask.cdap.test.TestBase;
@@ -43,7 +42,7 @@ public class DatasetUpgradeEnabledTest extends TestBase {
   @Category(XSlowTests.class)
   @Test
   public void testDatasetUncheckedUpgrade() throws Exception {
-    ApplicationManager applicationManager = deployApplication(DatasetUncheckedUpgradeApp.class);
+    deployApplication(DatasetUncheckedUpgradeApp.class);
     DataSetManager<DatasetUncheckedUpgradeApp.RecordDataset> datasetManager =
       getDataset(DatasetUncheckedUpgradeApp.DATASET_NAME);
     DatasetUncheckedUpgradeApp.Record expectedRecord = new DatasetUncheckedUpgradeApp.Record("0AXB", "john", "doe");
@@ -55,14 +54,14 @@ public class DatasetUpgradeEnabledTest extends TestBase {
     Assert.assertEquals(expectedRecord, actualRecord);
 
     // Test compatible upgrade
-    applicationManager = deployApplication(CompatibleDatasetUncheckedUpgradeApp.class);
+    deployApplication(CompatibleDatasetUncheckedUpgradeApp.class);
     datasetManager = getDataset(DatasetUncheckedUpgradeApp.DATASET_NAME);
     CompatibleDatasetUncheckedUpgradeApp.Record compatibleRecord =
       (CompatibleDatasetUncheckedUpgradeApp.Record) datasetManager.get().getRecord("key");
     Assert.assertEquals(new CompatibleDatasetUncheckedUpgradeApp.Record("0AXB", "john", false), compatibleRecord);
 
     // Test in-compatible upgrade
-    applicationManager = deployApplication(IncompatibleDatasetUncheckedUpgradeApp.class);
+    deployApplication(IncompatibleDatasetUncheckedUpgradeApp.class);
     datasetManager = getDataset(DatasetUncheckedUpgradeApp.DATASET_NAME);
     try {
       datasetManager.get().getRecord("key");
@@ -72,7 +71,7 @@ public class DatasetUpgradeEnabledTest extends TestBase {
     }
 
     // Revert the upgrade
-    applicationManager = deployApplication(CompatibleDatasetUncheckedUpgradeApp.class);
+    deployApplication(CompatibleDatasetUncheckedUpgradeApp.class);
     datasetManager = getDataset(DatasetUncheckedUpgradeApp.DATASET_NAME);
     CompatibleDatasetUncheckedUpgradeApp.Record revertRecord =
       (CompatibleDatasetUncheckedUpgradeApp.Record) datasetManager.get().getRecord("key");

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,7 +28,6 @@ import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -45,6 +44,7 @@ import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.logging.read.FileLogReader;
 import co.cask.cdap.logging.read.LogEvent;
 import co.cask.cdap.logging.read.ReadRange;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.Iterables;
 import com.google.inject.Guice;
@@ -106,7 +106,7 @@ public class TestResilientLogging {
       new TransactionMetricsModule(),
       new ExploreClientModule(),
       new LoggingModules().getInMemoryModules(),
-      new NamespaceClientRuntimeModule().getInMemoryModules());
+      new NamespaceStoreModule().getInMemoryModules());
 
     TransactionManager txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();


### PR DESCRIPTION
- This removes the dependency of NamespaceClient from DatasetInstanceService.
- This is needed because we want to start dataset service in upgrade tool without starting app-fabric or other services. The dependency on NamespaceClient needs app-fabric service to be running.

Issue: https://issues.cask.co/browse/CDAP-3901
Build: http://builds.cask.co/browse/CDAP-RBT634-1


**Note: Please don't delete this branch as a follow-up pr is going to be based on this.**