### PR TITLE
CDAP-5076 fix update app command

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/UpdateAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/UpdateAppCommand.java
@@ -31,16 +31,19 @@ import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.common.cli.Arguments;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.PrintStream;
+import java.lang.reflect.Type;
 
 /**
  * Deploys an application from an existing artifact.
  */
 public class UpdateAppCommand extends AbstractAuthCommand {
+  private static final Type CONFIG_TYPE = new TypeToken<AppRequest<JsonObject>>() { }.getType();
   private static final Gson GSON = new Gson();
   private final ApplicationClient applicationClient;
   private final FilePathResolver resolver;
@@ -67,7 +70,8 @@ public class UpdateAppCommand extends AbstractAuthCommand {
     if (configPath != null) {
       File configFile = resolver.resolvePathToFile(configPath);
       try (FileReader reader = new FileReader(configFile)) {
-        config = GSON.fromJson(reader, JsonObject.class);
+        AppRequest<JsonObject> appRequest = GSON.fromJson(reader, CONFIG_TYPE);
+        config = appRequest.getConfig();
       }
     }
 

--- a/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
@@ -27,7 +27,6 @@ import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.ApplicationRecord;
-import co.cask.cdap.proto.BatchProgramStatus;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
@@ -350,7 +349,8 @@ public class ApplicationClient {
     if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new NotFoundException("app or app artifact");
     } else if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) {
-      throw new BadRequestException(response.getResponseBodyAsString());
+      throw new BadRequestException(String.format("Bad Request. Reason: %s",
+                                                  response.getResponseBodyAsString()));
     }
   }
 


### PR DESCRIPTION
Fix the update app command to use the same format for its input
file as the create app command. This will also let somebody use
the contents of a pipeline export directly rather than modifying
it first.