### PR TITLE
Exclude asm from jersey-servlet

### DIFF
--- a/cdap-unit-test/pom.xml
+++ b/cdap-unit-test/pom.xml
@@ -117,6 +117,12 @@
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-servlet</artifactId>
       <version>1.18</version>
+      <exclusions>
+        <exclusion>
+          <groupId>asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Currently when running tests of an CDAP application, the following exception is thrown -
```
test(co.cask.tracker.TrackerAppTest)  Time elapsed: 0.08 sec  <<< ERROR!
java.lang.IncompatibleClassChangeError: class org.apache.twill.internal.utils.Dependencies$DependencyClassVisitor has interface org.objectweb.asm.ClassVisitor as super class
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:760)
        at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
        at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
        at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at org.apache.twill.internal.utils.Dependencies.findClassDependencies(Dependencies.java:86)
        at co.cask.cdap.common.lang.ProgramResources.findClassDependencies(ProgramResources.java:289)
        at co.cask.cdap.common.lang.ProgramResources.createBaseResources(ProgramResources.java:155)
        at co.cask.cdap.common.lang.ProgramResources.getBaseResources(ProgramResources.java:132)
        at co.cask.cdap.common.lang.ProgramResources.createVisibleResources(ProgramResources.java:115)
        at co.cask.cdap.common.lang.ProgramResources.getVisibleResources(ProgramResources.java:105)
        at co.cask.cdap.internal.test.AppJarHelper.createDeploymentJar(AppJarHelper.java:52)
        at co.cask.cdap.internal.test.AppJarHelper.createDeploymentJar(AppJarHelper.java:127)
        at co.cask.cdap.internal.AppFabricClient.deployApplication(AppFabricClient.java:360)
        at co.cask.cdap.test.UnitTestManager.deployApplication(UnitTestManager.java:157)
        at co.cask.cdap.test.TestBase.deployApplication(TestBase.java:409)
        at co.cask.cdap.test.TestBase.deployApplication(TestBase.java:403)
        at co.cask.cdap.test.TestBase.deployApplication(TestBase.java:424)
        at co.cask.tracker.TrackerAppTest.test(TrackerAppTest.java:50)
```

Build - http://builds.cask.co/browse/CDAP-DUT3617-2