### PR TITLE
update ntp configuration to point to same ntp servers as hdinsight

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-conf.json
+++ b/cdap-distributions/src/hdinsight/cdap-conf.json
@@ -12,5 +12,11 @@
   "hadoop": {
     "distribution": "hdp",
     "distribution_version": "{{HDP_VERSION}}"
+  },
+  "ntp": {
+    "servers": [
+      "time.windows.com",
+      "ntp.ubuntu.com"
+    ]
   }
 }


### PR DESCRIPTION
Configure ntp on the edgenode to use the same servers as ntp on the hdinsight cluster nodes.