### PR TITLE
Adding getApplicationManager() method to IntegrationTestBase

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -299,6 +299,10 @@ public abstract class IntegrationTestBase {
     return deployApplication(Id.Namespace.DEFAULT, applicationClz);
   }
 
+  protected ApplicationManager getApplicationManager(Id.Application appId) throws Exception {
+    return getTestManager().getApplicationManager(appId);
+  }
+
   private boolean isUserDataset(DatasetSpecificationSummary specification) {
     final DefaultDatasetNamespace dsNamespace = new DefaultDatasetNamespace(CConfiguration.create());
     return !dsNamespace.contains(specification.getName(), Id.Namespace.SYSTEM.getId());

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -167,6 +167,11 @@ public class IntegrationTestManager implements TestManager {
   public ApplicationManager deployApplication(Id.Application appId,
                                               AppRequest appRequest) throws Exception {
     applicationClient.deploy(appId, appRequest);
+    return new RemoteApplicationManager(appId, clientConfig, restClient);
+  }
+
+  @Override
+  public ApplicationManager getApplicationManager(Id.Application appId) {
     return new RemoteApplicationManager(appId, clientConfig, restClient);
   }
 

--- a/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
+++ b/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -55,9 +55,19 @@ public class IntegrationTestBaseTest extends IntegrationTestBase {
     Assert.assertEquals(0, new ApplicationClient(defaultClientConfig).list(Id.Namespace.DEFAULT).size());
 
     ApplicationClient applicationClient = new ApplicationClient(clientConfig);
-    Assert.assertEquals("TestApplication", applicationClient.list(namespace).get(0).getName());
-    applicationClient.delete(Id.Application.from(namespace, "TestApplication"));
+    Assert.assertEquals(TestApplication.NAME, applicationClient.list(namespace).get(0).getName());
+    applicationClient.delete(Id.Application.from(namespace, TestApplication.NAME));
     Assert.assertEquals(0, new ApplicationClient(clientConfig).list(namespace).size());
+
+  }
+
+  @Test
+  public void testGetApplicationManager() throws Exception {
+    ApplicationManager applicationManager = deployApplication(TestApplication.class);
+    ApplicationManager testApplicationManager = getApplicationManager(Id.Application.from(Id.Namespace.DEFAULT,
+                                                                                          TestApplication.NAME));
+    Assert.assertEquals(applicationManager.getFlowManager(TestFlow.NAME).getFlowletInstances(TestFlowlet.NAME),
+                        testApplicationManager.getFlowManager(TestFlow.NAME).getFlowletInstances(TestFlowlet.NAME));
 
   }
 }

--- a/cdap-integration-test/src/test/java/co/cask/cdap/test/TestApplication.java
+++ b/cdap-integration-test/src/test/java/co/cask/cdap/test/TestApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,6 +22,7 @@ import co.cask.cdap.api.app.AbstractApplication;
  *
  */
 public final class TestApplication extends AbstractApplication {
+  public static final String NAME = "TestApplication";
 
   @Override
   public void configure() {

--- a/cdap-integration-test/src/test/java/co/cask/cdap/test/TestFlow.java
+++ b/cdap-integration-test/src/test/java/co/cask/cdap/test/TestFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,11 +26,12 @@ public final class TestFlow extends AbstractFlow {
   public static final String NAME = "SomeFlow";
   public static final String INPUT_STREAM = "someStream";
 
+
   @Override
   protected void configureFlow() {
     setName(NAME);
     setDescription("SomeDescription");
-    addFlowlet("theFlowlet", new TestFlowlet());
+    addFlowlet(TestFlowlet.NAME, new TestFlowlet());
     connectStream(INPUT_STREAM, "theFlowlet");
   }
 }

--- a/cdap-integration-test/src/test/java/co/cask/cdap/test/TestFlowlet.java
+++ b/cdap-integration-test/src/test/java/co/cask/cdap/test/TestFlowlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,6 +24,7 @@ import co.cask.cdap.api.flow.flowlet.StreamEvent;
  *
  */
 public final class TestFlowlet extends AbstractFlowlet {
+  public static final String NAME = "theFlowlet";
 
   @ProcessInput
   public void process(StreamEvent event) {

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -73,6 +73,14 @@ public interface TestManager {
    * @return An {@link ApplicationManager} to manage the deployed application.
    */
   ApplicationManager deployApplication(Id.Application appId, AppRequest appRequest) throws Exception;
+
+  /**
+   * Gets an Application Manager for an {@link Application}.
+   *
+   * @param appId the id of deployed application
+   * @return An {@link ApplicationManager} to manage the deployed application.
+   */
+  ApplicationManager getApplicationManager(Id.Application appId) throws Exception;
 
   /**
    * Add the specified artifact.

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/ApplicationManagerFactory.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/ApplicationManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,12 +19,11 @@ package co.cask.cdap.test.internal;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.ApplicationManager;
 import com.google.inject.assistedinject.Assisted;
-import org.apache.twill.filesystem.Location;
 
 /**
  *
  */
 public interface ApplicationManagerFactory {
 
-  ApplicationManager create(@Assisted("applicationId") Id.Application applicationId, Location deployedJar);
+  ApplicationManager create(@Assisted("applicationId") Id.Application applicationId);
 }


### PR DESCRIPTION
Changes made in TestManager to get ApplicationManager. This change is required for long running tests. Cherry-picked changes from #5200 .

release build: http://builds.cask.co/browse/CDAP-RBT650-1