### PR TITLE
CDAP-2696 Document stream formats

### DIFF
--- a/cdap-docs/cdap-apps/source/data-quality/index.rst
+++ b/cdap-docs/cdap-apps/source/data-quality/index.rst
@@ -48,29 +48,29 @@ The application can be created from the ``cdap-data-quality`` system artifact by
         "datasetName": "dataQuality",
         "workflowScheduleMinutes": 5,
         "fieldAggregations": {
-          "referrer": [ "DiscreteValuesHistogram" ],
-          "status": [ "DiscreteValuesHistogram" ],
+          "remote_host": [ "DiscreteValuesHistogram" ],
           "remote_login": [ "DiscreteValuesHistogram" ],
-          "request": [ "DiscreteValuesHistogram" ],
-          "user_agent": [ "DiscreteValuesHistogram" ],
           "auth_user": [ "DiscreteValuesHistogram" ],
-          "content_length": [ "DiscreteValuesHistogram" ],
           "date": [ "DiscreteValuesHistogram" ],
-          "remote_host": [ "DiscreteValuesHistogram" ]
+          "request": [ "DiscreteValuesHistogram" ],
+          "status": [ "DiscreteValuesHistogram" ],
+          "content_length": [ "DiscreteValuesHistogram" ],
+          "referrer": [ "DiscreteValuesHistogram" ],
+          "user_agent": [ "DiscreteValuesHistogram" ]
         }
       }
     }
 
 
-* ``source`` : Data Quality Source
+* ``source``: Data Quality Source
 
   - ``name``: Name of the :ref:`Batch Source Plugin <cdap-apps-etl-plugins-batchsources>`.
-  - ``id``: Unique ID that can be used to query for Data Quality metrics using DataQualityService.
-  - ``properties``: Properties required by the :ref:`Batch Source Plugin <cdap-apps-etl-plugins-batchsources>`.
+  - ``id``: Unique ID that can be used to query for Data Quality metrics using DataQualityService
+  - ``properties``: Properties required by the :ref:`Batch Source Plugin <cdap-apps-etl-plugins-batchsources>`
   
-* ``workflowScheduleMinutes`` : Frequency (in minutes) with which the workflow runs the aggregation MapReduce.
-* ``datasetName`` : Name of the destination dataset.
-* ``fieldAggregations`` : Map that relates each field value to a set of aggregation functions.
+* ``workflowScheduleMinutes``: Frequency (in minutes) with which the workflow runs the aggregation MapReduce
+* ``datasetName``: Name of the destination dataset
+* ``fieldAggregations``: Map that relates each field value to a set of aggregation functions
 
 Deploying the Application
 -------------------------
@@ -85,12 +85,12 @@ See :ref:`Batch Sources <cdap-apps-etl-plugins-batchsources>` for more informati
 End-to-End Example
 ==================
 
-Let's take the example of a user who wants wants to use the Data Quality Application to:
+Let's take the example of a user who wants to use the Data Quality Application to:
 
-- Ingest a stream of CLF log data.
-- Generate several histograms partitioned by the time distribution of status codes.
-- Generate the aforementioned-aggregations every 10 minutes.
-- Query ranges of timestamps for aggregated histogram data.
+- ingest a stream of CLF log data;
+- generate histograms partitioned by the time distribution of status codes;
+- generate these aggregations every 10 minutes; and
+- query ranges of timestamps for aggregated histogram data.
 
 We would create a Data Quality Application by creating a JSON file ``appconfig.json`` that contains:
 
@@ -162,7 +162,7 @@ We would make this request::
 
   $ curl -w'\n' http://localhost:10000/v3/namespaces/default/apps/StreamDQ/services/DataQualityService/methods/v1/sources/logStream/fields/status/aggregations/DiscreteValuesHistogram/totals
 
-If you use the aforementioned sample Apache Access logs, your response should look like this: 
+If you use the above sample Apache Access logs, your response should look like this: 
 
 .. code:: json
 
