### PR TITLE
[cdap 5182] add a way to retrieve the original properties used to create/update a dataset

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetSpecification.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 
 /**
  * A {@link DatasetSpecification} is a hierarchical meta data object that contains all
@@ -45,6 +46,8 @@ public final class DatasetSpecification {
   private final String name;
   // the name of the type of the dataset
   private final String type;
+  // the properties of the dataset as passed in when the dataset was created or reconfigured
+  private final Map<String, String> originalProperties;
   // the custom properties of the dataset.
   // NOTE: we need the map to be ordered because we compare serialized to JSON form as Strings during deploy validation
   private final SortedMap<String, String> properties;
@@ -56,9 +59,11 @@ public final class DatasetSpecification {
     return new Builder(name, typeName);
   }
 
-  public static DatasetSpecification changeName(DatasetSpecification spec, String newName) {
-    return new DatasetSpecification(newName, spec.type,
-                                    spec.properties, spec.datasetSpecs);
+  /**
+   * @return a new spec that is the same as this one, with the original properties set to the provided properties.
+   */
+  public DatasetSpecification setOriginalProperties(DatasetProperties originalProps) {
+    return new DatasetSpecification(name, type, originalProps.getProperties(), properties, datasetSpecs);
   }
 
   /**
@@ -72,9 +77,26 @@ public final class DatasetSpecification {
                                String type,
                                SortedMap<String, String> properties,
                                SortedMap<String, DatasetSpecification> datasetSpecs) {
+    this(name, type, null, properties, datasetSpecs);
+  }
+
+  /**
+   * Private constructor, only to be used by static method setOriginalProperties.
+   * @param name the name of the dataset
+   * @param type the type of the dataset
+   * @param properties the custom properties
+   * @param datasetSpecs the specs of embedded datasets
+   */
+  private DatasetSpecification(String name,
+                               String type,
+                               @Nullable Map<String, String> originalProperties,
+                               SortedMap<String, String> properties,
+                               SortedMap<String, DatasetSpecification> datasetSpecs) {
     this.name = name;
     this.type = type;
     this.properties = Collections.unmodifiableSortedMap(new TreeMap<>(properties));
+    this.originalProperties = originalProperties == null ? null :
+      Collections.unmodifiableMap(new TreeMap<String, String>(originalProperties));
     this.datasetSpecs = Collections.unmodifiableSortedMap(new TreeMap<>(datasetSpecs));
   }
 
@@ -134,6 +156,15 @@ public final class DatasetSpecification {
   }
 
   /**
+   * Return the original properties with which the dataset was created/reconfigured.
+   * @return an immutable map. For embedded datasets, this will always return null.
+   */
+  @Nullable
+  public Map<String, String> getOriginalProperties() {
+    return originalProperties;
+  }
+
+  /**
    * Return map of all properties set in this specification.
    * @return an immutable map.
    */
@@ -181,25 +212,26 @@ public final class DatasetSpecification {
   }
 
   /**
-   * Returns true if the tableName corresponds to the dataset specification.
-   * @param tableName
-   * @return <code>true</code> if the tableName represents the dataset spec;
+   * Returns true if the datasetName is the name of a non-composite dataset represented by this spec.
+   * That is, it is represented by one of the leaf-nodes of this dataset spec.
+   * @param datasetName the name of a dataset
+   * @return <code>true</code> if the datasetName is represented by the dataset spec;
    *         <code>false</code> otherwise
    */
