### PR TITLE
CDAP-5075 allow overwriting logical start time with runtime args

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/AbstractSparkBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/AbstractSparkBatchContext.java
@@ -43,7 +43,8 @@ public abstract class AbstractSparkBatchContext extends AbstractTransformContext
 
   @Override
   public long getLogicalStartTime() {
-    return sparkContext.getLogicalStartTime();
+    String logicalStartTimeStr = runtimeArguments.get("logicalStartTime");
+    return logicalStartTimeStr == null ? sparkContext.getLogicalStartTime() : Long.parseLong(logicalStartTimeStr);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchRuntimeContext.java
@@ -42,7 +42,8 @@ public class SparkBatchRuntimeContext extends AbstractTransformContext implement
 
   @Override
   public long getLogicalStartTime() {
-    return logicalStartTime;
+    String logicalStartTimeStr = runtimeArguments.get("logicalStartTime");
+    return logicalStartTimeStr == null ? logicalStartTime : Long.parseLong(logicalStartTimeStr);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceBatchContext.java
@@ -52,7 +52,8 @@ public abstract class MapReduceBatchContext extends AbstractTransformContext imp
     return LogContext.runWithoutLoggingUnchecked(new Callable<Long>() {
       @Override
       public Long call() throws Exception {
-        return mrContext.getLogicalStartTime();
+        String logicalStartTimeStr = runtimeArguments.get("logicalStartTime");
+        return logicalStartTimeStr == null ? mrContext.getLogicalStartTime() : Long.parseLong(logicalStartTimeStr);
       }
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceRuntimeContext.java
@@ -24,7 +24,6 @@ import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.common.AbstractTransformContext;
 import co.cask.cdap.etl.log.LogContext;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -53,7 +52,8 @@ public class MapReduceRuntimeContext extends AbstractTransformContext implements
     return LogContext.runWithoutLoggingUnchecked(new Callable<Long>() {
       @Override
       public Long call() throws Exception {
-        return context.getLogicalStartTime();
+        String logicalStartTimeStr = runtimeArgs.get("logicalStartTime");
+        return logicalStartTimeStr == null ? context.getLogicalStartTime() : Long.parseLong(logicalStartTimeStr);
       }
     });
   }


### PR DESCRIPTION
If runtime arguments contain a 'logicalStartTime' key, use its
value as the logical start time instead of the actual start time
of the run. This allows manual re-runs of pipelines.