### PR TITLE
create yum/apt repo definition file for new repos

### DIFF
--- a/cdap-distributions/bin/build_apt_repo.sh
+++ b/cdap-distributions/bin/build_apt_repo.sh
@@ -113,6 +113,15 @@ function createrepo_in_repo_staging() {
   rm -rf ${STAGE_DIR}/${__maj_min}/dists/precise{/.refs,} && mv ${STAGE_DIR}/${__maj_min}/dists/precise{-*,} || return 1
 }
 
+function create_definition_file() {
+  [ -f "${STAGE_DIR}/${__maj_min}/cask.list" ] && return
+  echo "Create APT repository definition file"
+  cd ${STAGE_DIR}/${__maj_min}
+  cat <<EOF > cask.list
+deb [ arch=amd64 ] http://${S3_BUCKET}/${S3_REPO_PATH}/${__maj_min} precise cdap
+EOF
+}
+
 function create_repo_tarball() {
   cd ${STAGE_DIR}
   echo "Create APT repository tarball"
@@ -125,6 +134,7 @@ function create_repo_tarball() {
 setup_repo_staging || die "Something went wrong setting up the staging directory"
 add_packages_to_repo_staging || die "Failed copying packages to staging directory"
 createrepo_in_repo_staging || die "Failed to create repository from staging directory"
+create_definition_file || die "Failed to create repository definition file"
 create_repo_tarball || die "Failed to create APT repository tarball"
 
 echo "Complete: cdap-aptrepo-${__maj_min}.tar.gz created"

--- a/cdap-distributions/bin/build_yum_repo.sh
+++ b/cdap-distributions/bin/build_yum_repo.sh
@@ -123,6 +123,19 @@ function createrepo_in_repo_staging() {
   createrepo ${__maj_min}
 }
 
+function create_definition_file() {
+  [ -f "${STAGE_DIR}/${__maj_min}/cask.repo" ] && return
+  echo "Create YUM repository definition file"
+  cd ${STAGE_DIR}/${__maj_min}
+  cat <<EOF > cask.repo
+[cask]
+name=Cask Packages
+baseurl=http://${S3_BUCKET}/${S3_REPO_PATH}/${__maj_min}
+enabled=1
+gpgcheck=1
+EOF
+}
+
 function create_repo_tarball() {
   cd ${STAGE_DIR}
   echo "Create YUM repository tarball"
@@ -137,6 +150,7 @@ add_packages_to_repo_staging || die "Failed copying packages to staging director
 sign_packages_in_repo_staging
 export_public_key
 createrepo_in_repo_staging || die "Failed to create repository from staging directory"
+create_definition_file || die "Failed to create repository definition file"
 create_repo_tarball || die "Failed to create YUM repository tarball"
 
 echo "Complete: cdap-yumrepo-${__maj_min}.tar.gz created"


### PR DESCRIPTION
backport of https://github.com/caskdata/cdap/pull/5117

Not strictly necessary as the repo definition file is already manually created, but keeping buildscripts consistent across release branches