### PR TITLE
CDAP-5117 Implementation for creating the local dataset instances and using them for MapReduce programs in the Workflow.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ProgramWorkflowRunnerFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ProgramWorkflowRunnerFactory.java
@@ -66,7 +66,7 @@ public class ProgramWorkflowRunnerFactory {
     if (actionSpec.getProperties().containsKey(ProgramWorkflowAction.PROGRAM_TYPE)) {
       switch (SchedulableProgramType.valueOf(actionSpec.getProperties().get(ProgramWorkflowAction.PROGRAM_TYPE))) {
         case MAPREDUCE:
-          return new MapReduceProgramWorkflowRunner(workflowSpec, programRunnerFactory, workflowProgram, 
+          return new MapReduceProgramWorkflowRunner(workflowSpec, programRunnerFactory, workflowProgram,
                                                     workflowProgramOptions, token, nodeId);
         case SPARK:
           return new SparkProgramWorkflowRunner(workflowSpec, programRunnerFactory, workflowProgram,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDatasetFramework.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDatasetFramework.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.runtime.workflow;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.workflow.Workflow;
+import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
+import co.cask.cdap.data2.dataset2.ForwardingProgramContextAwareDatasetFramework;
+import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
+import co.cask.cdap.proto.DatasetSpecificationSummary;
+import co.cask.cdap.proto.Id;
+import org.apache.twill.filesystem.Location;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Implementation of the {@link DatasetFramework} which forwards all calls to the underlying
+ * dataset framework. Before forwarding the calls, local dataset names are mapped to the names
+ * assigned to them for the current run of the {@link Workflow}.
+ */
+public class WorkflowDatasetFramework extends ForwardingProgramContextAwareDatasetFramework {
+
+  private final Map<String, String> datasetNameMapping;
+
+  public WorkflowDatasetFramework(DatasetFramework delegate, Map<String, String> datasetNameMapping) {
+    super(delegate);
+    this.datasetNameMapping = datasetNameMapping;
+  }
+
+  /**
+   * Return the dataset name mapping.
+   */
+  public Map<String, String> getDatasetNameMapping() {
+    return datasetNameMapping;
+  }
+
+  @Override
+  public void addInstance(String datasetTypeName, Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+    throws IOException, DatasetManagementException {
+    super.addInstance(datasetTypeName, getMappedDatasetInstance(datasetInstanceId), props);
+  }
+
+  @Override
+  public void updateInstance(Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+    throws DatasetManagementException, IOException {
+    super.updateInstance(getMappedDatasetInstance(datasetInstanceId), props);
+  }
+
+  @Nullable
+  @Override
+  public DatasetSpecification getDatasetSpec(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+    return super.getDatasetSpec(getMappedDatasetInstance(datasetInstanceId));
+  }
+
+  @Override
+  public boolean hasInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+    return super.hasInstance(getMappedDatasetInstance(datasetInstanceId));
+  }
+
+  @Override
+  public void deleteInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException, IOException {
+    super.deleteInstance(getMappedDatasetInstance(datasetInstanceId));
+  }
+
+  @Nullable
+  @Override
+  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader)
+    throws DatasetManagementException, IOException {
+    return super.getAdmin(getMappedDatasetInstance(datasetInstanceId), classLoader);
+  }
+
+  @Nullable
+  @Override
+  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader,
+                                             DatasetClassLoaderProvider classLoaderProvider)
+    throws DatasetManagementException, IOException {
+    return super.getAdmin(getMappedDatasetInstance(datasetInstanceId), classLoader, classLoaderProvider);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader, @Nullable Iterable<? extends Id> owners)
+    throws DatasetManagementException, IOException {
+    return super.getDataset(getMappedDatasetInstance(datasetInstanceId), arguments, classLoader, owners);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader)
+    throws DatasetManagementException, IOException {
+    return super.getDataset(getMappedDatasetInstance(datasetInstanceId), arguments, classLoader);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader,
+                                          DatasetClassLoaderProvider classLoaderProvider,
+                                          @Nullable Iterable<? extends Id> owners)
+    throws DatasetManagementException, IOException {
+    return super.getDataset(getMappedDatasetInstance(datasetInstanceId), arguments, classLoader,
+                               classLoaderProvider, owners);
+  }
+
+  private Id.DatasetInstance getMappedDatasetInstance(Id.DatasetInstance datasetInstanceId) {
+    if (datasetNameMapping.containsKey(datasetInstanceId.getId())) {
+      return Id.DatasetInstance.from(datasetInstanceId.getNamespaceId(),
+                                     datasetNameMapping.get(datasetInstanceId.getId()));
+    }
+    return datasetInstanceId;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,13 +23,14 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
-import co.cask.cdap.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
+import co.cask.cdap.data2.registry.UsageRegistry;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
@@ -37,9 +38,11 @@ import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.ServiceAnnouncer;
 import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.net.InetAddress;
 
@@ -47,7 +50,6 @@ import java.net.InetAddress;
  * A {@link ProgramRunner} that runs a {@link Workflow}.
  */
 public class WorkflowProgramRunner implements ProgramRunner {
-  private final ProgramRunnerFactory programRunnerFactory;
   private final ServiceAnnouncer serviceAnnouncer;
   private final InetAddress hostname;
   private final MetricsCollectionService metricsCollectionService;
@@ -55,16 +57,19 @@ public class WorkflowProgramRunner implements ProgramRunner {
   private final DiscoveryServiceClient discoveryServiceClient;
   private final TransactionSystemClient txClient;
   private final Store store;
+  private final StreamAdmin streamAdmin;
   private final CConfiguration cConf;
+  private final Configuration hConf;
+  private final LocationFactory locationFactory;
+  private final UsageRegistry usageRegistry;
 
   @Inject
-  public WorkflowProgramRunner(ProgramRunnerFactory programRunnerFactory,
-                               ServiceAnnouncer serviceAnnouncer,
+  public WorkflowProgramRunner(ServiceAnnouncer serviceAnnouncer,
                                @Named(Constants.AppFabric.SERVER_ADDRESS) InetAddress hostname,
                                MetricsCollectionService metricsCollectionService, DatasetFramework datasetFramework,
                                DiscoveryServiceClient discoveryServiceClient, TransactionSystemClient txClient,
-                               Store store, CConfiguration cConf) {
-    this.programRunnerFactory = programRunnerFactory;
+                               Store store, CConfiguration cConf, Configuration hConf, StreamAdmin streamAdmin,
+                               LocationFactory locationFactory, UsageRegistry usageRegistry) {
     this.serviceAnnouncer = serviceAnnouncer;
     this.hostname = hostname;
     this.metricsCollectionService = metricsCollectionService;
@@ -73,6 +78,10 @@ public class WorkflowProgramRunner implements ProgramRunner {
     this.txClient = txClient;
     this.store = store;
     this.cConf = cConf;
+    this.hConf = hConf;
+    this.locationFactory = locationFactory;
+    this.streamAdmin = streamAdmin;
+    this.usageRegistry = usageRegistry;
   }
 
   @Override
@@ -96,9 +105,9 @@ public class WorkflowProgramRunner implements ProgramRunner {
       ((ProgramContextAware) datasetFramework).initContext(new Id.Run(programId, runId.getId()));
     }
 
-    WorkflowDriver driver = new WorkflowDriver(program, options, hostname, workflowSpec, programRunnerFactory,
-                                               metricsCollectionService, datasetFramework,
-                                               discoveryServiceClient, txClient, store, cConf);
+    WorkflowDriver driver = new WorkflowDriver(program, options, hostname, workflowSpec, metricsCollectionService,
+                                               datasetFramework, discoveryServiceClient, txClient, store, cConf, hConf,
+                                               locationFactory, streamAdmin, usageRegistry);
 
     // Controller needs to be created before starting the driver so that the state change of the driver
     // service can be fully captured by the controller.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunnerFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunnerFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.runtime.workflow;
+
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.workflow.Workflow;
+import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.app.runtime.ProgramRunnerFactory;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.registry.UsageRegistry;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.internal.app.runtime.batch.MapReduceProgramRunner;
+import co.cask.cdap.internal.app.runtime.spark.SparkProgramRunner;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.tephra.TransactionSystemClient;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.filesystem.LocationFactory;
+
+/**
+ * Factory for instantiating the programs that are going to run inside a {@link Workflow}.
+ */
+public class WorkflowProgramRunnerFactory implements ProgramRunnerFactory {
+
+  private final CConfiguration cConf;
+  private final Configuration hConf;
+  private final LocationFactory locationFactory;
+  private final StreamAdmin streamAdmin;
+  private final DatasetFramework datasetFramework;
+  private final TransactionSystemClient txSystemClient;
+  private final MetricsCollectionService metricsCollectionService;
+  private final DiscoveryServiceClient discoveryServiceClient;
+  private final Store store;
+  private final UsageRegistry usageRegistry;
+
+  public WorkflowProgramRunnerFactory(CConfiguration cConf, Configuration hConf, LocationFactory locationFactory,
+                                      StreamAdmin streamAdmin, DatasetFramework datasetFramework,
+                                      TransactionSystemClient txSystemClient,
+                                      MetricsCollectionService metricsCollectionService,
+                                      DiscoveryServiceClient discoveryServiceClient, Store store,
+                                      UsageRegistry usageRegistry) {
+    this.cConf = cConf;
+    this.hConf = hConf;
+    this.locationFactory = locationFactory;
+    this.streamAdmin = streamAdmin;
+    this.datasetFramework = datasetFramework;
+    this.txSystemClient = txSystemClient;
+    this.metricsCollectionService = metricsCollectionService;
+    this.discoveryServiceClient = discoveryServiceClient;
+    this.store = store;
+    this.usageRegistry = usageRegistry;
+  }
+
+  @Override
+  public ProgramRunner create(ProgramType programType) {
+    switch(programType) {
+      case MAPREDUCE:
+        return new MapReduceProgramRunner(cConf, hConf, locationFactory, streamAdmin, datasetFramework, txSystemClient,
+                                          metricsCollectionService, discoveryServiceClient, store, usageRegistry);
+      case SPARK:
+        return new SparkProgramRunner(cConf, hConf, txSystemClient, datasetFramework, metricsCollectionService,
+                                      discoveryServiceClient, streamAdmin, store);
+      default:
+        throw new IllegalArgumentException(String.format("Program of type %s cannot be run by the Workflow.",
+                                                         programType));
+
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingDatasetFramework.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.dataset2;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
+import co.cask.cdap.proto.DatasetSpecificationSummary;
+import co.cask.cdap.proto.Id;
+import org.apache.twill.filesystem.Location;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Implementation of the {@link DatasetFramework} which forwards all calls to the underlying
+ * delegate.
+ */
+public class ForwardingDatasetFramework implements DatasetFramework {
+
+  protected final DatasetFramework delegate;
+
+  public ForwardingDatasetFramework(DatasetFramework datasetFramework) {
+    this.delegate = datasetFramework;
+  }
+
+  @Override
+  public void addModule(Id.DatasetModule moduleId, DatasetModule module) throws DatasetManagementException {
+    delegate.addModule(moduleId, module);
+  }
+
+  @Override
+  public void addModule(Id.DatasetModule moduleId, DatasetModule module, Location jarLocation)
+    throws DatasetManagementException {
+    delegate.addModule(moduleId, module, jarLocation);
+  }
+
+  @Override
+  public void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException {
+    delegate.deleteModule(moduleId);
+  }
+
+  @Override
+  public void deleteAllModules(Id.Namespace namespaceId) throws DatasetManagementException {
+    delegate.deleteAllModules(namespaceId);
+  }
+
+  @Override
+  public void addInstance(String datasetTypeName, Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+    throws DatasetManagementException, IOException {
+    delegate.addInstance(datasetTypeName, datasetInstanceId, props);
+  }
+
+  @Override
+  public void updateInstance(Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+    throws DatasetManagementException, IOException {
+    delegate.updateInstance(datasetInstanceId, props);
+  }
+
+  @Override
+  public Collection<DatasetSpecificationSummary> getInstances(Id.Namespace namespaceId)
+    throws DatasetManagementException {
+    return delegate.getInstances(namespaceId);
+  }
+
+  @Nullable
+  @Override
+  public DatasetSpecification getDatasetSpec(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+    return delegate.getDatasetSpec(datasetInstanceId);
+  }
+
+  @Override
+  public boolean hasInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+    return delegate.hasInstance(datasetInstanceId);
+  }
+
+  @Override
+  public boolean hasSystemType(String typeName) throws DatasetManagementException {
+    return delegate.hasSystemType(typeName);
+  }
+
+  @Override
+  public boolean hasType(Id.DatasetType datasetTypeId) throws DatasetManagementException {
+    return delegate.hasType(datasetTypeId);
+  }
+
+  @Override
+  public void deleteInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException, IOException {
+    delegate.deleteInstance(datasetInstanceId);
+  }
+
+  @Override
+  public void deleteAllInstances(Id.Namespace namespaceId) throws DatasetManagementException, IOException {
+    delegate.deleteAllInstances(namespaceId);
+  }
+
+  @Nullable
+  @Override
+  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader)
+    throws DatasetManagementException, IOException {
+    return delegate.getAdmin(datasetInstanceId, classLoader);
+  }
+
+  @Nullable
+  @Override
+  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader,
+                                             DatasetClassLoaderProvider classLoaderProvider)
+    throws DatasetManagementException, IOException {
+    return delegate.getAdmin(datasetInstanceId, classLoader, classLoaderProvider);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader, @Nullable Iterable<? extends Id> owners)
+    throws DatasetManagementException, IOException {
+    return delegate.getDataset(datasetInstanceId, arguments, classLoader, owners);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader)
+    throws DatasetManagementException, IOException {
+    return delegate.getDataset(datasetInstanceId, arguments, classLoader);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader,
+                                          DatasetClassLoaderProvider classLoaderProvider,
+                                          @Nullable Iterable<? extends Id> owners)
+    throws DatasetManagementException, IOException {
+    return delegate.getDataset(datasetInstanceId, arguments, classLoader, classLoaderProvider, owners);
+  }
+
+  @Override
+  public void createNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
+    delegate.createNamespace(namespaceId);
+  }
+
+  @Override
+  public void deleteNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
+    delegate.deleteNamespace(namespaceId);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingProgramContextAwareDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingProgramContextAwareDatasetFramework.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.dataset2;
+
+import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
+import co.cask.cdap.proto.Id;
+
+/**
+ * Implementation of the {@link ForwardingDatasetFramework} which is also {@link ProgramContextAware}.
+ */
+public class ForwardingProgramContextAwareDatasetFramework extends ForwardingDatasetFramework
+  implements ProgramContextAware {
+
+  public ForwardingProgramContextAwareDatasetFramework(DatasetFramework datasetFramework) {
+    super(datasetFramework);
+  }
+
+  @Override
+  public void initContext(Id.Run run) {
+    if (delegate instanceof ProgramContextAware) {
+      ((ProgramContextAware) delegate).initContext(run);
+    }
+  }
+
+  @Override
+  public void initContext(Id.Run run, Id.NamespacedId componentId) {
+    if (delegate instanceof ProgramContextAware) {
+      ((ProgramContextAware) delegate).initContext(run, componentId);
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WorkflowAppWithLocalDatasets.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WorkflowAppWithLocalDatasets.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.annotation.UseDataSet;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+import co.cask.cdap.api.workflow.AbstractWorkflowAction;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Workflow application containing local datasets.
+ */
+public class WorkflowAppWithLocalDatasets extends AbstractApplication {
+  public static final String WORDCOUNT_DATASET = "wordcount";
+  public static final String RESULT_DATASET = "result";
+  @Override
+  public void configure() {
+    setName("WorkflowAppWithLocalDatasets");
+    setDescription("App to test the local dataset functionality for the Workflow.");
+
+    addMapReduce(new WordCount());
+    addWorkflow(new WorkflowWithLocalDatasets());
+    createDataset(RESULT_DATASET, KeyValueTable.class);
+  }
+
+  /**
+   * Workflow which configures the local dataset.
+   */
+  public static class WorkflowWithLocalDatasets extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      setName("WorkflowWithLocalDatasets");
+      setDescription("Workflow program with local datasets.");
+      createLocalDataset(WORDCOUNT_DATASET, KeyValueTable.class);
+      addMapReduce("WordCount");
+      addAction(new LocalDatasetReader());
+    }
+  }
+
+  /**
+   * MapReduce program that simply counts the number of occurrences of the words in the input files.
+   */
+  public static class WordCount extends AbstractMapReduce {
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      Map<String, String> args = context.getRuntimeArguments();
+      String inputPath = args.get("input.path");
+      context.addOutput(WORDCOUNT_DATASET);
+      Job job = context.getHadoopJob();
+      job.setMapperClass(TokenizerMapper.class);
+      job.setReducerClass(IntSumReducer.class);
+
+      job.setNumReduceTasks(1);
+      FileInputFormat.addInputPath(job, new Path(inputPath));
+    }
+  }
+
+  /**
+   * Mapper to tokenized the the line into words.
+   */
+  public static class TokenizerMapper extends Mapper<Object, Text, Text, IntWritable> {
+
+    private static final IntWritable ONE = new IntWritable(1);
+    private Text word = new Text();
+
+    public void map(Object key, Text value, Context context) throws IOException, InterruptedException {
+      StringTokenizer itr = new StringTokenizer(value.toString());
+      while (itr.hasMoreTokens()) {
+        word.set(itr.nextToken());
+        context.write(word, ONE);
+      }
+    }
+  }
+
+  /**
+   * Reducer to write the word counts to the local Workflow dataset.
+   */
+  public static class IntSumReducer extends Reducer<Text, IntWritable, byte[], byte[]> {
+    private IntWritable result = new IntWritable();
+
+    public void reduce(Text key, Iterable<IntWritable> values, Context context)
+      throws IOException, InterruptedException {
+      int sum = 0;
+      for (IntWritable val : values) {
+        sum += val.get();
+      }
+      result.set(sum);
+      context.write(Bytes.toBytes(key.toString()), Bytes.toBytes(String.valueOf(result.get())));
+    }
+  }
+
+  /**
+   * Custom action that reads the local dataset and writes to the non-local dataset.
+   */
+  public static class LocalDatasetReader extends AbstractWorkflowAction {
+    private static final Logger LOG = LoggerFactory.getLogger(LocalDatasetReader.class);
+
+    @UseDataSet("wordcount")
+    private KeyValueTable wordCount;
+
+    @UseDataSet("result")
+    private KeyValueTable result;
+
+    @Override
+    public void run() {
+      LOG.info("Read the local dataset");
+      try {
+        File waitFile = new File(getContext().getRuntimeArguments().get("wait.file"));
+        waitFile.createNewFile();
+
+        int uniqueWordCount = 0;
+        CloseableIterator<KeyValue<byte[], byte[]>> scanner = wordCount.scan(null, null);
+        try {
+          while (scanner.hasNext()) {
+            scanner.next();
+            uniqueWordCount++;
+          }
+        } finally {
+          scanner.close();
+        }
+        result.write("UniqueWordCount", String.valueOf(uniqueWordCount));
+        File doneFile = new File(getContext().getRuntimeArguments().get("done.file"));
+        while (!doneFile.exists()) {
+          TimeUnit.MILLISECONDS.sleep(50);
+        }
+      } catch (Exception e) {
+        // no-op
+      }
+    }
+  }
+}


### PR DESCRIPTION
Following changes are implemented in this PR: 
1. Added implementation for creating and deleting the local datasets in the Workflow driver.
2. Using `ForwardingDatasetFramework` in the `WorkflowDriver` now which delegates the calls to the underlying dataset framework. It also maintains the mapping of the local dataset to the name assigned to them for the particular run of the Workflow which is of the form `datasetName.<workflow_run_id>`.
3. Passing the dataset name mapping to the `MapperWrapper` as well through the job configuration.

Spark related changes and deletion of the local datasets based on the the runtime argument will be done in separate PR.