### PR TITLE
CDAP-4988: Documenting CDAP CLI in Distributed CDAP

### DIFF
--- a/cdap-docs/admin-manual/source/_includes/installation/installation.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/installation.txt
@@ -107,11 +107,17 @@ minimum of two boxes.
 
 This will download and install the latest version of CDAP with all of its dependencies. 
 
+.. _|distribution|-cli-package-installation:
+
+To install the optional :ref:`CDAP-CLI <cli>` on a node, add the ``cdap-cli`` package to
+the list of packages in the commands below.
 
 Using Chef
 ..........
 If you are using `Chef <https://www.getchef.com>`__ to install CDAP, an `official
 cookbook is available <https://supermarket.getchef.com/cookbooks/cdap>`__.
+
+To install the optional :ref:`CDAP-CLI <cli>` on a node, use the ``fullstack`` recipe.
 
 
 On RPM using Yum

--- a/cdap-docs/admin-manual/source/cdap-components.rst
+++ b/cdap-docs/admin-manual/source/cdap-components.rst
@@ -16,6 +16,10 @@ These are the CDAP components:
 - **CDAP UI:** User interface for managing CDAP applications (package *cdap-ui*); and
 - **CDAP Authentication Server:** Performs client authentication for CDAP when security is enabled (package *cdap-security*).
 
+An *optional* component is available:
+
+- **CDAP CLI:** User interface for interacting with CDAP from within a shell, similar to the HBase or bash shells (package *cdap-ui*).
+
 Some CDAP components run on YARN, while others orchestrate “containers” in the Hadoop cluster.
 The CDAP Router service starts a router instance on each of the local boxes and instantiates
 one or more gateway instances on YARN as determined by the gateway service configuration.

--- a/cdap-docs/reference-manual/source/cli-api.rst
+++ b/cdap-docs/reference-manual/source/cli-api.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. _cli:
 
@@ -15,6 +15,10 @@ The Command Line Interface (CLI) provides methods to interact with the CDAP serv
 similar to the HBase or ``bash`` shells. It is located within the SDK, at ``bin/cdap-cli`` as either a bash
 script or a Windows ``.bat`` file.
 
+It can be :ref:`installed on Distributed CDAP <packages-cli-package-installation>`, in
+which case it will be installed either in ``/opt/cdap/cli`` or, in the case of Cloudera
+Manager, ``opt/cloudera/parcels/cdap/cli/``.
+
 The CLI may be used in two ways: interactive mode and non-interactive mode.
 
 Interactive Mode
@@ -26,13 +30,21 @@ To run the CLI in interactive mode, run the ``cdap-cli.sh`` executable with no a
 
   $ ./bin/cdap-cli.sh
 
-or, on Windows::
+On Windows::
 
   > bin\cdap-cli.bat
+  
+On Distributed CDAP::
 
-The executable should bring you into a shell, with this prompt::
+  $ ./opt/cdap/cli/bin/cdap-cli.sh
 
-  cdap (http://localhost:10000)>
+On Cloudera Manager clusters::
+
+  $ ./opt/cloudera/parcels/cdap/cli/bin/cdap-cli.sh
+
+The executable should bring you into a shell, with a prompt similar to::
+
+  cdap (http://localhost:10000/namespace:default)>
 
 This indicates that the CLI is currently set to interact with the CDAP server at ``localhost``.
 
@@ -43,11 +55,11 @@ This indicates that the CLI is currently set to interact with the CDAP server at
 For example, with ``CDAP_HOST`` set to ``example.com``, the CLI would be interacting with
 a CDAP instance at ``example.com``, port ``10000``::
 
-  cdap (http://example.com:10000)>
+  cdap (http://example.com:10000/namespace:default)>
 
 To list all of the available commands, enter the CLI command ``help``::
 
-  cdap (http://localhost:10000)> help
+  cdap (http://localhost:10000/namespace:default)> help
 
 Non-Interactive Mode
 --------------------

--- a/cdap-docs/reference-manual/source/glossary.rst
+++ b/cdap-docs/reference-manual/source/glossary.rst
@@ -114,6 +114,13 @@ Glossary
    CDAP Console
       See :term:`CDAP UI`.
 
+   CDAP CLI
+      See :term:`Command Line Interface`.
+
+   Command Line Interface
+      The :ref:`Command Line Interface (CLI) <cli>` provides methods to interact with CDAP
+      from within a shell, similar to the HBase or ``bash`` shells.
+
    Apache Spark
       See :term:`Spark Program <spark>`.
 


### PR DESCRIPTION
Adds [CDAP CLI as an optional component for installation](http://builds.cask.co/artifact/CDAP-DOB126/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/admin-manual/cdap-components.html).
Added [installation instructions](http://builds.cask.co/artifact/CDAP-DOB126/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/admin-manual/installation/packages.html#installing-cdap-services).
Added [startup instructions to the CLI docs](http://builds.cask.co/artifact/CDAP-DOB126/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/reference-manual/cli-api.html).
Added [CLI glossary entries](http://builds.cask.co/artifact/CDAP-DOB126/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/reference-manual/glossary.html#term-command-line-interface).

Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DOB126-1).

Fix for https://issues.cask.co/browse/CDAP-4988.