### PR TITLE
CDAP-4906 Exiting with code 1 in Upgrade Tool on exception

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -337,7 +337,7 @@ public class UpgradeTool {
       }
     } catch (Exception e) {
       System.out.println(String.format("Failed to perform action '%s'. Reason: '%s'.", action, e.getMessage()));
-      e.printStackTrace(System.out);
+      throw e;
     }
   }
 
@@ -411,8 +411,10 @@ public class UpgradeTool {
     try {
       UpgradeTool upgradeTool = new UpgradeTool();
       upgradeTool.doMain(args);
+      LOG.info("Upgrade completed successfully");
     } catch (Throwable t) {
       LOG.error("Failed to upgrade ...", t);
+      System.exit(1);
     }
   }
 


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-4906
Build - http://builds.cask.co/browse/CDAP-RBT636-3

Note: Upgrade Tool logging needs to be fixed. Filed JIRA https://issues.cask.co/browse/CDAP-4912 for it.