### PR TITLE
Implementation of creating and deleting the local datasets.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.workflow;
 
 import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.dataset.DatasetProperties;
 
 import java.util.Map;
 
@@ -125,5 +126,27 @@ public abstract class AbstractWorkflow implements Workflow {
   protected final WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(
     Predicate<WorkflowContext> predicate) {
     return configurer.condition(predicate);
+  }
+
+  /**
+   * Adds a local dataset instance to the {@link Workflow}.
+   * See {@link co.cask.cdap.api.dataset.DatasetDefinition} for details.
+   *
+   * @param datasetName name of the dataset instance
+   * @param typeName name of the dataset type
+   * @param properties dataset instance properties
+   */
+  protected final void createLocalDataset(String datasetName, String typeName, DatasetProperties properties) {
+    configurer.createLocalDataset(datasetName, typeName, properties);
+  }
+
+  /**
+   * Adds a local dataset instance with {@link DatasetProperties#EMPTY} to the {@link Workflow}.
+   *
+   * @param datasetName name of the dataset instance
+   * @param typeName name of the dataset type
+   */
+  protected final void createLocalDataset(String datasetName, String typeName) {
+    createLocalDataset(datasetName, typeName, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.workflow;
 
 import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetProperties;
 
 import java.util.Map;
@@ -129,8 +130,10 @@ public abstract class AbstractWorkflow implements Workflow {
   }
 
   /**
-   * Adds a local dataset instance to the {@link Workflow}.
-   * See {@link co.cask.cdap.api.dataset.DatasetDefinition} for details.
+   * Adds a local dataset instance to the {@link Workflow}. Local datasets are created at the
+   * start of every {@code Workflow} run and deleted once the run is complete. User can decide to
+   * keep the local datasets even after the run is complete by specifying the appropriate runtime
+   * arguments.
    *
    * @param datasetName name of the dataset instance
    * @param typeName name of the dataset type
@@ -142,11 +145,44 @@ public abstract class AbstractWorkflow implements Workflow {
 
   /**
    * Adds a local dataset instance with {@link DatasetProperties#EMPTY} to the {@link Workflow}.
+   * Local datasets are created at the start of every {@code Workflow} run and deleted once the run
+   * is complete. User can decide to keep the local datasets even after the run is complete by
+   * specifying the appropriate runtime arguments.
    *
    * @param datasetName name of the dataset instance
    * @param typeName name of the dataset type
    */
   protected final void createLocalDataset(String datasetName, String typeName) {
     createLocalDataset(datasetName, typeName, DatasetProperties.EMPTY);
+  }
+
+  /**
+   * Adds a local dataset instance to the {@link Workflow}. Also deploys the dataset type
+   * represented by the datasetClass parameter in the current namespace. Local datasets are created
+   * at the start of every {@code Workflow} run and deleted once the run is complete. User can decide
+   * to keep the local datasets even after the run is complete by specifying the appropriate runtime
+   * arguments.
+   *
+   * @param datasetName name of the dataset instance
+   * @param datasetClass dataset class to create the Dataset type from
+   * @param props dataset instance properties
+   */
+  protected final void createLocalDataset(String datasetName, Class<? extends Dataset> datasetClass,
+                                          DatasetProperties props) {
+    configurer.createLocalDataset(datasetName, datasetClass, props);
+  }
+
+  /**
+   * Adds a local dataset instance with {@link DatasetProperties#EMPTY} to the {@link Workflow}.
+   * Also deploys the dataset type represented by the datasetClass parameter in the current namespace.
+   * Local datasets are created at the start of every {@code Workflow} run and deleted once the run
+   * is complete. User can decide to keep the local datasets even after the run is complete by specifying
+   * the appropriate runtime arguments.
+   *
+   * @param datasetName name of the dataset instance
+   * @param datasetClass dataset class to create the Dataset type from
+   */
+  protected final void createLocalDataset(String datasetName, Class<? extends Dataset> datasetClass) {
+    createLocalDataset(datasetName, datasetClass, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,8 @@ package co.cask.cdap.api.workflow;
 
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.api.ProgramConfigurer;
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.dataset.DatasetProperties;
 
 /**
  * Configurer for configuring the {@link Workflow}.
@@ -63,4 +65,15 @@ public interface WorkflowConfigurer extends ProgramConfigurer {
    * @return the configurer for the condition
    */
   WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(Predicate<WorkflowContext> condition);
+
+  /**
+   * Adds a local dataset instance to the {@link Workflow}.
+   * See {@link co.cask.cdap.api.dataset.DatasetDefinition} for details.
+   *
+   * @param datasetName name of the dataset instance
+   * @param typeName name of the dataset type
+   * @param properties dataset instance properties
+   */
+  @Beta
+  void createLocalDataset(String datasetName, String typeName, DatasetProperties properties);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
@@ -19,6 +19,7 @@ package co.cask.cdap.api.workflow;
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.api.ProgramConfigurer;
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetProperties;
 
 /**
@@ -67,7 +68,10 @@ public interface WorkflowConfigurer extends ProgramConfigurer {
   WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(Predicate<WorkflowContext> condition);
 
   /**
-   * Adds a local dataset instance to the {@link Workflow}.
+   * Adds a local dataset instance to the {@link Workflow}. Local datasets are created at the
+   * start of every {@code Workflow} run and deleted once the run is complete. User can decide to
+   * keep the local datasets even after the run is complete by specifying the appropriate runtime
+   * arguments.
    * See {@link co.cask.cdap.api.dataset.DatasetDefinition} for details.
    *
    * @param datasetName name of the dataset instance
@@ -76,4 +80,18 @@ public interface WorkflowConfigurer extends ProgramConfigurer {
    */
   @Beta
   void createLocalDataset(String datasetName, String typeName, DatasetProperties properties);
+
+  /**
+   * Adds a local dataset instance to the {@link Workflow}. Also deploys the dataset type
+   * represented by the datasetClass parameter in the current namespace. Local datasets are created
+   * at the start of every {@code Workflow} run and deleted once the run is complete. User can decide
+   * to keep the local datasets even after the run is complete by specifying the appropriate runtime
+   * arguments.
+   *
+   * @param datasetName dataset instance name
+   * @param datasetClass dataset class to create the Dataset type from
+   * @param props dataset instance properties
+   */
+  @Beta
+  void createLocalDataset(String datasetName, Class<? extends Dataset> datasetClass, DatasetProperties props);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
@@ -17,6 +17,7 @@ package co.cask.cdap.api.workflow;
 
 import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.common.PropertyProvider;
+import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,9 +37,11 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
   private final Map<String, String> properties;
   private final List<WorkflowNode> nodes;
   private final Map<String, WorkflowNode> nodeIdMap;
+  private final Map<String, DatasetCreationSpec> localDatasetSpecs;
 
   public WorkflowSpecification(String className, String name, String description,
-                               Map<String, String> properties, List<WorkflowNode> nodes) {
+                               Map<String, String> properties, List<WorkflowNode> nodes,
+                               Map<String, DatasetCreationSpec> localDatasetSpecs) {
     this.className = className;
     this.name = name;
     this.description = description;
@@ -46,6 +49,7 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
                                            Collections.unmodifiableMap(new HashMap<>(properties));
     this.nodes = Collections.unmodifiableList(new ArrayList<>(nodes));
     this.nodeIdMap = Collections.unmodifiableMap(generateNodeIdMap(nodes));
+    this.localDatasetSpecs = Collections.unmodifiableMap(new HashMap<>(localDatasetSpecs));
   }
 
   /**
@@ -113,6 +117,10 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
     return nodeIdMap;
   }
 
+  public Map<String, DatasetCreationSpec> getLocalDatasetSpecs() {
+    return localDatasetSpecs;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("WorkflowSpecification{");
@@ -121,6 +129,7 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
     sb.append(", description='").append(description).append('\'');
     sb.append(", properties=").append(properties);
     sb.append(", nodes=").append(nodes);
+    sb.append(", localDatasetSpecs=").append(localDatasetSpecs);
     sb.append('}');
     return sb.toString();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
@@ -149,7 +149,7 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
   @Override
   public void addWorkflow(Workflow workflow) {
     Preconditions.checkArgument(workflow != null, "Workflow cannot be null.");
-    DefaultWorkflowConfigurer configurer = new DefaultWorkflowConfigurer(workflow);
+    DefaultWorkflowConfigurer configurer = new DefaultWorkflowConfigurer(workflow, this);
     workflow.configure(configurer);
     WorkflowSpecification spec = configurer.createSpecification();
     workflows.put(spec.getName(), spec);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -38,6 +38,8 @@ public final class ProgramOptionConstants {
   public static final String PROGRAM_NAME_IN_WORKFLOW = "programNameInWorkflow";
 
   public static final String WORKFLOW_TOKEN = "workflowToken";
+
+  public static final String WORKFLOW_LOCAL_DATASET_NAME_MAPPING = "workflowLocalDatasetNameMapping";
 
   public static final String WORKFLOW_RUN_ID = "workflowRunId";
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -42,6 +42,7 @@ import co.cask.cdap.internal.app.runtime.batch.dataset.DatasetInputFormatProvide
 import co.cask.cdap.internal.app.runtime.batch.dataset.DatasetOutputFormatProvider;
 import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.internal.app.runtime.workflow.ForwardingDatasetFramework;
 import co.cask.cdap.logging.context.MapReduceLoggingContext;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionContext;
@@ -77,6 +78,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   private final StreamAdmin streamAdmin;
   private final File pluginArchive;
   private final Map<String, LocalizeResource> resourcesToLocalize;
+  private final Map<String, String> localDatasetNameMapping;
 
   private InputFormatProvider inputFormatProvider;
 
@@ -101,6 +103,11 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     super(program, runId, runtimeArguments, Collections.<String>emptySet(),
           getMetricsCollector(program, runId.getId(), metricsCollectionService),
           dsFramework, txClient, discoveryServiceClient, false, pluginInstantiator);
+    if (dsFramework instanceof ForwardingDatasetFramework) {
+      localDatasetNameMapping = ((ForwardingDatasetFramework) dsFramework).getDatasetNameMapping();
+    } else {
+      localDatasetNameMapping = null;
+    }
     this.logicalStartTime = logicalStartTime;
     this.programNameInWorkflow = programNameInWorkflow;
     this.workflowToken = workflowToken;
@@ -342,5 +349,10 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     }
     return new DatasetInputFormatProvider(datasetName, datasetArgs, getDataset(datasetName, datasetArgs),
                                           splits, MapReduceBatchReadableInputFormat.class);
+  }
+
+  @Nullable
+  public Map<String, String> getLocalDatasetNameMapping() {
+    return localDatasetNameMapping;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -61,6 +61,8 @@ public final class MapReduceContextConfig {
   private static final String HCONF_ATTR_LOGICAL_START_TIME = "hconf.program.logical.start.time";
   private static final String HCONF_ATTR_PROGRAM_NAME_IN_WORKFLOW = "hconf.program.name.in.workflow";
   private static final String HCONF_ATTR_WORKFLOW_TOKEN = "hconf.program.workflow.token";
+  private static final String HCONF_ATTR_WORKFLOW_LOCAL_DATASET_NAME_MAPPING
+    = "hconf.program.workflow.localdatasetnamemapping";
   private static final String HCONF_ATTR_PLUGINS = "hconf.program.plugins.map";
   private static final String HCONF_ATTR_ARGS = "hconf.program.args";
   private static final String HCONF_ATTR_PROGRAM_JAR_URI = "hconf.program.jar.uri";
@@ -93,6 +95,7 @@ public final class MapReduceContextConfig {
     setLogicalStartTime(context.getLogicalStartTime());
     setProgramNameInWorkflow(context.getProgramNameInWorkflow());
     setWorkflowToken(context.getWorkflowToken());
+    setLocalDatasetNameMapping(context.getLocalDatasetNameMapping());
     setPlugins(context.getPlugins());
     setArguments(context.getRuntimeArguments());
     setProgramJarURI(programJarURI);
@@ -171,6 +174,26 @@ public final class MapReduceContextConfig {
     BasicWorkflowToken token = GSON.fromJson(tokenJson, BasicWorkflowToken.class);
     token.disablePut();
     return token;
+  }
+
+  /**
+   * Returns the mapping of the local dataset names to the names assigned to them for the current run of the Workflow.
+   */
+  @Nullable
+  public Map<String, String> getLocalDatasetNameMapping() {
+    String mappingJson = hConf.get(HCONF_ATTR_WORKFLOW_LOCAL_DATASET_NAME_MAPPING);
+    if (mappingJson == null) {
+      return null;
+    }
+
+    Type type = new TypeToken<Map<String, String>>() { }.getType();
+    return GSON.fromJson(mappingJson, type);
+  }
+
+  private void setLocalDatasetNameMapping(@Nullable Map<String, String> localDatasetNameMapping) {
+    if (localDatasetNameMapping != null) {
+      hConf.set(HCONF_ATTR_WORKFLOW_LOCAL_DATASET_NAME_MAPPING, GSON.toJson(localDatasetNameMapping));
+    }
   }
 
   private void setPlugins(Map<String, Plugin> plugins) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/AbstractProgramWorkflowRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/AbstractProgramWorkflowRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -63,10 +63,12 @@ public abstract class AbstractProgramWorkflowRunner implements ProgramWorkflowRu
   protected final ProgramRunnerFactory programRunnerFactory;
   protected final Program workflowProgram;
   protected final WorkflowToken token;
+  protected final Map<String, String> localDatasetNameMapping;
 
   public AbstractProgramWorkflowRunner(Program workflowProgram, ProgramOptions workflowProgramOptions,
                                        ProgramRunnerFactory programRunnerFactory, WorkflowSpecification workflowSpec,
-                                       WorkflowToken token, String nodeId) {
+                                       WorkflowToken token, String nodeId,
+                                       Map<String, String> localDatasetNameMapping) {
     this.userArguments = workflowProgramOptions.getUserArguments();
     this.workflowProgram = workflowProgram;
     this.programRunnerFactory = programRunnerFactory;
@@ -74,6 +76,7 @@ public abstract class AbstractProgramWorkflowRunner implements ProgramWorkflowRu
     this.systemArguments = workflowProgramOptions.getArguments();
     this.token = token;
     this.nodeId = nodeId;
+    this.localDatasetNameMapping = localDatasetNameMapping;
   }
 
   @Override
@@ -102,6 +105,8 @@ public abstract class AbstractProgramWorkflowRunner implements ProgramWorkflowRu
     systemArgumentsMap.put(ProgramOptionConstants.WORKFLOW_NODE_ID, nodeId);
     systemArgumentsMap.put(ProgramOptionConstants.PROGRAM_NAME_IN_WORKFLOW, name);
     systemArgumentsMap.put(ProgramOptionConstants.WORKFLOW_TOKEN, GSON.toJson(token));
+    systemArgumentsMap.put(ProgramOptionConstants.WORKFLOW_LOCAL_DATASET_NAME_MAPPING,
+                           GSON.toJson(localDatasetNameMapping));
 
     final ProgramOptions options = new SimpleProgramOptions(
       program.getName(),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ForwardingDatasetFramework.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ForwardingDatasetFramework.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.runtime.workflow;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.workflow.Workflow;
+import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
+import co.cask.cdap.proto.DatasetSpecificationSummary;
+import co.cask.cdap.proto.Id;
+import org.apache.twill.filesystem.Location;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Implementation of the {@link DatasetFramework} which forwards all calls to the underlying
+ * dataset framework. Before forwarding the calls, local dataset names are mapped to the names
+ * assigned to them for the current run of the {@link Workflow}.
+ */
+public class ForwardingDatasetFramework implements DatasetFramework {
+
+  private final DatasetFramework delegate;
+  private final Map<String, String> datasetNameMapping;
+
+  public ForwardingDatasetFramework(DatasetFramework delegate, Map<String, String> datasetNameMapping) {
+    this.delegate = delegate;
+    this.datasetNameMapping = datasetNameMapping;
+  }
+
+  public Map<String, String> getDatasetNameMapping() {
+    return datasetNameMapping;
+  }
+
+  @Override
+  public void addModule(Id.DatasetModule moduleId, DatasetModule module) throws DatasetManagementException {
+    delegate.addModule(moduleId, module);
+  }
+
+  @Override
+  public void addModule(Id.DatasetModule moduleId, DatasetModule module, Location jarLocation)
+    throws DatasetManagementException {
+    delegate.addModule(moduleId, module, jarLocation);
+  }
+
+  @Override
+  public void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException {
+    delegate.deleteModule(moduleId);
+  }
+
+  @Override
+  public void deleteAllModules(Id.Namespace namespaceId) throws DatasetManagementException {
+    delegate.deleteAllModules(namespaceId);
+  }
+
+  @Override
+  public void addInstance(String datasetTypeName, Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+    throws IOException, DatasetManagementException {
+    delegate.addInstance(datasetTypeName, getMappedDatasetInstance(datasetInstanceId), props);
+  }
+
+  @Override
+  public void updateInstance(Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+    throws DatasetManagementException, IOException {
+    delegate.updateInstance(getMappedDatasetInstance(datasetInstanceId), props);
+  }
+
+  @Override
+  public Collection<DatasetSpecificationSummary> getInstances(Id.Namespace namespaceId)
+    throws DatasetManagementException {
+    return delegate.getInstances(namespaceId);
+  }
+
+  @Nullable
+  @Override
+  public DatasetSpecification getDatasetSpec(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+    return delegate.getDatasetSpec(getMappedDatasetInstance(datasetInstanceId));
+  }
+
+  @Override
+  public boolean hasInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+    return delegate.hasInstance(getMappedDatasetInstance(datasetInstanceId));
+  }
+
+  @Override
+  public boolean hasSystemType(String typeName) throws DatasetManagementException {
+    return delegate.hasSystemType(typeName);
+  }
+
+  @Override
+  public boolean hasType(Id.DatasetType datasetTypeId) throws DatasetManagementException {
+    return delegate.hasType(datasetTypeId);
+  }
+
+  @Override
+  public void deleteInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException, IOException {
+    delegate.deleteInstance(getMappedDatasetInstance(datasetInstanceId));
+  }
+
+  @Override
+  public void deleteAllInstances(Id.Namespace namespaceId) throws DatasetManagementException, IOException {
+    delegate.deleteAllInstances(namespaceId);
+  }
+
+  @Nullable
+  @Override
+  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader)
+    throws DatasetManagementException, IOException {
+    return delegate.getAdmin(getMappedDatasetInstance(datasetInstanceId), classLoader);
+  }
+
+  @Nullable
+  @Override
+  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader,
+                                             DatasetClassLoaderProvider classLoaderProvider)
+    throws DatasetManagementException, IOException {
+    return delegate.getAdmin(getMappedDatasetInstance(datasetInstanceId), classLoader, classLoaderProvider);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader, @Nullable Iterable<? extends Id> owners)
+    throws DatasetManagementException, IOException {
+    return delegate.getDataset(getMappedDatasetInstance(datasetInstanceId), arguments, classLoader, owners);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader)
+    throws DatasetManagementException, IOException {
+    return delegate.getDataset(getMappedDatasetInstance(datasetInstanceId), arguments, classLoader);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader,
+                                          DatasetClassLoaderProvider classLoaderProvider,
+                                          @Nullable Iterable<? extends Id> owners)
+    throws DatasetManagementException, IOException {
+    return delegate.getDataset(getMappedDatasetInstance(datasetInstanceId), arguments, classLoader,
+                               classLoaderProvider, owners);
+  }
+
+  @Override
+  public void createNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
+    delegate.createNamespace(namespaceId);
+  }
+
+  @Override
+  public void deleteNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
+    delegate.deleteNamespace(namespaceId);
+  }
+
+  private Id.DatasetInstance getMappedDatasetInstance(Id.DatasetInstance datasetInstanceId) {
+    if (datasetNameMapping.containsKey(datasetInstanceId.getId())) {
+      return Id.DatasetInstance.from(datasetInstanceId.getNamespaceId(),
+                                     datasetNameMapping.get(datasetInstanceId.getId()));
+    }
+    return datasetInstanceId;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/MapReduceProgramWorkflowRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/MapReduceProgramWorkflowRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -44,8 +44,9 @@ final class MapReduceProgramWorkflowRunner extends AbstractProgramWorkflowRunner
 
   MapReduceProgramWorkflowRunner(WorkflowSpecification workflowSpec, ProgramRunnerFactory programRunnerFactory,
                                  Program workflowProgram, ProgramOptions workflowProgramOptions, WorkflowToken token,
-                                 String nodeId) {
-    super(workflowProgram, workflowProgramOptions, programRunnerFactory, workflowSpec, token, nodeId);
+                                 String nodeId, Map<String, String> localDatasetNameMapping) {
+    super(workflowProgram, workflowProgramOptions, programRunnerFactory, workflowSpec, token, nodeId,
+          localDatasetNameMapping);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ProgramWorkflowRunnerFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ProgramWorkflowRunnerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,6 +28,8 @@ import co.cask.cdap.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.internal.workflow.ProgramWorkflowAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 
 /**
  * A Factory for {@link ProgramWorkflowRunner} which returns the appropriate {@link ProgramWorkflowRunner}
@@ -61,16 +63,16 @@ public class ProgramWorkflowRunnerFactory {
    * @return the appropriate concrete implementation of {@link ProgramWorkflowRunner} for the program
    */
   public ProgramWorkflowRunner getProgramWorkflowRunner(WorkflowActionSpecification actionSpec, WorkflowToken token,
-                                                        String nodeId) {
+                                                        String nodeId, Map<String, String> localDatasetNameMapping) {
 
     if (actionSpec.getProperties().containsKey(ProgramWorkflowAction.PROGRAM_TYPE)) {
       switch (SchedulableProgramType.valueOf(actionSpec.getProperties().get(ProgramWorkflowAction.PROGRAM_TYPE))) {
         case MAPREDUCE:
           return new MapReduceProgramWorkflowRunner(workflowSpec, programRunnerFactory, workflowProgram, 
-                                                    workflowProgramOptions, token, nodeId);
+                                                    workflowProgramOptions, token, nodeId, localDatasetNameMapping);
         case SPARK:
           return new SparkProgramWorkflowRunner(workflowSpec, programRunnerFactory, workflowProgram,
-                                                workflowProgramOptions, token, nodeId);
+                                                workflowProgramOptions, token, nodeId, localDatasetNameMapping);
         default:
           LOG.debug("No workflow program runner found for this program");
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/SparkProgramWorkflowRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/SparkProgramWorkflowRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -30,6 +30,8 @@ import co.cask.cdap.internal.app.runtime.spark.SparkProgramController;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
 
+import java.util.Map;
+
 /**
  * Creates {@link Runnable} for executing {@link Spark} programs from {@link Workflow}.
  */
@@ -37,8 +39,9 @@ final class SparkProgramWorkflowRunner extends AbstractProgramWorkflowRunner {
 
   SparkProgramWorkflowRunner(WorkflowSpecification workflowSpec, ProgramRunnerFactory programRunnerFactory,
                              Program workflowProgram, ProgramOptions workflowProgramOptions, WorkflowToken token,
-                             String nodeId) {
-    super(workflowProgram, workflowProgramOptions, programRunnerFactory, workflowSpec, token, nodeId);
+                             String nodeId, Map<String, String> localDatasetNameMapping) {
+    super(workflowProgram, workflowProgramOptions, programRunnerFactory, workflowSpec, token, nodeId,
+          localDatasetNameMapping);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.workflow;
 
 import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowAction;
@@ -28,9 +29,11 @@ import co.cask.cdap.api.workflow.WorkflowForkConfigurer;
 import co.cask.cdap.api.workflow.WorkflowForkNode;
 import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -43,6 +46,7 @@ public class DefaultWorkflowConfigurer implements WorkflowConfigurer, WorkflowFo
   private String name;
   private String description;
   private Map<String, String> properties;
+  private final Map<String, DatasetCreationSpec> localDatasetSpecs = new HashMap<>();
   private int nodeIdentifier = 0;
 
   private final List<WorkflowNode> nodes = Lists.newArrayList();
@@ -94,8 +98,32 @@ public class DefaultWorkflowConfigurer implements WorkflowConfigurer, WorkflowFo
                                                     predicate.getClass().getName());
   }
 
+  private void checkArgument(boolean condition, String template, Object...args) {
+    if (!condition) {
+      throw new IllegalArgumentException(String.format(template, args));
+    }
+  }
+
+  @Override
+  public void createLocalDataset(String datasetName, String typeName, DatasetProperties properties) {
+    checkArgument(datasetName != null, "Dataset instance name cannot be null.");
+    checkArgument(typeName != null, "Dataset type name cannot be null.");
+    checkArgument(properties != null, "Instance properties name cannot be null.");
+
+    DatasetCreationSpec spec = new DatasetCreationSpec(datasetName, typeName, properties);
+    DatasetCreationSpec existingSpec = localDatasetSpecs.get(datasetName);
+    if (existingSpec != null && !existingSpec.equals(spec)) {
+      throw new IllegalArgumentException(String.format("DatasetInstance '%s' was added multiple times with" +
+                                                         " different specifications. Please resolve the conflict so" +
+                                                         " that there is only one specification for the local dataset" +
+                                                         " instance in the Workflow.", datasetName));
+    }
+    localDatasetSpecs.put(datasetName, spec);
+  }
+
   public WorkflowSpecification createSpecification() {
-    return new WorkflowSpecification(className, name, description, properties, createNodesWithId(nodes));
+    return new WorkflowSpecification(className, name, description, properties, createNodesWithId(nodes),
+                                     localDatasetSpecs);
   }
 
   private List<WorkflowNode> createNodesWithId(List<WorkflowNode> nodes) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.workflow;
 
 import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.workflow.Workflow;
@@ -29,6 +30,7 @@ import co.cask.cdap.api.workflow.WorkflowForkConfigurer;
 import co.cask.cdap.api.workflow.WorkflowForkNode;
 import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.app.DefaultAppConfigurer;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -48,13 +50,15 @@ public class DefaultWorkflowConfigurer implements WorkflowConfigurer, WorkflowFo
   private Map<String, String> properties;
   private final Map<String, DatasetCreationSpec> localDatasetSpecs = new HashMap<>();
   private int nodeIdentifier = 0;
+  private final DefaultAppConfigurer appConfigurer;
 
   private final List<WorkflowNode> nodes = Lists.newArrayList();
 
-  public DefaultWorkflowConfigurer(Workflow workflow) {
+  public DefaultWorkflowConfigurer(Workflow workflow, DefaultAppConfigurer appConfigurer) {
     this.className = workflow.getClass().getName();
     this.name = workflow.getClass().getSimpleName();
     this.description = "";
+    this.appConfigurer = appConfigurer;
   }
 
   @Override
@@ -119,6 +123,12 @@ public class DefaultWorkflowConfigurer implements WorkflowConfigurer, WorkflowFo
                                                          " instance in the Workflow.", datasetName));
     }
     localDatasetSpecs.put(datasetName, spec);
+  }
+
+  @Override
+  public void createLocalDataset(String datasetName, Class<? extends Dataset> datasetClass, DatasetProperties props) {
+    createLocalDataset(datasetName, datasetClass.getName(), props);
+    appConfigurer.addDatasetType(datasetClass);
   }
 
   public WorkflowSpecification createSpecification() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/GoodWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/GoodWorkflowApp.java
@@ -143,7 +143,7 @@ public class GoodWorkflowApp extends AbstractApplication {
   }
 
   /**
-   *
+   * Workflow configured with local datasets.
    */
   public class WorkflowWithLocalDatasets extends AbstractWorkflow {
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/GoodWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/GoodWorkflowApp.java
@@ -18,6 +18,9 @@ package co.cask.cdap;
 
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.workflow.AbstractWorkflow;
 import co.cask.cdap.api.workflow.AbstractWorkflowAction;
@@ -37,6 +40,7 @@ public class GoodWorkflowApp extends AbstractApplication {
     addMapReduce(new DummyMR());
     addWorkflow(new GoodWorkflow());
     addWorkflow(new AnotherGoodWorkflow());
+    addWorkflow(new WorkflowWithLocalDatasets());
   }
 
   /**
@@ -135,6 +139,24 @@ public class GoodWorkflowApp extends AbstractApplication {
      .end();
 
      addSpark("SP7");
+    }
+  }
+
+  /**
+   *
+   */
+  public class WorkflowWithLocalDatasets extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      setName("WorkflowWithLocalDatasets");
+      setDescription("Workflow containing local datasets.");
+      createLocalDataset("mytable", Table.class.getName());
+      createLocalDataset("myfile", FileSet.class.getName());
+      createLocalDataset("myfile_with_properties", FileSet.class.getName(),
+                         DatasetProperties.builder().add("prop_key", "prop_value").build());
+      addMapReduce("MR1");
+      addSpark("SP1");
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/GoodWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/GoodWorkflowApp.java
@@ -155,6 +155,9 @@ public class GoodWorkflowApp extends AbstractApplication {
       createLocalDataset("myfile", FileSet.class.getName());
       createLocalDataset("myfile_with_properties", FileSet.class.getName(),
                          DatasetProperties.builder().add("prop_key", "prop_value").build());
+      createLocalDataset("mytablefromtype", Table.class);
+      createLocalDataset("myfilefromtype", FileSet.class,
+                         DatasetProperties.builder().add("another_prop_key", "another_prop_value").build());
       addMapReduce("MR1");
       addSpark("SP1");
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/verification/WorkflowVerificationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/verification/WorkflowVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,8 @@ package co.cask.cdap.internal.app.verification;
 
 import co.cask.cdap.GoodWorkflowApp;
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.workflow.ScheduleProgramInfo;
 import co.cask.cdap.api.workflow.WorkflowActionNode;
@@ -28,11 +30,13 @@ import co.cask.cdap.api.workflow.WorkflowNodeType;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.app.Specifications;
+import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -43,10 +47,45 @@ public class WorkflowVerificationTest {
     ApplicationSpecification appSpec = Specifications.from(new GoodWorkflowApp());
     verifyGoodWorkflowSpecifications(appSpec);
     verifyAnotherGoodWorkflowSpecification(appSpec);
+    verifyWorkflowWithLocalDatasetSpecification(appSpec);
     ApplicationSpecificationAdapter adapter = ApplicationSpecificationAdapter.create(new ReflectionSchemaGenerator());
     ApplicationSpecification newSpec = adapter.fromJson(adapter.toJson(appSpec));
     verifyGoodWorkflowSpecifications(newSpec);
-    verifyAnotherGoodWorkflowSpecification(appSpec);
+    verifyAnotherGoodWorkflowSpecification(newSpec);
+    verifyWorkflowWithLocalDatasetSpecification(newSpec);
+  }
+
+  private void verifyWorkflowWithLocalDatasetSpecification(ApplicationSpecification appSpec) {
+    WorkflowSpecification spec = appSpec.getWorkflows().get("WorkflowWithLocalDatasets");
+    List<WorkflowNode> nodes = spec.getNodes();
+    Assert.assertTrue(nodes.size() == 2);
+
+    WorkflowNode node = nodes.get(0);
+    Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    WorkflowActionNode actionNode = (WorkflowActionNode) node;
+    Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
+                                                                             "MR1")));
+
+    node = nodes.get(1);
+    Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    actionNode = (WorkflowActionNode) node;
+    Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.SPARK,
+                                                                             "SP1")));
+
+    Map<String, DatasetCreationSpec> localDatasetSpecs = spec.getLocalDatasetSpecs();
+    Assert.assertEquals(3, localDatasetSpecs.size());
+
+    DatasetCreationSpec datasetCreationSpec = localDatasetSpecs.get("mytable");
+    Assert.assertEquals(Table.class.getName(), datasetCreationSpec.getTypeName());
+    Assert.assertEquals(0, datasetCreationSpec.getProperties().getProperties().size());
+
+    datasetCreationSpec = localDatasetSpecs.get("myfile");
+    Assert.assertEquals(FileSet.class.getName(), datasetCreationSpec.getTypeName());
+    Assert.assertEquals(0, datasetCreationSpec.getProperties().getProperties().size());
+
+    datasetCreationSpec = localDatasetSpecs.get("myfile_with_properties");
+    Assert.assertEquals(FileSet.class.getName(), datasetCreationSpec.getTypeName());
+    Assert.assertEquals("prop_value", datasetCreationSpec.getProperties().getProperties().get("prop_key"));
   }
 
   private void verifyAnotherGoodWorkflowSpecification(ApplicationSpecification appSpec) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/verification/WorkflowVerificationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/verification/WorkflowVerificationTest.java
