### PR TITLE
Revert unintended new API.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/RowColumns.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/RowColumns.java
@@ -135,18 +135,6 @@ public abstract class RowColumns<T> {
   }
 
   /**
-   * @deprecated As of CDAP 3.3.1, no parameter {@code #add} method is deprecated. Use either {@link #add(String[])} or
-   * {@link #add(byte[][])}.
-   *
-   * @return the {@link RowColumns} object being defined
-   */
-  @SuppressWarnings("unchecked")
-  public T add() {
-    // here only for backwards compatibility in 3.3.1.
-    return (T) this;
-  }
-
-  /**
    * @return the row that was included
    */
   public byte[] getRow() {


### PR DESCRIPTION
In https://github.com/caskdata/cdap/pull/5108, a no-parameter `add` method was introduced for backwards compatibility. However, this is not needed, since users can not actually call any of the `add` methods without parameters. I had intended to remove it from that PR. I even mentioned that I removed it (https://github.com/caskdata/cdap/pull/5108#issuecomment-181659208), but didn't actually remove it. 
So, removing it now.

Revert "Add a deprecated, no-parameter add method for backwards compatability."
This reverts commit a97d9431c1b2e42109cd0adf332f1439be4351d8.

http://builds.cask.co/browse/CDAP-RBT633-12