### PR TITLE
CDAP-4944 make hydrator upgrade more robust

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/UpgradeTool.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/UpgradeTool.java
@@ -174,8 +174,15 @@ public class UpgradeTool {
         for (Map.Entry<String, Map<String, Map<String, PluginTemplate>>> appEntry :
           namespaceEntry.getValue().entrySet()) {
           String appName = appEntry.getKey();
-          PluginArtifactFinder pluginArtifactFinder =
-            appName.equals(BATCH_NAME) ? batchPluginArtifactFinder : realtimePluginArtifactFinder;
+          PluginArtifactFinder pluginArtifactFinder;
+          if (BATCH_NAME.equals(appName)) {
+            pluginArtifactFinder = batchPluginArtifactFinder;
+          } else if (REALTIME_NAME.equals(appName)) {
+            pluginArtifactFinder = realtimePluginArtifactFinder;
+          } else {
+            // don't know what this is, ignore it.
+            continue;
+          }
 
           for (Map.Entry<String, Map<String, PluginTemplate>> pluginTypeEntry : appEntry.getValue().entrySet()) {
 
@@ -326,8 +333,8 @@ public class UpgradeTool {
 
     UpgradeTool upgradeTool = new UpgradeTool(clientConfig);
 
-    upgradeTool.upgradeUIData();
     if (commandLine.hasOption("d")) {
+      upgradeTool.upgradeUIData();
       System.exit(0);
     }
 
@@ -353,6 +360,12 @@ public class UpgradeTool {
     }
 
     printUpgraded(upgradeTool.upgrade());
+
+    try {
+      upgradeTool.upgradeUIData();
+    } catch (Exception e) {
+      LOG.warn("There was an error upgrading UI data. Old pipeline drafts and plugin templates may no longer work.", e);
+    }
   }
 
   private static void printUpgraded(Set<Id.Application> pipelines) {


### PR DESCRIPTION
Fix a bug when the upgrade tool is told to only upgrade pipelines
but still tries to upgrade ui data.

The tool assumes that the ui data is in the 3.2.x format. This may
not be true, as the console store is not cleaned up or upgraded
in between cdap versions. This change moves ui data upgrade to the
end so that it does not interfere with upgrading pipelines, which
is more important. It also does not assume application names are
cdap-etl-batch or cdap-etl-realtime, since that is not the case
with really old ui data.

In general... that console store needs to be removed.