### PR TITLE
Release 3.3.1 Minor Doc Fixes

### DIFF
--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -78,30 +78,31 @@ These roles map to the :ref:`CDAP components <admin-manual-cdap-components>` of 
 
 #. Add additional entries to the YARN Application Classpath for Spark jobs.
 
-   .. highlight:: console
-
    If you plan on running Spark programs from CDAP, CDAP requires that additional entries be added to
    the YARN application classpath, as the Spark installed on Cloudera Manager clusters
    is a "Hadoop-less" build and does not include Hadoop jars required by Spark.
 
-   To resolve this, go to the CM page for your cluster, click on the YARN service, then click on
-   the configuration tab, and then enter "mapreduce.application.classpath" in the search box. You will see entries similar to these:
+   To resolve this, go to the CM page for your cluster, click on the YARN service, click on
+   the configuration tab, and then enter ``mapreduce.application.classpath`` in the search box.
+   You will see entries similar to these::
 
-    $HADOOP_MAPRED_HOME/*
+     $HADOOP_MAPRED_HOME/*
 
-    $HADOOP_MAPRED_HOME/lib/*
+     $HADOOP_MAPRED_HOME/lib/*
 
-    $MR2_CLASSPATH
+     $MR2_CLASSPATH
 
+   Copy all the entries to the ``yarn.application.classpath`` configuration for YARN on your Cluster. 
+   The ``yarn.application.classpath`` setting can be found by searching as mentioned above.
 
-   Copy all the entries to "yarn.application.classpath" configuration
-   for Yarn on your Cluster. The "yarn.application.classpath" setting can be found the similar way  mentioned above.
+   Add the entries required by scrolling to the last entry in the class path form,
+   clicking the "+" button to add a new text box entry field at the end. Once you have
+   added all the entries from the ``mapreduce.application.classpath`` to the
+   ``yarn.application.classpath``, click on *Save*.
 
-   Add the entries required by scrolling to the last entry in the classpath form, clicking the "+" button to add a new text box entry field at the end. Once you have added all the entries from "mapreduce.application.classpath" to "yarn.application.classpath click on Save.
-
-   You can make these changes `using Cloudera Manager
-   <http://www.cloudera.com/content/www/en-us/documentation/enterprise/latest/topics/cm_mc_mod_configs.html>`__.
-   You will be prompted to restart the stale services after making changes.
+You can make these changes `using Cloudera Manager
+<http://www.cloudera.com/content/www/en-us/documentation/enterprise/latest/topics/cm_mc_mod_configs.html>`__.
+You will be prompted to restart the stale services after making changes.
 
 .. HDFS Permissions
 .. ----------------

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -129,15 +129,15 @@ Bug Fixes
 
 - `CDAP-4865 <https://issues.cask.co/browse/CDAP-4865>`__ - Enhanced the CDAP SDK to be
   able to publish metadata updates to an external Kafka, identified by the configuration
-  property metadata.updates.kafka.broker.list. Publishing can be enabled by setting
-  metadata.updates.publish.enabled to true. Updates are published to the Kafka topic
-  identified by the property metadata.updates.kafka.topic.
+  property ``metadata.updates.kafka.broker.list``. Publishing can be enabled by setting
+  ``metadata.updates.publish.enabled`` to true. Updates are published to the Kafka topic
+  identified by the property ``metadata.updates.kafka.topic``.
 
 - `CDAP-4877 <https://issues.cask.co/browse/CDAP-4877>`__ - Fixed errors in Cask Hydrator
-  Plugins. Two plugin documents (core-plugins/docs/Database-batchsink.md and
-  core-plugins/docs/Database-batchsource.md) were removed, as the plugins have been moved
-  from core-plugins to database-plugins (to database-plugins/docs/Database-batchsink.md and
-  database-plugins/docs/Database-batchsource.md).
+  Plugins. Two plugin documents (``core-plugins/docs/Database-batchsink.md`` and
+  ``core-plugins/docs/Database-batchsource.md``) were removed, as the plugins have been moved
+  from *core-plugins* to *database-plugins* (to ``database-plugins/docs/Database-batchsink.md``
+  and ``database-plugins/docs/Database-batchsource.md``).
 
 - `CDAP-4889 <https://issues.cask.co/browse/CDAP-4889>`__ - Fixed an issue with upgrading
   HBase tables while using the CDAP Upgrade Tool.


### PR DESCRIPTION
Correct indentation, text and formatting of the Cloudera instructions.
Correct formatting of release notes.

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DOB120-1).

Pages:
- [Cloudera Hadoop Configuration](http://builds.cask.co/artifact/CDAP-DOB120/shared/build-1/Docs-HTML/3.3.1/en/admin-manual/installation/cloudera.html#hadoop-configuration)
- [Release Notes 3.3.1](http://builds.cask.co/artifact/CDAP-DOB120/shared/build-1/Docs-HTML/3.3.1/en/reference-manual/release-notes.html#release-3-3-1)