### PR TITLE
create an el7 parcel

### DIFF
--- a/cdap-distributions/bin/build_parcel_repo.sh
+++ b/cdap-distributions/bin/build_parcel_repo.sh
@@ -79,7 +79,7 @@ function add_parcels_to_repo_staging() {
   done
   # We only build el6, so use that as key
   for p in $(ls -1 CDAP-*-el6.parcel) ; do
-    for d in precise trusty wheezy ; do
+    for d in el7 precise trusty wheezy ; do
       ln -sf ${p} ${p/el6/${d}} || (echo "Failed to symlink ${p/el6/${d}} to ${p}" && return 1)
     done
   done


### PR DESCRIPTION
backporting https://github.com/caskdata/cdap/pull/5075 to release/3.3, so that any future 3.3.x patch releases will include a centos7 parcel.