### PR TITLE
CDAP-5117 Ability to create the local datasets inside the Workflow configure method.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,8 @@
 package co.cask.cdap.api.workflow;
 
 import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
 
 import java.util.Map;
 
@@ -125,5 +127,66 @@ public abstract class AbstractWorkflow implements Workflow {
   protected final WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(
     Predicate<WorkflowContext> predicate) {
     return configurer.condition(predicate);
+  }
+
+  /**
+   * Adds a local dataset instance to the {@link Workflow}.
+   * <p>
+   * Local datasets are created at the start of every {@code Workflow} run and deleted once the run
+   * is complete. User can decide to keep the local datasets even after the run is complete by specifying
+   * the runtime arguments - <code>dataset.dataset_name.keep.local=true</code>.
+   *
+   * @param datasetName name of the dataset instance
+   * @param typeName name of the dataset type
+   * @param properties dataset instance properties
+   */
+  protected final void createLocalDataset(String datasetName, String typeName, DatasetProperties properties) {
+    configurer.createLocalDataset(datasetName, typeName, properties);
+  }
+
+  /**
+   * Adds a local dataset instance with {@link DatasetProperties#EMPTY} to the {@link Workflow}.
+   * <p>
+   * Local datasets are created at the start of every {@code Workflow} run and deleted once the run
+   * is complete. User can decide to keep the local datasets even after the run is complete by specifying
+   * the runtime arguments - <code>dataset.dataset_name.keep.local=true</code>.
+   *
+   * @param datasetName name of the dataset instance
+   * @param typeName name of the dataset type
+   */
+  protected final void createLocalDataset(String datasetName, String typeName) {
+    createLocalDataset(datasetName, typeName, DatasetProperties.EMPTY);
+  }
+
+  /**
+   * Adds a local dataset instance to the {@link Workflow}. Also deploys the dataset type
+   * represented by the datasetClass parameter in the current namespace.
+   * <p>
+   * Local datasets are created at the start of every {@code Workflow} run and deleted once the run
+   * is complete. User can decide to keep the local datasets even after the run is complete by specifying
+   * the runtime arguments - <code>dataset.dataset_name.keep.local=true</code>.
+   *
+   * @param datasetName name of the dataset instance
+   * @param datasetClass dataset class to create the Dataset type from
+   * @param props dataset instance properties
+   */
+  protected final void createLocalDataset(String datasetName, Class<? extends Dataset> datasetClass,
+                                          DatasetProperties props) {
+    configurer.createLocalDataset(datasetName, datasetClass, props);
+  }
+
+  /**
+   * Adds a local dataset instance with {@link DatasetProperties#EMPTY} to the {@link Workflow}.
+   * Also deploys the dataset type represented by the datasetClass parameter in the current namespace.
+   * <p>
+   * Local datasets are created at the start of every {@code Workflow} run and deleted once the run
+   * is complete. User can decide to keep the local datasets even after the run is complete by specifying
+   * the runtime arguments - <code>dataset.dataset_name.keep.local=true</code>.
+   *
+   * @param datasetName name of the dataset instance
+   * @param datasetClass dataset class to create the Dataset type from
+   */
+  protected final void createLocalDataset(String datasetName, Class<? extends Dataset> datasetClass) {
+    createLocalDataset(datasetName, datasetClass, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,9 @@ package co.cask.cdap.api.workflow;
 
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.api.ProgramConfigurer;
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
 
 /**
  * Configurer for configuring the {@link Workflow}.
@@ -63,4 +66,33 @@ public interface WorkflowConfigurer extends ProgramConfigurer {
    * @return the configurer for the condition
    */
   WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(Predicate<WorkflowContext> condition);
+
+  /**
+   * Adds a local dataset instance to the {@link Workflow}.
+   * <p>
+   * Local datasets are created at the start of every {@code Workflow} run and deleted once the run
+   * is complete. User can decide to keep the local datasets even after the run is complete by specifying
+   * the runtime arguments - <code>dataset.dataset_name.keep.local=true</code>.
+   *
+   * @param datasetName name of the dataset instance
+   * @param typeName name of the dataset type
+   * @param properties dataset instance properties
+   */
+  @Beta
+  void createLocalDataset(String datasetName, String typeName, DatasetProperties properties);
+
+  /**
+   * Adds a local dataset instance to the {@link Workflow}. Also deploys the dataset type
+   * represented by the datasetClass parameter in the current namespace.
+   * <p>
+   * Local datasets are created at the start of every {@code Workflow} run and deleted once the run
+   * is complete. User can decide to keep the local datasets even after the run is complete by specifying
+   * the runtime arguments - <code>dataset.dataset_name.keep.local=true</code>.
+   *
+   * @param datasetName dataset instance name
+   * @param datasetClass dataset class to create the Dataset type from
+   * @param props dataset instance properties
+   */
+  @Beta
+  void createLocalDataset(String datasetName, Class<? extends Dataset> datasetClass, DatasetProperties props);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
@@ -17,6 +17,7 @@ package co.cask.cdap.api.workflow;
 
 import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.common.PropertyProvider;
+import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,9 +37,11 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
   private final Map<String, String> properties;
   private final List<WorkflowNode> nodes;
   private final Map<String, WorkflowNode> nodeIdMap;
+  private final Map<String, DatasetCreationSpec> localDatasetSpecs;
 
   public WorkflowSpecification(String className, String name, String description,
-                               Map<String, String> properties, List<WorkflowNode> nodes) {
+                               Map<String, String> properties, List<WorkflowNode> nodes,
+                               Map<String, DatasetCreationSpec> localDatasetSpecs) {
     this.className = className;
     this.name = name;
     this.description = description;
@@ -46,6 +49,7 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
                                            Collections.unmodifiableMap(new HashMap<>(properties));
     this.nodes = Collections.unmodifiableList(new ArrayList<>(nodes));
     this.nodeIdMap = Collections.unmodifiableMap(generateNodeIdMap(nodes));
+    this.localDatasetSpecs = Collections.unmodifiableMap(new HashMap<>(localDatasetSpecs));
   }
 
   /**
@@ -105,12 +109,25 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
     return properties.get(key);
   }
 
+  /**
+   * Return the list of nodes in the {@link Workflow}.
+   */
   public List<WorkflowNode> getNodes() {
     return nodes;
   }
 
+  /**
+   * Return the map of the node id to the {@link WorkflowNode}.
+   */
   public Map<String, WorkflowNode> getNodeIdMap() {
     return nodeIdMap;
+  }
+
+  /**
+   * Return the map of local dataset names and associated specifications required for dataset instance creation.
+   */
+  public Map<String, DatasetCreationSpec> getLocalDatasetSpecs() {
+    return localDatasetSpecs;
   }
 
   @Override
@@ -121,6 +138,7 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
     sb.append(", description='").append(description).append('\'');
     sb.append(", properties=").append(properties);
     sb.append(", nodes=").append(nodes);
+    sb.append(", localDatasetSpecs=").append(localDatasetSpecs);
     sb.append('}');
     return sb.toString();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
@@ -149,7 +149,7 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
   @Override
   public void addWorkflow(Workflow workflow) {
     Preconditions.checkArgument(workflow != null, "Workflow cannot be null.");
-    DefaultWorkflowConfigurer configurer = new DefaultWorkflowConfigurer(workflow);
+    DefaultWorkflowConfigurer configurer = new DefaultWorkflowConfigurer(workflow, this);
     workflow.configure(configurer);
     WorkflowSpecification spec = configurer.createSpecification();
     workflows.put(spec.getName(), spec);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/GoodWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/GoodWorkflowApp.java
@@ -18,6 +18,9 @@ package co.cask.cdap;
 
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.workflow.AbstractWorkflow;
 import co.cask.cdap.api.workflow.AbstractWorkflowAction;
@@ -37,6 +40,7 @@ public class GoodWorkflowApp extends AbstractApplication {
     addMapReduce(new DummyMR());
     addWorkflow(new GoodWorkflow());
     addWorkflow(new AnotherGoodWorkflow());
+    addWorkflow(new WorkflowWithLocalDatasets());
   }
 
   /**
@@ -135,6 +139,27 @@ public class GoodWorkflowApp extends AbstractApplication {
      .end();
 
      addSpark("SP7");
+    }
+  }
+
+  /**
+   * Workflow configured with local datasets.
+   */
+  public class WorkflowWithLocalDatasets extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      setName("WorkflowWithLocalDatasets");
+      setDescription("Workflow containing local datasets.");
+      createLocalDataset("mytable", Table.class.getName());
+      createLocalDataset("myfile", FileSet.class.getName());
+      createLocalDataset("myfile_with_properties", FileSet.class.getName(),
+                         DatasetProperties.builder().add("prop_key", "prop_value").build());
+      createLocalDataset("mytablefromtype", Table.class);
+      createLocalDataset("myfilefromtype", FileSet.class,
+                         DatasetProperties.builder().add("another_prop_key", "another_prop_value").build());
+      addMapReduce("MR1");
+      addSpark("SP1");
     }
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowSpecificationCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@ package co.cask.cdap.proto.codec;
 
 import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -41,7 +42,7 @@ public final class WorkflowSpecificationCodec extends AbstractSpecificationCodec
     jsonObj.add("description", new JsonPrimitive(src.getDescription()));
     jsonObj.add("properties", serializeMap(src.getProperties(), context, String.class));
     jsonObj.add("nodes", serializeList(src.getNodes(), context, WorkflowNode.class));
-
+    jsonObj.add("localDatasetSpecs", serializeMap(src.getLocalDatasetSpecs(), context, DatasetCreationSpec.class));
     return jsonObj;
   }
 
@@ -55,7 +56,9 @@ public final class WorkflowSpecificationCodec extends AbstractSpecificationCodec
     String description = jsonObj.get("description").getAsString();
     Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
     List<WorkflowNode> nodes = deserializeList(jsonObj.get("nodes"), context, WorkflowNode.class);
+    Map<String, DatasetCreationSpec> localDatasetSpec = deserializeMap(jsonObj.get("localDatasetSpecs"), context,
+                                                                       DatasetCreationSpec.class);
 
-    return new WorkflowSpecification(className, name, description, properties, nodes);
+    return new WorkflowSpecification(className, name, description, properties, nodes, localDatasetSpec);
   }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-5117

Following changes are done as a part of this PR:
1. Added `createLocalDataset` methods in the `WorkflowConfigurer` interface.
2. The local datasets are stored as a part of `WorkflowSpecification`.