### PR TITLE
Fix broken links.

### DIFF
--- a/cdap-docs/admin-manual/source/cdap-components.rst
+++ b/cdap-docs/admin-manual/source/cdap-components.rst
@@ -26,8 +26,9 @@ configuration is set in the ``cdap-site.xml`` file (documented in :ref:`an appen
 installation procedure steps detailed in later sections. You edit a version of this file
 to configure CDAP to your specific requirements prior to starting CDAP services.
 
-CDAP generates log files. The location can be customized, but unless you have changed from
-the default, they will be located in ``/var/log/cdap``.
+CDAP generates log files, following the settings in the configuration file ``logback.xml``, using
+`Logback <http://logback.qos.ch/>`__. Logs (for Distributed CDAP) are located in ``/var/log/cdap``.
+For Standalone CDAP, they are located in ``<CDAP-SDK-HOME>/logs``.
 
 If you have :ref:`CDAP Security <admin-security>` enabled, then you will have an
 additional file, ``cdap-security.xml`` (documented in :ref:`an appendix

--- a/cdap-docs/developers-manual/source/advanced/application-logback.rst
+++ b/cdap-docs/developers-manual/source/advanced/application-logback.rst
@@ -10,16 +10,19 @@ Application Logbacks
 
 .. highlight:: xml
 
-YARN containers launched by a CDAP application use the default container logback file
-present in :ref:Configuration <install-configuration> directory - ``logback-container.xml``,
-packaged with CDAP. This logback does log rotation once every day at midnight and
-deletes logs older than 14 days. Depending on the use case, the default configuration may be sufficient.
-However, it is also possible to specify a custom ``logback.xml`` for a CDAP application by packaging
+YARN containers launched by a CDAP application use a default container logback file
+|---| ``logback-container.xml`` |---| packaged with CDAP and installed in 
+the CDAP :ref:`configuration directory <admin-manual-cdap-components>`. This logback does
+log rotation once every day at midnight and deletes logs older than 14 days. Depending on
+the use case, the default configuration may be sufficient.
+
+However, you can specify a custom ``logback.xml`` for a CDAP application by packaging
 it with the application in the application's ``src/main/resources`` directory.
 The packaged ``logback.xml`` is then used for each container launched by the application.
 
-To write a custom logback, you may refer to `Logback <http://logback.qos.ch/>`__.
+To write a custom logback, refer to `Logback <http://logback.qos.ch/>`__ for information.
 
-**Note:** When a custom ``logback.xml`` is specified for an application, the custom ``logback.xml``
-will be used in place of ``logback-container.xml``. The custom ``logback.xml`` needs to be configured
-for log rotation and log clean-up to ensure that long-running containers don't fill up the disk.
+**Note:** When a custom ``logback.xml`` is specified for an application, the custom
+``logback.xml`` will be used in place of the ``logback-container.xml``. A custom
+``logback.xml`` needs to be configured for log rotation (``rollingPolicy``) and log
+clean-up (``maxHistory``) to ensure that long-running containers don't fill up the disk.

--- a/cdap-docs/developers-manual/source/advanced/index.rst
+++ b/cdap-docs/developers-manual/source/advanced/index.rst
@@ -11,9 +11,9 @@ Advanced Topics
 .. toctree::
    :maxdepth: 1
    
-    Application Logback <application-logback>
     Best Practices <best-practices>
     Class Loading <class-loading>
+    Application Logback <application-logback>
 
 
 This section of the documentation includes articles that cover advanced topics on CDAP that


### PR DESCRIPTION
- Fixes a broken link.
- Rewrites the "Application Logback" section to include useful links.
- Re-orders an index that did not match other content.
- Adds logging info to the CDAP components page.

Building [Quick Build 2](http://builds.cask.co/browse/CDAP-DOB135-2).

Pages of interest:
- [Advanced Topics](http://builds.cask.co/artifact/CDAP-DOB135/shared/build-2/Docs-HTML/3.3.2-SNAPSHOT/en/developers-manual/advanced/index.html)
- [Application Logback](http://builds.cask.co/artifact/CDAP-DOB135/shared/build-2/Docs-HTML/3.3.2-SNAPSHOT/en/developers-manual/advanced/application-logback.html)
- [CDAP Components](http://builds.cask.co/artifact/CDAP-DOB135/shared/build-2/Docs-HTML/3.3.2-SNAPSHOT/en/admin-manual/cdap-components.html#admin-manual-cdap-components)