### PR TITLE
[CDAP-4894] make coprocessor jar locations path-only instead of full URIs

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.dataset.table.Tables;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.io.FileContextLocationFactory;
 import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data.hbase.HBaseTestFactory;
 import co.cask.cdap.data2.dataset2.lib.table.BufferingTable;
@@ -54,14 +55,12 @@ import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
-import org.apache.twill.filesystem.LocalLocationFactory;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,8 +80,6 @@ import static org.junit.Assert.fail;
 public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
   private static final Logger LOG = LoggerFactory.getLogger(HBaseTableTest.class);
 
-  @ClassRule
-  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
   @ClassRule
   public static final HBaseTestBase TEST_HBASE = new HBaseTestFactory().get();
 
@@ -121,8 +118,13 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
   protected HBaseTableAdmin getTableAdmin(DatasetContext datasetContext, String name,
                                           DatasetProperties props) throws IOException {
     DatasetSpecification spec = new HBaseTableDefinition("foo").configure(name, props);
+    return getTableAdmin(datasetContext, spec);
+  }
+
+  protected HBaseTableAdmin getTableAdmin(DatasetContext datasetContext, DatasetSpecification spec)
+    throws IOException {
     return new HBaseTableAdmin(datasetContext, spec, TEST_HBASE.getConfiguration(), hBaseTableUtil,
-                               cConf, new LocalLocationFactory(TMP_FOLDER.newFolder()));
+                               cConf, new FileContextLocationFactory(TEST_HBASE.getConfiguration()));
   }
 
   @Override
@@ -291,9 +293,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     HBaseTableDefinition tableDefinition = new HBaseTableDefinition("foo");
     String tableName = "testcf";
     DatasetSpecification spec = tableDefinition.configure(tableName, props);
-
-    DatasetAdmin admin = new HBaseTableAdmin(CONTEXT1, spec, TEST_HBASE.getConfiguration(), hBaseTableUtil,
-                                             CConfiguration.create(), new LocalLocationFactory(TMP_FOLDER.newFolder()));
+    DatasetAdmin admin = getTableAdmin(CONTEXT1, spec);
     admin.create();
     final HBaseTable table = new HBaseTable(CONTEXT1, spec, cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -193,7 +193,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
     if (priority == null) {
       priority = Coprocessor.PRIORITY_USER;
     }
-    tableDescriptor.addCoprocessor(coprocessor.getName(), new Path(Locations.toURI(jarFile)), priority, null);
+    tableDescriptor.addCoprocessor(coprocessor.getName(), new Path(Locations.toURI(jarFile).getPath()), priority, null);
   }
 
   protected abstract CoprocessorJar createCoprocessorJar() throws IOException;


### PR DESCRIPTION
Jira: https://issues.cask.co/browse/CDAP-4894
Tested on a secure cluster.
 