### PR TITLE
Documentation Fixes

### DIFF
--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="2ceb80fcc13e52679cf07300010da370"
+DEFAULT_XML_MD5_HASH="26c863985113bf92643f8d3394b726ee"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-docs/developers-manual/source/building-blocks/metadata-lineage.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/metadata-lineage.rst
@@ -194,7 +194,8 @@ Here is an example JSON message, pretty-printed::
 
 Cloudera Navigator Integration
 ==============================
-CDAP Metadata can be pushed to Cloudera Navigator for metadata discovery and search. Refer to :ref:`Cloudera Navigator Integration <navigator-integration>` for more information.
+CDAP Metadata can be pushed to Cloudera Navigator for metadata discovery and search. 
+Refer to :ref:`Cloudera Navigator Integration <navigator-integration>` for more information.
 
 
 .. _metadata-lineage-lineage:


### PR DESCRIPTION
Fix MD5 hash. Breaks an overly-long line.

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB116-1).