### PR TITLE
Exclude asm from jersey-servlet

### DIFF
--- a/cdap-unit-test/pom.xml
+++ b/cdap-unit-test/pom.xml
@@ -117,6 +117,12 @@
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-servlet</artifactId>
       <version>1.18</version>
+      <exclusions>
+        <exclusion>
+          <groupId>asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Opening https://github.com/caskdata/cdap/pull/5223 against 3.3 release branch. See https://github.com/caskdata/cdap/pull/5223 for discussion.

Build - http://builds.cask.co/browse/CDAP-RBT649-1