### PR TITLE
CDAP-5062 make explore jdbc fetch size configurable

### DIFF
--- a/cdap-docs/integrations/source/jdbc.rst
+++ b/cdap-docs/integrations/source/jdbc.rst
@@ -66,6 +66,7 @@ Here are the parameters that can be used in the connection URL:
 - ``auth.token``: authentication token for the connection
 - ``ssl.enabled``: boolean; whether SSL is enabled or not
 - ``verify.ssl.cert``: boolean; false to suspend certificate checks and allow self-signed certificates
+- ``fetch.size``: int; number of rows to fetch at a time from the database cursor. Defaults to 1000. 0 means no limit.
 
 JDBC drivers are a standard in the Java ecosystem, with many `resources about them available
 <http://docs.oracle.com/javase/tutorial/jdbc/>`__.

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreConnection.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreConnection.java
@@ -52,12 +52,14 @@ public class ExploreConnection implements Connection {
   private static final Logger LOG = LoggerFactory.getLogger(ExploreConnection.class);
 
   private final String namespace;
+  private final ExploreConnectionParams connectionParams;
   private ExploreClient exploreClient;
   private boolean isClosed = false;
 
-  ExploreConnection(ExploreClient exploreClient, String namespace) {
+  ExploreConnection(ExploreClient exploreClient, String namespace, ExploreConnectionParams connectionParams) {
     this.exploreClient = exploreClient;
     this.namespace = namespace;
+    this.connectionParams = connectionParams;
   }
 
   @Override
@@ -65,7 +67,9 @@ public class ExploreConnection implements Connection {
     if (isClosed) {
       throw new SQLException("Can't create Statement, connection is closed");
     }
-    return new ExploreStatement(this, exploreClient, namespace);
+    Statement statement = new ExploreStatement(this, exploreClient, namespace);
+    statement.setFetchSize(connectionParams.getFetchSize());
+    return statement;
   }
 
   @Override
@@ -73,7 +77,9 @@ public class ExploreConnection implements Connection {
     if (isClosed) {
       throw new SQLException("Can't create Statement, connection is closed");
     }
-    return new ExplorePreparedStatement(this, exploreClient, sql, namespace);
+    PreparedStatement preparedStatement = new ExplorePreparedStatement(this, exploreClient, sql, namespace);
+    preparedStatement.setFetchSize(connectionParams.getFetchSize());
+    return preparedStatement;
   }
 
   @Override
@@ -194,17 +200,17 @@ public class ExploreConnection implements Connection {
 
   @Override
   public void setTransactionIsolation(int i) throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override
   public SQLWarning getWarnings() throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return null;
   }
 
   @Override
   public void clearWarnings() throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreConnectionParams.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreConnectionParams.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.jdbc;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.Collection;
+
+/**
+ * Explore connection parameters.
+ */
+public class ExploreConnectionParams {
+  private static final Logger LOG = LoggerFactory.getLogger(ExploreConnectionParams.class);
+  static final int DEFAULT_FETCH_SIZE = 1000;
+
+  /**
+   * Extra Explore connection parameter.
+   */
+  public enum Info {
+    EXPLORE_AUTH_TOKEN("auth.token"),
+    NAMESPACE("namespace"),
+    SSL_ENABLED("ssl.enabled"),
+    VERIFY_SSL_CERT("verify.ssl.cert"),
+    FETCH_SIZE("fetch.size");
+
+    private final String name;
+
+    Info(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public static Info fromStr(String name) {
+      for (Info info : Info.values()) {
+        if (info.getName().equals(name)) {
+          return info;
+        }
+      }
+      return null;
+    }
+  }
+
+  private final String host;
+  private final int port;
+  private final Multimap<Info, String> extraInfos;
+
+  ExploreConnectionParams(String host, int port, Multimap<Info, String> extraInfos) {
+    this.host = host;
+    this.port = port;
+    this.extraInfos = extraInfos;
+  }
+
+  public Multimap<Info, String> getExtraInfos() {
+    return extraInfos;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getFetchSize() {
+    Collection<String> fetchSizes = extraInfos.get(Info.FETCH_SIZE);
+    if (fetchSizes.isEmpty()) {
+      return DEFAULT_FETCH_SIZE;
+    } else {
+      String fetch = fetchSizes.iterator().next();
+      try {
+        return Integer.parseInt(fetch);
+      } catch (NumberFormatException e) {
+        LOG.warn("Could not parse fetch size '{}'. Using default of {}.", fetch, DEFAULT_FETCH_SIZE);
+        return DEFAULT_FETCH_SIZE;
+      }
+    }
+  }
+
+  /**
+   * Parse Explore connection url string to retrieve the necessary parameters to connect to CDAP.
+   */
+  public static ExploreConnectionParams parseConnectionUrl(String url) {
+    // URI does not accept two semicolons in a URL string, hence the substring
+    URI jdbcURI = URI.create(url.substring(ExploreJDBCUtils.URI_JDBC_PREFIX.length()));
+    String host = jdbcURI.getHost();
+    int port = jdbcURI.getPort();
+    ImmutableMultimap.Builder<ExploreConnectionParams.Info, String> builder = ImmutableMultimap.builder();
+
+    // get the query params - javadoc for getQuery says that it decodes the query URL with UTF-8 charset.
+    String query = jdbcURI.getQuery();
+    if (query != null) {
+      for (String entry : Splitter.on("&").split(query)) {
+        // Need to do it twice because of error in guava libs Issue: 1577
+        int idx = entry.indexOf('=');
+        if (idx <= 0) {
+          continue;
+        }
+
+        ExploreConnectionParams.Info info = ExploreConnectionParams.Info.fromStr(entry.substring(0, idx));
+        if (info != null) {
+          builder.putAll(info, Splitter.on(',').omitEmptyStrings().split(entry.substring(idx + 1)));
+        }
+      }
+    }
+    return new ExploreConnectionParams(host, port, builder.build());
+  }
+}

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreStatement.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreStatement.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ExecutionException;
 public class ExploreStatement implements Statement {
   private static final Logger LOG = LoggerFactory.getLogger(ExploreStatement.class);
 
-  private int fetchSize = 50;
+  private int fetchSize = 1000;
 
   /**
    * We need to keep a reference to the result set to support the following:

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreConnectionParamsTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreConnectionParamsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.jdbc;
+
+import co.cask.cdap.common.conf.Constants;
+import com.google.common.collect.ImmutableMultimap;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for explore connection params.
+ */
+public class ExploreConnectionParamsTest {
+  private static final String BASE = String.format("%s%s:%d", Constants.Explore.Jdbc.URL_PREFIX, "foobar", 10000);
+
+  @Test
+  public void testParseFetchSize() {
+    ExploreConnectionParams connectionParams = ExploreConnectionParams.parseConnectionUrl(BASE + "?fetch.size=500");
+    Assert.assertEquals(500, connectionParams.getFetchSize());
+    connectionParams = ExploreConnectionParams.parseConnectionUrl(BASE + "?fetchSize=12asd");
+    Assert.assertEquals(ExploreConnectionParams.DEFAULT_FETCH_SIZE, connectionParams.getFetchSize());
+  }
+
+  @Test
+  public void parseConnectionUrlTest() {
+    ExploreConnectionParams connectionParams;
+
+    connectionParams = ExploreConnectionParams.parseConnectionUrl(BASE);
+    Assert.assertEquals("foobar", connectionParams.getHost());
+    Assert.assertEquals(10000, connectionParams.getPort());
+    Assert.assertEquals(ImmutableMultimap.of(), connectionParams.getExtraInfos());
+
+    connectionParams = ExploreConnectionParams.parseConnectionUrl(BASE + "?auth.token=foo");
+    Assert.assertEquals("foobar", connectionParams.getHost());
+    Assert.assertEquals(10000, connectionParams.getPort());
+    Assert.assertEquals(
+      ImmutableMultimap.of(ExploreConnectionParams.Info.EXPLORE_AUTH_TOKEN, "foo"),
+      connectionParams.getExtraInfos());
+
+    connectionParams = ExploreConnectionParams.parseConnectionUrl(BASE + "?auth.token=foo&foo2=bar2");
+    Assert.assertEquals("foobar", connectionParams.getHost());
+    Assert.assertEquals(10000, connectionParams.getPort());
+    Assert.assertEquals(
+      ImmutableMultimap.of(ExploreConnectionParams.Info.EXPLORE_AUTH_TOKEN, "foo"),
+      connectionParams.getExtraInfos());
+
+    connectionParams = ExploreConnectionParams.parseConnectionUrl(
+      BASE + "?foo2=bar2&auth.token=foo&ssl.enabled=true&verify.ssl.cert=false");
+    Assert.assertEquals("foobar", connectionParams.getHost());
+    Assert.assertEquals(10000, connectionParams.getPort());
+    Assert.assertEquals(
+      ImmutableMultimap.of(ExploreConnectionParams.Info.EXPLORE_AUTH_TOKEN, "foo",
+                           ExploreConnectionParams.Info.SSL_ENABLED, "true",
+                           ExploreConnectionParams.Info.VERIFY_SSL_CERT, "false"),
+      connectionParams.getExtraInfos());
+
+    connectionParams = ExploreConnectionParams.parseConnectionUrl(BASE + "?foo2=bar2&auth.token");
+    Assert.assertEquals("foobar", connectionParams.getHost());
+    Assert.assertEquals(10000, connectionParams.getPort());
+    Assert.assertEquals(ImmutableMultimap.of(), connectionParams.getExtraInfos());
+
+    connectionParams = ExploreConnectionParams.parseConnectionUrl(BASE + "?foo2=bar2&auth.token=foo,bar");
+    Assert.assertEquals("foobar", connectionParams.getHost());
+    Assert.assertEquals(10000, connectionParams.getPort());
+    Assert.assertEquals(
+      ImmutableMultimap.of(ExploreConnectionParams.Info.EXPLORE_AUTH_TOKEN, "foo",
+                           ExploreConnectionParams.Info.EXPLORE_AUTH_TOKEN, "bar"),
+      connectionParams.getExtraInfos());
+
+    // Test that we don't decode URL more than once
+    connectionParams = ExploreConnectionParams.parseConnectionUrl(
+      BASE + "?" +
+        ExploreConnectionParams.Info.EXPLORE_AUTH_TOKEN.getName() +
+        "=AgxqdWxpZW4AyIOOuPRRyJPy%2BPhR4o%2B35wl%3DAA3");
+    Assert.assertEquals(
+      ImmutableMultimap.of(ExploreConnectionParams.Info.EXPLORE_AUTH_TOKEN,
+                           "AgxqdWxpZW4AyIOOuPRRyJPy+PhR4o+35wl=AA3"),
+      connectionParams.getExtraInfos());
+  }
+}

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreDriverTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreDriverTest.java
@@ -32,7 +32,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -82,65 +81,6 @@ public class ExploreDriverTest {
   public static void stop() throws Exception {
     httpService.stopAndWait();
   }
-
-  @Test
-  public void parseConnectionUrlTest() throws Exception {
-    ExploreDriver driver = new ExploreDriver();
-
-    String baseUrl = String.format("%s%s:%d", Constants.Explore.Jdbc.URL_PREFIX, "foobar", 10000);
-    ExploreDriver.ConnectionParams connectionParams;
-
-    connectionParams = driver.parseConnectionUrl(baseUrl);
-    Assert.assertEquals("foobar", connectionParams.getHost());
-    Assert.assertEquals(10000, connectionParams.getPort());
-    Assert.assertEquals(ImmutableMultimap.of(), connectionParams.getExtraInfos());
-
-    connectionParams = driver.parseConnectionUrl(baseUrl + "?auth.token=foo");
-    Assert.assertEquals("foobar", connectionParams.getHost());
-    Assert.assertEquals(10000, connectionParams.getPort());
-    Assert.assertEquals(
-      ImmutableMultimap.of(ExploreDriver.ConnectionParams.Info.EXPLORE_AUTH_TOKEN, "foo"),
-      connectionParams.getExtraInfos());
-
-    connectionParams = driver.parseConnectionUrl(baseUrl + "?auth.token=foo&foo2=bar2");
-    Assert.assertEquals("foobar", connectionParams.getHost());
-    Assert.assertEquals(10000, connectionParams.getPort());
-    Assert.assertEquals(
-      ImmutableMultimap.of(ExploreDriver.ConnectionParams.Info.EXPLORE_AUTH_TOKEN, "foo"),
-      connectionParams.getExtraInfos());
-
-    connectionParams =
-      driver.parseConnectionUrl(baseUrl + "?foo2=bar2&auth.token=foo&ssl.enabled=true&verify.ssl.cert=false");
-    Assert.assertEquals("foobar", connectionParams.getHost());
-    Assert.assertEquals(10000, connectionParams.getPort());
-    Assert.assertEquals(
-      ImmutableMultimap.of(ExploreDriver.ConnectionParams.Info.EXPLORE_AUTH_TOKEN, "foo",
-                           ExploreDriver.ConnectionParams.Info.SSL_ENABLED, "true",
-                           ExploreDriver.ConnectionParams.Info.VERIFY_SSL_CERT, "false"),
-      connectionParams.getExtraInfos());
-
-    connectionParams = driver.parseConnectionUrl(baseUrl + "?foo2=bar2&auth.token");
-    Assert.assertEquals("foobar", connectionParams.getHost());
-    Assert.assertEquals(10000, connectionParams.getPort());
-    Assert.assertEquals(ImmutableMultimap.of(), connectionParams.getExtraInfos());
-
-    connectionParams = driver.parseConnectionUrl(baseUrl + "?foo2=bar2&auth.token=foo,bar");
-    Assert.assertEquals("foobar", connectionParams.getHost());
-    Assert.assertEquals(10000, connectionParams.getPort());
-    Assert.assertEquals(
-      ImmutableMultimap.of(ExploreDriver.ConnectionParams.Info.EXPLORE_AUTH_TOKEN, "foo",
-                           ExploreDriver.ConnectionParams.Info.EXPLORE_AUTH_TOKEN, "bar"),
-      connectionParams.getExtraInfos());
-
-    // Test that we don't decode URL more than once
-    connectionParams = driver.parseConnectionUrl(baseUrl + "?" +
-                                                 ExploreDriver.ConnectionParams.Info.EXPLORE_AUTH_TOKEN.getName() +
-                                                 "=AgxqdWxpZW4AyIOOuPRRyJPy%2BPhR4o%2B35wl%3DAA3");
-    Assert.assertEquals(
-      ImmutableMultimap.of(ExploreDriver.ConnectionParams.Info.EXPLORE_AUTH_TOKEN,
-                           "AgxqdWxpZW4AyIOOuPRRyJPy+PhR4o+35wl=AA3"),
-      connectionParams.getExtraInfos());
- }
 
   @Test
   public void testDriverConnection() throws Exception {


### PR DESCRIPTION
Added a 'fetch.size' connection setting that controls how big the
fetch size should be. Also increasing the default fetch size from
50 to 1000 to make the default value more performant.