### PR TITLE
Support CDH 5.6, using the CDH 5.5 compat modules.

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -155,7 +155,7 @@ cdap_set_hbase() {
       0.98*)
         hbasecompat="${CDAP_HOME}/hbase-compat-0.98/lib/*"
         ;;
-      1.0-cdh5.5*)
+      1.0-cdh5.5* | 1.0-cdh5.6*)
         hbasecompat="${CDAP_HOME}/hbase-compat-1.0-cdh5.5.0/lib/*"
         ;;
       1.0-cdh*)

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -35,6 +35,7 @@ public class HBaseVersion {
   private static final String HBASE_10_VERSION = "1.0";
   private static final String HBASE_11_VERSION = "1.1";
   private static final String CDH55_CLASSIFIER = "cdh5.5";
+  private static final String CDH56_CLASSIFIER = "cdh5.6";
   private static final String CDH_CLASSIFIER = "cdh";
 
   private static final Logger LOG = LoggerFactory.getLogger(HBaseVersion.class);
@@ -49,6 +50,7 @@ public class HBaseVersion {
     HBASE_10("1.0"),
     HBASE_10_CDH("1.0-cdh"),
     HBASE_10_CDH55("1.0-cdh5.5"),
+    HBASE_10_CDH56("1.0-cdh5.6"),
     HBASE_11("1.1"),
     UNKNOWN("unknown");
 
@@ -80,6 +82,8 @@ public class HBaseVersion {
         VersionNumber ver = VersionNumber.create(versionString);
         if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH55_CLASSIFIER)) {
           currentVersion = Version.HBASE_10_CDH55;
+        } else if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH56_CLASSIFIER)) {
+          currentVersion = Version.HBASE_10_CDH56;
         } else if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
           currentVersion = Version.HBASE_10_CDH;
         } else {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
@@ -50,6 +50,7 @@ public abstract class HBaseVersionSpecificFactory<T> implements Provider<T> {
           instance = createInstance(getHBase11Classname());
           break;
         case HBASE_10_CDH55:
+        case HBASE_10_CDH56:
           instance = createInstance(getHBase10CHD550ClassName());
           break;
         case UNKNOWN:


### PR DESCRIPTION
There aren't any HBase incompatibilities between CDH 5.5 and CDH 5.6, but our version-detection needs updating.

https://issues.cask.co/browse/CDAP-5134
http://builds.cask.co/browse/CDAP-RBT648-1