### PR TITLE
CDAP-5048 Add doc support for Google Tag Manager

### DIFF
--- a/cdap-docs/_common/_themes/cdap/layout.html
+++ b/cdap-docs/_common/_themes/cdap/layout.html
@@ -4,7 +4,7 @@
 
     Master layout template for Sphinx themes.
     Modified by Cask Data, Inc.
-    Portions Copyright © 2014-2015 Cask Data, Inc.
+    Portions Copyright © 2014-2016 Cask Data, Inc.
     
     :copyright: Copyright 2007-2013 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
@@ -105,11 +105,23 @@
     <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
     {%- endfor %}
     
-    <!-- Amazon SQS Page Usage Logging start-->
+    <!-- Google Tag Manager start -->
+    {%- if html_google_tag_manager_code is defined %}
+    <script>dataLayer = [];</script>
+    <noscript><iframe src="//www.googletagmanager.com/ns.html?id={{ html_google_tag_manager_code }}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{ html_google_tag_manager_code }}');</script>
+    {%- endif %}
+    <!-- Google Tag Manager end -->
+    
+    <!-- Amazon SQS Page Usage Logging start -->
     <script type="text/javascript" src="https://sdk.amazonaws.com/js/aws-sdk-2.1.35.min.js"></script>
     <script type="text/javascript" src="http://docs.cask.co/resources/scripts/aws-sqs-1.0.0.js"></script>
-    <!-- Amazon SQS Page Usage Logging end-->
-    
+    <!-- Amazon SQS Page Usage Logging end -->
 {%- endmacro %}
 
 {%- macro css() %}
@@ -118,7 +130,6 @@
     {%- for cssfile in css_files %}
     <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
     {%- endfor %}
