### PR TITLE
Feature/hdinsight ambari api

### DIFF
--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -81,7 +81,7 @@ sed \
   ${__cdap_site_template} > ${__tmpdir}/generated-conf.json
 
 # Install/Configure ntp, CDAP
-chef-solo -o 'recipe[ntp::default],recipe[cdap::fullstack],recipe[cdap::init]' -j ${__tmpdir}/generated-conf.json
+chef-solo -o 'recipe[ntp::default],recipe[ulimit::default],recipe[cdap::fullstack],recipe[cdap::init]' -j ${__tmpdir}/generated-conf.json
 
 # Temporary Hack to workaround CDAP-4089
 rm -f /opt/cdap/kafka/lib/log4j.log4j-1.2.14.jar

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -18,8 +18,19 @@
 # Install CDAP for Azure HDInsight cluster
 #
 
-die() { echo "ERROR: ${*}"; exit 1; };
+# Arguments supplied by https://raw.githubusercontent.com/hdinsight/Edge-Node-Scripts/release-12-1-2015/edgeNodeSetup.sh
+CLUSTERNAME=${1}
+USERID=${2}
+PASSWD=${3}
+CUSTOMPARAMETER=${4} # Not used
+SSHUSER=${5}
 
+# Ambari constants
+AMBARICONFIGS_SH=/var/lib/ambari-server/resources/scripts/configs.sh
+AMBARIPORT=8080
+
+
+# CDAP config
 # The git branch to clone
 CDAP_BRANCH='release/3.3'
 # Optional tag to checkout - All released versions of this script should set this
@@ -29,7 +40,7 @@ CDAP_VERSION='3.3.0-1'
 # The version of Chef to install
 CHEF_VERSION='12.7.2'
 # cdap-site.xml configuration parameters
-EXPLORE_ENABLED='false'
+EXPLORE_ENABLED='true'
 
 __tmpdir="/tmp/cdap_install.$$.$(date +%s)"
 __gitdir="${__tmpdir}/cdap"
@@ -37,8 +48,137 @@ __gitdir="${__tmpdir}/cdap"
 __packerdir="${__gitdir}/cdap-distributions/src/packer/scripts"
 __cdap_site_template="${__gitdir}/cdap-distributions/src/hdinsight/cdap-conf.json"
 
+
+# Function definitions
+
+die() { echo "ERROR: ${*}"; exit 1; };
+
 __cleanup_tmpdir() { test -d ${__tmpdir} && rm -rf ${__tmpdir}; };
 __create_tmpdir() { mkdir -p ${__tmpdir}; };
