### PR TITLE
changes my-error badge padding + background-color

### DIFF
--- a/cdap-ui/app/directives/error/error.less
+++ b/cdap-ui/app/directives/error/error.less
@@ -72,7 +72,8 @@ my-error {
       overflow-y: auto;
 
       .badge {
-        background-color: @brand-danger;
+        background-color: black;
+        padding: 2px 6px 4px;
       }
     }
 
@@ -80,7 +81,7 @@ my-error {
       margin: 5px;
       padding: 5px 0;
     }
-    .alert-danger {
+    .alert-danger, .alert-success {
       background-image: none;
       color: white;
     }


### PR DESCRIPTION
*  Adds black background color to alert badges in alert popover
*  Adds white text to success alerts in alert popover

![alert](https://cloud.githubusercontent.com/assets/5335210/12860379/fddfb33c-cc10-11e5-86ec-c5e50e12eeb6.gif)


