### PR TITLE
Resolve compilation error after merging release/3.3

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/security/YarnTokenUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/YarnTokenUtils.java
@@ -61,6 +61,8 @@ public final class YarnTokenUtils {
         Text renewer = new Text(UserGroupInformation.getCurrentUser().getShortUserName());
         org.apache.hadoop.yarn.api.records.Token rmDelegationToken = yarnClient.getRMDelegationToken(renewer);
 
+        // TODO: The following logic should be replaced with call to ClientRMProxy.getRMDelegationTokenService after
+        // CDAP-4825 is resolved
         List<String> services = new ArrayList<>();
         if (HAUtil.isHAEnabled(configuration)) {
           // If HA is enabled, we need to enumerate all RM hosts
@@ -78,7 +80,7 @@ public final class YarnTokenUtils {
           services.add(SecurityUtil.buildTokenService(YarnUtils.getRMAddress(configuration)).toString());
         }
 
-        Token<TokenIdentifier> token = ConverterUtils.convertFromYarn(rmDelegationToken, null);
+        Token<TokenIdentifier> token = ConverterUtils.convertFromYarn(rmDelegationToken, (InetSocketAddress) null);
         token.setService(new Text(Joiner.on(',').join(services)));
         credentials.addToken(new Text(token.getService()), token);
 

--- a/cdap-common/src/main/java/org/apache/twill/internal/yarn/Hadoop21YarnAppClient.java
+++ b/cdap-common/src/main/java/org/apache/twill/internal/yarn/Hadoop21YarnAppClient.java
@@ -20,6 +20,11 @@ package org.apache.twill.internal.yarn;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.AbstractIdleService;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationResponse;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
@@ -28,9 +33,12 @@ import org.apache.hadoop.yarn.api.records.NodeReport;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.client.api.YarnClientApplication;
+import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.twill.api.TwillSpecification;
+import org.apache.twill.internal.Constants;
 import org.apache.twill.internal.ProcessController;
 import org.apache.twill.internal.ProcessLauncher;
+import org.apache.twill.internal.appmaster.ApplicationMasterInfo;
 import org.apache.twill.internal.appmaster.ApplicationMasterProcessLauncher;
 import org.apache.twill.internal.appmaster.ApplicationSubmitter;
 import org.slf4j.Logger;
@@ -59,8 +67,8 @@ public final class Hadoop21YarnAppClient extends AbstractIdleService implements 
   }
 
   @Override
-  public ProcessLauncher<ApplicationId> createLauncher(TwillSpecification twillSpec,
-                                                       @Nullable String schedulerQueue) throws Exception {
+  public ProcessLauncher<ApplicationMasterInfo> createLauncher(TwillSpecification twillSpec,
+                                                               @Nullable String schedulerQueue) throws Exception {
     // Request for new application
     YarnClientApplication application = yarnClient.createApplication();
     final GetNewApplicationResponse response = application.getNewApplicationResponse();
@@ -75,13 +83,19 @@ public final class Hadoop21YarnAppClient extends AbstractIdleService implements 
       appSubmissionContext.setQueue(schedulerQueue);
     }
 
+    // TODO: Make it adjustable through TwillSpec (TWILL-90)
+    // Set the resource requirement for AM
+    final Resource capability = adjustMemory(response, Resource.newInstance(Constants.APP_MASTER_MEMORY_MB, 1));
+    ApplicationMasterInfo appMasterInfo = new ApplicationMasterInfo(appId, capability.getMemory(),
+                                                                    capability.getVirtualCores());
+
     ApplicationSubmitter submitter = new ApplicationSubmitter() {
       @Override
-      public ProcessController<YarnApplicationReport> submit(YarnLaunchContext context, Resource capability) {
+      public ProcessController<YarnApplicationReport> submit(YarnLaunchContext context) {
         ContainerLaunchContext launchContext = context.getLaunchContext();
 
         appSubmissionContext.setAMContainerSpec(launchContext);
-        appSubmissionContext.setResource(adjustMemory(response, capability));
+        appSubmissionContext.setResource(capability);
         appSubmissionContext.setMaxAppAttempts(2);
 
         try {
@@ -94,7 +108,7 @@ public final class Hadoop21YarnAppClient extends AbstractIdleService implements 
       }
     };
 
-    return new ApplicationMasterProcessLauncher(appId, submitter);
+    return new ApplicationMasterProcessLauncher(appMasterInfo, submitter);
   }
 
   private Resource adjustMemory(GetNewApplicationResponse response, Resource capability) {
@@ -109,9 +123,9 @@ public final class Hadoop21YarnAppClient extends AbstractIdleService implements 
   }
 
   @Override
-  public ProcessLauncher<ApplicationId> createLauncher(String user,
-                                                       TwillSpecification twillSpec,
-                                                       @Nullable String schedulerQueue) throws Exception {
+  public ProcessLauncher<ApplicationMasterInfo> createLauncher(String user,
+                                                               TwillSpecification twillSpec,
+                                                               @Nullable String schedulerQueue) throws Exception {
     // Ignore user
     return createLauncher(twillSpec, schedulerQueue);
   }


### PR DESCRIPTION
- In YarnTokenUtils, cast the null parameter to resolve an ambiguous overloaded method
  - An overloaded method ConverterUtils.convertFromYarn is added in Hadoop 2.4
- The YarnAppClient interface has changed in Twill 0.7.0, modify the copied Hadoop21YarnAppClient class accordingly