@@ -73,7 +73,7 @@ public class WorkflowVerificationTest {
                                                                              "SP1")));
 
     Map<String, DatasetCreationSpec> localDatasetSpecs = spec.getLocalDatasetSpecs();
-    Assert.assertEquals(3, localDatasetSpecs.size());
+    Assert.assertEquals(5, localDatasetSpecs.size());
 
     DatasetCreationSpec datasetCreationSpec = localDatasetSpecs.get("mytable");
     Assert.assertEquals(Table.class.getName(), datasetCreationSpec.getTypeName());
@@ -86,6 +86,21 @@ public class WorkflowVerificationTest {
     datasetCreationSpec = localDatasetSpecs.get("myfile_with_properties");
     Assert.assertEquals(FileSet.class.getName(), datasetCreationSpec.getTypeName());
     Assert.assertEquals("prop_value", datasetCreationSpec.getProperties().getProperties().get("prop_key"));
+
+    datasetCreationSpec = localDatasetSpecs.get("mytablefromtype");
+    Assert.assertEquals(Table.class.getName(), datasetCreationSpec.getTypeName());
+    Assert.assertEquals(0, datasetCreationSpec.getProperties().getProperties().size());
+
+    datasetCreationSpec = localDatasetSpecs.get("myfilefromtype");
+    Assert.assertEquals(FileSet.class.getName(), datasetCreationSpec.getTypeName());
+    Assert.assertEquals("another_prop_value",
+                        datasetCreationSpec.getProperties().getProperties().get("another_prop_key"));
+
+    // Check if the application specification has correct modules
+    Map<String, String> datasetModules = appSpec.getDatasetModules();
+    Assert.assertEquals(2, datasetModules.size());
+    Assert.assertTrue(datasetModules.containsKey(FileSet.class.getName()));
+    Assert.assertTrue(datasetModules.containsKey(Table.class.getName()));
   }
 
   private void verifyAnotherGoodWorkflowSpecification(ApplicationSpecification appSpec) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowSpecificationCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@ package co.cask.cdap.proto.codec;
 
 import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -41,7 +42,7 @@ public final class WorkflowSpecificationCodec extends AbstractSpecificationCodec
     jsonObj.add("description", new JsonPrimitive(src.getDescription()));
     jsonObj.add("properties", serializeMap(src.getProperties(), context, String.class));
     jsonObj.add("nodes", serializeList(src.getNodes(), context, WorkflowNode.class));
