### PR TITLE
(CDAP-20) Removed guava dependency from cdap-api

### DIFF
--- a/cdap-api/pom.xml
+++ b/cdap-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -43,10 +43,6 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -29,7 +29,7 @@ import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
-import com.google.common.reflect.TypeToken;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Element.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Element.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2012 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import javax.annotation.Nullable;
+
+/**
+ * Represents either a {@link Field}, a {@link Method} or a {@link Constructor}.
+ * Provides convenience methods such as {@link #isPublic} and {@link #isPackagePrivate}.
+ */
+class Element extends AccessibleObject implements Member {
+
+  private final AccessibleObject accessibleObject;
+  private final Member member;
+
+  <M extends AccessibleObject & Member> Element(M member) {
+    Preconditions.checkNotNull(member);
+    this.accessibleObject = member;
+    this.member = member;
+  }
+
+  public TypeToken<?> getOwnerType() {
+    return TypeToken.of(getDeclaringClass());
+  }
+
+  @Override public final boolean isAnnotationPresent(Class<? extends Annotation> annotationClass) {
+    return accessibleObject.isAnnotationPresent(annotationClass);
+  }
+
+  @Override public final <A extends Annotation> A getAnnotation(Class<A> annotationClass) {
+    return accessibleObject.getAnnotation(annotationClass);
+  }
+
+  @Override public final Annotation[] getAnnotations() {
+    return accessibleObject.getAnnotations();
+  }
+
+  @Override public final Annotation[] getDeclaredAnnotations() {
+    return accessibleObject.getDeclaredAnnotations();
+  }
+
+  @Override public final void setAccessible(boolean flag) throws SecurityException {
+    accessibleObject.setAccessible(flag);
+  }
+
+  @Override public final boolean isAccessible() {
+    return accessibleObject.isAccessible();
+  }
+
+  @Override public Class<?> getDeclaringClass() {
+    return member.getDeclaringClass();
+  }
+
+  @Override public final String getName() {
+    return member.getName();
+  }
+
+  @Override public final int getModifiers() {
+    return member.getModifiers();
+  }
+
+  @Override public final boolean isSynthetic() {
+    return member.isSynthetic();
+  }
+
+  /** Returns true if the element is public. */
+  public final boolean isPublic() {
+    return Modifier.isPublic(getModifiers());
+  }
+
+  /** Returns true if the element is protected. */
+  public final boolean isProtected() {
+    return Modifier.isProtected(getModifiers());
+  }
+
+  /** Returns true if the element is package-private. */
+  public final boolean isPackagePrivate() {
+    return !isPrivate() && !isPublic() && !isProtected();
+  }
+
+  /** Returns true if the element is private. */
+  public final boolean isPrivate() {
+    return Modifier.isPrivate(getModifiers());
+  }
+
+  /** Returns true if the element is static. */
+  public final boolean isStatic() {
+    return Modifier.isStatic(getModifiers());
+  }
+
+  /**
+   * Returns {@code true} if this method is final, per {@code Modifier.isFinal(getModifiers())}.
+   * 
+   * <p>Note that a method may still be effectively "final", or non-overridable when it has no
+   * {@code final} keyword. For example, it could be private, or it could be declared by a final
+   * class. To tell whether a method is overridable, use {@link Invokable#isOverridable}.
+   */
+  public final boolean isFinal() {
+    return Modifier.isFinal(getModifiers());
+  }
+
+  /** Returns true if the method is abstract. */
+  public final boolean isAbstract() {
+    return Modifier.isAbstract(getModifiers());
+  }
+
+  /** Returns true if the element is native. */
+  public final boolean isNative() {
+    return Modifier.isNative(getModifiers());
+  }
+
+  /** Returns true if the method is synchronized. */
+  public final boolean isSynchronized() {
+    return Modifier.isSynchronized(getModifiers());
+  }
+
+  /** Returns true if the field is volatile. */
+  final boolean isVolatile() {
+    return Modifier.isVolatile(getModifiers());
+  }
+
+  /** Returns true if the field is transient. */
+  final boolean isTransient() {
+    return Modifier.isTransient(getModifiers());
+  }
+
+  @Override public boolean equals(@Nullable Object obj) {
+    if (obj instanceof Element) {
+      Element that = (Element) obj;
+      return getOwnerType().equals(that.getOwnerType()) && member.equals(that.member);
+    }
+    return false;
+  }
+
+  @Override public int hashCode() {
+    return member.hashCode();
+  }
+
+  @Override public String toString() {
+    return member.toString();
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Function.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Function.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2007 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Determines an output value based on an input value.
+ *
+ * @param <F> input type
+ * @param <T> output type
+ */
+interface Function<F, T> {
+  /**
+   * Returns the result of applying this function to {@code input}. This method is <i>generally
+   * expected</i>, but not absolutely required, to have the following properties:
+   *
+   * <ul>
+   * <li>Its execution does not cause any observable side effects.
+   * <li>The computation is <i>consistent with equals</i>; that is, {@link Objects#equals
+   *     Objects.equals}{@code (a, b)} implies that {@code Objects.equals(function.apply(a),
+   *     function.apply(b))}.
+   * </ul>
+   *
+   * @throws NullPointerException if {@code input} is null and this function does not accept null
+   *     arguments
+   */
+  @Nullable
+  T apply(@Nullable F input);
+
+  /**
+   * Indicates whether another object is equal to this function.
+   *
+   * <p>Most implementations will have no reason to override the behavior of {@link Object#equals}.
+   * However, an implementation may also choose to return {@code true} whenever {@code object} is a
+   * {@link Function} that it considers <i>interchangeable</i> with this one. "Interchangeable"
+   * <i>typically</i> means that {@code Objects.equal(this.apply(f), that.apply(f))} is true for all
+   * {@code f} of type {@code F}. Note that a {@code false} result from this method does not imply
+   * that the functions are known <i>not</i> to be interchangeable.
+   */
+  @Override
+  boolean equals(@Nullable Object object);
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Invokable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Invokable.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2012 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.GenericDeclaration;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Wrapper around either a {@link Method} or a {@link Constructor}.
+ * Convenience API is provided to make common reflective operation easier to deal with,
+ * such as {@link #isPublic}, {@link #getParameters} etc.
+ *
+ * <p>In addition to convenience methods, {@link TypeToken#method} and {@link
+ * TypeToken#constructor} will resolve the type parameters of the method or constructor in the
+ * context of the owner type, which may be a subtype of the declaring class. For example:
+ *
+ * <pre>   {@code
+ *   Method getMethod = List.class.getMethod("get", int.class);
+ *   Invokable<List<String>, ?> invokable = new TypeToken<List<String>>() {}.method(getMethod);
+ *   assertEquals(TypeToken.of(String.class), invokable.getReturnType()); // Not Object.class!
+ *   assertEquals(new TypeToken<List<String>>() {}, invokable.getOwnerType());}</pre>
+ * 
+ * @param <T> the type that owns this method or constructor.
+ * @param <R> the return type of (or supertype thereof) the method or the declaring type of the
+ *            constructor.
+ */
+public abstract class Invokable<T, R> extends Element implements GenericDeclaration {
+
+  <M extends AccessibleObject & Member> Invokable(M member) {
+    super(member);
+  }
+
+  /** Returns {@link Invokable} of {@code method}. */
+  public static Invokable<?, Object> from(Method method) {
+    return new MethodInvokable<Object>(method);
+  }
+
+  /** Returns {@link Invokable} of {@code constructor}. */
+  public static <T> Invokable<T, T> from(Constructor<T> constructor) {
+    return new ConstructorInvokable<T>(constructor);
+  }
+
+  /**
+   * Returns {@code true} if this is an overridable method. Constructors, private, static or final
+   * methods, or methods declared by final classes are not overridable.
+   */
+  public abstract boolean isOverridable();
+
+  /** Returns {@code true} if this was declared to take a variable number of arguments. */
+  public abstract boolean isVarArgs();
+
+  /**
+   * Invokes with {@code receiver} as 'this' and {@code args} passed to the underlying method
+   * and returns the return value; or calls the underlying constructor with {@code args} and returns
+   * the constructed instance.
+   *
+   * @throws IllegalAccessException if this {@code Constructor} object enforces Java language
+   *         access control and the underlying method or constructor is inaccessible.
+   * @throws IllegalArgumentException if the number of actual and formal parameters differ;
+   *         if an unwrapping conversion for primitive arguments fails; or if, after possible
+   *         unwrapping, a parameter value cannot be converted to the corresponding formal
+   *         parameter type by a method invocation conversion.
+   * @throws InvocationTargetException if the underlying method or constructor throws an exception.
+   */
+  // All subclasses are owned by us and we'll make sure to get the R type right.
+  @SuppressWarnings("unchecked")
+  public final R invoke(@Nullable T receiver, Object... args)
+      throws InvocationTargetException, IllegalAccessException {
+    return (R) invokeInternal(receiver, Preconditions.checkNotNull(args));
+  }
+
+  /** Returns the return type of this {@code Invokable}. */
+  // All subclasses are owned by us and we'll make sure to get the R type right.
+  @SuppressWarnings("unchecked")
+  public final TypeToken<? extends R> getReturnType() {
+    return (TypeToken<? extends R>) TypeToken.of(getGenericReturnType());
+  }
+
+  /**
+   * Returns all declared parameters of this {@code Invokable}. Note that if this is a constructor
+   * of a non-static inner class, unlike {@link Constructor#getParameterTypes}, the hidden
+   * {@code this} parameter of the enclosing class is excluded from the returned parameters.
+   */
+  public final List<Parameter> getParameters() {
+    Type[] parameterTypes = getGenericParameterTypes();
+    Annotation[][] annotations = getParameterAnnotations();
+    List<Parameter> builder = new ArrayList<>();
+    for (int i = 0; i < parameterTypes.length; i++) {
+      builder.add(new Parameter(
+          this, i, TypeToken.of(parameterTypes[i]), annotations[i]));
+    }
+    return Collections.unmodifiableList(builder);
+  }
+
+  /** Returns all declared exception types of this {@code Invokable}. */
+  public final List<TypeToken<? extends Throwable>> getExceptionTypes() {
+    List<TypeToken<? extends Throwable>> builder = new ArrayList<>();
+    for (Type type : getGenericExceptionTypes()) {
+       // getGenericExceptionTypes() will never return a type that's not exception
+      @SuppressWarnings("unchecked")
+      TypeToken<? extends Throwable> exceptionType = (TypeToken<? extends Throwable>)
+          TypeToken.of(type);
+      builder.add(exceptionType);
+    }
+    return Collections.unmodifiableList(builder);
+  }
+
+  /**
+   * Explicitly specifies the return type of this {@code Invokable}. For example:
+   * <pre>   {@code
+   *   Method factoryMethod = Person.class.getMethod("create");
+   *   Invokable<?, Person> factory = Invokable.of(getNameMethod).returning(Person.class);}</pre>
+   */
+  public final <R1 extends R> Invokable<T, R1> returning(Class<R1> returnType) {
+    return returning(TypeToken.of(returnType));
+  }
+
+  /** Explicitly specifies the return type of this {@code Invokable}. */
+  public final <R1 extends R> Invokable<T, R1> returning(TypeToken<R1> returnType) {
+    if (!returnType.isAssignableFrom(getReturnType())) {
+      throw new IllegalArgumentException(
+          "Invokable is known to return " + getReturnType() + ", not " + returnType);
+    }
+    @SuppressWarnings("unchecked") // guarded by previous check
+    Invokable<T, R1> specialized = (Invokable<T, R1>) this;
+    return specialized;
+  }
+
+  @SuppressWarnings("unchecked") // The declaring class is T's raw class, or one of its supertypes.
+  @Override public final Class<? super T> getDeclaringClass() {
+    return (Class<? super T>) super.getDeclaringClass();
+  }
+
+  /** Returns the type of {@code T}. */
+  // Overridden in TypeToken#method() and TypeToken#constructor()
+  @SuppressWarnings("unchecked") // The declaring class is T.
+  @Override public TypeToken<T> getOwnerType() {
+    return (TypeToken<T>) TypeToken.of(getDeclaringClass());
+  }
+
+  abstract Object invokeInternal(@Nullable Object receiver, Object[] args)
+      throws InvocationTargetException, IllegalAccessException;
+
+  abstract Type[] getGenericParameterTypes();
+
+  /** This should never return a type that's not a subtype of Throwable. */
+  abstract Type[] getGenericExceptionTypes();
+
+  abstract Annotation[][] getParameterAnnotations();
+
+  abstract Type getGenericReturnType();
+  
+  static class MethodInvokable<T> extends Invokable<T, Object> {
+
+    final Method method;
+
+    MethodInvokable(Method method) {
+      super(method);
+      this.method = method;
+    }
+
+    @Override final Object invokeInternal(@Nullable Object receiver, Object[] args)
+        throws InvocationTargetException, IllegalAccessException {
+      return method.invoke(receiver, args);
+    }
+
+    @Override Type getGenericReturnType() {
+      return method.getGenericReturnType();
+    }
+
+    @Override Type[] getGenericParameterTypes() {
+      return method.getGenericParameterTypes();
+    }
+
+    @Override Type[] getGenericExceptionTypes() {
+      return method.getGenericExceptionTypes();
+    }
+
+    @Override final Annotation[][] getParameterAnnotations() {
+      return method.getParameterAnnotations();
+    }
+
+    @Override public final TypeVariable<?>[] getTypeParameters() {
+      return method.getTypeParameters();
+    }
+
+    @Override public final boolean isOverridable() {
+      return  !(isFinal() || isPrivate() || isStatic()
+          || Modifier.isFinal(getDeclaringClass().getModifiers()));
+    }
+
+    @Override public final boolean isVarArgs() {
+      return method.isVarArgs();
+    }
+  }
+
+  static class ConstructorInvokable<T> extends Invokable<T, T> {
+
+    final Constructor<?> constructor;
+
+    ConstructorInvokable(Constructor<?> constructor) {
+      super(constructor);
+      this.constructor = constructor;
+    }
+
+    @Override final Object invokeInternal(@Nullable Object receiver, Object[] args)
+        throws InvocationTargetException, IllegalAccessException {
+      try {
+        return constructor.newInstance(args);
+      } catch (InstantiationException e) {
+        throw new RuntimeException(constructor + " failed.", e);
+      }
+    }
+
+    /** If the class is parameterized, such as ArrayList, this returns ArrayList<E>. */
+    @Override Type getGenericReturnType() {
+      Class<?> declaringClass = getDeclaringClass();
+      TypeVariable<?>[] typeParams = declaringClass.getTypeParameters();
+      if (typeParams.length > 0) {
+        return Types.newParameterizedType(declaringClass, typeParams);
+      } else {
+        return declaringClass;
+      }
+    }
+
+    @Override Type[] getGenericParameterTypes() {
+      Type[] types = constructor.getGenericParameterTypes();
+      if (types.length > 0 && mayNeedHiddenThis()) {
+        Class<?>[] rawParamTypes = constructor.getParameterTypes();
+        if (types.length == rawParamTypes.length
+            && rawParamTypes[0] == getDeclaringClass().getEnclosingClass()) {
+          // first parameter is the hidden 'this'
+          return Arrays.copyOfRange(types, 1, types.length);
+        }
+      }
+      return types;
+    }
+
+    @Override Type[] getGenericExceptionTypes() {
+      return constructor.getGenericExceptionTypes();
+    }
+
+    @Override final Annotation[][] getParameterAnnotations() {
+      return constructor.getParameterAnnotations();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * {@code [<E>]} will be returned for ArrayList's constructor. When both the class and the
+     * constructor have type parameters, the class parameters are prepended before those of the
+     * constructor's. This is an arbitrary rule since no existing language spec mandates one way or
+     * the other. From the declaration syntax, the class type parameter appears first, but the
+     * call syntax may show up in opposite order such as {@code new <A>Foo<B>()}.
+     */
+    @Override public final TypeVariable<?>[] getTypeParameters() {
+      TypeVariable<?>[] declaredByClass = getDeclaringClass().getTypeParameters();
+      TypeVariable<?>[] declaredByConstructor = constructor.getTypeParameters();
+      TypeVariable<?>[] result =
+          new TypeVariable<?>[declaredByClass.length + declaredByConstructor.length];
+      System.arraycopy(declaredByClass, 0, result, 0, declaredByClass.length);
+      System.arraycopy(
+          declaredByConstructor, 0,
+          result, declaredByClass.length,
+          declaredByConstructor.length);
+      return result;
+    }
+
+    @Override public final boolean isOverridable() {
+      return false;
+    }
+
+    @Override public final boolean isVarArgs() {
+      return constructor.isVarArgs();
+    }
+
+    private boolean mayNeedHiddenThis() {
+      Class<?> declaringClass = constructor.getDeclaringClass();
+      if (declaringClass.getEnclosingConstructor() != null) {
+        // Enclosed in a constructor, needs hidden this
+        return true;
+      }
+      Method enclosingMethod = declaringClass.getEnclosingMethod();
+      if (enclosingMethod != null) {
+        // Enclosed in a method, if it's not static, must need hidden this.
+        return !Modifier.isStatic(enclosingMethod.getModifiers());
+      } else {
+        // Strictly, this doesn't necessarily indicate a hidden 'this' in the case of
+        // static initializer. But there seems no way to tell in that case. :(
+        // This may cause issues when an anonymous class is created inside a static initializer,
+        // and the class's constructor's first parameter happens to be the enclosing class.
+        // In such case, we may mistakenly think that the class is within a non-static context
+        // and the first parameter is the hidden 'this'.
+        return declaringClass.getEnclosingClass() != null
+            && !Modifier.isStatic(declaringClass.getModifiers());
+      }
+    }
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Iterables.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Iterables.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import co.cask.cdap.api.Predicate;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * This class contains static utility methods that operate on or return objects
+ * of type {@code Iterable}.
+ */
+final class Iterables {
+
+  static <F, T> Iterable<T> transform(final Iterable<F> iterable, final Function<? super F, ? extends T> transform) {
+    return new Iterable<T>() {
+      @Override
+      public Iterator<T> iterator() {
+        final Iterator<F> itor = iterable.iterator();
+        return new Iterator<T>() {
+          @Override
+          public boolean hasNext() {
+            return itor.hasNext();
+          }
+
+          @Override
+          public T next() {
+            return transform.apply(itor.next());
+          }
+
+          @Override
+          public void remove() {
+            itor.remove();
+          }
+        };
+      }
+    };
+  }
+
+  static <T, C> Iterable<C> filter(Iterable<T> iterable, final Class<C> cls) {
+    @SuppressWarnings("unchecked")
+    Iterable<C> result = (Iterable<C>) filter(iterable, new Predicate<T>() {
+      @Override
+      public boolean apply(T input) {
+        return cls.isInstance(input);
+      }
+    });
+    return result;
+  }
+
+  static <T> Iterable<T> filter(final Iterable<T> iterable, final Predicate<? super T> predicate) {
+    return new Iterable<T>() {
+      @Override
+      public Iterator<T> iterator() {
+        final Iterator<T> itor = iterable.iterator();
+        return new Iterator<T>() {
+
+          private boolean hasNext = false;
+          private T next = null;
+
+          @Override
+          public boolean hasNext() {
+            while (!hasNext) {
+              boolean sourceHasNext = itor.hasNext();
+              if (!sourceHasNext) {
+                break;
+              }
+              T sourceNext = itor.next();
+              if (predicate.apply(sourceNext)) {
+                hasNext = true;
+                next = sourceNext;
+                break;
+              }
+            }
+            return hasNext;
+          }
+
+          @Override
+          public T next() {
+            if (hasNext()) {
+              hasNext = false;
+              T result = next;
+              next = null;
+              return result;
+            }
+            throw new NoSuchElementException();
+          }
+
+          @Override
+          public void remove() {
+            throw new UnsupportedOperationException();
+          }
+        };
+      }
+    };
+  }
+
+  static <E, C extends Collection<? super E>> C addAll(Iterable<E> iterable, C collection) {
+    for (E element : iterable) {
+      collection.add(element);
+    }
+    return collection;
+  }
+
+  private Iterables() {
+    // no-op
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Joiner.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Joiner.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2008 The Guava Authors
+ * Derived from the Google Guava Project
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import co.cask.cdap.api.annotation.Beta;
+
+import java.io.IOException;
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+
+/**
+ * This class is copied form the guava Joiner class.
+ */
+class Joiner {
+  /**
+   * Returns a joiner which automatically places {@code separator} between consecutive elements.
+   */
+  @CheckReturnValue
+  public static Joiner on(String separator) {
+    return new Joiner(separator);
+  }
+
+  /**
+   * Returns a joiner which automatically places {@code separator} between consecutive elements.
+   */
+  @CheckReturnValue
+  public static Joiner on(char separator) {
+    return new Joiner(String.valueOf(separator));
+  }
+
+  private final String separator;
+
+  private Joiner(String separator) {
+    this.separator = Preconditions.checkNotNull(separator);
+  }
+
+  private Joiner(Joiner prototype) {
+    this.separator = prototype.separator;
+  }
+
+  /**
+   * Appends the string representation of each of {@code parts}, using the previously configured
+   * separator between each, to {@code appendable}.
+   */
+  public <A extends Appendable> A appendTo(A appendable, Iterable<?> parts) throws IOException {
+    return appendTo(appendable, parts.iterator());
+  }
+
+  /**
+   * Appends the string representation of each of {@code parts}, using the previously configured
+   * separator between each, to {@code appendable}.
+   *
+   * @since 11.0
+   */
+  public <A extends Appendable> A appendTo(A appendable, Iterator<?> parts) throws IOException {
+    Preconditions.checkNotNull(appendable);
+    if (parts.hasNext()) {
+      appendable.append(toString(parts.next()));
+      while (parts.hasNext()) {
+        appendable.append(separator);
+        appendable.append(toString(parts.next()));
+      }
+    }
+    return appendable;
+  }
+
+  /**
+   * Appends the string representation of each of {@code parts}, using the previously configured
+   * separator between each, to {@code appendable}.
+   */
+  public final <A extends Appendable> A appendTo(A appendable, Object[] parts) throws IOException {
+    return appendTo(appendable, Arrays.asList(parts));
+  }
+
+  /**
+   * Appends to {@code appendable} the string representation of each of the remaining arguments.
+   */
+  public final <A extends Appendable> A appendTo(
+    A appendable, @Nullable Object first, @Nullable Object second, Object... rest)
+    throws IOException {
+    return appendTo(appendable, iterable(first, second, rest));
+  }
+
+  /**
+   * Appends the string representation of each of {@code parts}, using the previously configured
+   * separator between each, to {@code builder}. Identical to {@link #appendTo(Appendable,
+   * Iterable)}, except that it does not throw {@link IOException}.
+   */
+  public final StringBuilder appendTo(StringBuilder builder, Iterable<?> parts) {
+    return appendTo(builder, parts.iterator());
+  }
+
+  /**
+   * Appends the string representation of each of {@code parts}, using the previously configured
+   * separator between each, to {@code builder}. Identical to {@link #appendTo(Appendable,
+   * Iterable)}, except that it does not throw {@link IOException}.
+   *
+   * @since 11.0
+   */
+  public final StringBuilder appendTo(StringBuilder builder, Iterator<?> parts) {
+    try {
+      appendTo((Appendable) builder, parts);
+    } catch (IOException impossible) {
+      throw new AssertionError(impossible);
+    }
+    return builder;
+  }
+
+  /**
+   * Appends the string representation of each of {@code parts}, using the previously configured
+   * separator between each, to {@code builder}. Identical to {@link #appendTo(Appendable,
+   * Iterable)}, except that it does not throw {@link IOException}.
+   */
+  public final StringBuilder appendTo(StringBuilder builder, Object[] parts) {
+    return appendTo(builder, Arrays.asList(parts));
+  }
+
+  /**
+   * Appends to {@code builder} the string representation of each of the remaining arguments.
+   * Identical to {@link #appendTo(Appendable, Object, Object, Object...)}, except that it does not
+   * throw {@link IOException}.
+   */
+  public final StringBuilder appendTo(
+    StringBuilder builder, @Nullable Object first, @Nullable Object second, Object... rest) {
+    return appendTo(builder, iterable(first, second, rest));
+  }
+
+  /**
+   * Returns a string containing the string representation of each of {@code parts}, using the
+   * previously configured separator between each.
+   */
+  @CheckReturnValue
+  public final String join(Iterable<?> parts) {
+    return join(parts.iterator());
+  }
+
+  /**
+   * Returns a string containing the string representation of each of {@code parts}, using the
+   * previously configured separator between each.
+   *
+   * @since 11.0
+   */
+  @CheckReturnValue
+  public final String join(Iterator<?> parts) {
+    return appendTo(new StringBuilder(), parts).toString();
+  }
+
+  /**
+   * Returns a string containing the string representation of each of {@code parts}, using the
+   * previously configured separator between each.
+   */
+  @CheckReturnValue
+  public final String join(Object[] parts) {
+    return join(Arrays.asList(parts));
+  }
+
+  /**
+   * Returns a string containing the string representation of each argument, using the previously
+   * configured separator between each.
+   */
+  @CheckReturnValue
+  public final String join(@Nullable Object first, @Nullable Object second, Object... rest) {
+    return join(iterable(first, second, rest));
+  }
+
+  /**
+   * Returns a joiner with the same behavior as this one, except automatically substituting {@code
+   * nullText} for any provided null elements.
+   */
+  @CheckReturnValue
+  public Joiner useForNull(final String nullText) {
+    Preconditions.checkNotNull(nullText);
+    return new Joiner(this) {
+      @Override
+      CharSequence toString(@Nullable Object part) {
+        return (part == null) ? nullText : Joiner.this.toString(part);
+      }
+
+      @Override
+      public Joiner useForNull(String nullText) {
+        throw new UnsupportedOperationException("already specified useForNull");
+      }
+
+      @Override
+      public Joiner skipNulls() {
+        throw new UnsupportedOperationException("already specified useForNull");
+      }
+    };
+  }
+
+  /**
+   * Returns a joiner with the same behavior as this joiner, except automatically skipping over any
+   * provided null elements.
+   */
+  @CheckReturnValue
+  public Joiner skipNulls() {
+    return new Joiner(this) {
+      @Override
+      public <A extends Appendable> A appendTo(A appendable, Iterator<?> parts) throws IOException {
+        Preconditions.checkNotNull(appendable, "appendable");
+        Preconditions.checkNotNull(parts, "parts");
+        while (parts.hasNext()) {
+          Object part = parts.next();
+          if (part != null) {
+            appendable.append(Joiner.this.toString(part));
+            break;
+          }
+        }
+        while (parts.hasNext()) {
+          Object part = parts.next();
+          if (part != null) {
+            appendable.append(separator);
+            appendable.append(Joiner.this.toString(part));
+          }
+        }
+        return appendable;
+      }
+
+      @Override
+      public Joiner useForNull(String nullText) {
+        throw new UnsupportedOperationException("already specified skipNulls");
+      }
+
+      @Override
+      public MapJoiner withKeyValueSeparator(String kvs) {
+        throw new UnsupportedOperationException("can't use .skipNulls() with maps");
+      }
+    };
+  }
+
+  /**
+   * Returns a {@code MapJoiner} using the given key-value separator, and the same configuration as
+   * this {@code Joiner} otherwise.
+   */
+  @CheckReturnValue
+  public MapJoiner withKeyValueSeparator(String keyValueSeparator) {
+    return new MapJoiner(this, keyValueSeparator);
+  }
+
+  /**
+   * An object that joins map entries in the same manner as {@code Joiner} joins iterables and
+   * arrays. Like {@code Joiner}, it is thread-safe and immutable.
+   *
+   * <p>In addition to operating on {@code Map} instances, {@code MapJoiner} can operate on {@code
+   * Multimap} entries in two distinct modes:
+   *
+   * <ul>
+   * <li>To output a separate entry for each key-value pair, pass {@code multimap.entries()} to a
+   *     {@code MapJoiner} method that accepts entries as input, and receive output of the form
+   *     {@code key1=A&key1=B&key2=C}.
+   * <li>To output a single entry for each key, pass {@code multimap.asMap()} to a {@code MapJoiner}
+   *     method that accepts a map as input, and receive output of the form {@code
+   *     key1=[A, B]&key2=C}.
+   * </ul>
+   *
+   * @since 2.0
+   */
+  public static final class MapJoiner {
+    private final Joiner joiner;
+    private final String keyValueSeparator;
+
+    private MapJoiner(Joiner joiner, String keyValueSeparator) {
+      this.joiner = joiner; // only "this" is ever passed, so don't checkNotNull
+      this.keyValueSeparator = Preconditions.checkNotNull(keyValueSeparator);
+    }
+
+    /**
+     * Appends the string representation of each entry of {@code map}, using the previously
+     * configured separator and key-value separator, to {@code appendable}.
+     */
+    public <A extends Appendable> A appendTo(A appendable, Map<?, ?> map) throws IOException {
+      return appendTo(appendable, map.entrySet());
+    }
+
+    /**
+     * Appends the string representation of each entry of {@code map}, using the previously
+     * configured separator and key-value separator, to {@code builder}. Identical to {@link
+     * #appendTo(Appendable, Map)}, except that it does not throw {@link IOException}.
+     */
+    public StringBuilder appendTo(StringBuilder builder, Map<?, ?> map) {
+      return appendTo(builder, map.entrySet());
+    }
+
+    /**
+     * Returns a string containing the string representation of each entry of {@code map}, using the
+     * previously configured separator and key-value separator.
+     */
+    @CheckReturnValue
+    public String join(Map<?, ?> map) {
+      return join(map.entrySet());
+    }
+
+    /**
+     * Appends the string representation of each entry in {@code entries}, using the previously
+     * configured separator and key-value separator, to {@code appendable}.
+     *
+     * @since 10.0
+     */
+    @Beta
+    public <A extends Appendable> A appendTo(A appendable, Iterable<? extends Map.Entry<?, ?>> entries)
+      throws IOException {
+      return appendTo(appendable, entries.iterator());
+    }
+
+    /**
+     * Appends the string representation of each entry in {@code entries}, using the previously
+     * configured separator and key-value separator, to {@code appendable}.
+     *
+     * @since 11.0
+     */
+    @Beta
+    public <A extends Appendable> A appendTo(A appendable, Iterator<? extends Map.Entry<?, ?>> parts)
+      throws IOException {
+      Preconditions.checkNotNull(appendable);
+      if (parts.hasNext()) {
+        Map.Entry<?, ?> entry = parts.next();
+        appendable.append(joiner.toString(entry.getKey()));
+        appendable.append(keyValueSeparator);
+        appendable.append(joiner.toString(entry.getValue()));
+        while (parts.hasNext()) {
+          appendable.append(joiner.separator);
+          Map.Entry<?, ?> e = parts.next();
+          appendable.append(joiner.toString(e.getKey()));
+          appendable.append(keyValueSeparator);
+          appendable.append(joiner.toString(e.getValue()));
+        }
+      }
+      return appendable;
+    }
+
+    /**
+     * Appends the string representation of each entry in {@code entries}, using the previously
+     * configured separator and key-value separator, to {@code builder}. Identical to {@link
+     * #appendTo(Appendable, Iterable)}, except that it does not throw {@link IOException}.
+     *
+     * @since 10.0
+     */
+    @Beta
+    public StringBuilder appendTo(StringBuilder builder, Iterable<? extends Map.Entry<?, ?>> entries) {
+      return appendTo(builder, entries.iterator());
+    }
+
+    /**
+     * Appends the string representation of each entry in {@code entries}, using the previously
+     * configured separator and key-value separator, to {@code builder}. Identical to {@link
+     * #appendTo(Appendable, Iterable)}, except that it does not throw {@link IOException}.
+     *
+     * @since 11.0
+     */
+    @Beta
+    public StringBuilder appendTo(StringBuilder builder, Iterator<? extends Map.Entry<?, ?>> entries) {
+      try {
+        appendTo((Appendable) builder, entries);
+      } catch (IOException impossible) {
+        throw new AssertionError(impossible);
+      }
+      return builder;
+    }
+
+    /**
+     * Returns a string containing the string representation of each entry in {@code entries}, using
+     * the previously configured separator and key-value separator.
+     *
+     * @since 10.0
+     */
+    @Beta
+    @CheckReturnValue
+    public String join(Iterable<? extends Map.Entry<?, ?>> entries) {
+      return join(entries.iterator());
+    }
+
+    /**
+     * Returns a string containing the string representation of each entry in {@code entries}, using
+     * the previously configured separator and key-value separator.
+     *
+     * @since 11.0
+     */
+    @Beta
+    @CheckReturnValue
+    public String join(Iterator<? extends Map.Entry<?, ?>> entries) {
+      return appendTo(new StringBuilder(), entries).toString();
+    }
+
+    /**
+     * Returns a map joiner with the same behavior as this one, except automatically substituting
+     * {@code nullText} for any provided null keys or values.
+     */
+    @CheckReturnValue
+    public MapJoiner useForNull(String nullText) {
+      return new MapJoiner(joiner.useForNull(nullText), keyValueSeparator);
+    }
+  }
+
+  CharSequence toString(Object part) {
+    Preconditions.checkNotNull(part); // checkNotNull for GWT (do not optimize).
+    return (part instanceof CharSequence) ? (CharSequence) part : part.toString();
+  }
+
+  private static Iterable<Object> iterable(
+    final Object first, final Object second, final Object[] rest) {
+    Preconditions.checkNotNull(rest);
+    return new AbstractList<Object>() {
+      @Override
+      public int size() {
+        return rest.length + 2;
+      }
+
+      @Override
+      public Object get(int index) {
+        switch (index) {
+          case 0:
+            return first;
+          case 1:
+            return second;
+          default:
+            return rest[index - 2];
+        }
+      }
+    };
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Parameter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Parameter.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2012 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a method or constructor parameter.
+ */
+public final class Parameter implements AnnotatedElement {
+
+  private final Invokable<?, ?> declaration;
+  private final int position;
+  private final TypeToken<?> type;
+  private final List<Annotation> annotations;
+
+  Parameter(
+      Invokable<?, ?> declaration,
+      int position,
+      TypeToken<?> type,
+      Annotation[] annotations) {
+    this.declaration = declaration;
+    this.position = position;
+    this.type = type;
+    this.annotations = Arrays.asList(annotations);
+  }
+
+  /** Returns the type of the parameter. */
+  public TypeToken<?> getType() {
+    return type;
+  }
+
+  /** Returns the {@link Invokable} that declares this parameter. */
+  public Invokable<?, ?> getDeclaringInvokable() {
+    return declaration;
+  }
+
+  @Override public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+    return getAnnotation(annotationType) != null;
+  }
+
+  @Override
+  @Nullable
+  public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+    Preconditions.checkNotNull(annotationType);
+    for (Annotation annotation : annotations) {
+      if (annotationType.isInstance(annotation)) {
+        return annotationType.cast(annotation);
+      }
+    }
+    return null;
+  }
+
+  @Override public Annotation[] getAnnotations() {
+    return getDeclaredAnnotations();
+  }
+
+  /**
+   * @since 18.0
+   */
+  // @Override on JDK8
+  public <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
+    return getDeclaredAnnotationsByType(annotationType);
+  }
+
+  /**
+   * @since 18.0
+   */
+  // @Override on JDK8
+  @Override public Annotation[] getDeclaredAnnotations() {
+    return annotations.toArray(new Annotation[annotations.size()]);
+  }
+
+  /**
+   * @since 18.0
+   */
+  // @Override on JDK8
+  @Nullable
+  public <A extends Annotation> A getDeclaredAnnotation(Class<A> annotationType) {
+    Preconditions.checkNotNull(annotationType);
+    Iterator<A> itor = Iterables.filter(annotations, annotationType).iterator();
+    return itor.hasNext() ? itor.next() : null;
+  }
+
+  /**
+   * @since 18.0
+   */
+  // @Override on JDK8
+  public <A extends Annotation> A[] getDeclaredAnnotationsByType(Class<A> annotationType) {
+    List<A> list = Iterables.addAll(Iterables.filter(annotations, annotationType), new ArrayList<A>());
+    @SuppressWarnings("unchecked")
+    A[] array = (A[]) Array.newInstance(annotationType, list.size());
+    return list.toArray(array);
+  }
+
+  @Override public boolean equals(@Nullable Object obj) {
+    if (obj instanceof Parameter) {
+      Parameter that = (Parameter) obj;
+      return position == that.position && declaration.equals(that.declaration);
+    }
+    return false;
+  }
+
+  @Override public int hashCode() {
+    return position;
+  }
+
+  @Override public String toString() {
+    return type + " arg" + position;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Preconditions.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Preconditions.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2007 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import javax.annotation.Nullable;
+
+/**
+ * This class is copied form guava Preconditions class.
+ */
+final class Preconditions {
+  private Preconditions() {}
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @throws IllegalArgumentException if {@code expression} is false
+   */
+  public static void checkArgument(boolean expression) {
+    if (!expression) {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @param errorMessage the exception message to use if the check fails; will be converted to a
+   *     string using {@link String#valueOf(Object)}
+   * @throws IllegalArgumentException if {@code expression} is false
+   */
+  public static void checkArgument(boolean expression, @Nullable Object errorMessage) {
+    if (!expression) {
+      throw new IllegalArgumentException(String.valueOf(errorMessage));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @param errorMessageTemplate a template for the exception message should the check fail. The
+   *     message is formed by replacing each {@code %s} placeholder in the template with an
+   *     argument. These are matched by position - the first {@code %s} gets {@code
+   *     errorMessageArgs[0]}, etc.  Unmatched arguments will be appended to the formatted message
+   *     in square braces. Unmatched placeholders will be left as-is.
+   * @param errorMessageArgs the arguments to be substituted into the message template. Arguments
+   *     are converted to strings using {@link String#valueOf(Object)}.
+   * @throws IllegalArgumentException if {@code expression} is false
+   * @throws NullPointerException if the check fails and either {@code errorMessageTemplate} or
+   *     {@code errorMessageArgs} is null (don't let this happen)
+   */
+  public static void checkArgument(
+    boolean expression,
+    @Nullable String errorMessageTemplate,
+    @Nullable Object... errorMessageArgs) {
+    if (!expression) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, errorMessageArgs));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @throws IllegalStateException if {@code expression} is false
+   */
+  public static void checkState(boolean expression) {
+    if (!expression) {
+      throw new IllegalStateException();
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @param errorMessage the exception message to use if the check fails; will be converted to a
+   *     string using {@link String#valueOf(Object)}
+   * @throws IllegalStateException if {@code expression} is false
+   */
+  public static void checkState(boolean expression, @Nullable Object errorMessage) {
+    if (!expression) {
+      throw new IllegalStateException(String.valueOf(errorMessage));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @param errorMessageTemplate a template for the exception message should the check fail. The
+   *     message is formed by replacing each {@code %s} placeholder in the template with an
+   *     argument. These are matched by position - the first {@code %s} gets {@code
+   *     errorMessageArgs[0]}, etc.  Unmatched arguments will be appended to the formatted message
+   *     in square braces. Unmatched placeholders will be left as-is.
+   * @param errorMessageArgs the arguments to be substituted into the message template. Arguments
+   *     are converted to strings using {@link String#valueOf(Object)}.
+   * @throws IllegalStateException if {@code expression} is false
+   * @throws NullPointerException if the check fails and either {@code errorMessageTemplate} or
+   *     {@code errorMessageArgs} is null (don't let this happen)
+   */
+  public static void checkState(
+    boolean expression,
+    @Nullable String errorMessageTemplate,
+    @Nullable Object... errorMessageArgs) {
+    if (!expression) {
+      throw new IllegalStateException(format(errorMessageTemplate, errorMessageArgs));
+    }
+  }
+
+  /**
+   * Ensures that an object reference passed as a parameter to the calling method is not null.
+   *
+   * @param reference an object reference
+   * @return the non-null reference that was validated
+   * @throws NullPointerException if {@code reference} is null
+   */
+  public static <T> T checkNotNull(T reference) {
+    if (reference == null) {
+      throw new NullPointerException();
+    }
+    return reference;
+  }
+
+  /**
+   * Ensures that an object reference passed as a parameter to the calling method is not null.
+   *
+   * @param reference an object reference
+   * @param errorMessage the exception message to use if the check fails; will be converted to a
+   *     string using {@link String#valueOf(Object)}
+   * @return the non-null reference that was validated
+   * @throws NullPointerException if {@code reference} is null
+   */
+  public static <T> T checkNotNull(T reference, @Nullable Object errorMessage) {
+    if (reference == null) {
+      throw new NullPointerException(String.valueOf(errorMessage));
+    }
+    return reference;
+  }
+
+  /**
+   * Ensures that an object reference passed as a parameter to the calling method is not null.
+   *
+   * @param reference an object reference
+   * @param errorMessageTemplate a template for the exception message should the check fail. The
+   *     message is formed by replacing each {@code %s} placeholder in the template with an
+   *     argument. These are matched by position - the first {@code %s} gets {@code
+   *     errorMessageArgs[0]}, etc.  Unmatched arguments will be appended to the formatted message
+   *     in square braces. Unmatched placeholders will be left as-is.
+   * @param errorMessageArgs the arguments to be substituted into the message template. Arguments
+   *     are converted to strings using {@link String#valueOf(Object)}.
+   * @return the non-null reference that was validated
+   * @throws NullPointerException if {@code reference} is null
+   */
+  public static <T> T checkNotNull(
+    @Nullable T reference, @Nullable String errorMessageTemplate, @Nullable Object... errorMessageArgs) {
+    if (reference == null) {
+      // If either of these parameters is null, the right thing happens anyway
+      throw new NullPointerException(format(errorMessageTemplate, errorMessageArgs));
+    }
+    return reference;
+  }
+
+  /*
+   * All recent hotspots (as of 2009) *really* like to have the natural code
+   *
+   * if (guardExpression) {
+   *    throw new BadException(messageExpression);
+   * }
+   *
+   * refactored so that messageExpression is moved to a separate String-returning method.
+   *
+   * if (guardExpression) {
+   *    throw new BadException(badMsg(...));
+   * }
+   *
+   * The alternative natural refactorings into void or Exception-returning methods are much slower.
+   * This is a big deal - we're talking factors of 2-8 in microbenchmarks, not just 10-20%.  (This
+   * is a hotspot optimizer bug, which should be fixed, but that's a separate, big project).
+   *
+   * The coding pattern above is heavily used in java.util, e.g. in ArrayList.  There is a
+   * RangeCheckMicroBenchmark in the JDK that was used to test this.
+   *
+   * But the methods in this class want to throw different exceptions, depending on the args, so it
+   * appears that this pattern is not directly applicable.  But we can use the ridiculous, devious
+   * trick of throwing an exception in the middle of the construction of another exception.  Hotspot
+   * is fine with that.
+   */
+
+  /**
+   * Ensures that {@code index} specifies a valid <i>element</i> in an array, list or string of size
+   * {@code size}. An element index may range from zero, inclusive, to {@code size}, exclusive.
+   *
+   * @param index a user-supplied index identifying an element of an array, list or string
+   * @param size the size of that array, list or string
+   * @return the value of {@code index}
+   * @throws IndexOutOfBoundsException if {@code index} is negative or is not less than {@code size}
+   * @throws IllegalArgumentException if {@code size} is negative
+   */
+  public static int checkElementIndex(int index, int size) {
+    return checkElementIndex(index, size, "index");
+  }
+
+  /**
+   * Ensures that {@code index} specifies a valid <i>element</i> in an array, list or string of size
+   * {@code size}. An element index may range from zero, inclusive, to {@code size}, exclusive.
+   *
+   * @param index a user-supplied index identifying an element of an array, list or string
+   * @param size the size of that array, list or string
+   * @param desc the text to use to describe this index in an error message
+   * @return the value of {@code index}
+   * @throws IndexOutOfBoundsException if {@code index} is negative or is not less than {@code size}
+   * @throws IllegalArgumentException if {@code size} is negative
+   */
+  public static int checkElementIndex(int index, int size, @Nullable String desc) {
+    // Carefully optimized for execution by hotspot (explanatory comment above)
+    if (index < 0 || index >= size) {
+      throw new IndexOutOfBoundsException(badElementIndex(index, size, desc));
+    }
+    return index;
+  }
+
+  private static String badElementIndex(int index, int size, String desc) {
+    if (index < 0) {
+      return format("%s (%s) must not be negative", desc, index);
+    } else if (size < 0) {
+      throw new IllegalArgumentException("negative size: " + size);
+    } else { // index >= size
+      return format("%s (%s) must be less than size (%s)", desc, index, size);
+    }
+  }
+
+  /**
+   * Ensures that {@code index} specifies a valid <i>position</i> in an array, list or string of
+   * size {@code size}. A position index may range from zero to {@code size}, inclusive.
+   *
+   * @param index a user-supplied index identifying a position in an array, list or string
+   * @param size the size of that array, list or string
+   * @return the value of {@code index}
+   * @throws IndexOutOfBoundsException if {@code index} is negative or is greater than {@code size}
+   * @throws IllegalArgumentException if {@code size} is negative
+   */
+  public static int checkPositionIndex(int index, int size) {
+    return checkPositionIndex(index, size, "index");
+  }
+
+  /**
+   * Ensures that {@code index} specifies a valid <i>position</i> in an array, list or string of
+   * size {@code size}. A position index may range from zero to {@code size}, inclusive.
+   *
+   * @param index a user-supplied index identifying a position in an array, list or string
+   * @param size the size of that array, list or string
+   * @param desc the text to use to describe this index in an error message
+   * @return the value of {@code index}
+   * @throws IndexOutOfBoundsException if {@code index} is negative or is greater than {@code size}
+   * @throws IllegalArgumentException if {@code size} is negative
+   */
+  public static int checkPositionIndex(int index, int size, @Nullable String desc) {
+    // Carefully optimized for execution by hotspot (explanatory comment above)
+    if (index < 0 || index > size) {
+      throw new IndexOutOfBoundsException(badPositionIndex(index, size, desc));
+    }
+    return index;
+  }
+
+  private static String badPositionIndex(int index, int size, String desc) {
+    if (index < 0) {
+      return format("%s (%s) must not be negative", desc, index);
+    } else if (size < 0) {
+      throw new IllegalArgumentException("negative size: " + size);
+    } else { // index > size
+      return format("%s (%s) must not be greater than size (%s)", desc, index, size);
+    }
+  }
+
+  /**
+   * Ensures that {@code start} and {@code end} specify a valid <i>positions</i> in an array, list
+   * or string of size {@code size}, and are in order. A position index may range from zero to
+   * {@code size}, inclusive.
+   *
+   * @param start a user-supplied index identifying a starting position in an array, list or string
+   * @param end a user-supplied index identifying a ending position in an array, list or string
+   * @param size the size of that array, list or string
+   * @throws IndexOutOfBoundsException if either index is negative or is greater than {@code size},
+   *     or if {@code end} is less than {@code start}
+   * @throws IllegalArgumentException if {@code size} is negative
+   */
+  public static void checkPositionIndexes(int start, int end, int size) {
+    // Carefully optimized for execution by hotspot (explanatory comment above)
+    if (start < 0 || end < start || end > size) {
+      throw new IndexOutOfBoundsException(badPositionIndexes(start, end, size));
+    }
+  }
+
+  private static String badPositionIndexes(int start, int end, int size) {
+    if (start < 0 || start > size) {
+      return badPositionIndex(start, size, "start index");
+    }
+    if (end < 0 || end > size) {
+      return badPositionIndex(end, size, "end index");
+    }
+    // end < start
+    return format("end index (%s) must not be less than start index (%s)", end, start);
+  }
+
+  /**
+   * Substitutes each {@code %s} in {@code template} with an argument. These are matched by
+   * position: the first {@code %s} gets {@code args[0]}, etc.  If there are more arguments than
+   * placeholders, the unmatched arguments will be appended to the end of the formatted message in
+   * square braces.
+   *
+   * @param template a non-null string containing 0 or more {@code %s} placeholders.
+   * @param args the arguments to be substituted into the message template. Arguments are converted
+   *     to strings using {@link String#valueOf(Object)}. Arguments can be null.
+   */
+  // Note that this is somewhat-improperly used from Verify.java as well.
+  static String format(String template, @Nullable Object... args) {
+    template = String.valueOf(template); // null -> "null"
+
+    // start substituting the arguments into the '%s' placeholders
+    StringBuilder builder = new StringBuilder(template.length() + 16 * args.length);
+    int templateStart = 0;
+    int i = 0;
+    while (i < args.length) {
+      int placeholderStart = template.indexOf("%s", templateStart);
+      if (placeholderStart == -1) {
+        break;
+      }
+      builder.append(template.substring(templateStart, placeholderStart));
+      builder.append(args[i++]);
+      templateStart = placeholderStart + 2;
+    }
+    builder.append(template.substring(templateStart));
+
+    // if we run out of placeholders, append the extra args in square braces
+    if (i < args.length) {
+      builder.append(" [");
+      builder.append(args[i++]);
+      while (i < args.length) {
+        builder.append(", ");
+        builder.append(args[i++]);
+      }
+      builder.append(']');
+    }
+
+    return builder.toString();
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Primitives.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Primitives.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2007 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class is copied from guava Primitives class.
+ */
+final class Primitives {
+  private Primitives() {}
+
+  /** A map from primitive types to their corresponding wrapper types. */
+  private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER_TYPE;
+
+  /** A map from wrapper types to their corresponding primitive types. */
+  private static final Map<Class<?>, Class<?>> WRAPPER_TO_PRIMITIVE_TYPE;
+
+  // Sad that we can't use a BiMap. :(
+
+  static {
+    Map<Class<?>, Class<?>> primToWrap = new HashMap<>(16);
+    Map<Class<?>, Class<?>> wrapToPrim = new HashMap<>(16);
+
+    add(primToWrap, wrapToPrim, boolean.class, Boolean.class);
+    add(primToWrap, wrapToPrim, byte.class, Byte.class);
+    add(primToWrap, wrapToPrim, char.class, Character.class);
+    add(primToWrap, wrapToPrim, double.class, Double.class);
+    add(primToWrap, wrapToPrim, float.class, Float.class);
+    add(primToWrap, wrapToPrim, int.class, Integer.class);
+    add(primToWrap, wrapToPrim, long.class, Long.class);
+    add(primToWrap, wrapToPrim, short.class, Short.class);
+    add(primToWrap, wrapToPrim, void.class, Void.class);
+
+    PRIMITIVE_TO_WRAPPER_TYPE = Collections.unmodifiableMap(primToWrap);
+    WRAPPER_TO_PRIMITIVE_TYPE = Collections.unmodifiableMap(wrapToPrim);
+  }
+
+  private static void add(
+    Map<Class<?>, Class<?>> forward,
+    Map<Class<?>, Class<?>> backward,
+    Class<?> key,
+    Class<?> value) {
+    forward.put(key, value);
+    backward.put(value, key);
+  }
+
+  /**
+   * Returns an immutable set of all nine primitive types (including {@code
+   * void}). Note that a simpler way to test whether a {@code Class} instance is a member of this
+   * set is to call {@link Class#isPrimitive}.
+   *
+   * @since 3.0
+   */
+  public static Set<Class<?>> allPrimitiveTypes() {
+    return PRIMITIVE_TO_WRAPPER_TYPE.keySet();
+  }
+
+  /**
+   * Returns an immutable set of all nine primitive-wrapper types (including {@link Void}).
+   *
+   * @since 3.0
+   */
+  public static Set<Class<?>> allWrapperTypes() {
+    return WRAPPER_TO_PRIMITIVE_TYPE.keySet();
+  }
+
+  /**
+   * Returns {@code true} if {@code type} is one of the nine primitive-wrapper types, such as
+   * {@link Integer}.
+   *
+   * @see Class#isPrimitive
+   */
+  public static boolean isWrapperType(Class<?> type) {
+    return WRAPPER_TO_PRIMITIVE_TYPE.containsKey(Preconditions.checkNotNull(type));
+  }
+
+  /**
+   * Returns the corresponding wrapper type of {@code type} if it is a primitive type; otherwise
+   * returns {@code type} itself. Idempotent.
+   *
+   * <pre>
+   *     wrap(int.class) == Integer.class
+   *     wrap(Integer.class) == Integer.class
+   *     wrap(String.class) == String.class
+   * </pre>
+   */
+  public static <T> Class<T> wrap(Class<T> type) {
+    Preconditions.checkNotNull(type);
+
+    // cast is safe: long.class and Long.class are both of type Class<Long>
+    @SuppressWarnings("unchecked")
+    Class<T> wrapped = (Class<T>) PRIMITIVE_TO_WRAPPER_TYPE.get(type);
+    return (wrapped == null) ? type : wrapped;
+  }
+
+  /**
+   * Returns the corresponding primitive type of {@code type} if it is a wrapper type; otherwise
+   * returns {@code type} itself. Idempotent.
+   *
+   * <pre>
+   *     unwrap(Integer.class) == int.class
+   *     unwrap(int.class) == int.class
+   *     unwrap(String.class) == String.class
+   * </pre>
+   */
+  public static <T> Class<T> unwrap(Class<T> type) {
+    Preconditions.checkNotNull(type);
+
+    // cast is safe: long.class and Long.class are both of type Class<Long>
+    @SuppressWarnings("unchecked")
+    Class<T> unwrapped = (Class<T>) WRAPPER_TO_PRIMITIVE_TYPE.get(type);
+    return (unwrapped == null) ? type : unwrapped;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Reflection.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Reflection.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2005 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+/**
+ * Static utilities relating to Java reflection.
+ */
+final class Reflection {
+
+  /**
+   * Returns the package name of {@code clazz} according to the Java Language Specification (section
+   * 6.7). Unlike {@link Class#getPackage}, this method only parses the class name, without
+   * attempting to define the {@link Package} and hence load files.
+   */
+  public static String getPackageName(Class<?> clazz) {
+    return getPackageName(clazz.getName());
+  }
+
+  /**
+   * Returns the package name of {@code classFullName} according to the Java Language Specification
+   * (section 6.7). Unlike {@link Class#getPackage}, this method only parses the class name, without
+   * attempting to define the {@link Package} and hence load files.
+   */
+  public static String getPackageName(String classFullName) {
+    int lastDot = classFullName.lastIndexOf('.');
+    return (lastDot < 0) ? "" : classFullName.substring(0, lastDot);
+  }
+
+  /**
+   * Ensures that the given classes are initialized, as described in
+   * <a href="http://java.sun.com/docs/books/jls/third_edition/html/execution.html#12.4.2">
+   * JLS Section 12.4.2</a>.
+   *
+   * <p>WARNING: Normally it's a smell if a class needs to be explicitly initialized, because static
+   * state hurts system maintainability and testability. In cases when you have no choice while
+   * inter-operating with a legacy framework, this method helps to keep the code less ugly.
+   *
+   * @throws ExceptionInInitializerError if an exception is thrown during
+   *   initialization of a class
+   */
+  public static void initialize(Class<?>... classes) {
+    for (Class<?> clazz : classes) {
+      try {
+        Class.forName(clazz.getName(), true, clazz.getClassLoader());
+      } catch (ClassNotFoundException e) {
+        throw new AssertionError(e);
+      }
+    }
+  }
+
+  /**
+   * Returns a proxy instance that implements {@code interfaceType} by
+   * dispatching method invocations to {@code handler}. The class loader of
+   * {@code interfaceType} will be used to define the proxy class. To implement
+   * multiple interfaces or specify a class loader, use
+   * {@link Proxy#newProxyInstance}.
+   *
+   * @throws IllegalArgumentException if {@code interfaceType} does not specify
+   *     the type of a Java interface
+   */
+  public static <T> T newProxy(
+    Class<T> interfaceType, InvocationHandler handler) {
+    Preconditions.checkNotNull(handler);
+    Preconditions.checkArgument(interfaceType.isInterface(), "%s is not an interface", interfaceType);
+    Object object = Proxy.newProxyInstance(
+      interfaceType.getClassLoader(),
+      new Class<?>[] { interfaceType },
+      handler);
+    return interfaceType.cast(object);
+  }
+
+  private Reflection() {}
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/TypeCapture.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/TypeCapture.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2012 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * Captures the actual type of {@code T}.
+ *
+ * @param <T> The type being captured
+ */
+abstract class TypeCapture<T> {
+
+  /** Returns the captured type. */
+  final Type capture() {
+    Type superclass = getClass().getGenericSuperclass();
+    Preconditions.checkArgument(superclass instanceof ParameterizedType,
+        "%s isn't parameterized", superclass);
+    return ((ParameterizedType) superclass).getActualTypeArguments()[0];
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/TypeParameter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/TypeParameter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2011 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import javax.annotation.Nullable;
+
+/**
+ * Captures a free type variable that can be used in {@link TypeToken#where}.
+ * For example:
+ *
+ * <pre>   {@code
+ *   static <T> TypeToken<List<T>> listOf(Class<T> elementType) {
+ *     return new TypeToken<List<T>>() {}
+ *         .where(new TypeParameter<T>() {}, elementType);
+ *   }}</pre>
+ *
+ * @param <T> Type being captured
+ *
+ */
+public abstract class TypeParameter<T> extends TypeCapture<T> {
+
+  final TypeVariable<?> typeVariable;
+
+  protected TypeParameter() {
+    Type type = capture();
+    Preconditions.checkArgument(type instanceof TypeVariable, "%s should be a type variable.", type);
+    this.typeVariable = (TypeVariable<?>) type;
+  }
+
+  @Override public final int hashCode() {
+    return typeVariable.hashCode();
+  }
+
+  @Override public final boolean equals(@Nullable Object o) {
+    if (o instanceof TypeParameter) {
+      TypeParameter<?> that = (TypeParameter<?>) o;
+      return typeVariable.equals(that.typeVariable);
+    }
+    return false;
+  }
+
+  @Override public String toString() {
+    return typeVariable.toString();
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/TypeResolver.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/TypeResolver.java
@@ -1,0 +1,493 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2009 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+/**
+ * An object of this class encapsulates type mappings from type variables. Mappings are established
+ * with {@link #where} and types are resolved using {@link #resolveType}.
+ *
+ * <p>Note that usually type mappings are already implied by the static type hierarchy (for example,
+ * the {@code E} type variable declared by class {@code List} naturally maps to {@code String} in
+ * the context of {@code class MyStringList implements List<String>}. In such case, prefer to use
+ * {@link TypeToken#resolveType} since it's simpler and more type safe. This class should only be
+ * used when the type mapping isn't implied by the static type hierarchy, but provided through other
+ * means such as an annotation or external configuration file.
+ */
+public final class TypeResolver {
+
+  private final TypeTable typeTable;
+
+  public TypeResolver() {
+    this.typeTable = new TypeTable();
+  }
+
+  private TypeResolver(TypeTable typeTable) {
+    this.typeTable = typeTable;
+  }
+
+  static TypeResolver accordingTo(Type type) {
+    return new TypeResolver().where(TypeMappingIntrospector.getTypeMappings(type));
+  }
+
+  /**
+   * Returns a new {@code TypeResolver} with type variables in {@code formal} mapping to types in
+   * {@code actual}.
+   *
+   * <p>For example, if {@code formal} is a {@code TypeVariable T}, and {@code actual} is {@code
+   * String.class}, then {@code new TypeResolver().where(formal, actual)} will {@linkplain
+   * #resolveType resolve} {@code ParameterizedType List<T>} to {@code List<String>}, and resolve
+   * {@code Map<T, Something>} to {@code Map<String, Something>} etc. Similarly, {@code formal} and
+   * {@code actual} can be {@code Map<K, V>} and {@code Map<String, Integer>} respectively, or they
+   * can be {@code E[]} and {@code String[]} respectively, or even any arbitrary combination
+   * thereof.
+   *
+   * @param formal The type whose type variables or itself is mapped to other type(s). It's almost
+   *        always a bug if {@code formal} isn't a type variable and contains no type variable. Make
+   *        sure you are passing the two parameters in the right order.
+   * @param actual The type that the formal type variable(s) are mapped to. It can be or contain yet
+   *        other type variables, in which case these type variables will be further resolved if
+   *        corresponding mappings exist in the current {@code TypeResolver} instance.
+   */
+  public TypeResolver where(Type formal, Type actual) {
+    Map<TypeVariableKey, Type> mappings = new HashMap<>();
+    populateTypeMappings(mappings, Preconditions.checkNotNull(formal), Preconditions.checkNotNull(actual));
+    return where(mappings);
+  }
+
+  /** Returns a new {@code TypeResolver} with {@code variable} mapping to {@code type}. */
+  TypeResolver where(Map<TypeVariableKey, ? extends Type> mappings) {
+    return new TypeResolver(typeTable.where(mappings));
+  }
+
+  private static void populateTypeMappings(
+      final Map<TypeVariableKey, Type> mappings, Type from, final Type to) {
+    if (from.equals(to)) {
+      return;
+    }
+    new TypeVisitor() {
+      @Override void visitTypeVariable(TypeVariable<?> typeVariable) {
+        mappings.put(new TypeVariableKey(typeVariable), to);
+      }
+      @Override void visitWildcardType(WildcardType fromWildcardType) {
+        WildcardType toWildcardType = expectArgument(WildcardType.class, to);
+        Type[] fromUpperBounds = fromWildcardType.getUpperBounds();
+        Type[] toUpperBounds = toWildcardType.getUpperBounds();
+        Type[] fromLowerBounds = fromWildcardType.getLowerBounds();
+        Type[] toLowerBounds = toWildcardType.getLowerBounds();
+        Preconditions.checkArgument(
+            fromUpperBounds.length == toUpperBounds.length
+                && fromLowerBounds.length == toLowerBounds.length,
+            "Incompatible type: %s vs. %s", fromWildcardType, to);
+        for (int i = 0; i < fromUpperBounds.length; i++) {
+          populateTypeMappings(mappings, fromUpperBounds[i], toUpperBounds[i]);
+        }
+        for (int i = 0; i < fromLowerBounds.length; i++) {
+          populateTypeMappings(mappings, fromLowerBounds[i], toLowerBounds[i]);
+        }
+      }
+      @Override void visitParameterizedType(ParameterizedType fromParameterizedType) {
+        ParameterizedType toParameterizedType = expectArgument(ParameterizedType.class, to);
+        Preconditions.checkArgument(fromParameterizedType.getRawType().equals(toParameterizedType.getRawType()),
+            "Inconsistent raw type: %s vs. %s", fromParameterizedType, to);
+        Type[] fromArgs = fromParameterizedType.getActualTypeArguments();
+        Type[] toArgs = toParameterizedType.getActualTypeArguments();
+        Preconditions.checkArgument(fromArgs.length == toArgs.length,
+            "%s not compatible with %s", fromParameterizedType, toParameterizedType);
+        for (int i = 0; i < fromArgs.length; i++) {
+          populateTypeMappings(mappings, fromArgs[i], toArgs[i]);
+        }
+      }
+      @Override void visitGenericArrayType(GenericArrayType fromArrayType) {
+        Type componentType = Types.getComponentType(to);
+        Preconditions.checkArgument(componentType != null, "%s is not an array type.", to);
+        populateTypeMappings(mappings, fromArrayType.getGenericComponentType(), componentType);
+      }
+      @Override void visitClass(Class<?> fromClass) {
+        // Can't map from a raw class to anything other than itself.
+        // You can't say "assuming String is Integer".
+        // And we don't support "assuming String is T"; user has to say "assuming T is String". 
+        throw new IllegalArgumentException("No type mapping from " + fromClass);
+      }
+    }.visit(from);
+  }
+
+  /**
+   * Resolves all type variables in {@code type} and all downstream types and
+   * returns a corresponding type with type variables resolved.
+   */
+  public Type resolveType(Type type) {
+    Preconditions.checkNotNull(type);
+    if (type instanceof TypeVariable) {
+      return typeTable.resolve((TypeVariable<?>) type);
+    } else if (type instanceof ParameterizedType) {
+      return resolveParameterizedType((ParameterizedType) type);
+    } else if (type instanceof GenericArrayType) {
+      return resolveGenericArrayType((GenericArrayType) type);
+    } else if (type instanceof WildcardType) {
+      return resolveWildcardType((WildcardType) type);
+    } else {
+      // if Class<?>, no resolution needed, we are done.
+      return type;
+    }
+  }
+
+  private Type[] resolveTypes(Type[] types) {
+    Type[] result = new Type[types.length];
+    for (int i = 0; i < types.length; i++) {
+      result[i] = resolveType(types[i]);
+    }
+    return result;
+  }
+
+  private WildcardType resolveWildcardType(WildcardType type) {
+    Type[] lowerBounds = type.getLowerBounds();
+    Type[] upperBounds = type.getUpperBounds();
+    return new Types.WildcardTypeImpl(
+        resolveTypes(lowerBounds), resolveTypes(upperBounds));
+  }
+
+  private Type resolveGenericArrayType(GenericArrayType type) {
+    Type componentType = type.getGenericComponentType();
+    Type resolvedComponentType = resolveType(componentType);
+    return Types.newArrayType(resolvedComponentType);
+  }
+
+  private ParameterizedType resolveParameterizedType(ParameterizedType type) {
+    Type owner = type.getOwnerType();
+    Type resolvedOwner = (owner == null) ? null : resolveType(owner);
+    Type resolvedRawType = resolveType(type.getRawType());
+
+    Type[] args = type.getActualTypeArguments();
+    Type[] resolvedArgs = resolveTypes(args);
+    return Types.newParameterizedTypeWithOwner(
+        resolvedOwner, (Class<?>) resolvedRawType, resolvedArgs);
+  }
+
+  private static <T> T expectArgument(Class<T> type, Object arg) {
+    try {
+      return type.cast(arg);
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(arg + " is not a " + type.getSimpleName());
+    }
+  }
+
+  /** A TypeTable maintains mapping from {@link TypeVariable} to types. */
+  private static class TypeTable {
+    private final Map<TypeVariableKey, Type> map;
+  
+    TypeTable() {
+      this.map = Collections.emptyMap();
+    }
+    
+    private TypeTable(Map<TypeVariableKey, Type> map) {
+      this.map = map;
+    }
+
+    /** Returns a new {@code TypeResolver} with {@code variable} mapping to {@code type}. */
+    final TypeTable where(Map<TypeVariableKey, ? extends Type> mappings) {
+      Map<TypeVariableKey, Type> builder = new HashMap<>(map);
+      builder.putAll(map);
+      for (Map.Entry<TypeVariableKey, ? extends Type> mapping : mappings.entrySet()) {
+        TypeVariableKey variable = mapping.getKey();
+        Type type = mapping.getValue();
+        Preconditions.checkArgument(!variable.equalsType(type), "Type variable %s bound to itself", variable);
+        builder.put(variable, type);
+      }
+      return new TypeTable(Collections.unmodifiableMap(builder));
+    }
+
+    final Type resolve(final TypeVariable<?> var) {
+      final TypeTable unguarded = this;
+      TypeTable guarded = new TypeTable() {
+        @Override public Type resolveInternal(
+            TypeVariable<?> intermediateVar, TypeTable forDependent) {
+          if (intermediateVar.getGenericDeclaration().equals(var.getGenericDeclaration())) {
+            return intermediateVar;
+          }
+          return unguarded.resolveInternal(intermediateVar, forDependent);
+        }
+      };
+      return resolveInternal(var, guarded);
+    }
+
+    /**
+     * Resolves {@code var} using the encapsulated type mapping. If it maps to yet another
+     * non-reified type or has bounds, {@code forDependants} is used to do further resolution, which
+     * doesn't try to resolve any type variable on generic declarations that are already being
+     * resolved.
+     *
+     * <p>Should only be called and overridden by {@link #resolve(TypeVariable)}.
+     */
+    Type resolveInternal(TypeVariable<?> var, TypeTable forDependants) {
+      Type type = map.get(new TypeVariableKey(var));
+      if (type == null) {
+        Type[] bounds = var.getBounds();
+        if (bounds.length == 0) {
+          return var;
+        }
+        Type[] resolvedBounds = new TypeResolver(forDependants).resolveTypes(bounds);
+        /*
+         * We'd like to simply create our own TypeVariable with the newly resolved bounds. There's
+         * just one problem: Starting with JDK 7u51, the JDK TypeVariable's equals() method doesn't
+         * recognize instances of our TypeVariable implementation. This is a problem because users
+         * compare TypeVariables from the JDK against TypeVariables returned by TypeResolver. To
+         * work with all JDK versions, TypeResolver must return the appropriate TypeVariable
+         * implementation in each of the three possible cases:
+         *
+         * 1. Prior to JDK 7u51, the JDK TypeVariable implementation interoperates with ours.
+         * Therefore, we can always create our own TypeVariable.
+         *
+         * 2. Starting with JDK 7u51, the JDK TypeVariable implementations does not interoperate
+         * with ours. Therefore, we have to be careful about whether we create our own TypeVariable:
+         *
+         * 2a. If the resolved types are identical to the original types, then we can return the
+         * original, identical JDK TypeVariable. By doing so, we sidestep the problem entirely.
+         *
+         * 2b. If the resolved types are different from the original types, things are trickier. The
+         * only way to get a TypeVariable instance for the resolved types is to create our own. The
+         * created TypeVariable will not interoperate with any JDK TypeVariable. But this is OK: We
+         * don't _want_ our new TypeVariable to be equal to the JDK TypeVariable because it has
+         * _different bounds_ than the JDK TypeVariable. And it wouldn't make sense for our new
+         * TypeVariable to be equal to any _other_ JDK TypeVariable, either, because any other JDK
+         * TypeVariable must have a different declaration or name. The only TypeVariable that our
+         * new TypeVariable _will_ be equal to is an equivalent TypeVariable that was also created
+         * by us. And that equality is guaranteed to hold because it doesn't involve the JDK
+         * TypeVariable implementation at all.
+         */
+        if (Types.NativeTypeVariableEquals.NATIVE_TYPE_VARIABLE_ONLY
+            && Arrays.equals(bounds, resolvedBounds)) {
+          return var;
+        }
+        return Types.newArtificialTypeVariable(
+            var.getGenericDeclaration(), var.getName(), resolvedBounds);
+      }
+      // in case the type is yet another type variable.
+      return new TypeResolver(forDependants).resolveType(type);
+    }
+  }
+
+  private static final class TypeMappingIntrospector extends TypeVisitor {
+
+    private static final WildcardCapturer wildcardCapturer = new WildcardCapturer();
+
+    private final Map<TypeVariableKey, Type> mappings = new HashMap<>();
+
+    /**
+     * Returns type mappings using type parameters and type arguments found in
+     * the generic superclass and the super interfaces of {@code contextClass}.
+     */
+    static Map<TypeVariableKey, Type> getTypeMappings(
+        Type contextType) {
+      TypeMappingIntrospector introspector = new TypeMappingIntrospector();
+      introspector.visit(wildcardCapturer.capture(contextType));
+      return Collections.unmodifiableMap(new HashMap<>(introspector.mappings));
+    }
+
+    @Override void visitClass(Class<?> clazz) {
+      visit(clazz.getGenericSuperclass());
+      visit(clazz.getGenericInterfaces());
+    }
+
+    @Override void visitParameterizedType(ParameterizedType parameterizedType) {
+      Class<?> rawClass = (Class<?>) parameterizedType.getRawType();
+      TypeVariable<?>[] vars = rawClass.getTypeParameters();
+      Type[] typeArgs = parameterizedType.getActualTypeArguments();
+      Preconditions.checkState(vars.length == typeArgs.length);
+      for (int i = 0; i < vars.length; i++) {
+        map(new TypeVariableKey(vars[i]), typeArgs[i]);
+      }
+      visit(rawClass);
+      visit(parameterizedType.getOwnerType());
+    }
+
+    @Override void visitTypeVariable(TypeVariable<?> t) {
+      visit(t.getBounds());
+    }
+
+    @Override void visitWildcardType(WildcardType t) {
+      visit(t.getUpperBounds());
+    }
+
+    private void map(final TypeVariableKey var, final Type arg) {
+      if (mappings.containsKey(var)) {
+        // Mapping already established
+        // This is possible when following both superClass -> enclosingClass
+        // and enclosingclass -> superClass paths.
+        // Since we follow the path of superclass first, enclosing second,
+        // superclass mapping should take precedence.
+        return;
+      }
+      // First, check whether var -> arg forms a cycle
+      for (Type t = arg; t != null; t = mappings.get(TypeVariableKey.forLookup(t))) {
+        if (var.equalsType(t)) {
+          // cycle detected, remove the entire cycle from the mapping so that
+          // each type variable resolves deterministically to itself.
+          // Otherwise, a F -> T cycle will end up resolving both F and T
+          // nondeterministically to either F or T.
+          for (Type x = arg; x != null; x = mappings.remove(TypeVariableKey.forLookup(x))) {
+
+          }
+          return;
+        }
+      }
+      mappings.put(var, arg);
+    }
+  }
+
+  // This is needed when resolving types against a context with wildcards
+  // For example:
+  // class Holder<T> {
+  //   void set(T data) {...}
+  // }
+  // Holder<List<?>> should *not* resolve the set() method to set(List<?> data).
+  // Instead, it should create a capture of the wildcard so that set() rejects any List<T>.
+  private static final class WildcardCapturer {
+
+    private final AtomicInteger id = new AtomicInteger();
+
+    Type capture(Type type) {
+      Preconditions.checkNotNull(type);
+      if (type instanceof Class) {
+        return type;
+      }
+      if (type instanceof TypeVariable) {
+        return type;
+      }
+      if (type instanceof GenericArrayType) {
+        GenericArrayType arrayType = (GenericArrayType) type;
+        return Types.newArrayType(capture(arrayType.getGenericComponentType()));
+      }
+      if (type instanceof ParameterizedType) {
+        ParameterizedType parameterizedType = (ParameterizedType) type;
+        return Types.newParameterizedTypeWithOwner(
+            captureNullable(parameterizedType.getOwnerType()),
+            (Class<?>) parameterizedType.getRawType(),
+            capture(parameterizedType.getActualTypeArguments()));
+      }
+      if (type instanceof WildcardType) {
+        WildcardType wildcardType = (WildcardType) type;
+        Type[] lowerBounds = wildcardType.getLowerBounds();
+        if (lowerBounds.length == 0) { // ? extends something changes to capture-of
+          Type[] upperBounds = wildcardType.getUpperBounds();
+          String name = "capture#" + id.incrementAndGet() + "-of ? extends "
+              + Joiner.on('&').join(upperBounds);
+          return Types.newArtificialTypeVariable(
+              WildcardCapturer.class, name, wildcardType.getUpperBounds());
+        } else {
+          // TODO(benyu): handle ? super T somehow.
+          return type;
+        }
+      }
+      throw new AssertionError("must have been one of the known types");
+    }
+
+    private Type captureNullable(@Nullable Type type) {
+      if (type == null) {
+        return null;
+      }
+      return capture(type);
+    }
+
+    private Type[] capture(Type[] types) {
+      Type[] result = new Type[types.length];
+      for (int i = 0; i < types.length; i++) {
+        result[i] = capture(types[i]);
+      }
+      return result;
+    }
+  }
+
+  /**
+   * Wraps around {@code TypeVariable<?>} to ensure that any two type variables are equal as long as
+   * they are declared by the same {@link java.lang.reflect.GenericDeclaration} and have the same
+   * name, even if their bounds differ.
+   *
+   * <p>While resolving a type variable from a {var -> type} map, we don't care whether the
+   * type variable's bound has been partially resolved. As long as the type variable "identity"
+   * matches.
+   *
+   * <p>On the other hand, if for example we are resolving List<A extends B> to
+   * List<A extends String>, we need to compare that <A extends B> is unequal to
+   * <A extends String> in order to decide to use the transformed type instead of the original
+   * type.
+   */
+  static final class TypeVariableKey {
+    private final TypeVariable<?> var;
+
+    TypeVariableKey(TypeVariable<?> var) {
+      this.var = Preconditions.checkNotNull(var);
+    }
+
+    @Override public int hashCode() {
+      return Objects.hash(var.getGenericDeclaration(), var.getName());
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (obj instanceof TypeVariableKey) {
+        TypeVariableKey that = (TypeVariableKey) obj;
+        return equalsTypeVariable(that.var);
+      } else {
+        return false;
+      }
+    }
+
+    @Override public String toString() {
+      return var.toString();
+    }
+
+    /** Wraps {@code t} in a {@code TypeVariableKey} if it's a type variable. */
+    static Object forLookup(Type t) {
+      if (t instanceof TypeVariable) {
+        return new TypeVariableKey((TypeVariable<?>) t);
+      } else {
+        return null;
+      }
+    }
+
+    /**
+     * Returns true if {@code type} is a {@code TypeVariable} with the same name and declared by
+     * the same {@code GenericDeclaration}.
+     */
+    boolean equalsType(Type type) {
+      if (type instanceof TypeVariable) {
+        return equalsTypeVariable((TypeVariable<?>) type);
+      } else {
+        return false;
+      }
+    }
+
+    private boolean equalsTypeVariable(TypeVariable<?> that) {
+      return var.getGenericDeclaration().equals(that.getGenericDeclaration())
+          && var.getName().equals(that.getName());
+    }
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/TypeToken.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/TypeToken.java
@@ -1,0 +1,1171 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2006 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import co.cask.cdap.api.Predicate;
+
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link Type} with generics.
+ *
+ * <p>Operations that are otherwise only available in {@link Class} are implemented to support
+ * {@code Type}, for example {@link #isAssignableFrom}, {@link #isArray} and {@link
+ * #getComponentType}. It also provides additional utilities such as {@link #getTypes} and {@link
+ * #resolveType} etc.
+ *
+ * <p>There are three ways to get a {@code TypeToken} instance: <ul>
+ * <li>Wrap a {@code Type} obtained via reflection. For example: {@code
+ * TypeToken.of(method.getGenericReturnType())}.
+ * <li>Capture a generic type with a (usually anonymous) subclass. For example: <pre>   {@code
+ *   new TypeToken<List<String>>() {}}</pre>
+ * <p>Note that it's critical that the actual type argument is carried by a subclass.
+ * The following code is wrong because it only captures the {@code <T>} type variable
+ * of the {@code listType()} method signature; while {@code <String>} is lost in erasure:
+ * <pre>   {@code
+ *   class Util {
+ *     static <T> TypeToken<List<T>> listType() {
+ *       return new TypeToken<List<T>>() {};
+ *     }
+ *   }
+ *
+ *   TypeToken<List<String>> stringListType = Util.<String>listType();}</pre>
+ * <li>Capture a generic type with a (usually anonymous) subclass and resolve it against
+ * a context class that knows what the type parameters are. For example: <pre>   {@code
+ *   abstract class IKnowMyType<T> {
+ *     TypeToken<T> type = new TypeToken<T>(getClass()) {};
+ *   }
+ *   new IKnowMyType<String>() {}.type => String}</pre>
+ * </ul>
+ *
+ * <p>{@code TypeToken} is serializable when no type variable is contained in the type.
+ *
+ * <p>Note to Guice users: {@code} TypeToken is similar to Guice's {@code TypeLiteral} class
+ * except that it is serializable and offers numerous additional utility methods.
+ *
+ * @param <T> type represented by this TypeToken
+ */
+public abstract class TypeToken<T> extends TypeCapture<T> implements Serializable {
+
+  private final Type runtimeType;
+
+  /** Resolver for resolving types with {@link #runtimeType} as context. */
+  private transient TypeResolver typeResolver;
+
+  /**
+   * Constructs a new type token of {@code T}.
+   *
+   * <p>Clients create an empty anonymous subclass. Doing so embeds the type
+   * parameter in the anonymous class's type hierarchy so we can reconstitute
+   * it at runtime despite erasure.
+   *
+   * <p>For example: <pre>   {@code
+   *   TypeToken<List<String>> t = new TypeToken<List<String>>() {};}</pre>
+   */
+  protected TypeToken() {
+    this.runtimeType = capture();
+    Preconditions.checkState(!(runtimeType instanceof TypeVariable),
+        "Cannot construct a TypeToken for a type variable.\n" +
+        "You probably meant to call new TypeToken<%s>(getClass()) " +
+        "that can resolve the type variable for you.\n" +
+        "If you do need to create a TypeToken of a type variable, " +
+        "please use TypeToken.of() instead.", runtimeType);
+  }
+
+  /**
+   * Constructs a new type token of {@code T} while resolving free type variables in the context of
+   * {@code declaringClass}.
+   *
+   * <p>Clients create an empty anonymous subclass. Doing so embeds the type
+   * parameter in the anonymous class's type hierarchy so we can reconstitute
+   * it at runtime despite erasure.
+   *
+   * <p>For example: <pre>   {@code
+   *   abstract class IKnowMyType<T> {
+   *     TypeToken<T> getMyType() {
+   *       return new TypeToken<T>(getClass()) {};
+   *     }
+   *   }
+   *
+   *   new IKnowMyType<String>() {}.getMyType() => String}</pre>
+   */
+  protected TypeToken(Class<?> declaringClass) {
+    Type captured = super.capture();
+    if (captured instanceof Class) {
+      this.runtimeType = captured;
+    } else {
+      this.runtimeType = of(declaringClass).resolveType(captured).runtimeType;
+    }
+  }
+
+  private TypeToken(Type type) {
+    this.runtimeType = Preconditions.checkNotNull(type);
+  }
+
+  /** Returns an instance of type token that wraps {@code type}. */
+  public static <T> TypeToken<T> of(Class<T> type) {
+    return new SimpleTypeToken<>(type);
+  }
+
+  /** Returns an instance of type token that wraps {@code type}. */
+  public static TypeToken<?> of(Type type) {
+    return new SimpleTypeToken<Object>(type);
+  }
+
+  /**
+   * Returns the raw type of {@code T}. Formally speaking, if {@code T} is returned by
+   * {@link java.lang.reflect.Method#getGenericReturnType}, the raw type is what's returned by
+   * {@link java.lang.reflect.Method#getReturnType} of the same method object. Specifically:
+   * <ul>
+   * <li>If {@code T} is a {@code Class} itself, {@code T} itself is returned.
+   * <li>If {@code T} is a {@link ParameterizedType}, the raw type of the parameterized type is
+   *     returned.
+   * <li>If {@code T} is a {@link GenericArrayType}, the returned type is the corresponding array
+   *     class. For example: {@code List<Integer>[] => List[]}.
+   * <li>If {@code T} is a type variable or a wildcard type, the raw type of the first upper bound
+   *     is returned. For example: {@code <X extends Foo> => Foo}.
+   * </ul>
+   */
+  public final Class<? super T> getRawType() {
+    Class<?> rawType = getRawType(runtimeType);
+    @SuppressWarnings("unchecked") // raw type is |T|
+    Class<? super T> result = (Class<? super T>) rawType;
+    return result;
+  }
+
+  /**
+   * Returns the raw type of the class or parameterized type; if {@code T} is type variable or
+   * wildcard type, the raw types of all its upper bounds are returned.
+   */
+  private Set<Class<? super T>> getImmediateRawTypes() {
+    // Cast from ImmutableSet<Class<?>> to ImmutableSet<Class<? super T>>
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Set<Class<? super T>> result = (Set) getRawTypes(runtimeType);
+    return result;
+  }
+
+  /** Returns the represented type. */
+  public final Type getType() {
+    return runtimeType;
+  }
+
+  /**
+   * <p>Returns a new {@code TypeToken} where type variables represented by {@code typeParam}
+   * are substituted by {@code typeArg}. For example, it can be used to construct
+   * {@code Map<K, V>} for any {@code K} and {@code V} type: <pre>   {@code
+   *   static <K, V> TypeToken<Map<K, V>> mapOf(
+   *       TypeToken<K> keyType, TypeToken<V> valueType) {
+   *     return new TypeToken<Map<K, V>>() {}
+   *         .where(new TypeParameter<K>() {}, keyType)
+   *         .where(new TypeParameter<V>() {}, valueType);
+   *   }}</pre>
+   *
+   * @param <X> The parameter type
+   * @param typeParam the parameter type variable
+   * @param typeArg the actual type to substitute
+   */
+  public final <X> TypeToken<T> where(TypeParameter<X> typeParam, TypeToken<X> typeArg) {
+    TypeResolver resolver = new TypeResolver()
+        .where(Collections.singletonMap(
+            new TypeResolver.TypeVariableKey(typeParam.typeVariable),
+            typeArg.runtimeType));
+    // If there's any type error, we'd report now rather than later.
+    return new SimpleTypeToken<>(resolver.resolveType(runtimeType));
+  }
+
+  /**
+   * <p>Returns a new {@code TypeToken} where type variables represented by {@code typeParam}
+   * are substituted by {@code typeArg}. For example, it can be used to construct
+   * {@code Map<K, V>} for any {@code K} and {@code V} type: <pre>   {@code
+   *   static <K, V> TypeToken<Map<K, V>> mapOf(
+   *       Class<K> keyType, Class<V> valueType) {
+   *     return new TypeToken<Map<K, V>>() {}
+   *         .where(new TypeParameter<K>() {}, keyType)
+   *         .where(new TypeParameter<V>() {}, valueType);
+   *   }}</pre>
+   *
+   * @param <X> The parameter type
+   * @param typeParam the parameter type variable
+   * @param typeArg the actual type to substitute
+   */
+  public final <X> TypeToken<T> where(TypeParameter<X> typeParam, Class<X> typeArg) {
+    return where(typeParam, of(typeArg));
+  }
+
+  /**
+   * <p>Resolves the given {@code type} against the type context represented by this type.
+   * For example: <pre>   {@code
+   *   new TypeToken<List<String>>() {}.resolveType(
+   *       List.class.getMethod("get", int.class).getGenericReturnType())
+   *   => String.class}</pre>
+   */
+  public final TypeToken<?> resolveType(Type type) {
+    Preconditions.checkNotNull(type);
+    TypeResolver resolver = typeResolver;
+    if (resolver == null) {
+      resolver = (typeResolver = TypeResolver.accordingTo(runtimeType));
+    }
+    return of(resolver.resolveType(type));
+  }
+
+  private Type[] resolveInPlace(Type[] types) {
+    for (int i = 0; i < types.length; i++) {
+      types[i] = resolveType(types[i]).getType();
+    }
+    return types;
+  }
+
+  private TypeToken<?> resolveSupertype(Type type) {
+    TypeToken<?> supertype = resolveType(type);
+    // super types' type mapping is a subset of type mapping of this type.
+    supertype.typeResolver = typeResolver;
+    return supertype;
+  }
+
+  /**
+   * Returns the generic superclass of this type or {@code null} if the type represents
+   * {@link Object} or an interface. This method is similar but different from {@link
+   * Class#getGenericSuperclass}. For example, {@code
+   * new TypeToken<StringArrayList>() {}.getGenericSuperclass()} will return {@code
+   * new TypeToken<ArrayList<String>>() {}}; while {@code
+   * StringArrayList.class.getGenericSuperclass()} will return {@code ArrayList<E>}, where {@code E}
+   * is the type variable declared by class {@code ArrayList}.
+   *
+   * <p>If this type is a type variable or wildcard, its first upper bound is examined and returned
+   * if the bound is a class or extends from a class. This means that the returned type could be a
+   * type variable too.
+   */
+  @Nullable
+  final TypeToken<? super T> getGenericSuperclass() {
+    if (runtimeType instanceof TypeVariable) {
+      // First bound is always the super class, if one exists.
+      return boundAsSuperclass(((TypeVariable<?>) runtimeType).getBounds()[0]);
+    }
+    if (runtimeType instanceof WildcardType) {
+      // wildcard has one and only one upper bound.
+      return boundAsSuperclass(((WildcardType) runtimeType).getUpperBounds()[0]);
+    }
+    Type superclass = getRawType().getGenericSuperclass();
+    if (superclass == null) {
+      return null;
+    }
+    @SuppressWarnings("unchecked") // super class of T
+    TypeToken<? super T> superToken = (TypeToken<? super T>) resolveSupertype(superclass);
+    return superToken;
+  }
+
+  @Nullable private TypeToken<? super T> boundAsSuperclass(Type bound) {
+    TypeToken<?> token = of(bound);
+    if (token.getRawType().isInterface()) {
+      return null;
+    }
+    @SuppressWarnings("unchecked") // only upper bound of T is passed in.
+    TypeToken<? super T> superclass = (TypeToken<? super T>) token;
+    return superclass;
+  }
+
+  /**
+   * Returns the generic interfaces that this type directly {@code implements}. This method is
+   * similar but different from {@link Class#getGenericInterfaces()}. For example, {@code
+   * new TypeToken<List<String>>() {}.getGenericInterfaces()} will return a list that contains
+   * {@code new TypeToken<Iterable<String>>() {}}; while {@code List.class.getGenericInterfaces()}
+   * will return an array that contains {@code Iterable<T>}, where the {@code T} is the type
+   * variable declared by interface {@code Iterable}.
+   *
+   * <p>If this type is a type variable or wildcard, its upper bounds are examined and those that
+   * are either an interface or upper-bounded only by interfaces are returned. This means that the
+   * returned types could include type variables too.
+   */
+  final List<TypeToken<? super T>> getGenericInterfaces() {
+    if (runtimeType instanceof TypeVariable) {
+      return boundsAsInterfaces(((TypeVariable<?>) runtimeType).getBounds());
+    }
+    if (runtimeType instanceof WildcardType) {
+      return boundsAsInterfaces(((WildcardType) runtimeType).getUpperBounds());
+    }
+    List<TypeToken<? super T>> builder = new ArrayList<>();
+    for (Type interfaceType : getRawType().getGenericInterfaces()) {
+      @SuppressWarnings("unchecked") // interface of T
+      TypeToken<? super T> resolvedInterface = (TypeToken<? super T>)
+          resolveSupertype(interfaceType);
+      builder.add(resolvedInterface);
+    }
+    return Collections.unmodifiableList(builder);
+  }
+
+  private List<TypeToken<? super T>> boundsAsInterfaces(Type[] bounds) {
+    List<TypeToken<? super T>> builder = new ArrayList<>();
+    for (Type bound : bounds) {
+      @SuppressWarnings("unchecked") // upper bound of T
+      TypeToken<? super T> boundType = (TypeToken<? super T>) of(bound);
+      if (boundType.getRawType().isInterface()) {
+        builder.add(boundType);
+      }
+    }
+    return Collections.unmodifiableList(builder);
+  }
+
+  /**
+   * Returns the set of interfaces and classes that this type is or is a subtype of. The returned
+   * types are parameterized with proper type arguments.
+   *
+   * <p>Subtypes are always listed before supertypes. But the reverse is not true. A type isn't
+   * necessarily a subtype of all the types following. Order between types without subtype
+   * relationship is arbitrary and not guaranteed.
+   *
+   * <p>If this type is a type variable or wildcard, upper bounds that are themselves type variables
+   * aren't included (their super interfaces and superclasses are).
+   */
+  public final TypeSet getTypes() {
+    return new TypeSet();
+  }
+
+  /**
+   * Returns the generic form of {@code superclass}. For example, if this is
+   * {@code ArrayList<String>}, {@code Iterable<String>} is returned given the
+   * input {@code Iterable.class}.
+   */
+  public final TypeToken<? super T> getSupertype(Class<? super T> superclass) {
+    Preconditions.checkArgument(superclass.isAssignableFrom(getRawType()),
+        "%s is not a super class of %s", superclass, this);
+    if (runtimeType instanceof TypeVariable) {
+      return getSupertypeFromUpperBounds(superclass, ((TypeVariable<?>) runtimeType).getBounds());
+    }
+    if (runtimeType instanceof WildcardType) {
+      return getSupertypeFromUpperBounds(superclass, ((WildcardType) runtimeType).getUpperBounds());
+    }
+    if (superclass.isArray()) {
+      return getArraySupertype(superclass);
+    }
+    @SuppressWarnings("unchecked") // resolved supertype
+    TypeToken<? super T> supertype = (TypeToken<? super T>)
+        resolveSupertype(toGenericType(superclass).runtimeType);
+    return supertype;
+  }
+
+  /**
+   * Returns subtype of {@code this} with {@code subclass} as the raw class.
+   * For example, if this is {@code Iterable<String>} and {@code subclass} is {@code List},
+   * {@code List<String>} is returned.
+   */
+  public final TypeToken<? extends T> getSubtype(Class<?> subclass) {
+    Preconditions.checkArgument(!(runtimeType instanceof TypeVariable),
+        "Cannot get subtype of type variable <%s>", this);
+    if (runtimeType instanceof WildcardType) {
+      return getSubtypeFromLowerBounds(subclass, ((WildcardType) runtimeType).getLowerBounds());
+    }
+    Preconditions.checkArgument(getRawType().isAssignableFrom(subclass),
+        "%s isn't a subclass of %s", subclass, this);
+    // unwrap array type if necessary
+    if (isArray()) {
+      return getArraySubtype(subclass);
+    }
+    @SuppressWarnings("unchecked") // guarded by the isAssignableFrom() statement above
+    TypeToken<? extends T> subtype = (TypeToken<? extends T>)
+        of(resolveTypeArgsForSubclass(subclass));
+    return subtype;
+  }
+
+  /** Returns true if this type is assignable from the given {@code type}. */
+  public final boolean isAssignableFrom(TypeToken<?> type) {
+    return isAssignableFrom(type.runtimeType);
+  }
+
+  /** Check if this type is assignable from the given {@code type}. */
+  public final boolean isAssignableFrom(Type type) {
+    return isAssignable(Preconditions.checkNotNull(type), runtimeType);
+  }
+
+  /**
+   * Returns true if this type is known to be an array type, such as {@code int[]}, {@code T[]},
+   * {@code <? extends Map<String, Integer>[]>} etc.
+   */
+  public final boolean isArray() {
+    return getComponentType() != null;
+  }
+
+  /**
+   * Returns true if this type is one of the nine primitive types (including {@code void}).
+   *
+   * @since 15.0
+   */
+  public final boolean isPrimitive() {
+    return (runtimeType instanceof Class) && ((Class<?>) runtimeType).isPrimitive();
+  }
+
+  /**
+   * Returns the corresponding wrapper type if this is a primitive type; otherwise returns
+   * {@code this} itself. Idempotent.
+   *
+   * @since 15.0
+   */
+  public final TypeToken<T> wrap() {
+    if (isPrimitive()) {
+      @SuppressWarnings("unchecked") // this is a primitive class
+      Class<T> type = (Class<T>) runtimeType;
+      return of(Primitives.wrap(type));
+    }
+    return this;
+  }
+
+  private boolean isWrapper() {
+    return Primitives.allWrapperTypes().contains(runtimeType);
+  }
+
+  /**
+   * Returns the corresponding primitive type if this is a wrapper type; otherwise returns
+   * {@code this} itself. Idempotent.
+   *
+   * @since 15.0
+   */
+  public final TypeToken<T> unwrap() {
+    if (isWrapper()) {
+      @SuppressWarnings("unchecked") // this is a wrapper class
+      Class<T> type = (Class<T>) runtimeType;
+      return of(Primitives.unwrap(type));
+    }
+    return this;
+  }
+
+  /**
+   * Returns the array component type if this type represents an array ({@code int[]}, {@code T[]},
+   * {@code <? extends Map<String, Integer>[]>} etc.), or else {@code null} is returned.
+   */
+  @Nullable public final TypeToken<?> getComponentType() {
+    Type componentType = Types.getComponentType(runtimeType);
+    if (componentType == null) {
+      return null;
+    }
+    return of(componentType);
+  }
+
+  /**
+   * Returns the {@link Invokable} for {@code method}, which must be a member of {@code T}.
+   *
+   * @since 14.0
+   */
+  public final Invokable<T, Object> method(Method method) {
+    Preconditions.checkArgument(of(method.getDeclaringClass()).isAssignableFrom(this),
+        "%s not declared by %s", method, this);
+    return new Invokable.MethodInvokable<T>(method) {
+      @Override Type getGenericReturnType() {
+        return resolveType(super.getGenericReturnType()).getType();
+      }
+      @Override Type[] getGenericParameterTypes() {
+        return resolveInPlace(super.getGenericParameterTypes());
+      }
+      @Override Type[] getGenericExceptionTypes() {
+        return resolveInPlace(super.getGenericExceptionTypes());
+      }
+      @Override public TypeToken<T> getOwnerType() {
+        return TypeToken.this;
+      }
+      @Override public String toString() {
+        return getOwnerType() + "." + super.toString();
+      }
+    };
+  }
+
+  /**
+   * Returns the {@link Invokable} for {@code constructor}, which must be a member of {@code T}.
+   *
+   * @since 14.0
+   */
+  public final Invokable<T, T> constructor(Constructor<?> constructor) {
+    Preconditions.checkArgument(constructor.getDeclaringClass() == getRawType(),
+        "%s not declared by %s", constructor, getRawType());
+    return new Invokable.ConstructorInvokable<T>(constructor) {
+      @Override Type getGenericReturnType() {
+        return resolveType(super.getGenericReturnType()).getType();
+      }
+      @Override Type[] getGenericParameterTypes() {
+        return resolveInPlace(super.getGenericParameterTypes());
+      }
+      @Override Type[] getGenericExceptionTypes() {
+        return resolveInPlace(super.getGenericExceptionTypes());
+      }
+      @Override public TypeToken<T> getOwnerType() {
+        return TypeToken.this;
+      }
+      @Override public String toString() {
+        return getOwnerType() + "(" + Joiner.on(", ").join(getGenericParameterTypes()) + ")";
+      }
+    };
+  }
+
+  /**
+   * The set of interfaces and classes that {@code T} is or is a subtype of. {@link Object} is not
+   * included in the set if this type is an interface.
+   */
+  public class TypeSet extends AbstractSet<TypeToken<? super T>> implements Serializable {
+
+    private transient Set<TypeToken<? super T>> types;
+
+    TypeSet() {}
+
+    @Override
+    public Iterator<TypeToken<? super T>> iterator() {
+      return delegate().iterator();
+    }
+
+    @Override
+    public int size() {
+      return delegate().size();
+    }
+
+    /** Returns the types that are interfaces implemented by this type. */
+    public TypeSet interfaces() {
+      return new InterfaceSet(this);
+    }
+
+    /** Returns the types that are classes. */
+    public TypeSet classes() {
+      return new ClassSet();
+    }
+
+    protected Set<TypeToken<? super T>> delegate() {
+      Set<TypeToken<? super T>> filteredTypes = types;
+      if (filteredTypes == null) {
+        // Java has no way to express ? super T when we parameterize TypeToken vs. Class.
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        List<TypeToken<? super T>> collectedTypes = (List)
+            TypeCollector.FOR_GENERIC_TYPE.collectTypes(TypeToken.this);
+        return (types = filterIterableToSet(collectedTypes, TypeFilter.IGNORE_TYPE_VARIABLE_OR_WILDCARD));
+      } else {
+        return filteredTypes;
+      }
+    }
+
+    /** Returns the raw types of the types in this set, in the same order. */
+    public Set<Class<? super T>> rawTypes() {
+      // Java has no way to express ? super T when we parameterize TypeToken vs. Class.
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      List<Class<? super T>> collectedTypes = (List) TypeCollector.FOR_RAW_TYPE.collectTypes(getImmediateRawTypes());
+      return Collections.unmodifiableSet(new LinkedHashSet<>(collectedTypes));
+    }
+
+    private static final long serialVersionUID = 0;
+  }
+
+  private final class InterfaceSet extends TypeSet {
+
+    private final transient TypeSet allTypes;
+    private transient Set<TypeToken<? super T>> interfaces;
+
+    InterfaceSet(TypeSet allTypes) {
+      this.allTypes = allTypes;
+    }
+
+    @Override protected Set<TypeToken<? super T>> delegate() {
+      Set<TypeToken<? super T>> result = interfaces;
+      if (result == null) {
+        return (interfaces = filterIterableToSet(allTypes, TypeFilter.INTERFACE_ONLY));
+      } else {
+        return result;
+      }
+    }
+
+    @Override public TypeSet interfaces() {
+      return this;
+    }
+
+    @Override public Set<Class<? super T>> rawTypes() {
+      // Java has no way to express ? super T when we parameterize TypeToken vs. Class.
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      List<Class<? super T>> collectedTypes = (List)
+          TypeCollector.FOR_RAW_TYPE.collectTypes(getImmediateRawTypes());
+
+      return filterIterableToSet(collectedTypes, new Predicate<Class<?>>() {
+        @Override public boolean apply(Class<?> type) {
+          return type.isInterface();
+        }
+      });
+    }
+
+    @Override public TypeSet classes() {
+      throw new UnsupportedOperationException("interfaces().classes() not supported.");
+    }
+
+    private Object readResolve() {
+      return getTypes().interfaces();
+    }
+
+    private static final long serialVersionUID = 0;
+  }
+
+  private final class ClassSet extends TypeSet {
+
+    private transient Set<TypeToken<? super T>> classes;
+
+    @Override protected Set<TypeToken<? super T>> delegate() {
+      Set<TypeToken<? super T>> result = classes;
+      if (result == null) {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        List<TypeToken<? super T>> collectedTypes = (List)
+            TypeCollector.FOR_GENERIC_TYPE.classesOnly().collectTypes(TypeToken.this);
+
+        return (classes = filterIterableToSet(collectedTypes, TypeFilter.IGNORE_TYPE_VARIABLE_OR_WILDCARD));
+      } else {
+        return result;
+      }
+    }
+
+    @Override public TypeSet classes() {
+      return this;
+    }
+
+    @Override public Set<Class<? super T>> rawTypes() {
+      // Java has no way to express ? super T when we parameterize TypeToken vs. Class.
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      List<Class<? super T>> collectedTypes = (List)
+          TypeCollector.FOR_RAW_TYPE.classesOnly().collectTypes(getImmediateRawTypes());
+      return Collections.unmodifiableSet(new LinkedHashSet<>(collectedTypes));
+    }
+
+    @Override public TypeSet interfaces() {
+      throw new UnsupportedOperationException("classes().interfaces() not supported.");
+    }
+
+    private Object readResolve() {
+      return getTypes().classes();
+    }
+
+    private static final long serialVersionUID = 0;
+  }
+
+  private enum TypeFilter implements Predicate<TypeToken<?>> {
+
+    IGNORE_TYPE_VARIABLE_OR_WILDCARD {
+      @Override public boolean apply(TypeToken<?> type) {
+        return !(type.runtimeType instanceof TypeVariable
+            || type.runtimeType instanceof WildcardType);
+      }
+    },
+    INTERFACE_ONLY {
+      @Override public boolean apply(TypeToken<?> type) {
+        return type.getRawType().isInterface();
+      }
+    }
+  }
+
+  /**
+   * Returns true if {@code o} is another {@code TypeToken} that represents the same {@link Type}.
+   */
+  @Override public boolean equals(@Nullable Object o) {
+    if (o instanceof TypeToken) {
+      TypeToken<?> that = (TypeToken<?>) o;
+      return runtimeType.equals(that.runtimeType);
+    }
+    return false;
+  }
+
+  @Override public int hashCode() {
+    return runtimeType.hashCode();
+  }
+
+  @Override public String toString() {
+    return Types.toString(runtimeType);
+  }
+
+  /** Implemented to support serialization of subclasses. */
+  protected Object writeReplace() {
+    // TypeResolver just transforms the type to our own impls that are Serializable
+    // except TypeVariable.
+    return of(new TypeResolver().resolveType(runtimeType));
+  }
+
+  private static boolean isAssignable(Type from, Type to) {
+    if (to.equals(from)) {
+      return true;
+    }
+    if (to instanceof WildcardType) {
+      return isAssignableToWildcardType(from, (WildcardType) to);
+    }
+    // if "from" is type variable, it's assignable if any of its "extends"
+    // bounds is assignable to "to".
+    if (from instanceof TypeVariable) {
+      return isAssignableFromAny(((TypeVariable<?>) from).getBounds(), to);
+    }
+    // if "from" is wildcard, it'a assignable to "to" if any of its "extends"
+    // bounds is assignable to "to".
+    if (from instanceof WildcardType) {
+      return isAssignableFromAny(((WildcardType) from).getUpperBounds(), to);
+    }
+    if (from instanceof GenericArrayType) {
+      return isAssignableFromGenericArrayType((GenericArrayType) from, to);
+    }
+    // Proceed to regular Type assignability check
+    if (to instanceof Class) {
+      return isAssignableToClass(from, (Class<?>) to);
+    } else if (to instanceof ParameterizedType) {
+      return isAssignableToParameterizedType(from, (ParameterizedType) to);
+    } else if (to instanceof GenericArrayType) {
+      return isAssignableToGenericArrayType(from, (GenericArrayType) to);
+    } else { // to instanceof TypeVariable
+      return false;
+    }
+  }
+
+  private static boolean isAssignableFromAny(Type[] fromTypes, Type to) {
+    for (Type from : fromTypes) {
+      if (isAssignable(from, to)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isAssignableToClass(Type from, Class<?> to) {
+    return to.isAssignableFrom(getRawType(from));
+  }
+
+  private static boolean isAssignableToWildcardType(
+      Type from, WildcardType to) {
+    // if "to" is <? extends Foo>, "from" can be:
+    // Foo, SubFoo, <? extends Foo>, <? extends SubFoo>, <T extends Foo> or
+    // <T extends SubFoo>.
+    // if "to" is <? super Foo>, "from" can be:
+    // Foo, SuperFoo, <? super Foo> or <? super SuperFoo>.
+    return isAssignable(from, supertypeBound(to)) && isAssignableBySubtypeBound(from, to);
+  }
+
+  private static boolean isAssignableBySubtypeBound(Type from, WildcardType to) {
+    Type toSubtypeBound = subtypeBound(to);
+    if (toSubtypeBound == null) {
+      return true;
+    }
+    Type fromSubtypeBound = subtypeBound(from);
+    if (fromSubtypeBound == null) {
+      return false;
+    }
+    return isAssignable(toSubtypeBound, fromSubtypeBound);
+  }
+
+  private static boolean isAssignableToParameterizedType(Type from, ParameterizedType to) {
+    Class<?> matchedClass = getRawType(to);
+    if (!matchedClass.isAssignableFrom(getRawType(from))) {
+      return false;
+    }
+    Type[] typeParams = matchedClass.getTypeParameters();
+    Type[] toTypeArgs = to.getActualTypeArguments();
+    TypeToken<?> fromTypeToken = of(from);
+    for (int i = 0; i < typeParams.length; i++) {
+      // If "to" is "List<? extends CharSequence>"
+      // and "from" is StringArrayList,
+      // First step is to figure out StringArrayList "is-a" List<E> and <E> is
+      // String.
+      // typeParams[0] is E and fromTypeToken.get(typeParams[0]) will resolve to
+      // String.
+      // String is then matched against <? extends CharSequence>.
+      Type fromTypeArg = fromTypeToken.resolveType(typeParams[i]).runtimeType;
+      if (!matchTypeArgument(fromTypeArg, toTypeArgs[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isAssignableToGenericArrayType(Type from, GenericArrayType to) {
+    if (from instanceof Class) {
+      Class<?> fromClass = (Class<?>) from;
+      if (!fromClass.isArray()) {
+        return false;
+      }
+      return isAssignable(fromClass.getComponentType(), to.getGenericComponentType());
+    } else if (from instanceof GenericArrayType) {
+      GenericArrayType fromArrayType = (GenericArrayType) from;
+      return isAssignable(fromArrayType.getGenericComponentType(), to.getGenericComponentType());
+    } else {
+      return false;
+    }
+  }
+
+  private static boolean isAssignableFromGenericArrayType(GenericArrayType from, Type to) {
+    if (to instanceof Class) {
+      Class<?> toClass = (Class<?>) to;
+      if (!toClass.isArray()) {
+        return toClass == Object.class; // any T[] is assignable to Object
+      }
+      return isAssignable(from.getGenericComponentType(), toClass.getComponentType());
+    } else if (to instanceof GenericArrayType) {
+      GenericArrayType toArrayType = (GenericArrayType) to;
+      return isAssignable(from.getGenericComponentType(), toArrayType.getGenericComponentType());
+    } else {
+      return false;
+    }
+  }
+
+  private static boolean matchTypeArgument(Type from, Type to) {
+    if (from.equals(to)) {
+      return true;
+    }
+    if (to instanceof WildcardType) {
+      return isAssignableToWildcardType(from, (WildcardType) to);
+    }
+    return false;
+  }
+
+  private static Type supertypeBound(Type type) {
+    if (type instanceof WildcardType) {
+      return supertypeBound((WildcardType) type);
+    }
+    return type;
+  }
+
+  private static Type supertypeBound(WildcardType type) {
+    Type[] upperBounds = type.getUpperBounds();
+    if (upperBounds.length == 1) {
+      return supertypeBound(upperBounds[0]);
+    } else if (upperBounds.length == 0) {
+      return Object.class;
+    } else {
+      throw new AssertionError(
+          "There should be at most one upper bound for wildcard type: " + type);
+    }
+  }
+
+  @Nullable private static Type subtypeBound(Type type) {
+    if (type instanceof WildcardType) {
+      return subtypeBound((WildcardType) type);
+    } else {
+      return type;
+    }
+  }
+
+  @Nullable private static Type subtypeBound(WildcardType type) {
+    Type[] lowerBounds = type.getLowerBounds();
+    if (lowerBounds.length == 1) {
+      return subtypeBound(lowerBounds[0]);
+    } else if (lowerBounds.length == 0) {
+      return null;
+    } else {
+      throw new AssertionError(
+          "Wildcard should have at most one lower bound: " + type);
+    }
+  }
+
+  static Class<?> getRawType(Type type) {
+    // For wildcard or type variable, the first bound determines the runtime type.
+    return getRawTypes(type).iterator().next();
+  }
+
+  static Set<Class<?>> getRawTypes(Type type) {
+    Preconditions.checkNotNull(type);
+    final Set<Class<?>> builder = new LinkedHashSet<>();
+    new TypeVisitor() {
+      @Override void visitTypeVariable(TypeVariable<?> t) {
+        visit(t.getBounds());
+      }
+      @Override void visitWildcardType(WildcardType t) {
+        visit(t.getUpperBounds());
+      }
+      @Override void visitParameterizedType(ParameterizedType t) {
+        builder.add((Class<?>) t.getRawType());
+      }
+      @Override void visitClass(Class<?> t) {
+        builder.add(t);
+      }
+      @Override void visitGenericArrayType(GenericArrayType t) {
+        builder.add(Types.getArrayClass(getRawType(t.getGenericComponentType())));
+      }
+
+    }.visit(type);
+    return Collections.unmodifiableSet(builder);
+  }
+
+  /**
+   * Returns the type token representing the generic type declaration of {@code cls}. For example:
+   * {@code TypeToken.getGenericType(Iterable.class)} returns {@code Iterable<T>}.
+   *
+   * <p>If {@code cls} isn't parameterized and isn't a generic array, the type token of the class is
+   * returned.
+   */
+  static <T> TypeToken<? extends T> toGenericType(Class<T> cls) {
+    if (cls.isArray()) {
+      Type arrayOfGenericType = Types.newArrayType(
+          // If we are passed with int[].class, don't turn it to GenericArrayType
+          toGenericType(cls.getComponentType()).runtimeType);
+      @SuppressWarnings("unchecked") // array is covariant
+      TypeToken<? extends T> result = (TypeToken<? extends T>) of(arrayOfGenericType);
+      return result;
+    }
+    TypeVariable<Class<T>>[] typeParams = cls.getTypeParameters();
+    if (typeParams.length > 0) {
+      @SuppressWarnings("unchecked") // Like, it's Iterable<T> for Iterable.class
+      TypeToken<? extends T> type = (TypeToken<? extends T>)
+          of(Types.newParameterizedType(cls, typeParams));
+      return type;
+    } else {
+      return of(cls);
+    }
+  }
+
+  private TypeToken<? super T> getSupertypeFromUpperBounds(
+      Class<? super T> supertype, Type[] upperBounds) {
+    for (Type upperBound : upperBounds) {
+      @SuppressWarnings("unchecked") // T's upperbound is <? super T>.
+      TypeToken<? super T> bound = (TypeToken<? super T>) of(upperBound);
+      if (of(supertype).isAssignableFrom(bound)) {
+        @SuppressWarnings({"rawtypes", "unchecked"}) // guarded by the isAssignableFrom check.
+        TypeToken<? super T> result = bound.getSupertype((Class) supertype);
+        return result;
+      }
+    }
+    throw new IllegalArgumentException(supertype + " isn't a super type of " + this);
+  }
+
+  private TypeToken<? extends T> getSubtypeFromLowerBounds(Class<?> subclass, Type[] lowerBounds) {
+    for (Type lowerBound : lowerBounds) {
+      @SuppressWarnings("unchecked") // T's lower bound is <? extends T>
+      TypeToken<? extends T> bound = (TypeToken<? extends T>) of(lowerBound);
+      // Java supports only one lowerbound anyway.
+      return bound.getSubtype(subclass);
+    }
+    throw new IllegalArgumentException(subclass + " isn't a subclass of " + this);
+  }
+
+  private TypeToken<? super T> getArraySupertype(Class<? super T> supertype) {
+    // with component type, we have lost generic type information
+    // Use raw type so that compiler allows us to call getSupertype()
+    @SuppressWarnings("rawtypes")
+    TypeToken componentType = Preconditions.checkNotNull(getComponentType(),
+        "%s isn't a super type of %s", supertype, this);
+    // array is covariant. component type is super type, so is the array type.
+    @SuppressWarnings("unchecked") // going from raw type back to generics
+    TypeToken<?> componentSupertype = componentType.getSupertype(supertype.getComponentType());
+    @SuppressWarnings("unchecked") // component type is super type, so is array type.
+    TypeToken<? super T> result = (TypeToken<? super T>)
+        // If we are passed with int[].class, don't turn it to GenericArrayType
+        of(newArrayClassOrGenericArrayType(componentSupertype.runtimeType));
+    return result;
+  }
+
+  private TypeToken<? extends T> getArraySubtype(Class<?> subclass) {
+    // array is covariant. component type is subtype, so is the array type.
+    TypeToken<?> componentSubtype = getComponentType()
+        .getSubtype(subclass.getComponentType());
+    @SuppressWarnings("unchecked") // component type is subtype, so is array type.
+    TypeToken<? extends T> result = (TypeToken<? extends T>)
+        // If we are passed with int[].class, don't turn it to GenericArrayType
+        of(newArrayClassOrGenericArrayType(componentSubtype.runtimeType));
+    return result;
+  }
+
+  private Type resolveTypeArgsForSubclass(Class<?> subclass) {
+    if (runtimeType instanceof Class) {
+      // no resolution needed
+      return subclass;
+    }
+    // class Base<A, B> {}
+    // class Sub<X, Y> extends Base<X, Y> {}
+    // Base<String, Integer>.subtype(Sub.class):
+
+    // Sub<X, Y>.getSupertype(Base.class) => Base<X, Y>
+    // => X=String, Y=Integer
+    // => Sub<X, Y>=Sub<String, Integer>
+    TypeToken<?> genericSubtype = toGenericType(subclass);
+    @SuppressWarnings({"rawtypes", "unchecked"}) // subclass isn't <? extends T>
+    Type supertypeWithArgsFromSubtype = genericSubtype
+        .getSupertype((Class) getRawType())
+        .runtimeType;
+    return new TypeResolver().where(supertypeWithArgsFromSubtype, runtimeType)
+        .resolveType(genericSubtype.runtimeType);
+  }
+
+  private <E> Set<E> filterIterableToSet(Iterable<E> iterable, Predicate<? super E> filter) {
+    return Collections.unmodifiableSet(Iterables.addAll(Iterables.filter(iterable, filter), new LinkedHashSet<E>()));
+  }
+
+  /**
+   * Creates an array class if {@code componentType} is a class, or else, a
+   * {@link GenericArrayType}. This is what Java7 does for generic array type
+   * parameters.
+   */
+  private static Type newArrayClassOrGenericArrayType(Type componentType) {
+    return Types.JavaVersion.JAVA7.newArrayType(componentType);
+  }
+
+  private static final class SimpleTypeToken<T> extends TypeToken<T> {
+
+    SimpleTypeToken(Type type) {
+      super(type);
+    }
+
+    private static final long serialVersionUID = 0;
+  }
+
+  /**
+   * Collects parent types from a sub type.
+   *
+   * @param <K> The type "kind". Either a TypeToken, or Class.
+   */
+  private abstract static class TypeCollector<K> {
+
+    static final TypeCollector<TypeToken<?>> FOR_GENERIC_TYPE =
+        new TypeCollector<TypeToken<?>>() {
+          @Override Class<?> getRawType(TypeToken<?> type) {
+            return type.getRawType();
+          }
+
+          @Override Iterable<? extends TypeToken<?>> getInterfaces(TypeToken<?> type) {
+            return type.getGenericInterfaces();
+          }
+
+          @Nullable
+          @Override TypeToken<?> getSuperclass(TypeToken<?> type) {
+            return type.getGenericSuperclass();
+          }
+        };
+
+    static final TypeCollector<Class<?>> FOR_RAW_TYPE =
+        new TypeCollector<Class<?>>() {
+          @Override Class<?> getRawType(Class<?> type) {
+            return type;
+          }
+
+          @Override Iterable<? extends Class<?>> getInterfaces(Class<?> type) {
+            return Arrays.asList(type.getInterfaces());
+          }
+
+          @Nullable
+          @Override Class<?> getSuperclass(Class<?> type) {
+            return type.getSuperclass();
+          }
+        };
+
+    /** For just classes, we don't have to traverse interfaces. */
+    final TypeCollector<K> classesOnly() {
+      return new ForwardingTypeCollector<K>(this) {
+        @Override Iterable<? extends K> getInterfaces(K type) {
+          return Collections.unmodifiableList(Collections.<K>emptyList());
+        }
+        @Override List<K> collectTypes(Iterable<? extends K> types) {
+          List<K> builder = new ArrayList<>();
+          for (K type : types) {
+            if (!getRawType(type).isInterface()) {
+              builder.add(type);
+            }
+          }
+          return super.collectTypes(Collections.unmodifiableList(builder));
+        }
+      };
+    }
+
+    final List<K> collectTypes(K type) {
+      return collectTypes(Collections.singletonList(type));
+    }
+
+    List<K> collectTypes(Iterable<? extends K> types) {
+      // type -> order number. 1 for Object, 2 for anything directly below, so on so forth.
+      Map<K, Integer> map = new LinkedHashMap<>();
+      for (K type : types) {
+        collectTypes(type, map);
+      }
+      // Sort by the reverse order of the map value.
+      return sortKeysByValue(map, new Comparator<Integer>() {
+        @Override
+        public int compare(Integer o1, Integer o2) {
+          return o2.compareTo(o1);
+        }
+      });
+    }
+
+    /** Collects all types to map, and returns the total depth from T up to Object. */
+    private int collectTypes(K type, Map<? super K, Integer> map) {
+      Integer existing = map.get(this);
+      if (existing != null) {
+        // short circuit: if set contains type it already contains its supertypes
+        return existing;
+      }
+      int aboveMe = getRawType(type).isInterface()
+          ? 1 // interfaces should be listed before Object
+          : 0;
+      for (K interfaceType : getInterfaces(type)) {
+        aboveMe = Math.max(aboveMe, collectTypes(interfaceType, map));
+      }
+      K superclass = getSuperclass(type);
+      if (superclass != null) {
+        aboveMe = Math.max(aboveMe, collectTypes(superclass, map));
+      }
+      /*
+       * TODO(benyu): should we include Object for interface?
+       * Also, CharSequence[] and Object[] for String[]?
+       *
+       */
+      map.put(type, aboveMe + 1);
+      return aboveMe + 1;
+    }
+
+    private static <K, V> List<K> sortKeysByValue(final Map<K, V> map, final Comparator<? super V> valueComparator) {
+      List<K> list = new ArrayList<>(map.keySet());
+      Collections.sort(list, new Comparator<K>() {
+        @Override
+        public int compare(K left, K right) {
+          return valueComparator.compare(map.get(left), map.get(right));
+        }
+      });
+      return Collections.unmodifiableList(list);
+    }
+
+    abstract Class<?> getRawType(K type);
+    abstract Iterable<? extends K> getInterfaces(K type);
+    @Nullable abstract K getSuperclass(K type);
+
+    private static class ForwardingTypeCollector<K> extends TypeCollector<K> {
+
+      private final TypeCollector<K> delegate;
+
+      ForwardingTypeCollector(TypeCollector<K> delegate) {
+        this.delegate = delegate;
+      }
+
+      @Override Class<?> getRawType(K type) {
+        return delegate.getRawType(type);
+      }
+
+      @Override Iterable<? extends K> getInterfaces(K type) {
+        return delegate.getInterfaces(type);
+      }
+
+      @Override K getSuperclass(K type) {
+        return delegate.getSuperclass(type);
+      }
+    }
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/TypeVisitor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/TypeVisitor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2013 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Based on what a {@link Type} is, dispatch it to the corresponding {@code visit*} method. By
+ * default, no recursion is done for type arguments or type bounds. But subclasses can opt to do
+ * recursion by calling {@link #visit} for any {@code Type} while visitation is in progress. For
+ * example, this can be used to reject wildcards or type variables contained in a type as in:
+ *
+ * <pre>   {@code
+ *   new TypeVisitor() {
+ *     protected void visitParameterizedType(ParameterizedType t) {
+ *       visit(t.getOwnerType());
+ *       visit(t.getActualTypeArguments());
+ *     }
+ *     protected void visitGenericArrayType(GenericArrayType t) {
+ *       visit(t.getGenericComponentType());
+ *     }
+ *     protected void visitTypeVariable(TypeVariable<?> t) {
+ *       throw new IllegalArgumentException("Cannot contain type variable.");
+ *     }
+ *     protected void visitWildcardType(WildcardType t) {
+ *       throw new IllegalArgumentException("Cannot contain wildcard type.");
+ *     }
+ *   }.visit(type);}</pre>
+ * 
+ * <p>One {@code Type} is visited at most once. The second time the same type is visited, it's
+ * ignored by {@link #visit}. This avoids infinite recursion caused by recursive type bounds.
+ *
+ * <p>This class is <em>not</em> thread safe.
+ */
+@NotThreadSafe
+abstract class TypeVisitor {
+
+  private final Set<Type> visited = new HashSet<>();
+
+  /**
+   * Visits the given types. Null types are ignored. This allows subclasses to call
+   * {@code visit(parameterizedType.getOwnerType())} safely without having to check nulls.
+   */
+  public final void visit(Type... types) {
+    for (Type type : types) {
+      if (type == null || !visited.add(type)) {
+        // null owner type, or already visited;
+        continue;
+      }
+      boolean succeeded = false;
+      try {
+        if (type instanceof TypeVariable) {
+          visitTypeVariable((TypeVariable<?>) type);
+        } else if (type instanceof WildcardType) {
+          visitWildcardType((WildcardType) type);
+        } else if (type instanceof ParameterizedType) {
+          visitParameterizedType((ParameterizedType) type);
+        } else if (type instanceof Class) {
+          visitClass((Class<?>) type);
+        } else if (type instanceof GenericArrayType) {
+          visitGenericArrayType((GenericArrayType) type);
+        } else {
+          throw new AssertionError("Unknown type: " + type);
+        }
+        succeeded = true;
+      } finally {
+        if (!succeeded) { // When the visitation failed, we don't want to ignore the second.
+          visited.remove(type);
+        }
+      }
+    }
+  }
+
+  void visitClass(Class<?> t) {}
+  void visitGenericArrayType(GenericArrayType t) {}
+  void visitParameterizedType(ParameterizedType t) {}
+  void visitTypeVariable(TypeVariable<?> t) {}
+  void visitWildcardType(WildcardType t) {}
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Types.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/Types.java
@@ -1,0 +1,624 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ * Portions copyright (C) 2011 The Guava Authors
+ * Derived from the Google Guava Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.guava.reflect;
+
+import co.cask.cdap.api.Predicate;
+
+import java.io.Serializable;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.GenericDeclaration;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.security.AccessControlException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/**
+ * Utilities for working with {@link Type}.
+ */
+final class Types {
+
+  /** Class#toString without the "class " and "interface " prefixes */
+  private static final Function<Type, String> TYPE_NAME =
+    new Function<Type, String>() {
+      @Override public String apply(Type from) {
+        return JavaVersion.CURRENT.typeName(from);
+      }
+    };
+
+  private static final Joiner COMMA_JOINER = Joiner.on(", ").useForNull("null");
+
+  /** Returns the array type of {@code componentType}. */
+  static Type newArrayType(Type componentType) {
+    if (componentType instanceof WildcardType) {
+      WildcardType wildcard = (WildcardType) componentType;
+      Type[] lowerBounds = wildcard.getLowerBounds();
+      Preconditions.checkArgument(lowerBounds.length <= 1, "Wildcard cannot have more than one lower bounds.");
+      if (lowerBounds.length == 1) {
+        return supertypeOf(newArrayType(lowerBounds[0]));
+      } else {
+        Type[] upperBounds = wildcard.getUpperBounds();
+        Preconditions.checkArgument(upperBounds.length == 1, "Wildcard should have only one upper bound.");
+        return subtypeOf(newArrayType(upperBounds[0]));
+      }
+    }
+    return JavaVersion.CURRENT.newArrayType(componentType);
+  }
+
+  /**
+   * Returns a type where {@code rawType} is parameterized by
+   * {@code arguments} and is owned by {@code ownerType}.
+   */
+  static ParameterizedType newParameterizedTypeWithOwner(
+    @Nullable Type ownerType, Class<?> rawType, Type... arguments) {
+    if (ownerType == null) {
+      return newParameterizedType(rawType, arguments);
+    }
+    // ParameterizedTypeImpl constructor already checks, but we want to throw NPE before IAE
+    Preconditions.checkNotNull(arguments);
+    Preconditions.checkArgument(rawType.getEnclosingClass() != null, "Owner type for unenclosed %s", rawType);
+    return new ParameterizedTypeImpl(ownerType, rawType, arguments);
+  }
+
+  /**
+   * Returns a type where {@code rawType} is parameterized by
+   * {@code arguments}.
+   */
+  static ParameterizedType newParameterizedType(Class<?> rawType, Type... arguments) {
+    return new ParameterizedTypeImpl(
+      ClassOwnership.JVM_BEHAVIOR.getOwnerType(rawType), rawType, arguments);
+  }
+
+  /** Decides what owner type to use for constructing {@link ParameterizedType} from a raw class. */
+  private enum ClassOwnership {
+
+    OWNED_BY_ENCLOSING_CLASS {
+      @Nullable
+      @Override
+      Class<?> getOwnerType(Class<?> rawType) {
+        return rawType.getEnclosingClass();
+      }
+    },
+    LOCAL_CLASS_HAS_NO_OWNER {
+      @Nullable
+      @Override
+      Class<?> getOwnerType(Class<?> rawType) {
+        if (rawType.isLocalClass()) {
+          return null;
+        } else {
+          return rawType.getEnclosingClass();
+        }
+      }
+    };
+
+    @Nullable abstract Class<?> getOwnerType(Class<?> rawType);
+
+    static final ClassOwnership JVM_BEHAVIOR = detectJvmBehavior();
+
+    private static ClassOwnership detectJvmBehavior() {
+      class LocalClass<T> { }
+      Class<?> subclass = new LocalClass<String>() { }.getClass();
+      ParameterizedType parameterizedType = (ParameterizedType)
+        subclass.getGenericSuperclass();
+      for (ClassOwnership behavior : ClassOwnership.values()) {
+        if (behavior.getOwnerType(LocalClass.class) == parameterizedType.getOwnerType()) {
+          return behavior;
+        }
+      }
+      throw new AssertionError();
+    }
+  }
+
+  /**
+   * Returns a new {@link TypeVariable} that belongs to {@code declaration} with
+   * {@code name} and {@code bounds}.
+   */
+  static <D extends GenericDeclaration> TypeVariable<D> newArtificialTypeVariable(
+    D declaration, String name, Type... bounds) {
+    return newTypeVariableImpl(
+      declaration,
+      name,
+      (bounds.length == 0)
+        ? new Type[] { Object.class }
+        : bounds);
+  }
+
+  /** Returns a new {@link WildcardType} with {@code upperBound}. */
+  static WildcardType subtypeOf(Type upperBound) {
+    return new WildcardTypeImpl(new Type[0], new Type[] { upperBound });
+  }
+
+  /** Returns a new {@link WildcardType} with {@code lowerBound}. */
+  static WildcardType supertypeOf(Type lowerBound) {
+    return new WildcardTypeImpl(new Type[] { lowerBound }, new Type[] { Object.class });
+  }
+
+  /**
+   * Returns human readable string representation of {@code type}.
+   * <ul>
+   * <li> For array type {@code Foo[]}, {@code "com.mypackage.Foo[]"} are
+   * returned.
+   * <li> For any class, {@code theClass.getName()} are returned.
+   * <li> For all other types, {@code type.toString()} are returned.
+   * </ul>
+   */
+  static String toString(Type type) {
+    return (type instanceof Class)
+      ? ((Class<?>) type).getName()
+      : type.toString();
+  }
+
+  @Nullable static Type getComponentType(Type type) {
+    Preconditions.checkNotNull(type);
+    final AtomicReference<Type> result = new AtomicReference<Type>();
+    new TypeVisitor() {
+      @Override void visitTypeVariable(TypeVariable<?> t) {
+        result.set(subtypeOfComponentType(t.getBounds()));
+      }
+      @Override void visitWildcardType(WildcardType t) {
+        result.set(subtypeOfComponentType(t.getUpperBounds()));
+      }
+      @Override void visitGenericArrayType(GenericArrayType t) {
+        result.set(t.getGenericComponentType());
+      }
+      @Override void visitClass(Class<?> t) {
+        result.set(t.getComponentType());
+      }
+    }.visit(type);
+    return result.get();
+  }
+
+  /**
+   * Returns {@code ? extends X} if any of {@code bounds} is a subtype of {@code X[]}; or null
+   * otherwise.
+   */
+  @Nullable private static Type subtypeOfComponentType(Type[] bounds) {
+    for (Type bound : bounds) {
+      Type componentType = getComponentType(bound);
+      if (componentType != null) {
+        // Only the first bound can be a class or array.
+        // Bounds after the first can only be interfaces.
+        if (componentType instanceof Class) {
+          Class<?> componentClass = (Class<?>) componentType;
+          if (componentClass.isPrimitive()) {
+            return componentClass;
+          }
+        }
+        return subtypeOf(componentType);
+      }
+    }
+    return null;
+  }
+
+  private static final class GenericArrayTypeImpl
+    implements GenericArrayType, Serializable {
+
+    private final Type componentType;
+
+    GenericArrayTypeImpl(Type componentType) {
+      this.componentType = JavaVersion.CURRENT.usedInGenericType(componentType);
+    }
+
+    @Override public Type getGenericComponentType() {
+      return componentType;
+    }
+
+    @Override public String toString() {
+      return Types.toString(componentType) + "[]";
+    }
+
+    @Override public int hashCode() {
+      return componentType.hashCode();
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (obj instanceof GenericArrayType) {
+        GenericArrayType that = (GenericArrayType) obj;
+        return Objects.equals(
+          getGenericComponentType(), that.getGenericComponentType());
+      }
+      return false;
+    }
+
+    private static final long serialVersionUID = 0;
+  }
+
+  private static final class ParameterizedTypeImpl
+    implements ParameterizedType, Serializable {
+
+    private final Type ownerType;
+    private final List<Type> argumentsList;
+    private final Class<?> rawType;
+
+    ParameterizedTypeImpl(
+      @Nullable Type ownerType, Class<?> rawType, Type[] typeArguments) {
+      Preconditions.checkNotNull(rawType);
+      Preconditions.checkArgument(typeArguments.length == rawType.getTypeParameters().length);
+      disallowPrimitiveType(typeArguments, "type parameter");
+      this.ownerType = ownerType;
+      this.rawType = rawType;
+      this.argumentsList = JavaVersion.CURRENT.usedInGenericType(typeArguments);
+    }
+
+    @Override public Type[] getActualTypeArguments() {
+      return toArray(argumentsList);
+    }
+
+    @Override public Type getRawType() {
+      return rawType;
+    }
+
+    @Override public Type getOwnerType() {
+      return ownerType;
+    }
+
+    @Override public String toString() {
+      StringBuilder builder = new StringBuilder();
+      if (ownerType != null) {
+        builder.append(JavaVersion.CURRENT.typeName(ownerType)).append('.');
+      }
+      builder.append(rawType.getName())
+        .append('<')
+        .append(COMMA_JOINER.join(Iterables.transform(argumentsList, TYPE_NAME)))
+        .append('>');
+      return builder.toString();
+    }
+
+    @Override public int hashCode() {
+      return (ownerType == null ? 0 : ownerType.hashCode())
+        ^ argumentsList.hashCode() ^ rawType.hashCode();
+    }
+
+    @Override public boolean equals(Object other) {
+      if (!(other instanceof ParameterizedType)) {
+        return false;
+      }
+      ParameterizedType that = (ParameterizedType) other;
+      return getRawType().equals(that.getRawType())
+        && Objects.equals(getOwnerType(), that.getOwnerType())
+        && Arrays.equals(
+        getActualTypeArguments(), that.getActualTypeArguments());
+    }
+
+    private static final long serialVersionUID = 0;
+  }
+
+  private static <D extends GenericDeclaration> TypeVariable<D> newTypeVariableImpl(
+    D genericDeclaration, String name, Type[] bounds) {
+    TypeVariableImpl<D> typeVariableImpl =
+      new TypeVariableImpl<D>(genericDeclaration, name, bounds);
+    @SuppressWarnings("unchecked")
+    TypeVariable<D> typeVariable = Reflection.newProxy(
+      TypeVariable.class, new TypeVariableInvocationHandler(typeVariableImpl));
+    return typeVariable;
+  }
+
+  /**
+   * Invocation handler to work around a compatibility problem between Java 7 and Java 8.
+   *
+   * <p>Java 8 introduced a new method {@code getAnnotatedBounds()} in the {@link TypeVariable}
+   * interface, whose return type {@code AnnotatedType[]} is also new in Java 8. That means that we
+   * cannot implement that interface in source code in a way that will compile on both Java 7 and
+   * Java 8. If we include the {@code getAnnotatedBounds()} method then its return type means
+   * it won't compile on Java 7, while if we don't include the method then the compiler will
+   * complain that an abstract method is unimplemented. So instead we use a dynamic proxy to
+   * get an implementation. If the method being called on the {@code TypeVariable} instance has
+   * the same name as one of the public methods of {@link TypeVariableImpl}, the proxy calls
+   * the same method on its instance of {@code TypeVariableImpl}. Otherwise it throws {@link
+   * UnsupportedOperationException}; this should only apply to {@code getAnnotatedBounds()}. This
+   * does mean that users on Java 8 who obtain an instance of {@code TypeVariable} from {@link
+   * TypeResolver#resolveType} will not be able to call {@code getAnnotatedBounds()} on it, but that
+   * should hopefully be rare.
+   *
+   * <p>This workaround should be removed at a distant future time when we no longer support Java
+   * versions earlier than 8.
+   */
+  private static final class TypeVariableInvocationHandler implements InvocationHandler {
+    private static final Map<String, Method> typeVariableMethods;
+    static {
+      Map<String, Method> builder = new HashMap<>();
+      for (Method method : TypeVariableImpl.class.getMethods()) {
+        if (method.getDeclaringClass().equals(TypeVariableImpl.class)) {
+          try {
+            method.setAccessible(true);
+          } catch (AccessControlException e) {
+            // OK: the method is accessible to us anyway. The setAccessible call is only for
+            // unusual execution environments where that might not be true.
+          }
+          builder.put(method.getName(), method);
+        }
+      }
+      typeVariableMethods = Collections.unmodifiableMap(builder);
+    }
+
+    private final TypeVariableImpl<?> typeVariableImpl;
+
+    TypeVariableInvocationHandler(TypeVariableImpl<?> typeVariableImpl) {
+      this.typeVariableImpl = typeVariableImpl;
+    }
+
+    @Override public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      String methodName = method.getName();
+      Method typeVariableMethod = typeVariableMethods.get(methodName);
+      if (typeVariableMethod == null) {
+        throw new UnsupportedOperationException(methodName);
+      } else {
+        try {
+          return typeVariableMethod.invoke(typeVariableImpl, args);
+        } catch (InvocationTargetException e) {
+          throw e.getCause();
+        }
+      }
+    }
+  }
+
+  private static final class TypeVariableImpl<D extends GenericDeclaration> {
+
+    private final D genericDeclaration;
+    private final String name;
+    private final List<Type> bounds;
+
+    TypeVariableImpl(D genericDeclaration, String name, Type[] bounds) {
+      disallowPrimitiveType(bounds, "bound for type variable");
+      this.genericDeclaration = Preconditions.checkNotNull(genericDeclaration);
+      this.name = Preconditions.checkNotNull(name);
+      this.bounds = Collections.unmodifiableList(new ArrayList<>(Arrays.asList(bounds)));
+    }
+
+    public Type[] getBounds() {
+      return toArray(bounds);
+    }
+
+    public D getGenericDeclaration() {
+      return genericDeclaration;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getTypeName() {
+      return name;
+    }
+
+    @Override public String toString() {
+      return name;
+    }
+
+    @Override public int hashCode() {
+      return genericDeclaration.hashCode() ^ name.hashCode();
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (NativeTypeVariableEquals.NATIVE_TYPE_VARIABLE_ONLY) {
+        // equal only to our TypeVariable implementation with identical bounds
+        if (obj != null
+          && Proxy.isProxyClass(obj.getClass())
+          && Proxy.getInvocationHandler(obj) instanceof TypeVariableInvocationHandler) {
+          TypeVariableInvocationHandler typeVariableInvocationHandler =
+            (TypeVariableInvocationHandler) Proxy.getInvocationHandler(obj);
+          TypeVariableImpl<?> that = typeVariableInvocationHandler.typeVariableImpl;
+          return name.equals(that.getName())
+            && genericDeclaration.equals(that.getGenericDeclaration())
+            && bounds.equals(that.bounds);
+        }
+        return false;
+      } else {
+        // equal to any TypeVariable implementation regardless of bounds
+        if (obj instanceof TypeVariable) {
+          TypeVariable<?> that = (TypeVariable<?>) obj;
+          return name.equals(that.getName())
+            && genericDeclaration.equals(that.getGenericDeclaration());
+        }
+        return false;
+      }
+    }
+  }
+
+  static final class WildcardTypeImpl implements WildcardType, Serializable {
+
+    private final List<Type> lowerBounds;
+    private final List<Type> upperBounds;
+
+    WildcardTypeImpl(Type[] lowerBounds, Type[] upperBounds) {
+      disallowPrimitiveType(lowerBounds, "lower bound for wildcard");
+      disallowPrimitiveType(upperBounds, "upper bound for wildcard");
+      this.lowerBounds = JavaVersion.CURRENT.usedInGenericType(lowerBounds);
+      this.upperBounds = JavaVersion.CURRENT.usedInGenericType(upperBounds);
+    }
+
+    @Override public Type[] getLowerBounds() {
+      return toArray(lowerBounds);
+    }
+
+    @Override public Type[] getUpperBounds() {
+      return toArray(upperBounds);
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (obj instanceof WildcardType) {
+        WildcardType that = (WildcardType) obj;
+        return lowerBounds.equals(Arrays.asList(that.getLowerBounds()))
+          && upperBounds.equals(Arrays.asList(that.getUpperBounds()));
+      }
+      return false;
+    }
+
+    @Override public int hashCode() {
+      return lowerBounds.hashCode() ^ upperBounds.hashCode();
+    }
+
+    @Override public String toString() {
+      StringBuilder builder = new StringBuilder("?");
+      for (Type lowerBound : lowerBounds) {
+        builder.append(" super ").append(JavaVersion.CURRENT.typeName(lowerBound));
+      }
+      for (Type upperBound : filterUpperBounds(upperBounds)) {
+        builder.append(" extends ").append(JavaVersion.CURRENT.typeName(upperBound));
+      }
+      return builder.toString();
+    }
+
+    private static final long serialVersionUID = 0;
+  }
+
+  private static Type[] toArray(Collection<Type> types) {
+    return types.toArray(new Type[types.size()]);
+  }
+
+  private static Iterable<Type> filterUpperBounds(Iterable<Type> bounds) {
+    return Iterables.filter(
+      bounds, new Predicate<Type>() {
+        @Override
+        public boolean apply(@Nullable Type input) {
+          return !Objects.equals(Object.class, input);
+        }
+      });
+  }
+
+  private static void disallowPrimitiveType(Type[] types, String usedAs) {
+    for (Type type : types) {
+      if (type instanceof Class) {
+        Class<?> cls = (Class<?>) type;
+        Preconditions.checkArgument(!cls.isPrimitive(),
+                      "Primitive type '%s' used as %s", cls, usedAs);
+      }
+    }
+  }
+
+  /** Returns the {@code Class} object of arrays with {@code componentType}. */
+  static Class<?> getArrayClass(Class<?> componentType) {
+    // TODO(user): This is not the most efficient way to handle generic
+    // arrays, but is there another way to extract the array class in a
+    // non-hacky way (i.e. using String value class names- "[L...")?
+    return Array.newInstance(componentType, 0).getClass();
+  }
+
+  // TODO(benyu): Once we are on Java 8, delete this abstraction
+  enum JavaVersion {
+
+    JAVA6 {
+      @Override GenericArrayType newArrayType(Type componentType) {
+        return new GenericArrayTypeImpl(componentType);
+      }
+      @Override Type usedInGenericType(Type type) {
+        Preconditions.checkNotNull(type);
+        if (type instanceof Class) {
+          Class<?> cls = (Class<?>) type;
+          if (cls.isArray()) {
+            return new GenericArrayTypeImpl(cls.getComponentType());
+          }
+        }
+        return type;
+      }
+    },
+    JAVA7 {
+      @Override Type newArrayType(Type componentType) {
+        if (componentType instanceof Class) {
+          return getArrayClass((Class<?>) componentType);
+        } else {
+          return new GenericArrayTypeImpl(componentType);
+        }
+      }
+      @Override Type usedInGenericType(Type type) {
+        return Preconditions.checkNotNull(type);
+      }
+    },
+    JAVA8 {
+      @Override Type newArrayType(Type componentType) {
+        return JAVA7.newArrayType(componentType);
+      }
+      @Override Type usedInGenericType(Type type) {
+        return JAVA7.usedInGenericType(type);
+      }
+      @Override String typeName(Type type) {
+        try {
+          Method getTypeName = Type.class.getMethod("getTypeName");
+          return (String) getTypeName.invoke(type);
+        } catch (NoSuchMethodException e) {
+          throw new AssertionError("Type.getTypeName should be available in Java 8");
+        } catch (InvocationTargetException e) {
+          throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    ;
+
+    static final JavaVersion CURRENT;
+    static {
+      if (AnnotatedElement.class.isAssignableFrom(TypeVariable.class)) {
+        CURRENT = JAVA8;
+      } else if (new TypeCapture<int[]>() { }.capture() instanceof Class) {
+        CURRENT = JAVA7;
+      } else {
+        CURRENT = JAVA6;
+      }
+    }
+
+    abstract Type newArrayType(Type componentType);
+    abstract Type usedInGenericType(Type type);
+    String typeName(Type type) {
+      return Types.toString(type);
+    }
+
+    List<Type> usedInGenericType(Type[] types) {
+      List<Type> builder = new ArrayList<>();
+      for (Type type : types) {
+        builder.add(usedInGenericType(type));
+      }
+      return Collections.unmodifiableList(builder);
+    }
+  }
+
+  /**
+   * Per https://code.google.com/p/guava-libraries/issues/detail?id=1635,
+   * In JDK 1.7.0_51-b13, TypeVariableImpl.equals() is changed to no longer be equal to custom
+   * TypeVariable implementations. As a result, we need to make sure our TypeVariable implementation
+   * respects symmetry.
+   * Moreover, we don't want to reconstruct a native type variable <A> using our implementation
+   * unless some of its bounds have changed in resolution. This avoids creating unequal TypeVariable
+   * implementation unnecessarily. When the bounds do change, however, it's fine for the synthetic
+   * TypeVariable to be unequal to any native TypeVariable anyway.
+   */
+  static final class NativeTypeVariableEquals<X> {
+    static final boolean NATIVE_TYPE_VARIABLE_ONLY =
+      !NativeTypeVariableEquals.class.getTypeParameters()[0].equals(
+        newArtificialTypeVariable(NativeTypeVariableEquals.class, "X"));
+  }
+
+  private Types() {}
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/guava/reflect/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * This package contains utilities to work with Java reflection.
+ * It is copied and modified from the
+ * <a href="http://guava-libraries.googlecode.com">Guava libraries</a>.
+ *
+ * The modification is many about removing dependencies on too many other Guava classes, like immutable collections.
+ */
+@javax.annotation.ParametersAreNonnullByDefault
+package co.cask.cdap.internal.guava.reflect;

--- a/cdap-api/src/main/java/co/cask/cdap/internal/io/AbstractSchemaGenerator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/io/AbstractSchemaGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,7 +18,7 @@ package co.cask.cdap.internal.io;
 
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
-import com.google.common.reflect.TypeToken;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;

--- a/cdap-api/src/main/java/co/cask/cdap/internal/io/ReflectionSchemaGenerator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/io/ReflectionSchemaGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,7 +18,7 @@ package co.cask.cdap.internal.io;
 
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
-import com.google.common.reflect.TypeToken;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Fields.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Fields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.internal.lang;
 
-import com.google.common.reflect.TypeToken;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,7 +15,7 @@
  */
 package co.cask.cdap.internal.lang;
 
-import com.google.common.reflect.TypeToken;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.GenericArrayType;

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/OutputEmitterFieldExtractor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/OutputEmitterFieldExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,9 +18,9 @@ package co.cask.cdap.internal.specification;
 import co.cask.cdap.api.annotation.Output;
 import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.api.flow.flowlet.OutputEmitter;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
 import co.cask.cdap.internal.lang.FieldVisitor;
 import co.cask.cdap.internal.lang.Reflections;
-import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/ProcessMethodExtractor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/ProcessMethodExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,9 +20,9 @@ import co.cask.cdap.api.annotation.ProcessInput;
 import co.cask.cdap.api.annotation.Tick;
 import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.api.flow.flowlet.InputContext;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
 import co.cask.cdap.internal.lang.MethodVisitor;
 import co.cask.cdap.internal.lang.Reflections;
-import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -50,9 +50,7 @@ public final class ProcessMethodExtractor extends MethodVisitor {
 
   @Override
   public void visit(Object instance, Type inspectType, Type declareType, Method method) throws Exception {
-    TypeToken<?> inspectTypeToken = TypeToken.of(inspectType);
-
-    if (!seenMethods.add(new FlowletMethod(method, inspectTypeToken))) {
+    if (!seenMethods.add(FlowletMethod.create(method, inspectType))) {
       // The method is already seen. It can only happen if a children class override a parent class method and
       // is visting the parent method, since the method visiting order is always from the leaf class walking
       // up the class hierarchy.
@@ -61,6 +59,7 @@ public final class ProcessMethodExtractor extends MethodVisitor {
 
     ProcessInput processInputAnnotation = method.getAnnotation(ProcessInput.class);
     Tick tickAnnotation = method.getAnnotation(Tick.class);
+    TypeToken<?> inspectTypeToken = TypeToken.of(inspectType);
 
     if (processInputAnnotation == null && tickAnnotation == null) {
       return;

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/PropertyFieldExtractor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/PropertyFieldExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +16,8 @@
 package co.cask.cdap.internal.specification;
 
 import co.cask.cdap.api.annotation.Property;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
 import co.cask.cdap.internal.lang.FieldVisitor;
-import com.google.common.reflect.TypeToken;
 import com.google.gson.internal.Primitives;
 
 import java.lang.reflect.Field;

--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -87,6 +87,10 @@
       <artifactId>tephra-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
     </dependency>

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -292,9 +292,7 @@ public final class FlowUtils {
     Reflections.visit(null, flowletType, new MethodVisitor() {
       @Override
       public void visit(Object instance, Type inspectType, Type declareType, Method method) throws Exception {
-        TypeToken<?> inspectTypeToken = TypeToken.of(inspectType);
-
-        if (!seenMethods.add(new FlowletMethod(method, inspectTypeToken))) {
+        if (!seenMethods.add(FlowletMethod.create(method, inspectType))) {
           // The method is already seen. It can only happen if a children class override a parent class method and
           // is visiting the parent method, since the method visiting order is always from the leaf class walking
           // up the class hierarchy.
@@ -313,6 +311,7 @@ public final class FlowUtils {
           inputNames.add(FlowletDefinition.ANY_INPUT);
         }
 
+        TypeToken<?> inspectTypeToken = TypeToken.of(inspectType);
         TypeToken<?> dataType = inspectTypeToken.resolveType(method.getGenericParameterTypes()[0]);
         // For batch mode and if the parameter is Iterator, need to get the actual data type from the Iterator.
         if (method.isAnnotationPresent(Batch.class) && Iterator.class.equals(dataType.getRawType())) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -316,7 +316,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
         if (method.isSynthetic() || method.isBridge()) {
           continue;
         }
-        if (!seenMethods.add(new FlowletMethod(method, flowletType))) {
+        if (!seenMethods.add(FlowletMethod.create(method, flowletType.getType()))) {
           // The method is already seen. It can only happen if a children class override a parent class method and
           // is visting the parent method, since the method visiting order is always from the leaf class walking
           // up the class hierarchy.

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/pom.xml
@@ -63,7 +63,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/cdap-archetypes/cdap-mapreduce-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-mapreduce-archetype/src/main/resources/archetype-resources/pom.xml
@@ -64,7 +64,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/pom.xml
@@ -72,7 +72,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/pom.xml
@@ -32,7 +32,6 @@
     <cdap.version>3.4.0-SNAPSHOT</cdap.version>
     <spark.core.version>1.3.1</spark.core.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <guava.version>13.0.1</guava.version>
     <gson.version>2.2.4</gson.version>
   </properties>
 

--- a/cdap-client-tests/pom.xml
+++ b/cdap-client-tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright 2014 Cask Data, Inc.
+Copyright 2014-2016 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
@@ -33,6 +33,10 @@ the License.
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-api</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/cdap-formats/pom.xml
+++ b/cdap-formats/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2015 Cask Data, Inc.
+  ~ Copyright © 2015-2016 Cask Data, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
   ~ use this file except in compliance with the License. You may obtain a copy of
@@ -40,6 +40,10 @@
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-spi</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>io.thekraken</groupId>

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
@@ -64,6 +64,7 @@ import org.apache.http.util.EntityUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
 import java.net.InetAddress;
@@ -85,6 +86,9 @@ public abstract class GatewayTestBase {
 
   private static final String hostname = "127.0.0.1";
   private static int port;
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
   protected static final String TEST_NAMESPACE1 = "testnamespace1";
   protected static final NamespaceMeta TEST_NAMESPACE_META1 = new NamespaceMeta.Builder().setName(TEST_NAMESPACE1)

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/RuntimeArgumentTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/RuntimeArgumentTestRun.java
@@ -35,7 +35,8 @@ public class RuntimeArgumentTestRun extends GatewayTestBase {
 
   @Test
   public void testFlowRuntimeArgs() throws Exception {
-    HttpResponse response = GatewayFastTestsSuite.deploy(HighPassFilterApp.class, "HighPassFilterApp");
+    HttpResponse response = GatewayFastTestsSuite.deploy(HighPassFilterApp.class, "HighPassFilterApp",
+                                                         TEMP_FOLDER.newFolder());
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
     //Set flow runtime arg threshold to 30
     JsonObject json = new JsonObject();

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/StreamWriterTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/StreamWriterTestRun.java
@@ -35,7 +35,8 @@ public class StreamWriterTestRun extends GatewayTestBase {
 
   @Test
   public void testStreamWrites() throws Exception {
-    HttpResponse response = GatewayFastTestsSuite.deploy(AppWritingtoStream.class, AppWritingtoStream.APPNAME);
+    HttpResponse response = GatewayFastTestsSuite.deploy(AppWritingtoStream.class, AppWritingtoStream.APPNAME,
+                                                         TEMP_FOLDER.newFolder());
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
     //Start Flow
     response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/flows/%s/start",

--- a/cdap-proto/pom.xml
+++ b/cdap-proto/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -35,6 +35,10 @@
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-api</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
- Copy and modify the guava TypeToken class
  - Copy guava classes needed by the TypeToken class
  - Restrict copying all dependent classes by:
    - Removing usage on Immutable collections
    - Partially copy certain core guava classes
- Added missing guava dependencies that used to come from
  cdap-api transitively

This is the final PR for removing guava from cdap-api.
Also, please don't comment on the style/code/comment in the copied guava classes.