-  public boolean isParent(String tableName) {
-    return isParent(tableName, this);
+  public boolean isParent(String datasetName) {
+    return isParent(datasetName, this);
   }
 
-  private boolean isParent(String tableName, DatasetSpecification specification) {
-    if (tableName == null) {
+  private boolean isParent(String datasetName, DatasetSpecification specification) {
+    if (datasetName == null) {
       return false;
     }
-    if (specification.getSpecifications().size() == 0 && specification.getName().equals(tableName)) {
+    if (specification.getSpecifications().size() == 0 && specification.getName().equals(datasetName)) {
       return true;
     }
-    if (tableName.startsWith(specification.getName())) {
+    if (datasetName.startsWith(specification.getName())) {
       for (DatasetSpecification spec : specification.getSpecifications().values()) {
-        if (isParent(tableName, spec)) {
+        if (isParent(datasetName, spec)) {
           return true;
         }
       }

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -283,9 +283,10 @@ public class CLIMainTest {
 
     DatasetTypeClient datasetTypeClient = new DatasetTypeClient(cliConfig.getClientConfig());
     DatasetTypeMeta datasetType = datasetTypeClient.list(Id.Namespace.DEFAULT).get(0);
-    testCommandOutputContains(cli, "create dataset instance " + datasetType.getName() + " " + datasetName,
+    testCommandOutputContains(cli, "create dataset instance " + datasetType.getName() + " " + datasetName + " \"a=1\"",
                               "Successfully created dataset");
     testCommandOutputContains(cli, "list dataset instances", FakeDataset.class.getSimpleName());
+    testCommandOutputContains(cli, "get dataset instance properties " + datasetName, "\"a\":\"1\"");
 
     NamespaceClient namespaceClient = new NamespaceClient(cliConfig.getClientConfig());
     Id.Namespace barspace = Id.Namespace.from("bar");

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetDatasetInstancePropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetDatasetInstancePropertiesCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command;
+
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.util.AbstractCommand;
+import co.cask.cdap.client.DatasetClient;
+import co.cask.cdap.proto.Id;
+import co.cask.common.cli.Arguments;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import java.util.Map;
+
+/**
+ * Sets properties for a dataset instance.
+ */
+public class GetDatasetInstancePropertiesCommand extends AbstractCommand {
+
+  private static final Gson GSON = new Gson();
+  private final DatasetClient datasetClient;
+
+  @Inject
+  public GetDatasetInstancePropertiesCommand(DatasetClient datasetClient, CLIConfig cliConfig) {
+    super(cliConfig);
+    this.datasetClient = datasetClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream output) throws Exception {
+    Id.DatasetInstance instance = Id.DatasetInstance.from(cliConfig.getCurrentNamespace(),
+                                                          arguments.get(ArgumentName.DATASET.toString()));
+
+    Map<String, String> properties = datasetClient.getProperties(instance);
+    output.printf(GSON.toJson(properties));
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("get dataset instance properties <%s>",
+                         ArgumentName.DATASET);
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Gets the properties used to create or update %s.",
+                         Fragment.of(Article.A, ElementType.DATASET.getName()));
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/DatasetCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/DatasetCommands.java
@@ -25,6 +25,7 @@ import co.cask.cdap.cli.command.DeployDatasetModuleCommand;
 import co.cask.cdap.cli.command.DescribeDatasetInstanceCommand;
 import co.cask.cdap.cli.command.DescribeDatasetModuleCommand;
 import co.cask.cdap.cli.command.DescribeDatasetTypeCommand;
+import co.cask.cdap.cli.command.GetDatasetInstancePropertiesCommand;
 import co.cask.cdap.cli.command.ListDatasetInstancesCommand;
 import co.cask.cdap.cli.command.ListDatasetModulesCommand;
 import co.cask.cdap.cli.command.ListDatasetTypesCommand;
@@ -49,6 +50,7 @@ public class DatasetCommands extends CommandSet<Command> implements Categorized 
         .add(injector.getInstance(ListDatasetModulesCommand.class))
         .add(injector.getInstance(ListDatasetTypesCommand.class))
         .add(injector.getInstance(DescribeDatasetInstanceCommand.class))
+        .add(injector.getInstance(GetDatasetInstancePropertiesCommand.class))
         .add(injector.getInstance(SetDatasetInstancePropertiesCommand.class))
         .add(injector.getInstance(CreateDatasetInstanceCommand.class))
         .add(injector.getInstance(DeleteDatasetInstanceCommand.class))

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetClient.java
@@ -290,4 +290,21 @@ public class DatasetClient {
                                             String.format("data/datasets/%s/admin/truncate", instance.getId()));
     restClient.execute(HttpMethod.POST, url, config.getAccessToken());
   }
+
+  /**
+   * Retrieve the properties with which a dataset was created or updated.
+   * @param instance the dataset instance
+   * @return the properties as a map
+   */
+  public Map<String, String> getProperties(Id.DatasetInstance instance)
+    throws IOException, UnauthorizedException, NotFoundException {
+    URL url = config.resolveNamespacedURLV3(instance.getNamespace(),
+                                            String.format("data/datasets/%s/properties", instance.getId()));
+    HttpRequest request = HttpRequest.get(url).build();
+    HttpResponse response = restClient.execute(request, config.getAccessToken());
+    if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(instance);
+    }
+    return ObjectResponse.fromJsonBody(response, new TypeToken<Map<String, String>>() { }).getResponseObject();
+  }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetType.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetType.java
@@ -42,7 +42,8 @@ public final class DatasetType<D extends Dataset, A extends DatasetAdmin> {
   }
 
   public DatasetSpecification configure(String instanceName, DatasetProperties properties) {
-    return delegate.configure(instanceName, properties);
+    DatasetSpecification spec = delegate.configure(instanceName, properties);
+    return spec.setOriginalProperties(properties);
   }
 
   public A getAdmin(DatasetContext datasetContext, DatasetSpecification spec) throws IOException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.DatasetTypeNotFoundException;
 import co.cask.cdap.common.HandlerException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpResponse;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.Id;
@@ -108,6 +109,17 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
     } catch (HandlerException e) {
       responder.sendString(e.getFailureStatus(), e.getMessage());
     }
+  }
+
+  @GET
+  @Path("/data/datasets/{name}/properties")
+  public void getProperties(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId,
+                            @PathParam("name") String name) throws Exception {
+    Id.DatasetInstance instance = ConversionHelpers.toDatasetInstanceId(namespaceId, name);
+    responder.sendJson(HttpResponseStatus.OK,
+                       instanceService.getOriginalProperties(instance),
+                       new TypeToken<Map<String, String>>() { }.getType());
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
@@ -52,7 +52,7 @@ public final class FileSetDataset implements FileSet {
 
   private static final Logger LOG = LoggerFactory.getLogger(FileSetDataset.class);
 
-  static final String FILESET_VERSION_PROPERTY = "fileset.version";
+  public static final String FILESET_VERSION_PROPERTY = "fileset.version";
   static final String FILESET_VERSION = "2";
 
   private final DatasetSpecification spec;

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceServiceTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset.service;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.data.schema.UnsupportedTypeException;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+import co.cask.cdap.api.dataset.lib.IndexedTableDefinition;
+import co.cask.cdap.api.dataset.lib.ObjectMappedTable;
+import co.cask.cdap.api.dataset.lib.ObjectMappedTableProperties;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.api.dataset.table.ConflictDetection;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
+import co.cask.cdap.data2.dataset2.TestObject;
+import co.cask.cdap.data2.metadata.lineage.LineageDataset;
+import co.cask.cdap.data2.registry.UsageDataset;
+import co.cask.cdap.proto.Id;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class DatasetInstanceServiceTest extends DatasetServiceTestBase {
+
+  @Test
+  public void testFixProperties() throws DatasetManagementException, UnsupportedTypeException {
+    testFix("fileSet",
+            FileSetProperties.builder().setBasePath("/tmp/nn").setDataExternal(true).build());
+    testFix(FileSet.class.getName(),
+            FileSetProperties.builder().setEnableExploreOnCreate(true).setExploreFormat("csv").build());
+
+    testFix("timePartitionedFileSet",
+            FileSetProperties.builder().setBasePath("relative").build());
+    testFix(TimePartitionedFileSet.class.getName(),
+            FileSetProperties.builder().setBasePath("relative").add("custom", "value").build());
+
+    testFix("objectMappedTable",
+            ObjectMappedTableProperties.builder().setType(TestObject.class)
+              .setRowKeyExploreName("x").setRowKeyExploreType(Schema.Type.STRING)
+              .add(Table.PROPERTY_CONFLICT_LEVEL, ConflictDetection.NONE.name()).build());
+    testFix(ObjectMappedTable.class.getName(),
+            ObjectMappedTableProperties.builder().setType(TestObject.class)
+              .setRowKeyExploreName("x").setRowKeyExploreType(Schema.Type.STRING)
+              .add(Table.PROPERTY_CONFLICT_LEVEL, ConflictDetection.NONE.name()).build());
+
+    testFix("lineageDataset",
+            DatasetProperties.EMPTY);
+    testFix(LineageDataset.class.getName(),
+            DatasetProperties.builder().add(Table.PROPERTY_TTL, 1000).build());
+    testFix(UsageDataset.class.getName(),
+            DatasetProperties.EMPTY);
+
+    testFix("table",
+            DatasetProperties.builder().add(Table.PROPERTY_COLUMN_FAMILY, "fam").build());
+    testFix("indexedTable",
+            DatasetProperties.builder().add(IndexedTableDefinition.INDEX_COLUMNS_CONF_KEY, "a,c").build());
+  }
+
+  private void testFix(String type, DatasetProperties props) {
+    DatasetDefinition def = DatasetFrameworkTestUtil.getDatasetDefinition(
+      inMemoryDatasetFramework, Id.Namespace.DEFAULT, "fileSet");
+    Assert.assertNotNull(def);
+    DatasetSpecification spec = def.configure("nn", props);
+    Map<String, String> originalProperties = DatasetInstanceService.fixOriginalProperties(spec);
+    Assert.assertEquals(props.getProperties(), originalProperties);
+  }
+
+
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -110,6 +110,7 @@ public abstract class DatasetServiceTestBase {
   private NamespaceStore namespaceStore;
   protected TransactionManager txManager;
   protected RemoteDatasetFramework dsFramework;
+  protected InMemoryDatasetFramework inMemoryDatasetFramework;
 
   private int port = -1;
 
@@ -175,8 +176,8 @@ public abstract class DatasetServiceTestBase {
 
     TransactionExecutorFactory txExecutorFactory = injector.getInstance(TransactionExecutorFactory.class);
 
-    MDSDatasetsRegistry mdsDatasetsRegistry =
-      new MDSDatasetsRegistry(txSystemClientService, new InMemoryDatasetFramework(registryFactory, modules, cConf));
+    inMemoryDatasetFramework = new InMemoryDatasetFramework(registryFactory, modules, cConf);
+    MDSDatasetsRegistry mdsDatasetsRegistry = new MDSDatasetsRegistry(txSystemClientService, inMemoryDatasetFramework);
 
     ExploreFacade exploreFacade = new ExploreFacade(new DiscoveryExploreClient(discoveryService), cConf);
     namespaceStore = new InMemoryNamespaceStore();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -166,4 +166,11 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
   public TransactionManager getTxManager() {
     return txManager;
   }
+
+  // helper to make this method accessible to DatasetInstanceServiceTest
+  public static DatasetDefinition getDatasetDefinition(InMemoryDatasetFramework framework,
+                                                       Id.Namespace namespace, String type) {
+    return framework.getDefinitionForType(namespace, type);
+  }
+
 }

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="7e3228aefe286ca3f9627c75df0947c0"
+DEFAULT_XML_MD5_HASH="ccb3e93d81c9058e63f90c8ba437688b"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-docs/reference-manual/source/cli-api.rst
+++ b/cdap-docs/reference-manual/source/cli-api.rst
@@ -304,6 +304,7 @@ These are the available commands:
    ``describe dataset instance <dataset-name>``,"Shows information about a dataset."
    ``describe dataset module <dataset-module>``,"Shows information about a dataset module."
    ``describe dataset type <dataset-type>``,"Shows information about a dataset type."
+   ``get dataset instance properties <dataset-name>``,"Gets the properties with which a dataset was created or updated."
    ``list dataset instances``,"Lists all datasets."
    ``list dataset modules``,"Lists all dataset modules."
    ``list dataset types``,"Lists all dataset types."

--- a/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
@@ -107,6 +107,48 @@ with JSON-formatted name of the dataset type and properties in a body::
 
 .. _http-restful-api-dataset-updating:
 
+Properties of an Existing Dataset
+---------------------------------
+
+You can retrieve the properties with which a dataset was created or last updated by issuing an HTTP GET request to
+the URL::
+
+	GET <base-url>/namespaces/<namespace>/data/datasets/<dataset-name>/properties
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``<namespace>``
+     - Namespace ID
+   * - ``<dataset-name>``
+     - Name of the existing dataset
+
+.. rubric:: HTTP Responses
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Status Codes
+     - Description
+   * - ``200 OK``
+     - Requested dataset was successfully updated
+   * - ``404 Not Found``
+     - Requested dataset instance was not found
+
+The response |---| if successful |---| will contain the JSON-formatted properties::
+
+  {
+     "key1":"value1",
+     "key2":"value2"
+  }
+
+Note that this will return the original properties that were submitted when the dataset was created or updated.
+You can use these properties to create a clone of the dataset, or as a basis for updating some properties of this
+dataset without modifying the remaining properties.
+
 Updating an Existing Dataset
 ----------------------------
 


### PR DESCRIPTION
- stores the original properties in the dataset spec
- adds an endpoint and CLI command to retrieve them
- compatibility mode for datasets that were created pre-3.4
- unit tests
- documentation

Description: https://issues.cask.co/browse/CDAP-5182
Build: http://builds.cask.co/browse/CDAP-DUT3646
Docs Build: http://builds.cask.co/browse/CDAP-DOB140

Docs build failed initially due to a wrong MD5 hash that was not caused by this PR. 