### PR TITLE
Catch IllegalStateException instead of IllegalArgumentException

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -215,7 +215,7 @@ public class MasterServiceMain extends DaemonMain {
       public void run() {
         try {
           SparkUtils.getRewrittenSparkAssemblyJar(cConf);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalStateException e) {
           // It's ok if Spark is not configured at all
           LOG.debug("Spark library is not available: {}", e.getMessage());
         } catch (Throwable t) {


### PR DESCRIPTION
- Making it not too verbose when Spark is not available in the cluster

**Not a critical fix and it doesn't affect any functionality at all.**