@@ -192,7 +192,7 @@ under the ``functions`` directory (``DQApp/src/main/java/data/quality/app/functi
 
 All aggregation functions need to implement the ``BasicAggregationFunction`` interface. If
 a function produces aggregations that can be combined (for example, frequencies can be
-combined but standard deviations cannot), it should also implement the
+combined while standard deviations cannot), it should also implement the
 ``CombinableAggregationFunction`` interface. This will let you combine existing
 aggregations over custom time ranges at query time.
 

--- a/cdap-docs/developers-manual/source/building-blocks/views.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/views.rst
@@ -41,6 +41,8 @@ before any streams and stream views are created so that a Hive table can be crea
 each view. (See the :ref:`CDAP installation instructions <installation-index>` for your
 particular Hadoop distribution for details.)
 
+.. _stream-views:
+
 Stream View
 ===========
 A stream view is a read-only, schema-based, view of a stream. This feature is intended to

--- a/cdap-docs/developers-manual/source/data-exploration/streams.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/streams.rst
@@ -217,7 +217,7 @@ on an existing stream ``mystream`` using the CDAP CLI::
 
   $ cdap-cli.sh create stream-view mystream mygrok format grok \
       schema "facility string, priority string, message string" \
-      settings "pattern=<%{\b(?:[0-9]+)\b:facility}.%{\b(?:[0-9]+)\b:priority}> %{.*:message}"
+      settings "pattern=(?<facility>\b(?:[0-9]+)\b).(?<priority>\b(?:[0-9]+)\b) (?<message>.*)"
 
 
 .. _stream-exploration-stream-format-syslog:

--- a/cdap-docs/developers-manual/source/data-exploration/streams.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/streams.rst
@@ -55,22 +55,29 @@ As mentioned above, a format may support different **schemas**.
 CDAP schemas are adapted from the `Avro Schema Declaration <http://avro.apache.org/docs/1.7.3/spec.html#schemas>`__
 with a few differences:
 
-* Map keys do not have to be strings, but can be of any type.
-* No "name" property for the enum type.
-* No support of "doc" and "aliases" in record and enum types.
-* No support of "doc" and "default" in record fields.
-* No "fixed" type.
+- Map keys do not have to be of type name ``string``, but can be of any type.
+- No "name" property for the ``enum`` type.
+- No support of "doc" and "aliases" in ``record`` and ``enum`` types.
+- No support of "doc" and "default" in ``record`` fields.
+- No ``fixed`` type.
 
 There are a few additional limitations on the types of schemas that can be used for exploration:
 
-* Schemas must be a record of at least one field.
-* Enums are not supported.
-* Unions are not supported, unless it is a union of a null and another type, representing a nullable type.
-* Recursive types are not supported. This means you cannot have a record field that references itself in one of its fields.
+- For all formats:
 
-Data exploration using Impala has additional limitations:
+  - Schemas must be a record of at least one field.
+  
+- For all formats except :ref:`Avro <>`:
 
-* Fields must be a scalar type (no maps, arrays, or records).
+  - Enums are not supported.
+  - Unions are not supported, unless it is a union of a null and another type, representing a nullable type.
+  - Recursive types are not supported. This means you cannot have a record field that references itself in one of its fields.
+
+Data exploration using `Cloudera Impala
+<https://www.cloudera.com/products/apache-hadoop/impala.html>`__ has an additional
+limitation:
+
+- Fields must be a scalar type: no maps, arrays, or records allowed.
 
 On top of these general limitations, each format has its own restrictions on the types of
 schemas they support. For example, the CSV/TSV formats do not support maps or records as
