### PR TITLE
Remove snapshot - 3.3.1

### DIFF
--- a/cdap-api-common/pom.xml
+++ b/cdap-api-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-api-common</artifactId>

--- a/cdap-api/pom.xml
+++ b/cdap-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-api</artifactId>

--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-app-fabric</artifactId>

--- a/cdap-app-templates/cdap-data-quality/pom.xml
+++ b/cdap-app-templates/cdap-data-quality/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-app-templates</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-data-quality</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-etl-api</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl-archetypes</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-etl-batch-sink-archetype</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <cdap.version>3.3.1</cdap.version>
     <hadoop.version>2.3.0</hadoop.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl-archetypes</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-etl-batch-source-archetype</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <cdap.version>3.3.1</cdap.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl-archetypes</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-etl-realtime-sink-archetype</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <cdap.version>3.3.1</cdap.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl-archetypes</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-etl-realtime-source-archetype</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <cdap.version>3.3.1</cdap.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl-archetypes</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-etl-transform-archetype</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <cdap.version>3.3.1</cdap.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-etl-archetypes</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-etl-batch</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-etl-core</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-etl-realtime</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-etl-tools</artifactId>

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-app-templates</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-app-templates/pom.xml
+++ b/cdap-app-templates/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-app-templates</artifactId>

--- a/cdap-archetypes/cdap-app-archetype/pom.xml
+++ b/cdap-archetypes/cdap-app-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-archetypes</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-app-archetype</artifactId>

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <app.main.class>${package}.HelloWorld</app.main.class>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <cdap.version>3.3.1</cdap.version>
     <slf4j.version>1.7.5</slf4j.version>
     <guava.version>13.0.1</guava.version>
     <junit.version>4.11</junit.version>

--- a/cdap-archetypes/cdap-mapreduce-archetype/pom.xml
+++ b/cdap-archetypes/cdap-mapreduce-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-archetypes</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-mapreduce-archetype</artifactId>

--- a/cdap-archetypes/cdap-mapreduce-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-mapreduce-archetype/src/main/resources/archetype-resources/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <app.main.class>${package}.MapReduceApp</app.main.class>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <cdap.version>3.3.1</cdap.version>
     <slf4j.version>1.7.5</slf4j.version>
     <guava.version>13.0.1</guava.version>
     <junit.version>4.11</junit.version>

--- a/cdap-archetypes/cdap-spark-java-archetype/pom.xml
+++ b/cdap-archetypes/cdap-spark-java-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-archetypes</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-spark-java-archetype</artifactId>

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
     <app.main.class>${package}.SparkPageRankApp</app.main.class>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <cdap.version>3.3.1</cdap.version>
     <spark.core.version>1.3.1</spark.core.version>
     <slf4j.version>1.7.5</slf4j.version>
     <guava.version>13.0.1</guava.version>

--- a/cdap-archetypes/cdap-spark-scala-archetype/pom.xml
+++ b/cdap-archetypes/cdap-spark-scala-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-archetypes</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-spark-scala-archetype</artifactId>

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
     <app.main.class>${package}.SparkKMeansApp</app.main.class>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <cdap.version>3.3.1-SNAPSHOT</cdap.version>
+    <cdap.version>3.3.1</cdap.version>
     <spark.core.version>1.3.1</spark.core.version>
     <slf4j.version>1.7.5</slf4j.version>
     <guava.version>13.0.1</guava.version>

--- a/cdap-archetypes/pom.xml
+++ b/cdap-archetypes/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-archetypes</artifactId>

--- a/cdap-authorization-dataset-plugin/pom.xml
+++ b/cdap-authorization-dataset-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-cli-tests/pom.xml
+++ b/cdap-cli-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-cli</artifactId>

--- a/cdap-client-tests/pom.xml
+++ b/cdap-client-tests/pom.xml
@@ -22,7 +22,7 @@ the License.
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-client-tests</artifactId>

--- a/cdap-client/pom.xml
+++ b/cdap-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-client</artifactId>

