### PR TITLE
Expose an API to specify PartitionKeys (instead of list of Partitions)

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/AbstractPartitionConsumer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/AbstractPartitionConsumer.java
@@ -49,7 +49,8 @@ public abstract class AbstractPartitionConsumer implements PartitionConsumer {
    * @param partitionKeys list of partition keys to mark as either succeeded or failed processing
    * @param succeeded whether or not processing of the specified partitions was successful
    */
-  public abstract void doFinish(ConsumerWorkingSet workingSet, List<PartitionKey> partitionKeys, boolean succeeded);
+  public abstract void doFinish(ConsumerWorkingSet workingSet, List<? extends PartitionKey> partitionKeys,
+                                boolean succeeded);
 
 
   /**
@@ -133,6 +134,11 @@ public abstract class AbstractPartitionConsumer implements PartitionConsumer {
       }
     };
 
+    onFinishWithKeys(partitionKeys, succeeded);
+  }
+
+  @Override
+  public void onFinishWithKeys(List<? extends PartitionKey> partitionKeys, boolean succeeded) {
     ConsumerWorkingSet workingSet = readState();
 
     doFinish(workingSet, partitionKeys, succeeded);

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/ConcurrentPartitionConsumer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/ConcurrentPartitionConsumer.java
@@ -74,7 +74,7 @@ public class ConcurrentPartitionConsumer extends AbstractPartitionConsumer {
   }
 
   @Override
-  public void doFinish(ConsumerWorkingSet workingSet, List<PartitionKey> partitionKeys, boolean succeeded) {
+  public void doFinish(ConsumerWorkingSet workingSet, List<? extends PartitionKey> partitionKeys, boolean succeeded) {
     doExpiry(workingSet);
     if (succeeded) {
       commit(workingSet, partitionKeys);
@@ -86,7 +86,7 @@ public class ConcurrentPartitionConsumer extends AbstractPartitionConsumer {
   /**
    * Removes the given partition keys from the working set, as they have been successfully processed.
    */
-  protected void commit(ConsumerWorkingSet workingSet, List<PartitionKey> partitionKeys) {
+  protected void commit(ConsumerWorkingSet workingSet, List<? extends PartitionKey> partitionKeys) {
     for (PartitionKey key : partitionKeys) {
       ConsumablePartition consumablePartition = workingSet.lookup(key);
       assertInProgress(consumablePartition);
@@ -98,7 +98,7 @@ public class ConcurrentPartitionConsumer extends AbstractPartitionConsumer {
    * Resets the process state of the given partition keys, as they were not successfully processed, or discards the
    * partition if it has already been attempted the configured number of attempts.
    */
-  protected void abort(ConsumerWorkingSet workingSet, List<PartitionKey> partitionKeys) {
+  protected void abort(ConsumerWorkingSet workingSet, List<? extends PartitionKey> partitionKeys) {
     List<PartitionKey> discardedPartitions = new ArrayList<>();
     for (PartitionKey key : partitionKeys) {
       ConsumablePartition consumablePartition = workingSet.lookup(key);

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionConsumer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.dataset.lib.partitioned;
 
 import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 
 import java.util.List;
@@ -55,4 +56,13 @@ public interface PartitionConsumer {
    * @param succeeded whether or not processing of the specified partitions was successful
    */
   void onFinish(List<? extends Partition> partitions, boolean succeeded);
+
+  /**
+   * Same as {@link #onFinish(List, boolean)}, but allows specifying {@link PartitionKey}s
+   * instead of {@link co.cask.cdap.api.dataset.lib.Partition}s.
+   *
+   * @param partitionKeys list of partition keys to mark as either succeeded or failed processing
+   * @param succeeded whether or not processing of the specified partitions was successful
+   */
+  void onFinishWithKeys(List<? extends PartitionKey> partitionKeys, boolean succeeded);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/TransactionalPartitionConsumer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/TransactionalPartitionConsumer.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.dataset.lib.DatasetStatePersistor;
 import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.tephra.TransactionFailureException;
 
@@ -101,6 +102,20 @@ public final class TransactionalPartitionConsumer implements PartitionConsumer {
         @Override
         public void run(DatasetContext context) throws Exception {
           getPartitionConsumer(context).onFinish(partitions, succeeded);
+        }
+      });
+    } catch (TransactionFailureException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void onFinishWithKeys(final List<? extends PartitionKey> partitionKeys, final boolean succeeded) {
+    try {
+      transactional.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          getPartitionConsumer(context).onFinishWithKeys(partitionKeys, succeeded);
         }
       });
     } catch (TransactionFailureException e) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -447,9 +447,18 @@ public class PartitionConsumerTest {
         List<PartitionDetail> consumedBy3 = partitionConsumer3.consumePartitions(2).getPartitions();
         Assert.assertEquals(1, consumedBy3.size());
 
-        // partitionConsumers 2 and 3 marks that it succesfully processed the partitions
+        // partitionConsumers 2 and 3 marks that it successfully processed the partitions
         partitionConsumer3.onFinish(consumedBy3, true);
-        partitionConsumer2.onFinish(consumedBy2, true);
+
+        // test onFinishWithKeys API
+        List<PartitionKey> keysConsumedBy2 =
+          Lists.transform(consumedBy2, new Function<PartitionDetail, PartitionKey>() {
+          @Override
+          public PartitionKey apply(PartitionDetail input) {
+            return input.getPartitionKey();
+          }
+        });
+        partitionConsumer2.onFinishWithKeys(keysConsumedBy2, true);
 
         // at this point, all partitions are processed, so no additional partitions are available for consumption
         Assert.assertEquals(0, partitionConsumer3.consumePartitions().getPartitions().size());


### PR DESCRIPTION
Expose an API to specify PartitionKeys (instead of Partition) when calling onFinish of a PartitionConsumer.

https://issues.cask.co/browse/CDAP-4977
http://builds.cask.co/browse/CDAP-DUT3605-2