### PR TITLE
Fix 3 flaky tests

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunnerTest.java
@@ -203,7 +203,7 @@ public class SparkProgramRunnerTest {
         Assert.assertEquals(1, ts.getTimeValues().size());
         return ts.getTimeValues().get(0).getValue();
       }
-    }, 5L, TimeUnit.SECONDS, 50L, TimeUnit.MILLISECONDS);
+    }, 10L, TimeUnit.SECONDS, 50L, TimeUnit.MILLISECONDS);
   }
 
   @Test

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriterTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriterTestBase.java
@@ -166,7 +166,7 @@ public abstract class ConcurrentStreamWriterTestBase {
     }
 
     startLatch.countDown();
-    Assert.assertTrue(completion.await(120, TimeUnit.SECONDS));
+    Assert.assertTrue(completion.await(4, TimeUnit.MINUTES));
 
     // Verify all events are written.
     // There should be only one partition


### PR DESCRIPTION
- Longer timeout for SparkProgramRunnerTest and DFSConcurrentStreamWriterTest
- Attempt to eliminate race condition in deploy workflow test in TestFrameworkTestRun