### PR TITLE
CDAP-4927 dont error when there is no error

### DIFF
--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreConnection.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreConnection.java
@@ -165,12 +165,14 @@ public class ExploreConnection implements Connection {
 
   @Override
   public void setAutoCommit(boolean b) throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    if (!b) {
+      throw new SQLFeatureNotSupportedException("Explore only supports auto commit = true");
+    }
   }
 
   @Override
   public void commit() throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override
@@ -180,7 +182,9 @@ public class ExploreConnection implements Connection {
 
   @Override
   public void setReadOnly(boolean b) throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    if (!b) {
+      throw new SQLFeatureNotSupportedException("Explore only supports read only = true");
+    }
   }
 
   @Override


### PR DESCRIPTION
Changing set calls to only error when setting to invalid values.
For example, if we only support auto commit = true, setting auto
commit to true should not be an error. Similarly, calling commit
should not be an error. It doesn't do anything, so it should be
a no-op.