### PR TITLE
follow symlinks when constructing CDAP classpath

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -203,7 +203,7 @@ cdap_set_classpath() {
 
   # In order to ensure that we can do hacks, need to make sure classpath is sorted
   # so that cdap jars are placed earlier in the classpath than twill or hadoop jars
-  COMP_LIB=$(find "${COMP_HOME}/lib" -type f | sort | tr '\n' ':')
+  COMP_LIB=$(find -L "${COMP_HOME}/lib" -type f | sort | tr '\n' ':')
 
   if [ -n "${HBASE_CP}" ]; then
     CP="${COMP_LIB}:${HBASE_CP}:${CCONF}/:${COMP_HOME}/conf/:${EXTRA_CLASSPATH}"


### PR DESCRIPTION
This restores functionality to some internal tools that utilize symlinked ``lib`` directories.