-
+    jsonObj.add("localDatasetSpecs", serializeMap(src.getLocalDatasetSpecs(), context, DatasetCreationSpec.class));
     return jsonObj;
   }
 
@@ -55,7 +56,9 @@ public final class WorkflowSpecificationCodec extends AbstractSpecificationCodec
     String description = jsonObj.get("description").getAsString();
     Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
     List<WorkflowNode> nodes = deserializeList(jsonObj.get("nodes"), context, WorkflowNode.class);
+    Map<String, DatasetCreationSpec> localDatasetSpec = deserializeMap(jsonObj.get("localDatasetSpecs"), context,
+                                                                       DatasetCreationSpec.class);
 
-    return new WorkflowSpecification(className, name, description, properties, nodes);
+    return new WorkflowSpecification(className, name, description, properties, nodes, localDatasetSpec);
   }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -95,6 +95,7 @@ import java.io.OutputStreamWriter;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.util.Collection;
@@ -435,6 +436,61 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     try (InputStream in = fs.getLocation("test").getInputStream()) {
       Assert.assertEquals(42, in.read());
     }
+  }
+
+  @Category(XSlowTests.class)
+  @Test
+  public void testWorkflowLocalDatasets() throws Exception {
+    ApplicationManager applicationManager = deployApplication(testSpace, WorkflowAppWithLocalDatasets.class);
+    final WorkflowManager wfmanager = applicationManager.getWorkflowManager("WorkflowWithLocalDatasets");
+    File waitFile = new File(tmpFolder.newFolder() + "/wait.file");
+    File doneFile = new File(tmpFolder.newFolder() + "/done.file");
+
+    // Write some data to the input file
+    File inputDir = tmpFolder.newFolder();
+
+    File inputFile = new File(inputDir.getPath() + "/words.txt");
+    try (BufferedWriter writer = Files.newBufferedWriter(inputFile.toPath(), Charsets.UTF_8)) {
+      writer.write("this text has");
+      writer.newLine();
+      writer.write("two words text inside");
+    }
+
+    wfmanager.start(ImmutableMap.of("input.path", inputDir.getAbsolutePath(), "wait.file", waitFile.getAbsolutePath(),
+                                    "done.file", doneFile.getAbsolutePath()));
+
+    // Wait till custom action in the Workflow is triggerred.
+    while (!waitFile.exists()) {
+      TimeUnit.MILLISECONDS.sleep(50);
+    }
+
+    // Now the Workflow should have RUNNING status. Get its runid.
+    List<RunRecord> history = wfmanager.getHistory(ProgramRunStatus.RUNNING);
+    Assert.assertEquals(1, history.size());
+    String runId = history.get(0).getPid();
+
+    // Get the local dataset for this Workflow run
+    DataSetManager<KeyValueTable> localDataset = getDataset(testSpace, WorkflowAppWithLocalDatasets.WORDCOUNT_DATASET
+      + "." + runId);
+    Assert.assertEquals("2", Bytes.toString(localDataset.get().read("text")));
+
+    // Local dataset should not exist at the namespace level
+    localDataset = getDataset(testSpace, WorkflowAppWithLocalDatasets.WORDCOUNT_DATASET);
+    Assert.assertNull(localDataset.get());
+
+    // Signal the Workflow to continue
+    doneFile.createNewFile();
+
+    // Wait for workflow to finish
+    wfmanager.waitForFinish(1, TimeUnit.MINUTES);
+
+    // Once the Workflow run is complete local dataset should not be available
+    localDataset = getDataset(testSpace, WorkflowAppWithLocalDatasets.WORDCOUNT_DATASET + "." + runId);
+    Assert.assertNull(localDataset.get());
+
+    // Dataset which is not local should still be available
+    DataSetManager<KeyValueTable> dataset = getDataset(testSpace, WorkflowAppWithLocalDatasets.RESULT_DATASET);
+    Assert.assertEquals("6", Bytes.toString(dataset.get().read("UniqueWordCount")));
   }
 
   @Category(XSlowTests.class)

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WorkflowAppWithLocalDatasets.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WorkflowAppWithLocalDatasets.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.annotation.UseDataSet;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+import co.cask.cdap.api.workflow.AbstractWorkflowAction;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Workflow application containing local datasets.
+ */
+public class WorkflowAppWithLocalDatasets extends AbstractApplication {
+  public static final String WORDCOUNT_DATASET = "wordcount";
+  public static final String RESULT_DATASET = "result";
+  @Override
+  public void configure() {
+    setName("WorkflowAppWithLocalDatasets");
+    setDescription("App to test the local dataset functionality for the Workflow.");
+
+    addMapReduce(new WordCount());
+    addWorkflow(new WorkflowWithLocalDatasets());
+    createDataset(RESULT_DATASET, KeyValueTable.class);
+  }
+
+  /**
+   * Workflow which configures the local dataset.
+   */
+  public static class WorkflowWithLocalDatasets extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      setName("WorkflowWithLocalDatasets");
+      setDescription("Workflow program with local datasets.");
+      createLocalDataset(WORDCOUNT_DATASET, KeyValueTable.class);
+      addMapReduce("WordCount");
+      addAction(new LocalDatasetReader());
+    }
+  }
+
+  /**
+   * MapReduce program that simply counts the number of occurrences of the words in the input files.
+   */
+  public static class WordCount extends AbstractMapReduce {
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      Map<String, String> args = context.getRuntimeArguments();
+      String inputPath = args.get("input.path");
+
+      context.addOutput(WORDCOUNT_DATASET);
+      Job job = context.getHadoopJob();
+      job.setMapperClass(TokenizerMapper.class);
+      job.setReducerClass(IntSumReducer.class);
+
+      job.setNumReduceTasks(1);
+      FileInputFormat.addInputPath(job, new Path(inputPath));
+    }
+  }
+
+  /**
+   * Mapper to tokenized the the line into words.
+   */
+  public static class TokenizerMapper extends Mapper<Object, Text, Text, IntWritable> {
+
+    private static final IntWritable ONE = new IntWritable(1);
+    private Text word = new Text();
+
+    public void map(Object key, Text value, Context context
+    ) throws IOException, InterruptedException {
+      StringTokenizer itr = new StringTokenizer(value.toString());
+      while (itr.hasMoreTokens()) {
+        word.set(itr.nextToken());
+        context.write(word, ONE);
+      }
+    }
+  }
+
+  /**
+   * Reducer to write the word counts to the local Workflow dataset.
+   */
+  public static class IntSumReducer extends Reducer<Text, IntWritable, byte[], byte[]> {
+    private IntWritable result = new IntWritable();
+
+    public void reduce(Text key, Iterable<IntWritable> values, Context context)
+      throws IOException, InterruptedException {
+      int sum = 0;
+      for (IntWritable val : values) {
+        sum += val.get();
+      }
+      result.set(sum);
+      context.write(Bytes.toBytes(key.toString()), Bytes.toBytes(String.valueOf(result.get())));
+    }
+  }
+
+  /**
+   * Custom action that reads the local dataset and writes to the non-local dataset.
+   */
+  public static class LocalDatasetReader extends AbstractWorkflowAction {
+    private static final Logger LOG = LoggerFactory.getLogger(LocalDatasetReader.class);
+
+    @UseDataSet("wordcount")
+    private KeyValueTable wordCount;
+
+    @UseDataSet("result")
+    private KeyValueTable result;
+
+    @Override
+    public void run() {
+      LOG.info("Read the local dataset");
+      try {
+        File waitFile = new File(getContext().getRuntimeArguments().get("wait.file"));
+        waitFile.createNewFile();
+
+        int uniqueWordCount = 0;
+        CloseableIterator<KeyValue<byte[], byte[]>> scanner = wordCount.scan(null, null);
+        while (scanner.hasNext()) {
+          KeyValue<byte[], byte[]> next = scanner.next();
+          uniqueWordCount++;
+        }
+        result.write("UniqueWordCount", String.valueOf(uniqueWordCount));
+        File doneFile = new File(getContext().getRuntimeArguments().get("done.file"));
+        while (!doneFile.exists()) {
+          TimeUnit.MILLISECONDS.sleep(50);
+        }
+      } catch (Exception e) {
+        // no-op
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is based on #5219. So please review that PR before this one. 

Following changes are implemented in this PR: 
1. Added implementation for creating and deleting the local datasets in the Workflow driver.
2. Using `ForwardingDatasetFramework` in the `WorkflowDriver` now which delegates the calls to the underlying dataset framework. It also maintains the mapping of the local dataset to the name assigned to them for the particular run of the Workflow which is of the form `datasetName.<workflow_run_id>`.
3. Passing the dataset name mapping to the `MapperWrapper` as well through the job configuration.

Spark related changes and deletion of the local datasets based on the the runtime argument will be done in separate PR.