### PR TITLE
Feature/el7 parcel

### DIFF
--- a/cdap-distributions/bin/build_parcel_repo.sh
+++ b/cdap-distributions/bin/build_parcel_repo.sh
@@ -79,7 +79,7 @@ function add_parcels_to_repo_staging() {
   done
   # We only build el6, so use that as key
   for p in $(ls -1 CDAP-*-el6.parcel) ; do
-    for d in precise trusty wheezy ; do
+    for d in el7 precise trusty wheezy ; do
       ln -sf ${p} ${p/el6/${d}} || (echo "Failed to symlink ${p/el6/${d}} to ${p}" && return 1)
     done
   done


### PR DESCRIPTION
We manually released an -el7 parcel for 3.3.0. This adds it to our build script for all future releases.

This will need to be backported to 3.3 release branch (Cloudera only supports el7 in CDH 5.5+)
