### PR TITLE
CDAP-4450 Update default to concurrent workflows

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/workflows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/workflows.rst
@@ -28,7 +28,7 @@ subsequent programs in the sequence are executed.
 The control flow of a workflow can be described as a directed, acyclic graph (DAG) of actions.
 To be more precise, we require that it be a series-parallel graph. This is a graph with a
 single start node and a single finish node. As described below, execution can be either
-sequential (the default) or :ref:`concurrent <workflow-concurrent>`, and the graph can be 
+sequential or :ref:`concurrent <workflow-concurrent>` (the default), and the graph can be 
 either a simple series of nodes or a more complicated :ref:`parallel workflow <workflow_parallel>`.
 
 Workflows can be controlled by the :ref:`CDAP CLI <cli>` and the :ref:`Lifecycle HTTP
@@ -181,9 +181,9 @@ The workflow itself uses the same names in its configuration::
 
 Concurrent Workflows
 --------------------
-By default, a workflow runs sequentially. Multiple instances of a workflow can be run
-concurrently. To enable concurrent runs for a workflow, set its runtime argument
-``concurrent.runs.enabled`` to ``true``.
+By default, a workflow runs concurrently, allowing multiple instances of a workflow to be run
+simultaneously. To disable concurrent runs for a workflow, set its runtime argument
+``concurrent.runs.enabled`` to ``false``.
 
 
 .. _workflow_token:

--- a/cdap-docs/developers-manual/source/building-blocks/workflows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/workflows.rst
@@ -27,9 +27,8 @@ subsequent programs in the sequence are executed.
 
 The control flow of a workflow can be described as a directed, acyclic graph (DAG) of actions.
 To be more precise, we require that it be a series-parallel graph. This is a graph with a
-single start node and a single finish node. As described below, execution can be either
-sequential or :ref:`concurrent <workflow-concurrent>` (the default), and the graph can be 
-either a simple series of nodes or a more complicated :ref:`parallel workflow <workflow_parallel>`.
+single start node and a single finish node; in between, the graph can be either a simple
+series of nodes or a more complicated :ref:`parallel workflow <workflow_parallel>`.
 
 Workflows can be controlled by the :ref:`CDAP CLI <cli>` and the :ref:`Lifecycle HTTP
 RESTful API <http-restful-api-lifecycle>`. The :ref:`status of a workflow
@@ -181,9 +180,9 @@ The workflow itself uses the same names in its configuration::
 
 Concurrent Workflows
 --------------------
-By default, a workflow runs concurrently, allowing multiple instances of a workflow to be run
-simultaneously. To disable concurrent runs for a workflow, set its runtime argument
-``concurrent.runs.enabled`` to ``false``.
+By default, a workflow runs concurrently, allowing multiple instances of a workflow to be
+run simultaneously. However, for scheduled workflows, the number of concurrent runs can be
+controlled by :ref:`setting a maximum number <run-constraints>` of runs.
 
 
 .. _workflow_token:


### PR DESCRIPTION
Passed [Quick Build 2](http://builds.cask.co/browse/CDAP-DOB133-2).

Fix for https://issues.cask.co/browse/CDAP-4450.

[Revised Workflows page](http://builds.cask.co/artifact/CDAP-DOB133/shared/build-2/Docs-HTML/3.4.0-SNAPSHOT/en/developers-manual/building-blocks/workflows.html#concurrent-workflows)