--- a/cdap-common-unit-test/pom.xml
+++ b/cdap-common-unit-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-common-unit-test</artifactId>

--- a/cdap-common/pom.xml
+++ b/cdap-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-common</artifactId>

--- a/cdap-data-fabric-tests/pom.xml
+++ b/cdap-data-fabric-tests/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-data-fabric-tests</artifactId>

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-data-fabric</artifactId>

--- a/cdap-distributions/pom.xml
+++ b/cdap-distributions/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-distributions</artifactId>

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "sdk_version": "3.3.0"
+    "sdk_version": "3.3.1"
   },
   "builders": [
     {
@@ -125,7 +125,7 @@
       "skip_install": true,
       "json": {
         "cdap": {
-          "version": "3.3.0-1",
+          "version": "3.3.1-1",
           "sdk": {
             "url": "file:///tmp/cdap-sdk.zip"
           }

--- a/cdap-docs-gen/pom.xml
+++ b/cdap-docs-gen/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-docs-gen</artifactId>

--- a/cdap-examples/CountRandom/pom.xml
+++ b/cdap-examples/CountRandom/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/CubeService/pom.xml
+++ b/cdap-examples/CubeService/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cdap-examples</artifactId>
         <groupId>co.cask.cdap</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/DataCleansing/pom.xml
+++ b/cdap-examples/DataCleansing/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/FileSetExample/pom.xml
+++ b/cdap-examples/FileSetExample/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/HelloWorld/pom.xml
+++ b/cdap-examples/HelloWorld/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cdap-examples</artifactId>
         <groupId>co.cask.cdap</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/LogAnalysis/pom.xml
+++ b/cdap-examples/LogAnalysis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/Purchase/pom.xml
+++ b/cdap-examples/Purchase/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/SparkKMeans/pom.xml
+++ b/cdap-examples/SparkKMeans/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/SparkPageRank/pom.xml
+++ b/cdap-examples/SparkPageRank/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>SparkPageRank</artifactId>

--- a/cdap-examples/SportResults/pom.xml
+++ b/cdap-examples/SportResults/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/StreamConversion/pom.xml
+++ b/cdap-examples/StreamConversion/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/UserProfiles/pom.xml
+++ b/cdap-examples/UserProfiles/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/WebAnalytics/pom.xml
+++ b/cdap-examples/WebAnalytics/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/WikipediaPipeline/pom.xml
+++ b/cdap-examples/WikipediaPipeline/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/WordCount/pom.xml
+++ b/cdap-examples/WordCount/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/pom.xml
+++ b/cdap-examples/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-examples</artifactId>

--- a/cdap-examples/resources/weblog-analytics-config.json
+++ b/cdap-examples/resources/weblog-analytics-config.json
@@ -2,7 +2,7 @@
     "artifact": {
         "name": "cdap-etl-batch",
         "scope": "SYSTEM",
-        "version": "3.3.1-SNAPSHOT"
+        "version": "3.3.1"
     },
     "config": {
         "source": {

--- a/cdap-examples/resources/weblog-analytics.txt
+++ b/cdap-examples/resources/weblog-analytics.txt
@@ -1,3 +1,3 @@
-create app test cdap-etl-batch 3.3.1-SNAPSHOT system \$CDAP_HOME/examples/resources/weblog-analytics-config.json
+create app test cdap-etl-batch 3.3.1 system \$CDAP_HOME/examples/resources/weblog-analytics-config.json
 load stream logEventStream \$CDAP_HOME/examples/resources/accesslog.txt
 start mapreduce test.ETLMapReduce

--- a/cdap-examples/resources/weblog-service.txt
+++ b/cdap-examples/resources/weblog-service.txt
@@ -1,2 +1,2 @@
-deploy app \$CDAP_HOME/examples/CubeService/target/CubeServiceApp-3.3.1-SNAPSHOT.jar
+deploy app \$CDAP_HOME/examples/CubeService/target/CubeServiceApp-3.3.1.jar
 start service CubeServiceApp.CubeService 

--- a/cdap-explore-client/pom.xml
+++ b/cdap-explore-client/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-explore-client</artifactId>

--- a/cdap-explore-jdbc/pom.xml
+++ b/cdap-explore-jdbc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-explore-jdbc</artifactId>

--- a/cdap-explore/pom.xml
+++ b/cdap-explore/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-explore</artifactId>

--- a/cdap-formats/pom.xml
+++ b/cdap-formats/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-gateway/pom.xml
+++ b/cdap-gateway/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-gateway</artifactId>

--- a/cdap-hbase-compat-0.96/pom.xml
+++ b/cdap-hbase-compat-0.96/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-0.96</artifactId>

--- a/cdap-hbase-compat-0.98/pom.xml
+++ b/cdap-hbase-compat-0.98/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-0.98</artifactId>

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.0-cdh</artifactId>

--- a/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.0-cdh5.5.0</artifactId>

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.0</artifactId>

--- a/cdap-hbase-compat-1.1/pom.xml
+++ b/cdap-hbase-compat-1.1/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.1</artifactId>

--- a/cdap-integration-test/pom.xml
+++ b/cdap-integration-test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka/pom.xml
+++ b/cdap-kafka/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-kafka</artifactId>

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-master</artifactId>

--- a/cdap-notifications-api/pom.xml
+++ b/cdap-notifications-api/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-notifications-api</artifactId>

--- a/cdap-notifications/pom.xml
+++ b/cdap-notifications/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-notifications</artifactId>

--- a/cdap-proto/pom.xml
+++ b/cdap-proto/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-proto</artifactId>

--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-security</artifactId>

--- a/cdap-spi/pom.xml
+++ b/cdap-spi/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-spi</artifactId>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
 

--- a/cdap-test/pom.xml
+++ b/cdap-test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdap-ui",
-  "version": "3.3.1-SNAPSHOT",
+  "version": "3.3.1",
   "description": "Front-end for CDAP",
   "scripts": {
     "start": "node ./server.js",

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-ui</artifactId>

--- a/cdap-ui/templates/apps/predefined/AmazonSQSToHBase.json
+++ b/cdap-ui/templates/apps/predefined/AmazonSQSToHBase.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.1-SNAPSHOT"
+    "version": "3.3.1"
   },
   "config": {
     "source": {

--- a/cdap-ui/templates/apps/predefined/AmazonSQSToHBase.json
+++ b/cdap-ui/templates/apps/predefined/AmazonSQSToHBase.json
@@ -19,7 +19,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.1-SNAPSHOT"
+          "version": "1.2.1"
         }
       }
     },
@@ -36,7 +36,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.1-SNAPSHOT"
+            "version": "1.2.1"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/KafkaToHBase.json
+++ b/cdap-ui/templates/apps/predefined/KafkaToHBase.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.1-SNAPSHOT"
+    "version": "3.3.1"
   },
   "config": {
     "source": {

--- a/cdap-ui/templates/apps/predefined/KafkaToHBase.json
+++ b/cdap-ui/templates/apps/predefined/KafkaToHBase.json
@@ -21,7 +21,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.1-SNAPSHOT"
+          "version": "1.2.1"
         }
       }
     },
@@ -39,7 +39,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.1-SNAPSHOT"
+            "version": "1.2.1"
           }
         }
       }
