### PR TITLE
CDAP-5075 support specifying a logical start time instead of current …

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/AbstractInMemoryProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/AbstractInMemoryProgramRunner.java
@@ -106,7 +106,7 @@ public abstract class AbstractInMemoryProgramRunner implements ProgramRunner {
   }
 
   private ProgramOptions createComponentOptions(String name, int instanceId, int instances, RunId runId,
-                                                           ProgramOptions options) {
+                                                ProgramOptions options) {
     Map<String, String> systemOptions = Maps.newHashMap();
     systemOptions.putAll(options.getArguments().asMap());
     systemOptions.put(ProgramOptionConstants.INSTANCE_ID, Integer.toString(instanceId));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -31,7 +31,7 @@ public final class ProgramOptionConstants {
 
   public static final String HOST = "host";
 
-  public static final String LOGICAL_START_TIME = "logicalStartTime";
+  public static final String LOGICAL_START_TIME = "logical.start.time";
 
   public static final String RETRY_COUNT = "retryCount";
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -68,7 +68,6 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
 
   private final MapReduceSpecification spec;
   private final LoggingContext loggingContext;
-  private final long logicalStartTime;
   private final WorkflowProgramInfo workflowProgramInfo;
   private final Metrics userMetrics;
   private final Map<String, Plugin> plugins;
@@ -88,7 +87,6 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
                                RunId runId,
                                Arguments runtimeArguments,
                                MapReduceSpecification spec,
-                               long logicalStartTime,
                                @Nullable WorkflowProgramInfo workflowProgramInfo,
                                DiscoveryServiceClient discoveryServiceClient,
                                MetricsCollectionService metricsCollectionService,
@@ -100,7 +98,6 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     super(program, runId, runtimeArguments, Collections.<String>emptySet(),
           getMetricsCollector(program, runId.getId(), metricsCollectionService),
           dsFramework, txClient, discoveryServiceClient, false, pluginInstantiator);
-    this.logicalStartTime = logicalStartTime;
     this.workflowProgramInfo = workflowProgramInfo;
 
     if (metricsCollectionService != null) {
@@ -148,11 +145,6 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   @Override
   public MapReduceSpecification getSpecification() {
     return spec;
-  }
-
-  @Override
-  public long getLogicalStartTime() {
-    return logicalStartTime;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -43,7 +43,6 @@ import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
-import co.cask.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
 import co.cask.cdap.internal.app.runtime.workflow.NameMappedDatasetFramework;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.internal.lang.Reflections;
@@ -142,11 +141,6 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
 
     final RunId runId = RunIds.fromString(arguments.getOption(ProgramOptionConstants.RUN_ID));
 
-    long logicalStartTime = arguments.hasOption(ProgramOptionConstants.LOGICAL_START_TIME)
-                                ? Long.parseLong(arguments
-                                                   .getOption(ProgramOptionConstants.LOGICAL_START_TIME))
-                                : System.currentTimeMillis();
-
     WorkflowProgramInfo workflowInfo = WorkflowProgramInfo.create(arguments);
     DatasetFramework programDatasetFramework = workflowInfo == null ?
       datasetFramework :
@@ -176,7 +170,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
 
       final BasicMapReduceContext context =
         new BasicMapReduceContext(program, runId, options.getUserArguments(), spec,
-                                  logicalStartTime, workflowInfo, discoveryServiceClient,
+                                  workflowInfo, discoveryServiceClient,
                                   metricsCollectionService, txSystemClient, programDatasetFramework, streamAdmin,
                                   getPluginArchive(options), pluginInstantiator);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DefaultSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DefaultSchedulerService.java
@@ -73,9 +73,11 @@ public class DefaultSchedulerService {
       LOG.debug("Schedule execute {}", key);
       ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
-      builder.put(ProgramOptionConstants.LOGICAL_START_TIME, Long.toString(context.getScheduledFireTime().getTime()));
       builder.put(ProgramOptionConstants.RETRY_COUNT, Integer.toString(context.getRefireCount()));
       builder.put(ProgramOptionConstants.SCHEDULE_NAME, scheduleName);
+
+      Map<String, String> userOverrides = ImmutableMap.of(ProgramOptionConstants.LOGICAL_START_TIME,
+                                                          Long.toString(context.getScheduledFireTime().getTime()));
 
       JobDataMap jobDataMap = trigger.getJobDataMap();
       for (Map.Entry<String, Object> entry : jobDataMap.entrySet()) {
@@ -83,7 +85,8 @@ public class DefaultSchedulerService {
       }
 
       try {
-        taskRunner.run(Id.Program.from(namespaceId, applicationId, programType, programId), builder.build()).get();
+        taskRunner.run(Id.Program.from(namespaceId, applicationId, programType, programId),
+                       builder.build(), userOverrides).get();
       } catch (TaskExecutionException e) {
         throw new JobExecutionException(e.getMessage(), e.getCause(), e.isRefireImmediately());
       } catch (Throwable t) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
@@ -68,12 +68,13 @@ public final class ScheduleTaskRunner {
    *
    * @param programId Program Id
    * @param systemOverrides Arguments that would be supplied as system runtime arguments for the program.
+   * @param userOverrides Arguments to add to the user runtime arguments for the program.
    * @return a {@link ListenableFuture} object that completes when the program completes
    * @throws TaskExecutionException if program is already running or program is not found.
    * @throws IOException if program failed to start.
    */
-  public ListenableFuture<?> run(Id.Program programId, Map<String, String> systemOverrides)
-    throws TaskExecutionException, IOException {
+  public ListenableFuture<?> run(Id.Program programId, Map<String, String> systemOverrides,
+                                 Map<String, String> userOverrides) throws TaskExecutionException, IOException {
     Map<String, String> userArgs = Maps.newHashMap();
     Map<String, String> systemArgs = Maps.newHashMap();
 
@@ -92,6 +93,7 @@ public final class ScheduleTaskRunner {
     // Schedule properties are overriden by resolved preferences
     userArgs.putAll(spec.getProperties());
     userArgs.putAll(propertiesResolver.getUserProperties(programId));
+    userArgs.putAll(userOverrides);
 
     systemArgs.putAll(propertiesResolver.getSystemProperties(programId));
     systemArgs.putAll(systemOverrides);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeScheduler.java
@@ -1001,6 +1001,8 @@ public class StreamSizeScheduler implements Scheduler {
       argsBuilder.put(ProgramOptionConstants.RUN_BASE_COUNT_TIME, Long.toString(basePollTs));
       argsBuilder.put(ProgramOptionConstants.RUN_BASE_COUNT_SIZE, Long.toString(basePollSize));
       argsBuilder.putAll(properties);
+      final Map<String, String> userOverrides = ImmutableMap.of(ProgramOptionConstants.LOGICAL_START_TIME,
+                                                                Long.toString(pollingInfo.getTimestamp()));
 
       if (lastRunSize != -1 && lastRunTs != -1) {
         argsBuilder.put(ProgramOptionConstants.LAST_SCHEDULED_RUN_LOGICAL_START_TIME, Long.toString(lastRunTs));
@@ -1030,7 +1032,7 @@ public class StreamSizeScheduler implements Scheduler {
                                       @Override
                                       public void execute() throws Exception {
                                         LOG.info("About to start streamSizeSchedule {}", currentSchedule.getName());
-                                        taskRunner.run(programId, argsBuilder.build());
+                                        taskRunner.run(programId, argsBuilder.build(), userOverrides);
                                       }
                                     });
         lastRunSize = pollingInfo.getSize();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
@@ -56,7 +56,7 @@ public final class ClientSparkContext extends AbstractSparkContext {
   private final File pluginArchive;
   private final Map<String, LocalizeResource> resourcesToLocalize;
 
-  public ClientSparkContext(Program program, RunId runId, long logicalStartTime, Map<String, String> runtimeArguments,
+  public ClientSparkContext(Program program, RunId runId, Map<String, String> runtimeArguments,
                             TransactionSystemClient txClient, DatasetFramework datasetFramework,
                             DiscoveryServiceClient discoveryServiceClient,
                             MetricsCollectionService metricsCollectionService,
@@ -65,7 +65,7 @@ public final class ClientSparkContext extends AbstractSparkContext {
                             @Nullable WorkflowProgramInfo workflowProgramInfo) {
     super(program.getApplicationSpecification(),
           program.getApplicationSpecification().getSpark().get(program.getName()),
-          program.getId(), runId, program.getClassLoader(), logicalStartTime,
+          program.getId(), runId, program.getClassLoader(),
           runtimeArguments, discoveryServiceClient,
           createMetricsContext(metricsCollectionService, program.getId(), runId),
           createLoggingContext(program.getId(), runId),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionSparkContext.java
@@ -108,7 +108,7 @@ public class ExecutionSparkContext extends AbstractSparkContext {
    */
   public ExecutionSparkContext(ApplicationSpecification appSpec,
                                SparkSpecification specification, Id.Program programId, RunId runId,
-                               ClassLoader programClassLoader, long logicalStartTime,
+                               ClassLoader programClassLoader,
                                Map<String, String> runtimeArguments,
                                Transaction transaction, DatasetFramework datasetFramework,
                                TransactionSystemClient txClient,
@@ -118,7 +118,7 @@ public class ExecutionSparkContext extends AbstractSparkContext {
                                Map<String, File> localizedResources,
                                @Nullable PluginInstantiator pluginInstantiator,
                                @Nullable WorkflowProgramInfo workflowProgramInfo) {
-    this(appSpec, specification, programId, runId, programClassLoader, logicalStartTime, runtimeArguments,
+    this(appSpec, specification, programId, runId, programClassLoader, runtimeArguments,
          transaction, datasetFramework, txClient, discoveryServiceClient,
          createMetricsContext(metricsCollectionService, programId, runId),
          createLoggingContext(programId, runId), hConf, streamAdmin, localizedResources, pluginInstantiator,
@@ -130,7 +130,7 @@ public class ExecutionSparkContext extends AbstractSparkContext {
    */
   public ExecutionSparkContext(ApplicationSpecification appSpec,
                                SparkSpecification specification, Id.Program programId, RunId runId,
-                               ClassLoader programClassLoader, long logicalStartTime,
+                               ClassLoader programClassLoader,
                                Map<String, String> runtimeArguments,
                                Transaction transaction, DatasetFramework datasetFramework,
                                TransactionSystemClient txClient,
@@ -140,7 +140,7 @@ public class ExecutionSparkContext extends AbstractSparkContext {
                                Map<String, File> localizedResources,
                                @Nullable PluginInstantiator pluginInstantiator,
                                @Nullable WorkflowProgramInfo workflowProgramInfo) {
-    super(appSpec, specification, programId, runId, programClassLoader, logicalStartTime,
+    super(appSpec, specification, programId, runId, programClassLoader,
           runtimeArguments, discoveryServiceClient, metricsContext, loggingContext, datasetFramework,
           pluginInstantiator, workflowProgramInfo);
     this.datasets = new HashMap<>();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextFactory.java
@@ -65,7 +65,7 @@ final class SparkContextFactory {
                                                           clientContext.getExecutorResources());
     return new ExecutionSparkContext(clientContext.getApplicationSpecification(), spec, clientContext.getProgramId(),
                                      clientContext.getRunId(), clientContext.getProgramClassLoader(),
-                                     clientContext.getLogicalStartTime(), clientContext.getRuntimeArguments(),
+                                     clientContext.getRuntimeArguments(),
                                      transaction, datasetFramework, txClient, clientContext.getDiscoveryServiceClient(),
                                      clientContext.getMetricsContext(), clientContext.getLoggingContext(),
                                      hConf, streamAdmin, localizedResources,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextProvider.java
@@ -185,7 +185,7 @@ public final class SparkContextProvider {
       sparkContext = new ExecutionSparkContext(
         contextConfig.getApplicationSpecification(),
         contextConfig.getSpecification(), contextConfig.getProgramId(), contextConfig.getRunId(),
-        classLoader, contextConfig.getLogicalStartTime(), contextConfig.getArguments(),
+        classLoader, contextConfig.getArguments(),
         contextConfig.getTransaction(), programDatasetFramework,
         injector.getInstance(TransactionSystemClient.class),
         injector.getInstance(DiscoveryServiceClient.class), metricsCollectionService, hConf,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunner.java
@@ -117,9 +117,6 @@ public class SparkProgramRunner extends AbstractProgramRunnerWithPlugin {
     Arguments arguments = options.getArguments();
     RunId runId = RunIds.fromString(arguments.getOption(ProgramOptionConstants.RUN_ID));
 
-    long logicalStartTime = arguments.hasOption(ProgramOptionConstants.LOGICAL_START_TIME)
-      ? Long.parseLong(arguments.getOption(ProgramOptionConstants.LOGICAL_START_TIME)) : System.currentTimeMillis();
-
     WorkflowProgramInfo workflowInfo = WorkflowProgramInfo.create(arguments);
     DatasetFramework programDatasetFramework = workflowInfo == null ?
       datasetFramework :
@@ -138,7 +135,7 @@ public class SparkProgramRunner extends AbstractProgramRunnerWithPlugin {
         closeables.add(pluginInstantiator);
       }
 
-      ClientSparkContext context = new ClientSparkContext(program, runId, logicalStartTime,
+      ClientSparkContext context = new ClientSparkContext(program, runId,
                                                           options.getUserArguments().asMap(),
                                                           txSystemClient, programDatasetFramework,
                                                           discoveryServiceClient, metricsCollectionService,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
@@ -45,14 +45,13 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
 
   private final WorkflowSpecification workflowSpec;
   private final WorkflowActionSpecification specification;
-  private final long logicalStartTime;
   private final ProgramWorkflowRunner programWorkflowRunner;
   private final Map<String, String> runtimeArgs;
   private final WorkflowToken token;
   private final Metrics userMetrics;
 
   BasicWorkflowContext(WorkflowSpecification workflowSpec, @Nullable WorkflowActionSpecification spec,
-                       long logicalStartTime, @Nullable ProgramWorkflowRunner programWorkflowRunner,
+                       @Nullable ProgramWorkflowRunner programWorkflowRunner,
                        Arguments arguments, WorkflowToken token, Program program, RunId runId,
                        MetricsCollectionService metricsCollectionService,
                        DatasetFramework datasetFramework, TransactionSystemClient txClient,
@@ -63,7 +62,6 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
           datasetFramework, txClient, discoveryServiceClient, false);
     this.workflowSpec = workflowSpec;
     this.specification = spec;
-    this.logicalStartTime = logicalStartTime;
     this.programWorkflowRunner = programWorkflowRunner;
     this.runtimeArgs = ImmutableMap.copyOf(arguments.asMap());
     this.token = token;
@@ -96,11 +94,6 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
       throw new UnsupportedOperationException("Operation not allowed.");
     }
     return specification;
-  }
-
-  @Override
-  public long getLogicalStartTime() {
-    return logicalStartTime;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -112,7 +112,6 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   private final InetAddress hostname;
   private final Map<String, String> runtimeArgs;
   private final WorkflowSpecification workflowSpec;
-  private final long logicalStartTime;
   private final ProgramWorkflowRunnerFactory workflowProgramRunnerFactory;
   private final Map<String, WorkflowActionNode> status = new ConcurrentHashMap<>();
   private final LoggingContext loggingContext;
@@ -139,10 +138,6 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     this.hostname = hostname;
     this.runtimeArgs = createRuntimeArgs(options.getUserArguments());
     this.workflowSpec = workflowSpec;
-    Arguments arguments = options.getArguments();
-    this.logicalStartTime = arguments.hasOption(ProgramOptionConstants.LOGICAL_START_TIME)
-      ? Long.parseLong(arguments.getOption(ProgramOptionConstants.LOGICAL_START_TIME))
-      : System.currentTimeMillis();
     this.lock = new ReentrantLock();
     this.condition = lock.newCondition();
     this.runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
@@ -419,7 +414,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     Predicate<WorkflowContext> predicate = instantiator.get(
       TypeToken.of((Class<? extends Predicate<WorkflowContext>>) clz)).create();
 
-    WorkflowContext context = new BasicWorkflowContext(workflowSpec, null, logicalStartTime, null,
+    WorkflowContext context = new BasicWorkflowContext(workflowSpec, null, null,
                                                        new BasicArguments(runtimeArgs), token,
                                                        program, runId, metricsCollectionService,
                                                        datasetFramework, txClient, discoveryServiceClient);
@@ -513,7 +508,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
 
   private BasicWorkflowContext createWorkflowContext(WorkflowActionSpecification actionSpec,
                                                      WorkflowToken token, String nodeId) {
-    return new BasicWorkflowContext(workflowSpec, actionSpec, logicalStartTime,
+    return new BasicWorkflowContext(workflowSpec, actionSpec,
                                     workflowProgramRunnerFactory.getProgramWorkflowRunner(actionSpec, token, nodeId),
                                     new BasicArguments(runtimeArgs), token, program, runId, metricsCollectionService,
                                     datasetFramework, txClient, discoveryServiceClient);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
@@ -20,6 +20,7 @@ import co.cask.cdap.app.runtime.scheduler.SchedulerQueueResolver;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.config.PreferencesStore;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.store.NamespaceStore;
@@ -43,8 +44,10 @@ public class PropertiesResolver {
   }
 
   public Map<String, String> getUserProperties(Id.Program id) {
-    return prefStore.getResolvedProperties(id.getNamespaceId(), id.getApplicationId(),
-                                           id.getType().getCategoryName(), id.getId());
+    Map<String, String> userArgs = prefStore.getResolvedProperties(id.getNamespaceId(), id.getApplicationId(),
+                                                                   id.getType().getCategoryName(), id.getId());
+    userArgs.put(ProgramOptionConstants.LOGICAL_START_TIME, Long.toString(System.currentTimeMillis()));
+    return userArgs;
   }
 
   public Map<String, String> getSystemProperties(Id.Program id) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
@@ -60,7 +60,9 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
     public void beforeSubmit(MapReduceContext context) throws Exception {
       Map<String, String> args = context.getRuntimeArguments();
 
-      Preconditions.checkArgument(args.size() == 16);
+      Preconditions.checkArgument(args.size() == 18);
+      Preconditions.checkArgument(context.getLogicalStartTime() == 1234567890000L);
+      Preconditions.checkArgument(args.get("logical.start.time").equals("1234567890000"));
       Preconditions.checkArgument(args.get("input.path").contains("OneMRInput"));
       Preconditions.checkArgument(args.get("output.path").contains("OneMROutput"));
 
@@ -79,7 +81,7 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
     public void beforeSubmit(MapReduceContext context) throws Exception {
       Map<String, String> args = context.getRuntimeArguments();
 
-      Preconditions.checkArgument(args.size() == 16);
+      Preconditions.checkArgument(args.size() == 18);
       Preconditions.checkArgument(args.get("input.path").contains("AnotherMRInput"));
       Preconditions.checkArgument(args.get("output.path").contains("ProgramOutput"));
 
@@ -97,7 +99,7 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
     public void beforeSubmit(SparkContext context) throws Exception {
       Map<String, String> args = context.getRuntimeArguments();
 
-      Preconditions.checkArgument(args.size() == 15);
+      Preconditions.checkArgument(args.size() == 17);
       Preconditions.checkArgument(args.get("input.path").contains("SparkInput"));
       Preconditions.checkArgument(args.get("output.path").contains("ProgramOutput"));
     }
@@ -115,7 +117,7 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
     @Override
     public void beforeSubmit(SparkContext context) throws Exception {
       Map<String, String> args = context.getRuntimeArguments();
-      Preconditions.checkArgument(args.size() == 15);
+      Preconditions.checkArgument(args.size() == 17);
       Preconditions.checkArgument(args.get("input.path").contains("SparkInput"));
       Preconditions.checkArgument(args.get("output.path").contains("AnotherSparkOutput"));
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -567,6 +567,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     runtimeArguments.put("input.path", createInput("ProgramInput"));
     runtimeArguments.put("mapreduce.OneMR.input.path", createInput("OneMRInput"));
+    runtimeArguments.put("mapreduce.OneMR.logical.start.time", "1234567890000");
     runtimeArguments.put("mapreduce.AnotherMR.input.path", createInput("AnotherMRInput"));
     runtimeArguments.put("spark.*.input.path", createInput("SparkInput"));
 

--- a/cdap-docs/admin-manual/source/operations/preferences.rst
+++ b/cdap-docs/admin-manual/source/operations/preferences.rst
@@ -89,6 +89,17 @@ or provide Twitter API credentials::
       collector.start();
     }
 
+System Populated Runtime Arguments
+==================================
+
+Every program run, CDAP will populate the runtime arguments with some pre-defined values:
+
+``logical.start.time`` - the start time of the run as a timestamp in milliseconds.
+If the run was started by a schedule, this will be equal the trigger time for the schedule.
+For example, if the schedule was set to run at midnight Jan 1 2016 UTC, the logical start time would be 1451606400000.
+
+If any of these arguments are passed in to start a program run, they will override the system populated value.
+
 Scoped Runtime Arguments for Workflow
 =====================================
 When a workflow is configured, you may want to pass specific runtime arguments to the different programs

--- a/cdap-docs/admin-manual/source/operations/preferences.rst
+++ b/cdap-docs/admin-manual/source/operations/preferences.rst
@@ -89,16 +89,16 @@ or provide Twitter API credentials::
       collector.start();
     }
 
-System Populated Runtime Arguments
+System-populated Runtime Arguments
 ==================================
 
-Every program run, CDAP will populate the runtime arguments with some pre-defined values:
+On each program run, CDAP populates the runtime arguments with pre-defined values (currently, one):
 
-``logical.start.time`` - the start time of the run as a timestamp in milliseconds.
-If the run was started by a schedule, this will be equal the trigger time for the schedule.
-For example, if the schedule was set to run at midnight Jan 1 2016 UTC, the logical start time would be 1451606400000.
+- ``logical.start.time``: the start time of the run as a timestamp in milliseconds.
+  If the run was started by a schedule, this will be equal to the trigger time for the schedule.
+  For example, if the schedule was set to run at midnight on Jan 1, 2016 UTC, the logical start time would be ``1451606400000``.
 
-If any of these arguments are passed in to start a program run, they will override the system populated value.
+If an argument is passed in to start a program run, it will override the system-populated value.
 
 Scoped Runtime Arguments for Workflow
 =====================================

--- a/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
+++ b/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
@@ -16,28 +16,20 @@
 
 package co.cask.cdap.examples.streamconversion;
 
-import co.cask.cdap.api.common.RuntimeArguments;
-import co.cask.cdap.api.dataset.lib.TimePartitionDetail;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
-import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.util.Calendar;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicMarkableReference;
 
 /**
  * Test the stream conversion example app.
@@ -56,39 +48,20 @@ public class StreamConversionTest extends TestBase {
     streamManager.send("16");
     streamManager.send("17");
 
-    // record the current time
-    final long startTime = System.currentTimeMillis();
+    // record the current time. Add 1 in case the stream events are added with the same timestamp as the current time.
+    final long startTime = System.currentTimeMillis() + 1;
 
     // run the mapreduce
-    MapReduceManager mapReduceManager =
-      appManager.getMapReduceManager("StreamConversionMapReduce").start(RuntimeArguments.NO_ARGUMENTS);
+    MapReduceManager mapReduceManager = appManager.getMapReduceManager("StreamConversionMapReduce")
+      .start(ImmutableMap.of("logical.start.time", Long.toString(startTime)));
     mapReduceManager.waitForFinish(5, TimeUnit.MINUTES);
 
     // verify the single partition in the file set
-    long partitionTime = assertWithRetry(new Callable<Long>() {
-      @Override
-      public Long call() throws Exception {
-        DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset("converted");
-        TimePartitionedFileSet converted = fileSetManager.get();
-        Set<TimePartitionDetail> partitions = converted.getPartitionsByTime(startTime, System.currentTimeMillis());
-        Assert.assertEquals(1, partitions.size());
-        return partitions.iterator().next().getTime();
-      }
-    }, 15L, TimeUnit.SECONDS, 100L, TimeUnit.MILLISECONDS);
+    DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset("converted");
+    Assert.assertNotNull(fileSetManager.get().getPartitionByTime(startTime));
 
-    // we must round down the start time to the full minute before we compare the partition time
     Calendar calendar = Calendar.getInstance();
     calendar.setTimeInMillis(startTime);
-    calendar.set(Calendar.SECOND, 0);
-    calendar.set(Calendar.MILLISECOND, 0);
-    long startMinute = calendar.getTimeInMillis();
-
-    // partition time should be the logical start time of the MapReduce. That is between start and now.
-    Assert.assertTrue(partitionTime >= startMinute);
-    Assert.assertTrue(partitionTime <= System.currentTimeMillis());
-
-    // extract fields from partition time
-    calendar.setTimeInMillis(partitionTime);
     int year = calendar.get(Calendar.YEAR);
     int month = calendar.get(Calendar.MONTH) + 1;
     int day = calendar.get(Calendar.DAY_OF_MONTH);
@@ -109,41 +82,5 @@ public class StreamConversionTest extends TestBase {
     Assert.assertEquals(hour, results.getInt(4));
     Assert.assertEquals(minute, results.getInt(5));
     Assert.assertFalse(results.next());
-  }
-
-  @Test
-  public void testAssertWithRetry() throws InterruptedException, ExecutionException, TimeoutException {
-    final int requiredCount = 10;
-    final AtomicInteger count = new AtomicInteger(0);
-    int actualCount = assertWithRetry(new Callable<Integer>() {
-      @Override
-      public Integer call() throws Exception {
-        int actualCount = count.getAndIncrement();
-        Assert.assertEquals(requiredCount, actualCount);
-        return actualCount;
-      }
-    }, 10, TimeUnit.SECONDS, 0, TimeUnit.SECONDS);
-    Assert.assertEquals(requiredCount, actualCount);
-  }
-
-  // TODO: move elsewhere?
-  private <T> T assertWithRetry(final Callable<T> callable, long timeout, TimeUnit timeoutUnit,
-                        long sleepDelay, TimeUnit sleepDelayUnit)
-    throws InterruptedException, ExecutionException, TimeoutException {
-
-    final AtomicMarkableReference<T> result = new AtomicMarkableReference<>(null, false);
-    Tasks.waitFor(true, new Callable<Boolean>() {
-      public Boolean call() throws Exception {
-        try {
-          result.set(callable.call(), true);
-        } catch (AssertionError e) {
-          // retry
-          return false;
-        }
-        return true;
-      }
-    }, timeout, timeoutUnit, sleepDelay, sleepDelayUnit);
-    Assert.assertTrue(result.isMarked());
-    return result.getReference();
   }
 }


### PR DESCRIPTION
…time

Added support for using a specific logical start time instead of
using the current time for manually started programs. If a preference
or runtime argument named 'logicalStartTime' is present, its value
will be interpreted as a timestamp in milliseconds and used as the
logical start time of the run instead of the current time.

The preference or runtime argument is only applied if the program
was started manually. Scheduled program runs will ignore it.