### PR TITLE
Feature/hdinsight synchronous restart

### DIFF
--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -135,7 +135,6 @@ __waitForServiceState() {
     return 1
 }
 
-
 # Stop an Ambari cluster service
 stopServiceViaRest() {
     if [ -z "${1}" ]; then

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -144,7 +144,7 @@ stopServiceViaRest() {
     fi
     SERVICENAME=${1}
     echo "Stopping ${SERVICENAME}"
-    curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Stop Service for Hue installation"}, "Body": {"ServiceInfo": {"state": "INSTALLED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}
+    curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Stop Service for CDAP installation"}, "Body": {"ServiceInfo": {"state": "INSTALLED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}
 }
 
 # Start an Ambari cluster service
@@ -156,11 +156,11 @@ startServiceViaRest() {
     sleep 2
     SERVICENAME=${1}
     echo "Starting ${SERVICENAME}"
-    startResult=$(curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Start Service for Hue installation"}, "Body": {"ServiceInfo": {"state": "STARTED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME})
+    startResult=$(curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Start Service for CDAP installation"}, "Body": {"ServiceInfo": {"state": "STARTED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME})
     if [[ ${startResult} == *"500 Server Error"* || ${startResult} == *"internal system exception occurred"* ]]; then
         sleep 60
         echo "Retry starting ${SERVICENAME}"
-        startResult=$(curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Start Service for Hue installation"}, "Body": {"ServiceInfo": {"state": "STARTED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME})
+        startResult=$(curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Start Service for CDAP installation"}, "Body": {"ServiceInfo": {"state": "STARTED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME})
     fi
     echo ${startResult}
 }


### PR DESCRIPTION
The Ambari service stop/start api's are asynchronous.  This lead to CDAP being installed and started while the core cluster services were being restarted.

- [x] implement a polling method to wait for service to be in desired state
- [x] use it to achieve a synchronous cluster restart prior to installing CDAP
- [x] update "context" text under which the restart is listed as (Ambari metadata)