### PR TITLE
Explore preview - column names fix

### DIFF
--- a/cdap-ui/app/directives/explore/explore.js
+++ b/cdap-ui/app/directives/explore/explore.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -103,8 +103,12 @@ angular.module(PKG.name + '.commons')
               myExploreApi.getQuerySchema(params)
                 .$promise
                 .then(function (res) {
-                  angular.forEach(res, function(v) {
-                    v.name = v.name.split('.')[1];
+                  angular.forEach(res, function(column) {
+                    // check for '.' in the name, before splitting on it, because in the case that specific columns are
+                    // queried, the column names in the schema are not prefixed by the dataset name
+                    if (column.name.indexOf('.') != -1) {
+                      column.name = column.name.split('.')[1];
+                    }
                   });
 
                   $scope.schema = res;


### PR DESCRIPTION
Check for '.' in column name before splitting on it, because when specific columns are queried, the schema's column names are not prefixed by the dataset name.

The cause of the issue is described in more detail in the comments in the JIRA.
https://issues.cask.co/browse/CDAP-5036


Select *:
![image](https://cloud.githubusercontent.com/assets/2440977/13369765/fb11f4c8-dcad-11e5-8934-16a3a34e163f.png)

Select particular columns:
![image](https://cloud.githubusercontent.com/assets/2440977/13369767/0ae7f866-dcae-11e5-8bb0-11f3009199ef.png)