-    
 {#
     Code to number sections on pages, by setting in the field list at the top
 :section-numbering: true
@@ -147,11 +158,9 @@
     {%- if hidetoc %}
         <link rel="stylesheet" href="{{ pathto('_static/hide-toc.css', 1) }}" type="text/css" />
     {%- endif %}
-
 {#  Code to hide sidebar navigation on certain pages, by setting in the field list at the top
 :hide-nav: true
 #}
- 
     {%- set hidenav = '' %}
     {%- set hidenav_key = 'hide-nav' %}
     {%- if meta is defined %}
@@ -162,7 +171,6 @@
     {%- if hidenav %}
         <link rel="stylesheet" href="{{ pathto('_static/hide-nav.css', 1) }}" type="text/css" />
     {%- endif %}
-   
 {%- endmacro %}
 
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -170,6 +178,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
     {{ metatags }}
     {# Code to add custom theme values as meta_tags #}
+    {# Used to add the Git release, hash, timestamp values #}
     {%- for tag, tag_value in theme_meta_git.iteritems() %}
     <meta name="{{ tag }}" content="{{ tag_value }}">
     {%- endfor %}

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -1,4 +1,4 @@
-# Copyright © 2014-2015 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -100,11 +100,11 @@ ZIP="${ZIP_FILE_NAME}.zip"
 # Set Google Analytics Codes
 
 # Corporate Docs Code
-GOOGLE_ANALYTICS_WEB="UA-55077523-3"
+GOOGLE_TAG_MANAGER_CODE_WEB="GTM-KWLFGH"
 WEB="web"
 
 # CDAP Project Code
-GOOGLE_ANALYTICS_GITHUB="UA-55081520-2"
+GOOGLE_TAG_MANAGER_CODE_GITHUB="GTM-PBZ3JL"
 GITHUB="github"
 
 # BUILD.rst
@@ -156,7 +156,7 @@ function build_docs_google() {
   clean
   cd ${SCRIPT_PATH}
   check_includes
-  ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} -D googleanalytics_id=$1 -D googleanalytics_enabled=1 ${SOURCE} ${TARGET}/html
+  ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} -A html_google_tag_manager_code=$1 ${SOURCE} ${TARGET}/html
   consolidate_messages
 }
 
@@ -203,12 +203,12 @@ function build() {
 }
 
 function build_github() {
-  build_docs_google ${GOOGLE_ANALYTICS_GITHUB}
+  build_docs_google ${GOOGLE_TAG_MANAGER_CODE_GITHUB}
   build_extras
 }
 
 function build_web() {
-  build_docs_google ${GOOGLE_ANALYTICS_WEB}
+  build_docs_google ${GOOGLE_TAG_MANAGER_CODE_WEB}
   build_extras
 }
 

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -398,7 +398,7 @@ def get_manual_titles_bash():
 
 # Add Google Tag Manager Code, or over-ride on the command line with
 # -A html_google_tag_manager_code=GTM-XXXXXX
-html_google_tag_manager_code = 'GTM-XXXXXX'
+html_google_tag_manager_code = ''
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ['_themes','../../_common/_themes']

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright © 2014-2015 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -115,7 +115,6 @@ needs_sphinx = '1.3'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinxcontrib.googleanalytics',
     'sphinx.ext.ifconfig',
     'sphinx.ext.intersphinx',
     'sphinx.ext.extlinks',
@@ -310,15 +309,6 @@ highlight_language = 'java'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 #keep_warnings = False
 
-# Add Google Analytics ID, or over-ride on the command line with
-# -D googleanalytics_id=UA-999-999-999
-googleanalytics_id = 'UA-123-123-123'
-
-# True by default, use it to turn off tracking.
-# -D googleanalytics_enabled=1
-# Turned off so unless the code and flag are passed on the command line, tracking is off.
-googleanalytics_enabled = False
-
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -405,6 +395,10 @@ def get_manual_titles_bash():
         manual_titles += "'%s'" % title
     manual_titles += SUFFIX
     return manual_titles
+
+# Add Google Tag Manager Code, or over-ride on the command line with
+# -A html_google_tag_manager_code=GTM-XXXXXX
+html_google_tag_manager_code = 'GTM-XXXXXX'
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ['_themes','../../_common/_themes']

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -372,7 +372,7 @@ function build_docs_outer_level() {
   
   local google_options
   if [ "x${google_code}" != "x" ]; then
-    google_options="-D googleanalytics_id=${google_code} -D googleanalytics_enabled=1"
+    google_options="-A html_google_tag_manager_code=${google_code}"
   fi
   ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_options} ${TARGET_PATH}/${SOURCE} ${TARGET_PATH}/${HTML}
   consolidate_messages

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2014-2015 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -280,7 +280,7 @@ function build_docs_github_part() {
   echo "--------------------------------------------------------"
   echo
   # Don't add the zip_extras (.htaccess files) to Github
-  _build_docs build-github ${GOOGLE_ANALYTICS_GITHUB} ${GITHUB}
+  _build_docs build-github ${GOOGLE_TAG_MANAGER_CODE_GITHUB} ${GITHUB}
   return $?
 }
 
@@ -309,7 +309,7 @@ function build_docs_web_part() {
   echo "Building Web Docs"
   echo "--------------------------------------------------------"
   echo
-  _build_docs build-web ${GOOGLE_ANALYTICS_WEB} ${WEB} ${TRUE}
+  _build_docs build-web ${GOOGLE_TAG_MANAGER_CODE_WEB} ${WEB} ${TRUE}
   return $?
 }
 


### PR DESCRIPTION
Add new Google Tag Manager code support, and remove old Google Analytics.
Removes some blank lines in the layout template that were making the header extra long.
Corrected formatting of the Amazon SQS comment tags.

Fix for https://issues.cask.co/browse/CDAP-5048.

Passes [Quick Build 4](http://builds.cask.co/browse/CDAP-DOB127-4).

You can see the results by looking at the source of [any of the pages](http://builds.cask.co/artifact/CDAP-DOB127/shared/build-4/Docs-HTML/3.3.2-SNAPSHOT/en/index.html).