@@ -57,7 +57,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.1-SNAPSHOT"
+            "version": "1.2.1"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/KafkaToOLAPCube.json
+++ b/cdap-ui/templates/apps/predefined/KafkaToOLAPCube.json
@@ -21,7 +21,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.1-SNAPSHOT"
+          "version": "1.2.1"
         }
       }
     },
@@ -40,7 +40,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.1-SNAPSHOT"
+            "version": "1.2.1"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/KafkaToOLAPCube.json
+++ b/cdap-ui/templates/apps/predefined/KafkaToOLAPCube.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.1-SNAPSHOT"
+    "version": "3.3.1"
   },
   "config": {
     "source": {

--- a/cdap-ui/templates/apps/predefined/KafkaToStream.json
+++ b/cdap-ui/templates/apps/predefined/KafkaToStream.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.1-SNAPSHOT"
+    "version": "3.3.1"
   },
   "config": {
     "source": {

--- a/cdap-ui/templates/apps/predefined/KafkaToStream.json
+++ b/cdap-ui/templates/apps/predefined/KafkaToStream.json
@@ -17,7 +17,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.1-SNAPSHOT"
+          "version": "1.2.1"
         }
       }
     },
@@ -35,7 +35,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.1-SNAPSHOT"
+            "version": "1.2.1"
           }
         }
       }