@@ -92,7 +99,7 @@ is equivalent to the Avro-like JSON schema::
 
   {
     "type": "record",
-    "name": "rec",
+    "name": "rec1",
     "fields": [
       {
         "name": "f1",
@@ -116,7 +123,7 @@ is equivalent to the Avro-like JSON schema::
         "name": "f5",
         "type": {
           "type": "record",
-          "name": "rec1",
+          "name": "rec2",
           "fields": [
             { "name": "x", "type": [ "int", "null" ] },
             { "name": "y", "type": [ "double", "null" ] }
@@ -199,7 +206,7 @@ order. For example, if the ``mapping`` is ``1:age,0:name``, then the stream even
 
 These formats only support scalars as column types, except for the very last column, which
 can be an array of strings. All types can be nullable. If no schema is given, the default
-schema is an array of strings.
+schema is an array of strings. Neither maps nor records are supported as data types.
 
 For example::
 

--- a/cdap-docs/developers-manual/source/data-exploration/streams.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/streams.rst
@@ -18,6 +18,12 @@ schema of their own. For example, event bodies may be a format such as comma-del
 text or Avro-encoded binary data. In those cases, it is possible to set a format and
 schema on a stream, enabling more powerful queries.
 
+Some formats have a schema that describes the structure of data the format can read. A
+format such as the Avro format requires that a schema be explicitly given. Other formats,
+such as the CSV format, do not have a schema. CDAP supplies a default schema for formats
+such as CSV that you can |---| and usually will need to |---| replace with a custom schema
+to match your data's structure.
+
 Let's take a closer look at attaching formats and schemas on streams.
 
 
@@ -29,10 +35,6 @@ Formats
 A **format** defines how the bytes in an event body can be read as a higher-level object. For
 example, the CSV (comma-separated values) format can read each value in comma-delimited
 text as a separate column of some given type.
-
-Each format has a schema that describes the structure of data the format can read. Some
-formats, such as the Avro format, require a schema to be explicitly given. Other formats,
-such as the CSV format, have a default schema.
 
 Format is a configuration setting that can be set on a stream. This can be done either
 through the HTTP RESTful API or by using the CDAP Command Line Interface (CLI)::

--- a/cdap-docs/developers-manual/source/data-exploration/streams.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/streams.rst
@@ -8,129 +8,72 @@
 Stream Exploration
 ==================
 
-Streams are the primary method of ingesting real-time data into CDAP.
-It is often useful to be able to examine data in a stream in an ad-hoc manner through
-SQL-like queries
+Streams are the primary method of ingesting real-time data into CDAP. It is often useful
+to be able to examine data in a stream in an ad-hoc manner through SQL-like queries
 
 Each event in a stream contains a timestamp, a map of headers, and a body. When a stream
-is created, a corresponding Hive table is created that allows queries to be run over
-those three columns. Many times, stream event bodies are also structured and have
-a format and schema of their own. For example, event bodies may be comma-delimited
-text or Avro-encoded binary data. In those cases, it is possible to set a format and schema
-on a stream, enabling more powerful queries.
+is created, a corresponding Hive table is created that allows queries to be run over those
+three columns. Many times, stream event bodies are also structured and have a format and
+schema of their own. For example, event bodies may be a format such as comma-delimited
+text or Avro-encoded binary data. In those cases, it is possible to set a format and
+schema on a stream, enabling more powerful queries.
 
-Let's take a closer look at attaching format and schema on streams.
+Let's take a closer look at attaching formats and schemas on streams.
+
 
 .. _stream-exploration-stream-format:
 
 Formats
 =======
 
-A format defines how the bytes in an event body can be read as a higher level object.
-For example, the CSV (comma separated values) format can read each value in comma-delimited text
-as a separate column of some given type. Each format has
-a schema that describes the structure of data the format can read. Some formats, such as the Avro format,
-require a schema to be explicitly given. Other formats, such as the CSV format, have a default schema.
+A **format** defines how the bytes in an event body can be read as a higher-level object. For
+example, the CSV (comma-separated values) format can read each value in comma-delimited
+text as a separate column of some given type.
 
-Format is a configuration setting that can be set on a stream. This can be done either through the
-HTTP RESTful API or by using the CDAP Command Line Interface (CLI)::
+Each format has a schema that describes the structure of data the format can read. Some
+formats, such as the Avro format, require a schema to be explicitly given. Other formats,
+such as the CSV format, have a default schema.
+
+Format is a configuration setting that can be set on a stream. This can be done either
+through the HTTP RESTful API or by using the CDAP Command Line Interface (CLI)::
 
   set stream format <stream-id> <format-name> [<schema>] [<settings>]
   set stream format mystream csv "f1 int, f2 string"
 
-As mentioned above, a format may support different schemas, which will be discussed in more detail
-in the :ref:`next section <stream-exploration-stream-schema>`.
-
-It is important to note that formats are applied at read time.
-When events are added to a stream, there are no checks performed to enforce that
-all events added to the stream are readable by the format you have set on a stream.
-If any stream event cannot be read by the format you have set, your entire query will fail and you
-will not get any results.
-
-Accepted formats are:
-
-- ``avro`` (:ref:`format <stream-exploration-stream-format-avro>`);
-- ``clf`` (`format <http://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format>`__, :ref:`schema <stream-exploration-stream-schema-clf>`);
-
-- ``clf`` (`format <https://httpd.apache.org/docs/1.3/logs.html#combined>`__, :ref:`schema <stream-exploration-stream-schema-clf>`);
-
-- ``csv`` (:ref:`comma-separated <stream-exploration-stream-format_csv_tsv>`);
-- ``grok`` (`format <https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html>`__);
-- ``syslog`` (`format and schema <https://tools.ietf.org/html/rfc5424#section-6>`__);
-- ``text`` (:ref:`format <stream-exploration-stream-format-text>`); and
-- ``tsv`` (:ref:`tab-separated <stream-exploration-stream-format_csv_tsv>`). 
-
-.. _stream-exploration-stream-format-avro:
-
-Avro Format
------------
-The ``avro`` format reads event bodies as binary-encoded Avro. The format requires that a schema be given
-and has no settings.
-
-For example::
-
-  set stream format mystream avro "col1 string, col2 map<string,int> not null, col3 record<x:double, y:float>"
-
-.. _stream-exploration-stream-format_csv_tsv:
-
-CSV and TSV Formats
--------------------
-The ``csv`` (comma separated values) and ``tsv`` (tab separated values) formats read event bodies as delimited text.
-They have three settings: ``charset`` for the text charset, ``delimiter`` for the delimiter, and ``mapping`` for
-column-index-to-schema-field mapping.
-
-The ``charset`` setting defaults to ``utf-8``. The ``delimiter`` setting defaults to a comma
-for the ``csv`` format and to a tab for the ``tsv`` format. The ``mapping`` setting is optional, and
-is in the zero-based format ``index0:field0,index1:field1``. If provided, the CSV field order will be decided by the mapping
-rather than using the schema field order. For example, if the ``mapping`` is ``1:age,0:name``, then the stream event
-``foo,123,82`` will be parsed as ``{"age":123, "name":"foo"}``.
-
-These formats only support scalars as column types, except for the very last column, which can be an array of strings.
-All types can be nullable. If no schema is given, the default schema is an array of strings.
-
-For example::
-
-  set stream format mystream csv "col1 string, col2 int not null, col3 array<string>"
-
-.. _stream-exploration-stream-format-text:
-
-Text Format
------------
-The ``text`` format simply interprets each event body as a string. The format supports a very limited
-schema, namely a record with a single field of type ``string``. The format supports a ``charset`` setting
-that allows you to specify the charset of the text. It defaults to ``utf-8``.
-
-For example::
-
-  set stream format mystream text "data string not null" "charset=ISO-8859-1"
+It is important to note that formats are applied at read time. When events are added to a
+stream, there are no checks performed to enforce that all events added to the stream are
+readable by the format you have set on a stream. If any stream event cannot be read by the
+format you have set, your entire query will fail and you will not get any results.
 
 
 .. _stream-exploration-stream-schema:
 
-Schema
-======
+Schemas
+=======
+As mentioned above, a format may support different **schemas**.
+
 CDAP schemas are adapted from the `Avro Schema Declaration <http://avro.apache.org/docs/1.7.3/spec.html#schemas>`__
 with a few differences:
 
-  * Map keys do not have to be strings, but can be of any type.
-  * No "name" property for the enum type.
-  * No support of "doc" and "aliases" in record and enum types.
-  * No support of "doc" and "default" in record fields.
-  * No "fixed" type.
+* Map keys do not have to be strings, but can be of any type.
+* No "name" property for the enum type.
+* No support of "doc" and "aliases" in record and enum types.
+* No support of "doc" and "default" in record fields.
+* No "fixed" type.
 
 There are a few additional limitations on the types of schemas that can be used for exploration:
 
-  * Schemas must be a record of at least one field.
-  * Enums are not supported.
-  * Unions are not supported, unless it is a union of a null and another type, representing a nullable type.
-  * Recursive types are not supported. This means you cannot have a record field that references itself in one of its fields.
+* Schemas must be a record of at least one field.
+* Enums are not supported.
+* Unions are not supported, unless it is a union of a null and another type, representing a nullable type.
+* Recursive types are not supported. This means you cannot have a record field that references itself in one of its fields.
 
 Data exploration using Impala has additional limitations:
 
-  * Fields must be a scalar type (no maps, arrays, or records).
+* Fields must be a scalar type (no maps, arrays, or records).
 
-On top of these general limitations, each format has its own restrictions on the types
-of schemas they support. For example, the CSV format does not support maps or records as
+On top of these general limitations, each format has its own restrictions on the types of
+schemas they support. For example, the CSV/TSV formats do not support maps or records as
 data types.
 
 .. _stream-exploration-stream-schema-syntax:
@@ -182,40 +125,126 @@ is equivalent to the Avro-like JSON schema::
       }
     ]
   }
-  
-.. _stream-exploration-stream-schema-clf:
 
-CLF Schema
-----------
 
- * Stream record format that interprets stream body as data in Combined Log Format.
- * CLF format: remote_host remote_login auth_user [date] "request" status content_length referrer user_agent
- * Sample CLF data:
- * 220.181.108.77 - - [01/Feb/2015:06:59:57 +0000] "GET / HTTP/1.1" 301 295 "-"
- * "Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)"
+Accepted Formats
+================
+Accepted formats (some of which include schemas) are:
 
-- ``remote_host``: type String
-- ``remote_login``: type String
-- ``auth_user``: type String
-- ``date``: type String
-- ``request``: type String
-- ``status``: type Int
-- ``content_length``: type Int
-- ``referrer``: type String
-- ``user_agent``: type String
+- ``avro`` (Avro: :ref:`format <stream-exploration-stream-format-avro>`);
+- ``clf`` (`Apache Combined Log Format <https://httpd.apache.org/docs/1.3/logs.html#combined>`__, 
+  :ref:`schema <stream-exploration-stream-format-clf>`);
+- ``csv`` (comma-separated values: :ref:`format <stream-exploration-stream-format_csv_tsv>`);
+- ``grok`` (`format <https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html>`__);
+- ``syslog`` (`Syslog Message Format <https://tools.ietf.org/html/rfc5424#section-6>`__, :ref:`schema <stream-exploration-stream-format-syslog>`);
+- ``text`` (:ref:`format <stream-exploration-stream-format-text>`); and
+- ``tsv`` (tab-separated values: :ref:`format <stream-exploration-stream-format_csv_tsv>`). 
 
-.. _stream-exploration-stream-schema-syslog:
+.. _stream-exploration-stream-format-avro:
 
-Syslog Schema
+Avro Format
+-----------
+The ``avro`` format reads event bodies as binary-encoded Avro. The format requires that a schema be given
+and has no settings.
+
+.. highlight:: console
+
+For example::
+
+  $ cdap-cli.sh call set stream format mystream avro "col1 string, col2 map<string,int> not null, col3 record<x:double, y:float>"
+
+.. _stream-exploration-stream-format-clf:
+
+Combined Log Format
+-------------------
+The `Apache Combined Log Format <https://httpd.apache.org/docs/1.3/logs.html#combined>`__
+(``clf``) is a very common web server log file format. It is a super-set of the
+similarly-named `Common Logfile Format <https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format>`__,
+adding to it two fields ("Referer" and "User-Agent") of request headers. Though described
+as a format, it is actually a combination of format and schema. The format consists of
+fields separated by spaces, with fields containing spaces surrounded by quotes, and the
+date field enclosed in square brackets.
+
+The schema is:
+
+- ``remote_host``: Remote hostname or IP number; type string
+- ``remote_login``: The remote logname of the user; type string
+- ``auth_user``: The username as which the user has authenticated; type string
+- ``date``: Date and time of the request, enclosed in square brackets; type string
+- ``request``: The request line exactly as it came from the client, enclosed in double quotes; type string
+- ``status``: The HTTP status code returned to the client; type integer
+- ``content_length``: The content-length of the document transferred, in bytes; type integer
+- ``referrer``: "Referer" [sic] HTTP request header, with the site that the client
+  reports having been referred from, enclosed in double quotes; type string
+- ``user_agent``: User-Agent HTTP request header. This is the identifying information
+  that the client browser reports about itself, enclosed in double quotes; type integer
+
+Note that in CDAP's implementation, the "Referer" field uses the correct spelling of the word "referrer".
+
+.. _stream-exploration-stream-format-csv-tsv:
+.. _stream-exploration-stream-format_csv_tsv:
+
+CSV and TSV Formats
+-------------------
+The ``csv`` (comma-separated values) and ``tsv`` (tab-separated values) formats read event
+bodies as delimited text. They have three settings: ``charset`` for the text charset,
+``delimiter`` for the delimiter, and ``mapping`` for column-index-to-schema-field mapping.
+
+The ``charset`` setting defaults to ``utf-8``. The ``delimiter`` setting defaults to a
+comma for the ``csv`` format and to a tab for the ``tsv`` format. The ``mapping`` setting
+is optional, and is in the zero-based format ``index0:field0,index1:field1``. If provided,
+the CSV/TSV field order will be decided by the mapping rather than using the schema field
+order. For example, if the ``mapping`` is ``1:age,0:name``, then the stream event
+``foo,123,82`` will be parsed as ``{"age":123, "name":"foo"}``.
+
+These formats only support scalars as column types, except for the very last column, which
+can be an array of strings. All types can be nullable. If no schema is given, the default
+schema is an array of strings.
+
+For example::
+
+  $ cdap-cli.sh set stream format mystream csv "col1 string, col2 int not null, col3 array<string>"
+
+
+.. _stream-exploration-stream-format-grok:
+
+Grok Formats
+------------
+``grok`` allows unstructured data to be parsed into a structured format using `grok
+filters <http://logstash.net/docs/latest/filters/grok>`__. The grok filters are passed as
+a setting with the key ``"pattern"``. For example, to create a :ref:`stream-view <stream-views>` ``mygrok``
+on an existing stream ``mystream`` using the CDAP CLI::
+
+  $ cdap-cli.sh create stream-view mystream mygrok format grok \
+      schema "facility string, priority string, message string" \
+      settings "pattern=<%{\b(?:[0-9]+)\b:facility}.%{\b(?:[0-9]+)\b:priority}> %{.*:message}"
+
+
+.. _stream-exploration-stream-format-syslog:
+
+Syslog Format
 -------------
+The `Syslog Message Format <https://tools.ietf.org/html/rfc5424#section-6>`__ (``syslog``) is a combination of a
+`format <https://tools.ietf.org/html/rfc5424#section-6>`__ and this schema:
+
+- ``timestamp``: date-timestamp; type string
+- ``logsource``: type string
+- ``program``: type string
+- ``pid``: type integer
+- ``message``: type string
 
 
-- ``timestamp``: type String
-- ``logsource``: type String
-- ``program``: type String
-- ``message``: type String
-- ``pid``: type String
+.. _stream-exploration-stream-format-text:
 
+Text Format
+-----------
+The ``text`` format simply interprets each event body as a string. The format supports a very limited
+schema, namely a record with a single field of type ``string``. The format supports a ``charset`` setting
+that allows you to specify the charset of the text. It defaults to ``utf-8``.
+
+For example::
+
+  $ cdap-cli.sh set stream format mystream text "data string not null" "charset=ISO-8859-1"
 
 
 End-to-End Example
@@ -224,18 +253,21 @@ End-to-End Example
 In the following example, we will create a stream, send data to it, attach a format
 and schema to the stream, then query the stream.
 
+.. highlight:: console
+  
 Suppose we want to create a stream for stock trades. We first create the stream
 and send some data to it as comma-delimited text::
 
-  > create stream trades
-  > send stream trades "AAPL,50,112.98"
-  > send stream trades "AAPL,100,112.87"
-  > send stream trades "AAPL,8,113.02"
-  > send stream trades "NFLX,10,437.45"
+  $ cdap-cli.sh
+  cdap > create stream trades
+  cdap > send stream trades "AAPL,50,112.98"
+  cdap > send stream trades "AAPL,100,112.87"
+  cdap > send stream trades "AAPL,8,113.02"
+  cdap > send stream trades "NFLX,10,437.45"
 
 If we run a query over the stream, we can see each event as text::
 
-  > execute "select * from stream_trades"
+  cdap > execute "select * from stream_trades"
   +===================================================================================================+
   | stream_trades.ts: BIGINT | stream_trades.headers: map<string,string> | stream_trades.body: STRING |
   +===================================================================================================+
@@ -245,12 +277,12 @@ If we run a query over the stream, we can see each event as text::
   | 1422493036080            | {}                                        | NFLX,10,437.45             |
   +===================================================================================================+
 
-Since we know the body of every event is comma separated text and that each event
-contains three fields, we can set a format and schema on the stream to allow us to run more
+Since we know the body of every event is comma-separated text and that each event contains
+three fields, we can set a format and schema on the stream to allow us to run more
 complicated queries::
 
-  > set stream format trades csv "ticker string, num_traded int, price double"
-  > execute "select ticker, count(*) as transactions, sum(num_traded) as volume from stream_trades group by ticker order by volume desc"
+  cdap > set stream format trades csv "ticker string, num_traded int, price double"
+  cdap > execute "select ticker, count(*) as transactions, sum(num_traded) as volume from stream_trades group by ticker order by volume desc"
   +========================================================+
   | ticker: STRING | transactions: BIGINT | volume: BIGINT |
   +========================================================+
@@ -258,11 +290,13 @@ complicated queries::
   | NFLX           | 1                    | 10             |
   +========================================================+
 
+
 Formulating Queries
 ===================
 When creating your queries, keep these limitations in mind:
 
-- The query syntax of CDAP is a subset of the variant of SQL that was first defined by Apache Hive.
+- The query syntax of CDAP is a subset of the variant of SQL that was `first defined by
+  Apache Hive <https://cwiki.apache.org/confluence/display/Hive/LanguageManual>`__.
 - Writing into a stream using SQL is not supported.
 - The SQL command ``DELETE`` is not supported.
 - When addressing your streams in queries, you need to prefix the stream name with

--- a/cdap-docs/developers-manual/source/data-exploration/streams.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/streams.rst
@@ -67,7 +67,7 @@ There are a few additional limitations on the types of schemas that can be used 
 
   - Schemas must be a record of at least one field.
   
-- For all formats except :ref:`Avro <>`:
+- For all formats except :ref:`avro <stream-exploration-stream-format-avro>`:
 
   - Enums are not supported.
   - Unions are not supported, unless it is a union of a null and another type, representing a nullable type.

--- a/cdap-docs/reference-manual/source/licenses/index.rst
+++ b/cdap-docs/reference-manual/source/licenses/index.rst
@@ -51,7 +51,8 @@ be the trademarks of their respective owners. Where the ownership or registratio
 the addition of appropriate symbols has been made.
 
 Apache®, `Apache Hadoop <https://hadoop.apache.org>`__, `Hadoop®
-<https://hadoop.apache.org>`__, and `Apache ZooKeeper <https://zookeeper.apache.org/>`__, 
+<https://hadoop.apache.org>`__, Avro, `Apache Avro <http://avro.apache.org/>`__,
+and `Apache ZooKeeper <https://zookeeper.apache.org/>`__, 
 are either registered trademarks or trademarks of the
 `Apache Software Foundation <https://www.apache.org>`__ in the United States and/or other
 countries.


### PR DESCRIPTION
Revises the details on setting formats and schema on streams.

Passes [Quick Build 5](http://builds.cask.co/browse/CDAP-DOB131-5).

Fix for issue https://issues.cask.co/browse/CDAP-2696.

[Stream Exploration page](http://builds.cask.co/artifact/CDAP-DOB131/shared/build-5/Docs-HTML/3.4.0-SNAPSHOT/en/developers-manual/data-exploration/streams.html)