### PR TITLE
CDAP-4772 remove deprecated app create restful api

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -383,31 +383,12 @@ public abstract class AppFabricTestBase {
    * Deploys an application.
    */
   protected HttpResponse deploy(Class<?> application) throws Exception {
-    return deploy(application, null);
-  }
-
-  protected HttpResponse deploy(Class<?> application, @Nullable String appName) throws Exception {
-    return deploy(application, null, null, appName, null, null);
-  }
-
-  protected HttpResponse deploy(Class<?> application, @Nullable String appName, @Nullable Config appConfig)
-    throws Exception {
-    return deploy(application, null, null, appName, null, appConfig);
+    return deploy(application, null, null);
   }
 
   protected HttpResponse deploy(Class<?> application, @Nullable String apiVersion, @Nullable String namespace)
     throws Exception {
-    return deploy(application, apiVersion, namespace, null, null, null);
-  }
-
-  protected HttpResponse deploy(Class<?> application, @Nullable String apiVersion, @Nullable String namespace,
-                                @Nullable String appName) throws Exception {
-    return deploy(application, apiVersion, namespace, appName, null, null);
-  }
-
-  protected HttpResponse deploy(Class<?> application, @Nullable String apiVersion, @Nullable String namespace,
-                                @Nullable String appName, @Nullable String appVersion) throws Exception {
-    return deploy(application, apiVersion, namespace, appName, appVersion, null);
+    return deploy(application, apiVersion, namespace, null, null);
   }
 
   protected HttpResponse deploy(Id.Application appId,
@@ -425,8 +406,7 @@ public abstract class AppFabricTestBase {
    * Deploys an application with (optionally) a defined app name and app version
    */
   protected HttpResponse deploy(Class<?> application, @Nullable String apiVersion, @Nullable String namespace,
-                                @Nullable String appName, @Nullable String appVersion,
-                                @Nullable Config appConfig) throws Exception {
+                                @Nullable String appVersion, @Nullable Config appConfig) throws Exception {
     namespace = namespace == null ? Id.Namespace.DEFAULT.getId() : namespace;
     apiVersion = apiVersion == null ? Constants.Gateway.API_VERSION_3_TOKEN : apiVersion;
     appVersion = appVersion == null ? String.format("1.0.%d", System.currentTimeMillis()) : appVersion;
@@ -446,11 +426,7 @@ public abstract class AppFabricTestBase {
 
     HttpEntityEnclosingRequestBase request;
     String versionedApiPath = getVersionedAPIPath("apps/", apiVersion, namespace);
-    if (appName == null) {
-      request = getPost(versionedApiPath);
-    } else {
-      request = getPut(versionedApiPath + appName);
-    }
+    request = getPost(versionedApiPath);
     request.setHeader(Constants.Gateway.API_KEY, "api-key-example");
     request.setHeader("X-Archive-Name", String.format("%s-%s.jar", application.getSimpleName(), appVersion));
     if (appConfig != null) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -164,8 +164,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     response = createNamespace(METADATA_VALID, Id.Namespace.SYSTEM.getId());
     assertResponseCode(400, response);
     // we allow deleting the contents in default namespace. However, the namespace itself should never be deleted
-    deploy(AppWithDataset.class, Constants.Gateway.API_VERSION_3_TOKEN, Id.Namespace.DEFAULT.getId(),
-           AppWithDataset.class.getSimpleName());
+    deploy(AppWithDataset.class);
     response = deleteNamespace(Id.Namespace.DEFAULT.getId());
     assertResponseCode(200, response);
     response = getNamespace(Id.Namespace.DEFAULT.getId());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/audit/AuditPublishTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/audit/AuditPublishTest.java
@@ -23,6 +23,7 @@ import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.kafka.KafkaTester;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.audit.AuditMessage;
 import co.cask.cdap.proto.audit.AuditType;
 import co.cask.cdap.proto.codec.AuditMessageTypeAdapter;
@@ -101,7 +102,7 @@ public class AuditPublishTest {
 
     // Define expected values
     Set<? extends EntityId> expectedMetadataChangeEntities =
-      ImmutableSet.of(Ids.namespace(defaultNs).artifact("app", "1"),
+      ImmutableSet.of(Ids.namespace(defaultNs).artifact(WordCountApp.class.getSimpleName(), "1"),
                       Ids.namespace(defaultNs).app(appName),
                       Ids.namespace(defaultNs).app(appName).flow(WordCountApp.WordCountFlow.class.getSimpleName()),
                       Ids.namespace(defaultNs).app(appName).mr(WordCountApp.VoidMapReduceJob.class.getSimpleName()),
@@ -116,7 +117,7 @@ public class AuditPublishTest {
                                                                    Ids.namespace(defaultNs).stream("text")));
 
     // Deploy application
-    AppFabricTestHelper.deployApplication(WordCountApp.class);
+    AppFabricTestHelper.deployApplication(Id.Namespace.DEFAULT, WordCountApp.class, null, KAFKA_TESTER.getCConf());
 
     // Verify audit messages
     List<AuditMessage> publishedMessages =

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataKafkaPublishTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataKafkaPublishTest.java
@@ -76,7 +76,7 @@ public class SystemMetadataKafkaPublishTest {
   @Test
   public void testPublishing() throws Exception {
     CConfiguration cConf = KAFKA_TESTER.getCConf();
-    AppFabricTestHelper.deployApplication(AllProgramsApp.class, cConf);
+    AppFabricTestHelper.deployApplication(Id.Namespace.DEFAULT, AllProgramsApp.class, null, cConf);
     String topic = cConf.get(Constants.Metadata.UPDATES_KAFKA_TOPIC);
     Type metadataChangeRecordType = new TypeToken<MetadataChangeRecord>() { }.getType();
     // Expect 17 messages to be generated for system metadata additions:

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -31,7 +31,7 @@ and an optional application configuration. For example:
 .. container:: highlight
 
   .. parsed-literal::
-    |$| PUT <base-url>/namespaces/default/apps/purchaseWordCount -H "Content-Type: application/json" -d
+    |$| PUT <base-url>/namespaces/default/apps/purchaseWordCount -d
     {
       "artifact": {
         "name": "WordCount",
@@ -46,10 +46,6 @@ and an optional application configuration. For example:
 will create an application named ``purchaseWordCount`` from the example ``WordCount`` artifact. The application
 will receive the specified config, which will configure the application to create a stream named
 ``purchaseStream`` instead of using the default stream name. 
-
-Note that the ``Content-Type`` header must be set to ``application/json``. If not, the API will
-revert to a deprecated API which expects the request body to contain the contents
-of a JAR file. 
 
 Update an Application
 ---------------------

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayFastTestsSuite.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayFastTestsSuite.java
@@ -49,7 +49,6 @@ import org.junit.runners.Suite;
 
 import java.io.File;
 import java.io.IOException;
-import javax.annotation.Nullable;
 
 /**
  * Test Suite for running all API tests.
@@ -149,7 +148,6 @@ public class GatewayFastTestsSuite {
   }
 
   public static HttpResponse deploy(Class<?> application,
-                                    @Nullable String appName,
                                     File tmpFolder) throws Exception {
 
     File artifactJar = buildAppArtifact(application, application.getSimpleName(), tmpFolder);
@@ -163,11 +161,7 @@ public class GatewayFastTestsSuite {
     BundleJarUtil.createJar(expandDir, artifactJar);
 
     HttpEntityEnclosingRequestBase request;
-    if (appName == null) {
-      request = getPost("/v3/namespaces/default/apps");
-    } else {
-      request = getPut("/v3/namespaces/default/apps/" + appName);
-    }
+    request = getPost("/v3/namespaces/default/apps");
     request.setHeader(Constants.Gateway.API_KEY, "api-key-example");
     request.setHeader("X-Archive-Name",
                       String.format("%s-1.0.%d.jar", application.getSimpleName(), System.currentTimeMillis()));

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/apps/HighPassFilterApp.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/apps/HighPassFilterApp.java
@@ -41,11 +41,12 @@ import javax.ws.rs.Path;
  * To test runtimeArgs.
  */
 public class HighPassFilterApp extends AbstractApplication {
+  public static final String NAME = "HighPassFilterApp";
   private static final byte[] highPass = Bytes.toBytes("h");
 
   @Override
   public void configure() {
-    setName("HighPassFilterApp");
+    setName(NAME);
     setDescription("Application for filtering numbers. Test runtimeargs.");
     addStream(new Stream("inputvalue"));
     createDataset("counter", KeyValueTable.class);

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/RuntimeArgumentTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/RuntimeArgumentTestRun.java
@@ -35,8 +35,7 @@ public class RuntimeArgumentTestRun extends GatewayTestBase {
 
   @Test
   public void testFlowRuntimeArgs() throws Exception {
-    HttpResponse response = GatewayFastTestsSuite.deploy(HighPassFilterApp.class, "HighPassFilterApp",
-                                                         TEMP_FOLDER.newFolder());
+    HttpResponse response = GatewayFastTestsSuite.deploy(HighPassFilterApp.class, TEMP_FOLDER.newFolder());
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
     //Set flow runtime arg threshold to 30
     JsonObject json = new JsonObject();

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/StreamWriterTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/StreamWriterTestRun.java
@@ -35,8 +35,7 @@ public class StreamWriterTestRun extends GatewayTestBase {
 
   @Test
   public void testStreamWrites() throws Exception {
-    HttpResponse response = GatewayFastTestsSuite.deploy(AppWritingtoStream.class, AppWritingtoStream.APPNAME,
-                                                         TEMP_FOLDER.newFolder());
+    HttpResponse response = GatewayFastTestsSuite.deploy(AppWritingtoStream.class, TEMP_FOLDER.newFolder());
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
     //Start Flow
     response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/flows/%s/start",

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -151,7 +151,7 @@ public class UnitTestManager implements TestManager {
       Application app = applicationClz.newInstance();
       MockAppConfigurer configurer = new MockAppConfigurer(app);
       app.configure(configurer, new DefaultApplicationContext<>(configObject));
-      appFabricClient.deployApplication(namespace, configurer.getName(), applicationClz, appConfig, bundleEmbeddedJars);
+      appFabricClient.deployApplication(namespace, applicationClz, appConfig, bundleEmbeddedJars);
       return appManagerFactory.create(Id.Application.from(namespace, configurer.getName()));
     } catch (Exception e) {
       throw Throwables.propagate(e);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -143,7 +143,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
         deployApplication(appId, createRequest);
         // fail if we succeed with application deployment
         Assert.fail();
-      } catch (IllegalStateException e) {
+      } catch (Exception e) {
         // expected
       }
     }


### PR DESCRIPTION
When we first introduced artifacts, we overloaded the
PUT /apps/<app-id> api to have different behavior based on the
Content-Type header. This was to keep the endpoint backwards
compatible.

The old behavior, which expected the request body to be the jar
contents, has been deprecated for several releases so we are
removing it.