@@ -53,7 +53,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.1-SNAPSHOT"
+            "version": "1.2.1"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/StreamToHBase.json
+++ b/cdap-ui/templates/apps/predefined/StreamToHBase.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-batch",
     "scope": "SYSTEM",
-    "version": "3.3.1-SNAPSHOT"
+    "version": "3.3.1"
   },
   "config": {
     "source": {

--- a/cdap-ui/templates/apps/predefined/StreamToHBase.json
+++ b/cdap-ui/templates/apps/predefined/StreamToHBase.json
@@ -19,7 +19,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.1-SNAPSHOT"
+          "version": "1.2.1"
         }
       }
     },
@@ -37,7 +37,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.1-SNAPSHOT"
+            "version": "1.2.1"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/TwitterToHBase.json
+++ b/cdap-ui/templates/apps/predefined/TwitterToHBase.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.1-SNAPSHOT"
+    "version": "3.3.1"
   },
   "config": {
     "source": {

--- a/cdap-ui/templates/apps/predefined/TwitterToHBase.json
+++ b/cdap-ui/templates/apps/predefined/TwitterToHBase.json
@@ -19,7 +19,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.1-SNAPSHOT"
+          "version": "1.2.1"
         }
       }
     },
@@ -37,7 +37,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.1-SNAPSHOT"
+            "version": "1.2.1"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/TwitterToStream.json
+++ b/cdap-ui/templates/apps/predefined/TwitterToStream.json
@@ -19,7 +19,7 @@
         "artifact": {
           "name": "core-plugins",
           "scope": "SYSTEM",
-          "version": "1.2.1-SNAPSHOT"
+          "version": "1.2.1"
         }
       }
     },
@@ -37,7 +37,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.1-SNAPSHOT"
+            "version": "1.2.1"
           }
         }
       }
@@ -55,7 +55,7 @@
           "artifact": {
             "name": "core-plugins",
             "scope": "SYSTEM",
-            "version": "1.2.1-SNAPSHOT"
+            "version": "1.2.1"
           }
         }
       }

--- a/cdap-ui/templates/apps/predefined/TwitterToStream.json
+++ b/cdap-ui/templates/apps/predefined/TwitterToStream.json
@@ -2,7 +2,7 @@
   "artifact": {
     "name": "cdap-etl-realtime",
     "scope": "SYSTEM",
-    "version": "3.3.1-SNAPSHOT"
+    "version": "3.3.1"
   },
   "config": {
     "source": {

--- a/cdap-unit-test/pom.xml
+++ b/cdap-unit-test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-unit-test</artifactId>

--- a/cdap-watchdog-api/pom.xml
+++ b/cdap-watchdog-api/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-watchdog-api</artifactId>

--- a/cdap-watchdog/pom.xml
+++ b/cdap-watchdog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.3.1</version>
   </parent>
 
   <artifactId>cdap-watchdog</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>co.cask.cdap</groupId>
   <artifactId>cdap</artifactId>
-  <version>3.3.1-SNAPSHOT</version>
+  <version>3.3.1</version>
   <packaging>pom</packaging>
   <name>Cask Data Application Platform (CDAP)</name>
   <description>Data Application Platform for Hadoop</description>


### PR DESCRIPTION
Remove SNAPSHOT from the version.
Updates the same things as https://github.com/caskdata/cdap/pull/4987 (+112, -112).