### PR TITLE
Fix Documentation Build

### DIFF
--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -159,7 +159,7 @@ function build_docs() {
   echo "Building \"${doc_type}\" (${javadocs} Javadocs)"
   echo "--------------------------------------------------------"
   echo
-  if [ "${doc_type}" != "${DOCS}" && "${doc_type}" != "${DOCS_OUTER}" ]; then
+  if [[ "${doc_type}" != "${DOCS}" && "${doc_type}" != "${DOCS_OUTER}" ]]; then
     clean_targets
   fi
   clear_messages_set_messages_file

--- a/cdap-docs/cdap-apps/build.sh
+++ b/cdap-docs/cdap-apps/build.sh
@@ -107,9 +107,9 @@ function download_includes() {
   download_md_doc_file $base_target $hydrator_source core-plugins JavaScript-transform.md
   download_md_doc_file $base_target $hydrator_source core-plugins KVTable-batchsink.md
   download_md_doc_file $base_target $hydrator_source core-plugins KVTable-batchsource.md
-  download_md_doc_file $base_target $hydrator_source core-plugins Kafka-realtimesource.md
   download_md_doc_file $base_target $hydrator_source core-plugins LogParser-transform.md
   download_md_doc_file $base_target $hydrator_source core-plugins Projection-transform.md
+  download_md_doc_file $base_target $hydrator_source core-plugins PythonEvaluator-transform.md
   download_md_doc_file $base_target $hydrator_source core-plugins S3-batchsource.md
   download_md_doc_file $base_target $hydrator_source core-plugins S3Avro-batchsink.md
   download_md_doc_file $base_target $hydrator_source core-plugins S3Parquet-batchsink.md
@@ -148,13 +148,12 @@ function download_includes() {
   download_md_doc_file $base_target $hydrator_source hive-plugins Hive-batchsink.md
   download_md_doc_file $base_target $hydrator_source hive-plugins Hive-batchsource.md
   
+  download_md_doc_file $base_target $hydrator_source kafka-plugins Kafka-realtimesource.md
   download_md_doc_file $base_target $hydrator_source kafka-plugins KafkaProducer-realtimesink.md
   
   download_md_doc_file $base_target $hydrator_source mongodb-plugins MongoDB-batchsink.md
   download_md_doc_file $base_target $hydrator_source mongodb-plugins MongoDB-batchsource.md
   download_md_doc_file $base_target $hydrator_source mongodb-plugins MongoDB-realtimesink.md
-  
-  download_md_doc_file $base_target $hydrator_source python-evaluator-transform PythonEvaluator-transform.md
   
   download_md_doc_file $base_target $hydrator_source transform-plugins CSVFormatter-transform.md
   download_md_doc_file $base_target $hydrator_source transform-plugins CSVParser-transform.md


### PR DESCRIPTION
Fixes an error in the Bash script for the docs.
Fixes a broken build caused by changes in the Cask Hydrator documentation.

Passes a [Quick Build](http://builds.cask.co/browse/CDAP-DOB110-1)