+
+
+# HDInsight cluster maintains an /etc/hosts entry 'headnodehost' to designate active master.
+# Here on the edgenode we only have 'headnode0' and 'headnode1', so we can only guess and check
+# Sets ${ACTIVEAMBARIHOST} if successful
+setHeadNodeOrDie() {
+  __validateAmbariConnectivity "headnode0" || __validateAmbariConnectivity "headnode1" || die "Could not determine active headnode"
+}
+
+# Given a candidate Ambari host, try to perform an API GET
+# Dies if credentials are bad
+__validateAmbariConnectivity() {
+    ACTIVEAMBARIHOST=${1}
+    coreSiteContent=$(bash $AMBARICONFIGS_SH -u $USERID -p $PASSWD get ${ACTIVEAMBARIHOST} $CLUSTERNAME core-site)
+    local __ret=$?
+    echo "ret: ${__ret}"
+    if [[ $coreSiteContent == *"[ERROR]"* && $coreSiteContent == *"Bad credentials"* ]]; then
+        #echo "[ERROR] Username and password are invalid. Exiting!"
+        #exit 134
+        die "[ERROR] Username and password are invalid. Exiting!"
+    fi
+    return ${__ret}
+}
+
+# Given a config type, name, and value, set the configuration via the Ambari API
+# Dies if unsuccessful
+setAmbariConfig() {
+    local __configtype=${1} # core-site, etc
+    local __name=${2}
+    local __value=${3}
+    updateResult=$(bash $AMBARICONFIGS_SH -u $USERID -p $PASSWD set $ACTIVEAMBARIHOST $CLUSTERNAME ${__configtype} ${__name} ${__value})
+
+    if [[ $updateResult != *"Tag:version"* ]] && [[ $updateResult == *"[ERROR]"* ]]; then
+        #echo "[ERROR] Failed to update ${__configtype}. Exiting!"
+        #echo $updateResult
+        #exit 135
+        die "[ERROR] Failed to update ${__configtype}: ${updateResult}"
+    fi
+}
+
+# DANGEROUS! unless you know your input is unique
+# Runs sed -i to update local Hadoop/HBase client configuration
+substituteLocalConfigValue() {
+    local __oldVal=${1}
+    local __newVal=${2}
+
+    for f in $(ls -1 /etc/hadoop/conf/*.xml /etc/hbase/conf/*.xml) ; do
+      sed -i.old -e "s#${__oldVal}#${__newVal}#g" ${f}
+    done
+}
+
+# Fetches value of fs.azure.page.blob.dir, appends '/cdap' to it, updates it via Ambari API, updates the local client configurations, and restarts cluster services
+updateFsAzurePageBlobDirForCDAP() {
+    echo "bash $AMBARICONFIGS_SH -u $USERID -p $PASSWD get $ACTIVEAMBARIHOST $CLUSTERNAME core-site"
+    currentValue=$(bash $AMBARICONFIGS_SH -u $USERID -p $PASSWD get $ACTIVEAMBARIHOST $CLUSTERNAME core-site | grep 'fs.azure.page.blob.dir' | cut -d' ' -f3 | sed -e 's/"\(.*\)"[,]*/\1/')
+    echo "currentValue=${currentValue}"
+    if [ -n ${currentValue} ]; then
+      if echo ${currentValue} | grep -q '/cdap'; then
+        echo "fs.azure.page.blob.dir already contains /cdap"
+        return 0
+      else
+        newValue="${currentValue},/cdap"
+      fi
+    else
+      newValue="/cdap"
+    fi
+    setAmbariConfig 'core-site' 'fs.azure.page.blob.dir' ${newValue} || die "Could not update Ambari config"
+    substituteLocalConfigValue ${currentValue} ${newValue} || die "Could not update Local Hadoop Client config"
+    restartCdapDependentClusterServices
+}
+
+# Stop an Ambari cluster service
+stopServiceViaRest() {
+    if [ -z "$1" ]; then
+        echo "Need service name to stop service"
+        exit 136
+    fi
+    SERVICENAME=$1
+    echo "Stopping $SERVICENAME"
+    curl -u $USERID:$PASSWD -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Stop Service for Hue installation"}, "Body": {"ServiceInfo": {"state": "INSTALLED"}}}' http://$ACTIVEAMBARIHOST:$AMBARIPORT/api/v1/clusters/$CLUSTERNAME/services/$SERVICENAME
+}
+
+# Start an Ambari cluster service
+startServiceViaRest() {
+    if [ -z "$1" ]; then
+        echo "Need service name to start service"
+        exit 136
+    fi
+    sleep 2
+    SERVICENAME=$1
+    echo "Starting $SERVICENAME"
+    startResult=$(curl -u $USERID:$PASSWD -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Start Service for Hue installation"}, "Body": {"ServiceInfo": {"state": "STARTED"}}}' http://$ACTIVEAMBARIHOST:$AMBARIPORT/api/v1/clusters/$CLUSTERNAME/services/$SERVICENAME)
+    if [[ $startResult == *"500 Server Error"* || $startResult == *"internal system exception occurred"* ]]; then
+        sleep 60
+        echo "Retry starting $SERVICENAME"
+        startResult=$(curl -u $USERID:$PASSWD -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Start Service for Hue installation"}, "Body": {"ServiceInfo": {"state": "STARTED"}}}' http://$ACTIVEAMBARIHOST:$AMBARIPORT/api/v1/clusters/$CLUSTERNAME/services/$SERVICENAME)
+    fi
+    echo $startResult
+}
+
+# Restart Ambari cluster services
+restartCdapDependentClusterServices() {
+    stopServiceViaRest HBASE
+    stopServiceViaRest YARN
+    stopServiceViaRest MAPREDUCE2
+    stopServiceViaRest HDFS
+
+    startServiceViaRest HDFS
+    startServiceViaRest MAPREDUCE2
+    startServiceViaRest YARN
+    startServiceViaRest HBASE
+}
+
+
+# Begin Ambari Cluster Prep
+
+# Find/Validate Ambari connectivity
+setHeadNodeOrDie && echo "Found active Ambari host: ${ACTIVEAMBARIHOST}"
+
+# Update necessary hadoop configuration
+updateFsAzurePageBlobDirForCDAP
+
+
+# Begin CDAP Prep/Install
 
 # Install git
 apt-get install --yes git || die "Failed to install git"

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -27,7 +27,7 @@ CDAP_TAG=''
 # The CDAP package version passed to Chef
 CDAP_VERSION='3.3.0-1'
 # The version of Chef to install
-CHEF_VERSION='11.18.12'
+CHEF_VERSION='12.7.2'
 # cdap-site.xml configuration parameters
 EXPLORE_ENABLED='false'
 

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -36,7 +36,7 @@ CDAP_BRANCH='release/3.3'
 # Optional tag to checkout - All released versions of this script should set this
 CDAP_TAG=''
 # The CDAP package version passed to Chef
-CDAP_VERSION='3.3.0-1'
+CDAP_VERSION='3.3.1-1'
 # The version of Chef to install
 CHEF_VERSION='12.7.2'
 # cdap-site.xml configuration parameters


### PR DESCRIPTION
Updates the HDInsight installer script to: 
   * find and confirm Ambari API connectivity
   * append ``/cdap`` to the current value of ``fs.azure.page.blob.dir`` and set it:
      * on the Ambari cluster via Ambari API
      * on the edgenode client configs via ``sed -i``
   * restart cluster

The Ambari API code is adapted from their Hue example:  https://hdiconfigactions.blob.core.windows.net/linuxhueconfigactionv02/install-hue-uber-v02.sh