### PR TITLE
CDAP-5152 Invoke Plugin endpoint method from Artifact handler

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/EndpointPluginContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/EndpointPluginContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.plugin;
+
+import co.cask.cdap.api.annotation.Beta;
+
+import javax.annotation.Nullable;
+
+/**
+ * Provides access to load plugin class from plugin endpoint methods.
+ */
+@Beta
+public interface EndpointPluginContext {
+  /**
+   * loads and returns a plugin class.
+   *
+   * @param pluginType plugin type name
+   * @param pluginName plugin name
+   * @param pluginProperties properties for the plugin.
+   *                         The same set of properties will be used to instantiate the plugin
+   *                         instance at execution time
+   * @param <T> type of the plugin class
+   * @return A {@link Class} for the plugin class or {@code null} if no plugin was found
+   */
+  @Nullable <T> Class<T> loadPluginClass(String pluginType, String pluginName,
+                                         PluginProperties pluginProperties);
+
+  /**
+   * loads and returns a plugin class.
+   *
+   * @param pluginType plugin type name
+   * @param pluginName plugin name
+   * @param pluginProperties properties for the plugin.
+   *                         The same set of properties will be used to instantiate the plugin
+   *                         instance at execution time
+   * @param pluginSelector class for selecting plugin
+   * @param <T> type of the plugin class
+   * @return A {@link Class} for the plugin class or {@code null} if no plugin was found
+   */
+  @Nullable <T> Class<T> loadPluginClass(String pluginType, String pluginName,
+                                         PluginProperties pluginProperties, PluginSelector pluginSelector);
+
+  /**
+   * loads and returns a plugin class.
+   *
+   * @param pluginType plugin type name
+   * @param pluginName plugin name
+   * @param <T> type of the plugin class
+   * @return A {@link Class} for the plugin class or {@code null} if no plugin was found
+   */
+  @Nullable <T> Class<T> loadPluginClass(String pluginType, String pluginName);
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginClass.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginClass.java
@@ -18,7 +18,10 @@ package co.cask.cdap.api.plugin;
 
 import co.cask.cdap.api.annotation.Beta;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -33,9 +36,11 @@ public class PluginClass {
   private final String className;
   private final String configFieldName;
   private final Map<String, PluginPropertyField> properties;
+  private final Set<String> endpoints;
 
   public PluginClass(String type, String name, String description, String className,
-                     @Nullable String configfieldName, Map<String, PluginPropertyField> properties) {
+                     @Nullable String configfieldName, Map<String, PluginPropertyField> properties,
+                     Set<String> endpoints) {
     if (type == null) {
       throw new IllegalArgumentException("Plugin class type cannot be null");
     }
@@ -58,6 +63,12 @@ public class PluginClass {
     this.className = className;
     this.configFieldName = configfieldName;
     this.properties = properties;
+    this.endpoints = endpoints;
+  }
+
+  public PluginClass(String type, String name, String description, String className,
+                     @Nullable String configfieldName, Map<String, PluginPropertyField> properties) {
+    this(type, name, description, className, configfieldName, properties, new HashSet<String>());
   }
 
   /**
@@ -98,6 +109,14 @@ public class PluginClass {
   }
 
   /**
+   * Returns the set of plugin endpoints available in the plugin.
+   * If no such field will return empty set.
+   */
+  public Set<String> getEndpoints() {
+    return endpoints;
+  }
+
+  /**
    * Returns a map from config property name to {@link PluginPropertyField} that are supported by the plugin class.
    */
   public Map<String, PluginPropertyField> getProperties() {
@@ -115,12 +134,13 @@ public class PluginClass {
 
     PluginClass that = (PluginClass) o;
 
-    return type.equals(that.type)
-      && name.equals(that.name)
-      && description.equals(that.description)
-      && className.equals(that.className)
-      && !(configFieldName != null ? !configFieldName.equals(that.configFieldName) : that.configFieldName != null)
-      && properties.equals(that.properties);
+    return Objects.equals(type, that.type)
+      && Objects.equals(name, that.name)
+      && Objects.equals(description, that.description)
+      && Objects.equals(className, that.className)
+      && Objects.equals(configFieldName, that.configFieldName)
+      && Objects.equals(properties, that.properties)
+      && Objects.equals(endpoints, that.endpoints);
   }
 
   @Override
@@ -131,6 +151,7 @@ public class PluginClass {
     result = 31 * result + className.hashCode();
     result = 31 * result + (configFieldName != null ? configFieldName.hashCode() : 0);
     result = 31 * result + properties.hashCode();
+    result = 31 * result + (endpoints != null ? endpoints.hashCode() : 0);
     return result;
   }
 
@@ -142,7 +163,8 @@ public class PluginClass {
       ", name='" + name + '\'' +
       ", description='" + description + '\'' +
       ", configFieldName='" + configFieldName + '\'' +
-      ", properties=" + properties +
+      ", properties=" + properties + '\'' +
+      ", endpoints='" + endpoints +
       '}';
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
@@ -16,19 +16,22 @@
 
 package co.cask.cdap.internal.app;
 
-import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.DatasetConfigurer;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.plugin.Plugin;
-import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfigurer;
 import co.cask.cdap.api.plugin.PluginProperties;
-import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.api.plugin.PluginSelector;
 import co.cask.cdap.common.ArtifactNotFoundException;
 import co.cask.cdap.internal.api.DefaultDatasetConfigurer;
-import co.cask.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.plugin.FindPluginHelper;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.plugin.PluginNotExistsException;
+import co.cask.cdap.internal.test.PluginJarHelper;
 import co.cask.cdap.proto.Id;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -151,30 +154,7 @@ public class DefaultPluginConfigurer extends DefaultDatasetConfigurer implements
     throws PluginNotExistsException, ArtifactNotFoundException {
     Preconditions.checkArgument(!plugins.containsKey(pluginId),
                                 "Plugin of type %s, name %s was already added.", pluginType, pluginName);
-    Preconditions.checkArgument(properties != null, "Plugin properties cannot be null");
-
-    Map.Entry<ArtifactDescriptor, PluginClass> pluginEntry;
-    try {
-      pluginEntry = artifactRepository.findPlugin(deployNamespace, artifactId, pluginType, pluginName, selector);
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
-
-    // Just verify if all required properties are provided.
-    // No type checking is done for now.
-    for (PluginPropertyField field : pluginEntry.getValue().getProperties().values()) {
-      Preconditions.checkArgument(!field.isRequired() ||
-                                    (properties != null && properties.getProperties().containsKey(field.getName())),
-                                  "Required property '%s' missing for plugin of type %s, name %s.",
-                                  field.getName(), pluginType, pluginName);
-    }
-
-    ArtifactId artifactId = pluginEntry.getKey().getArtifactId();
-    try {
-      pluginInstantiator.addArtifact(pluginEntry.getKey().getLocation(), artifactId);
-    } catch (IOException e) {
-      Throwables.propagate(e);
-    }
-    return new Plugin(artifactId, pluginEntry.getValue(), properties);
+    return FindPluginHelper.findPlugin(artifactRepository, pluginInstantiator, deployNamespace.toEntityId(), artifactId,
+                                       pluginType, pluginName, properties, selector);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultEndpointPluginContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultEndpointPluginContext.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime;
+
+import co.cask.cdap.api.plugin.EndpointPluginContext;
+import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.plugin.PluginSelector;
+import co.cask.cdap.common.ArtifactNotFoundException;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.plugin.FindPluginHelper;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.internal.app.runtime.plugin.PluginNotExistsException;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.base.Throwables;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * An implementation of {@link EndpointPluginContext} that uses {@link PluginInstantiator}
+ */
+public class DefaultEndpointPluginContext implements EndpointPluginContext {
+
+  private final ArtifactRepository artifactRepository;
+  // this is the namespace of the artifact
+  private final NamespaceId namespace;
+
+  private final PluginInstantiator pluginInstantiator;
+  private final Id.Artifact parentArtifactId;
+
+  public DefaultEndpointPluginContext(NamespaceId namespace, ArtifactRepository artifactRepository,
+                                      PluginInstantiator pluginInstantiator, Id.Artifact parentArtifactId) {
+    this.namespace = namespace;
+    this.artifactRepository = artifactRepository;
+    this.pluginInstantiator = pluginInstantiator;
+    this.parentArtifactId = parentArtifactId;
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginType, String pluginName) {
+    return loadPluginClass(pluginType, pluginName, PluginProperties.builder().build(), new PluginSelector());
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginType, String pluginName,
+                                      PluginProperties pluginProperties) {
+    return loadPluginClass(pluginType, pluginName, pluginProperties, new PluginSelector());
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginType, String pluginName, PluginProperties pluginProperties,
+                                      PluginSelector pluginSelector) {
+    Plugin plugin;
+    try {
+      plugin = FindPluginHelper.findPlugin(artifactRepository, pluginInstantiator, namespace, parentArtifactId,
+                                           pluginType, pluginName, pluginProperties, pluginSelector);
+    } catch (PluginNotExistsException e) {
+      // Plugin not found, hence return null
+      return null;
+    } catch (ArtifactNotFoundException e) {
+      // this shouldn't happen, it means the artifact for this app does not exist.
+      throw new IllegalStateException(
+        String.format("Application artifact '%s' no longer exists. Please check if it was deleted.",
+                      parentArtifactId));
+    }
+
+    try {
+      return pluginInstantiator.loadClass(plugin);
+    } catch (IOException e) {
+      // If the plugin jar is deleted without notifying the artifact service.
+      return null;
+    } catch (ClassNotFoundException e) {
+      // Shouldn't happen
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -83,7 +83,7 @@ public class ArtifactRepository {
   ArtifactRepository(CConfiguration cConf, ArtifactStore artifactStore, MetadataStore metadataStore) {
     this.artifactStore = artifactStore;
     File baseUnpackDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
-      cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+                                  cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
     this.artifactClassLoaderFactory = new ArtifactClassLoaderFactory(cConf, baseUnpackDir);
     this.artifactInspector = new ArtifactInspector(cConf, artifactClassLoaderFactory, baseUnpackDir);
     this.systemArtifactDirs = new ArrayList<>();
@@ -159,6 +159,17 @@ public class ArtifactRepository {
   }
 
   /**
+   * Get all artifacts that match artifacts in the given ranges.
+   *
+   * @param range the range to match artifacts in
+   * @return an unmodifiable list of all artifacts that match the given ranges. If none exist, an empty list
+   *         is returned
+   */
+  public List<ArtifactDetail> getArtifacts(final ArtifactRange range) {
+    return artifactStore.getArtifacts(range);
+  }
+
+  /**
    * Get all application classes in the given namespace, optionally including classes from system artifacts as well.
    * Will never return null. If no artifacts exist, an empty list is returned. Namespace existence is not checked.
    *
@@ -198,6 +209,7 @@ public class ArtifactRepository {
     }
     return Collections.unmodifiableList(infos);
   }
+
 
   /**
    * Returns a {@link SortedMap} of plugin artifact to all plugins available for the given artifact. The keys
@@ -309,7 +321,7 @@ public class ArtifactRepository {
       validatePluginSet(artifactClasses.getPlugins());
       ArtifactMeta meta = new ArtifactMeta(artifactClasses, ImmutableSet.<ArtifactRange>of());
       ArtifactInfo artifactInfo = new ArtifactInfo(artifactId.toArtifactId(), artifactClasses,
-                                                  ImmutableMap.<String, String>of());
+                                                   ImmutableMap.<String, String>of());
       writeSystemMetadata(artifactId, artifactInfo);
       return artifactStore.write(artifactId, meta, Files.newInputStreamSupplier(artifactFile));
     }
@@ -616,7 +628,7 @@ public class ArtifactRepository {
       // shouldn't happen... but if it does for some reason it's fine, it means it was added some other way already.
     } catch (ArtifactRangeNotFoundException e) {
       LOG.warn(String.format("Could not add system artifact '%s' because it extends artifacts that do not exist.",
-        fileName), e);
+                             fileName), e);
     } catch (InvalidArtifactException e) {
       LOG.warn(String.format("Could not add system artifact '%s' because it is invalid.", fileName), e);
     }
@@ -661,7 +673,7 @@ public class ArtifactRepository {
 
     if (parents.isEmpty()) {
       throw new ArtifactRangeNotFoundException(String.format("Artifact %s extends artifacts '%s' that do not exist",
-        artifactId, Joiner.on('/').join(parentArtifacts)));
+                                                             artifactId, Joiner.on('/').join(parentArtifacts)));
     }
 
     // check if any of the parents also have parents, which is not allowed. This is to simplify things

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/FindPluginHelper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/FindPluginHelper.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.plugin;
+
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.api.plugin.PluginSelector;
+import co.cask.cdap.common.ArtifactNotFoundException;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Abstract class that can help in finding plugin's
+ */
+public final class FindPluginHelper {
+
+  private FindPluginHelper() {
+    // no-op
+  }
+
+  /**
+   * Find and return the requested plugin using the artifact repository, if found.
+   * @param artifactRepository artifact repository to find plugin artifact.
+   * @param pluginInstantiator plugin instantiator to add the identified plugin artifact.
+   * @param namespace namespace of plugin
+   * @param parentArtifactId parent artifact
+   * @param pluginType plugin type
+   * @param pluginName name of the plugin
+   * @param properties plugin properties
+   * @param selector seelector used to select a plugin
+   * @return {@link Plugin}
+   * @throws PluginNotExistsException
+   * @throws ArtifactNotFoundException
+   */
+  public static Plugin findPlugin(ArtifactRepository artifactRepository,
+                              PluginInstantiator pluginInstantiator,
+                              NamespaceId namespace,
+                              Id.Artifact parentArtifactId, String pluginType, String pluginName,
+                              PluginProperties properties, PluginSelector selector)
+    throws PluginNotExistsException, ArtifactNotFoundException {
+    Preconditions.checkArgument(properties != null, "Plugin properties cannot be null");
+    Map.Entry<ArtifactDescriptor, PluginClass> pluginEntry;
+    try {
+      pluginEntry = artifactRepository.findPlugin(namespace.toId(),
+                                                  parentArtifactId, pluginType, pluginName, selector);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+
+    // Just verify if all required properties are provided.
+    // No type checking is done for now.
+    for (PluginPropertyField field : pluginEntry.getValue().getProperties().values()) {
+      Preconditions.checkArgument(!field.isRequired() ||
+                                    (properties != null && properties.getProperties().containsKey(field.getName())),
+                                  "Required property '%s' missing for plugin of type %s, name %s.",
+                                  field.getName(), pluginType, pluginName);
+    }
+
+    ArtifactId artifact = pluginEntry.getKey().getArtifactId();
+    try {
+      pluginInstantiator.addArtifact(pluginEntry.getKey().getLocation(), artifact);
+    } catch (IOException e) {
+      Throwables.propagate(e);
+    }
+    return new Plugin(artifact, pluginEntry.getValue(), properties);
+  }
+
+}
+

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginEndpoint.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginEndpoint.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.plugin;
+
+import co.cask.cdap.api.annotation.Beta;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
+
+/**
+ * Provides access to plugin endpoint. get request type of method parameter, invoke plugin method and get response.
+ */
+@Beta
+public interface PluginEndpoint {
+  /**
+   * get the type of method parameter
+   *
+   * @return Type of method's first parameter
+   * @throws IllegalArgumentException if argument list is empty
+   */
+  Type getMethodParameterType() throws IllegalArgumentException;
+
+  /**
+   * get the return type of plugin method
+   *
+   * @return return type of method
+   */
+  Type getResultType();
+
+  /**
+   * invoke method with the request object as parameter.
+   *
+   * @param reqest request object
+   * @return result from invoking the object
+   * @throws IOException when instantiating plugin before invoking method on it
+   * @throws ClassNotFoundException when instantiating plugin before invoking method on it
+   * @throws InvocationTargetException method invoke can throw
+   * @throws IllegalAccessException method invoke can throw
+   * @throws IllegalArgumentException method invoke can throw
+   */
+  Object invoke(Object reqest) throws IOException, ClassNotFoundException,
+    InvocationTargetException, IllegalAccessException, IllegalArgumentException;
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -34,6 +34,7 @@ import co.cask.cdap.internal.app.runtime.artifact.Artifacts;
 import co.cask.cdap.internal.lang.FieldVisitor;
 import co.cask.cdap.internal.lang.Fields;
 import co.cask.cdap.internal.lang.Reflections;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -78,13 +79,13 @@ public class PluginInstantiator implements Closeable {
   public PluginInstantiator(CConfiguration cConf, ClassLoader parentClassLoader, File pluginDir) {
     this.instantiatorFactory = new InstantiatorFactory(false);
     File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
-      cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+                           cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
 
     this.pluginDir = pluginDir;
     this.tmpDir = DirUtils.createTempDir(tmpDir);
     this.classLoaders = CacheBuilder.newBuilder()
-                                    .removalListener(new ClassLoaderRemovalListener())
-                                    .build(new ClassLoaderCacheLoader());
+      .removalListener(new ClassLoaderRemovalListener())
+      .build(new ClassLoaderCacheLoader());
     this.parentClassLoader = PluginClassLoader.createParent(parentClassLoader);
   }
 
@@ -129,6 +130,20 @@ public class PluginInstantiator implements Closeable {
   @SuppressWarnings("unchecked")
   public <T> Class<T> loadClass(Plugin plugin) throws IOException, ClassNotFoundException {
     return (Class<T>) getArtifactClassLoader(plugin.getArtifactId()).loadClass(plugin.getPluginClass().getClassName());
+  }
+
+  /**
+   * Create a new instance of plugin class without any config, config will be null in the instantiated plugin.
+   * @param artifact artifact of the plugin
+   * @param pluginClass information about plugin class
+   * @param <T> Type of plugin
+   * @return a new plugin instance
+   */
+  public <T> T newInstanceWithoutConfig(ArtifactId artifact,
+                                        PluginClass pluginClass) throws IOException, ClassNotFoundException {
+    ClassLoader pluginClassLoader = getArtifactClassLoader(artifact);
+    Class pluginClassLoaded = pluginClassLoader.loadClass(pluginClass.getClassName());
+    return (T) instantiatorFactory.get(TypeToken.of(pluginClassLoaded)).create();
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginService.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.runtime.plugin;
+
+import co.cask.cdap.api.plugin.EndpointPluginContext;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.common.ArtifactNotFoundException;
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.internal.app.runtime.DefaultEndpointPluginContext;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactClassLoaderFactory;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactDetail;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.artifact.CloseableClassLoader;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ArtifactRange;
+import com.google.common.io.Closeables;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+import javax.ws.rs.Path;
+
+/**
+ * To find, instantiate and invoke methods in plugin artifacts
+ */
+public class PluginService implements Closeable {
+  private final ArtifactRepository artifactRepository;
+  private final ArtifactClassLoaderFactory artifactClassLoaderFactory;
+  private final File stageDir;
+  private final CConfiguration cConf;
+
+  private CloseableClassLoader parentClassLoader;
+  private PluginInstantiator pluginInstantiator;
+
+  public PluginService(ArtifactRepository artifactRepository, File tmpDir, CConfiguration cConf) {
+    this.artifactRepository = artifactRepository;
+    this.stageDir = DirUtils.createTempDir(tmpDir);
+    this.cConf = cConf;
+    this.artifactClassLoaderFactory = new ArtifactClassLoaderFactory(cConf, tmpDir);
+  }
+
+  /**
+   * Given plugin artifact, find the parent artifact of plugin, after creating classloader with parent artifact
+   * and plugin, we invoke the plugin method in the plugin identified by type and name and return the response.
+   * @param namespace namespace
+   * @param artifactId plugin artifact id
+   * @param pluginType type of the plugin
+   * @param pluginName name of the plugin
+   * @param methodName name of the method
+   * @return {@link PluginEndpoint}
+   * @throws IOException
+   * @throws NotFoundException
+   * @throws ClassNotFoundException
+   */
+  public PluginEndpoint getPluginEndpoint(Id.Namespace namespace,
+                                          Id.Artifact artifactId, String pluginType,
+                                          String pluginName, String methodName)
+    throws IOException, NotFoundException, ClassNotFoundException {
+
+    ArtifactDetail artifactDetail = artifactRepository.getArtifact(artifactId);
+    return getPluginEndpoint(namespace, artifactDetail, pluginType, pluginName,
+                             pickParentArtifact(artifactDetail, artifactId), methodName);
+  }
+
+  private ArtifactDescriptor pickParentArtifact(ArtifactDetail artifactDetail, Id.Artifact artifact)
+    throws ArtifactNotFoundException, IOException {
+
+    // get parent artifacts
+    Set<ArtifactRange> parentArtifactRanges = artifactDetail.getMeta().getUsableBy();
+    if (parentArtifactRanges.isEmpty()) {
+      throw new ArtifactNotFoundException(artifact);
+    }
+
+    // just pick the first parent artifact from the set.
+    ArtifactRange parentArtifactRange = parentArtifactRanges.iterator().next();
+
+    List<ArtifactDetail> artifactDetails = artifactRepository.getArtifacts(parentArtifactRange);
+    if (artifactDetails.isEmpty()) {
+      // should not happen
+      throw new ArtifactNotFoundException(artifact);
+    }
+
+    // return the first one from the artifact details list.
+    return artifactDetails.get(0).getDescriptor();
+  }
+
+  private PluginEndpoint getPluginEndpoint(Id.Namespace namespace, ArtifactDetail artifactDetail, String pluginType,
+                                           String pluginName, ArtifactDescriptor parentArtifactDescriptor,
+                                           String methodName)
+    throws NotFoundException, IOException, ClassNotFoundException {
+
+    Id.Artifact artifactId = Id.Artifact.from(namespace, artifactDetail.getDescriptor().getArtifactId());
+    Set<PluginClass> pluginClasses = artifactDetail.getMeta().getClasses().getPlugins();
+    PluginClass pluginClass = null;
+
+    for (PluginClass plugin : pluginClasses) {
+      if (plugin.getName().equals(pluginName) && plugin.getType().equals(pluginType)) {
+        // plugin type and name matched, next check for endpoint method presence
+        if (plugin.getEndpoints() == null || !plugin.getEndpoints().contains(methodName)) {
+          throw new NotFoundException(
+            String.format("Plugin with type: %s name: %s found, " +
+                            "but Endpoint %s was not found", pluginType, pluginName, methodName));
+        }
+        pluginClass = plugin;
+      }
+    }
+
+    if (pluginClass == null) {
+      throw new NotFoundException(
+        String.format("No Plugin with type : %s, name: %s was found", pluginType, pluginName));
+    }
+
+    // initialize parent classloader and plugin instantiator
+    parentClassLoader = artifactClassLoaderFactory.createClassLoader(parentArtifactDescriptor.getLocation());
+    pluginInstantiator = new PluginInstantiator(cConf, parentClassLoader, stageDir);
+
+    // add plugin artifact
+    pluginInstantiator.addArtifact(artifactDetail.getDescriptor().getLocation(), artifactId.toArtifactId());
+
+    // we pass the parent artifact to endpoint plugin context,
+    // as plugin method will use this context to load other plugins.
+    DefaultEndpointPluginContext defaultEndpointPluginContext =
+      new DefaultEndpointPluginContext(namespace.toEntityId(), artifactRepository, pluginInstantiator,
+                                       Id.Artifact.from(namespace, parentArtifactDescriptor.getArtifactId()));
+
+    return getPluginEndpoint(pluginInstantiator, artifactId,
+                             pluginClass, methodName, defaultEndpointPluginContext);
+  }
+
+  /**
+   * load and instantiate the plugin and return {@link PluginEndpoint}
+   * which can be used to invoke plugin method with request object.
+   *
+   * @param pluginInstantiator to instantiate plugin instances.
+   * @param artifact artifact of the plugin
+   * @param pluginClass class having the plugin method to invoke
+   * @param endpointName name of the endpoint to invoke
+   * @param endpointPluginContext endpoint plugin context that can optionally be passed to the method
+   * @throws IOException if there was an exception getting the classloader
+   * @throws ClassNotFoundException if plugin class cannot be loaded
+   * @throws NotFoundException Not Found exception thrown if no matching plugin found.
+   */
+  private PluginEndpoint getPluginEndpoint(final PluginInstantiator pluginInstantiator, Id.Artifact artifact,
+                                           PluginClass pluginClass, String endpointName,
+                                           final DefaultEndpointPluginContext endpointPluginContext)
+    throws IOException, ClassNotFoundException, NotFoundException {
+
+    ClassLoader pluginClassLoader = pluginInstantiator.getArtifactClassLoader(artifact.toArtifactId());
+    Class pluginClassLoaded = pluginClassLoader.loadClass(pluginClass.getClassName());
+
+    final Object pluginInstance = pluginInstantiator.newInstanceWithoutConfig(artifact.toArtifactId(), pluginClass);
+
+    Method[] methods = pluginClassLoaded.getMethods();
+    for (final Method method : methods) {
+      Path pathAnnotation = method.getAnnotation(Path.class);
+      // method should have path annotation else continue
+      if (pathAnnotation == null || !pathAnnotation.value().equals(endpointName)) {
+        continue;
+      }
+
+      return new PluginEndpoint() {
+        @Override
+        public java.lang.reflect.Type getMethodParameterType() throws IllegalArgumentException {
+          if (method.getParameterTypes().length == 0) {
+            // should not happen, checks should have happened during deploy artifact.
+            throw new IllegalArgumentException("No Method parameter type found");
+          }
+          return method.getGenericParameterTypes()[0];
+        }
+
+        @Override
+        public java.lang.reflect.Type getResultType() {
+          return method.getGenericReturnType();
+        }
+
+        @Override
+        public Object invoke(Object request) throws IOException, ClassNotFoundException,
+          InvocationTargetException, IllegalAccessException, IllegalArgumentException {
+
+          if (method.getParameterTypes().length == 2 &&
+            EndpointPluginContext.class.isAssignableFrom(method.getParameterTypes()[1])) {
+            return method.invoke(pluginInstance, request, endpointPluginContext);
+          } else if (method.getParameterTypes().length == 1) {
+            return method.invoke(pluginInstance, request);
+          } else {
+            throw new IllegalArgumentException(
+              String.format("Only method with 1 parameter and optional EndpointPluginContext as 2nd parameter is " +
+                              "allowed in Plugin endpoint method, Found %s parameters",
+                            method.getParameterTypes().length));
+          }
+        }
+      };
+    };
+
+    // cannot find the endpoint in plugin method. should not happen as this is checked earlier.
+    throw new NotFoundException("Could not find the plugin method with the requested method endpoint {}", endpointName);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (pluginInstantiator != null) {
+      Closeables.closeQuietly(pluginInstantiator);
+    }
+    if (parentClassLoader != null) {
+      Closeables.closeQuietly(parentClassLoader);
+    }
+    DirUtils.deleteDirectoryContents(stageDir);
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/endpointtest/MockEndpointPluginContext.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/endpointtest/MockEndpointPluginContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact.plugin.endpointtest;
+
+
+import co.cask.cdap.api.plugin.EndpointPluginContext;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.plugin.PluginSelector;
+
+import javax.annotation.Nullable;
+
+/**
+ * mock endpoint plugin context
+ */
+public class MockEndpointPluginContext implements EndpointPluginContext {
+
+  @Nullable
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginType, String pluginName, PluginProperties pluginProperties) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginType, String pluginName,
+                                      PluginProperties pluginProperties, PluginSelector pluginSelector) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginType, String pluginName) {
+    return null;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/endpointtest/PluginEndpointContextTestPlugin.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/endpointtest/PluginEndpointContextTestPlugin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact.plugin.endpointtest;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+
+import javax.ws.rs.Path;
+
+/**
+ * plugin doesn't actually do anything, just for testing add artifact
+ */
+@Plugin(type = "valid")
+@Name("extender")
+@Description("This is a Plugin that uses TestEndpointPluginContext")
+public class PluginEndpointContextTestPlugin {
+
+  @Path("ping1")
+  public String callMe(String input, TestEndpointPluginContext context) {
+    return "hello";
+  }
+
+  // dupliate endpoint "ping"
+  @Path("ping2")
+  public String callMeAgain(String input, MockEndpointPluginContext context) {
+    return "hello";
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/endpointtest/TestEndpointPluginContext.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/endpointtest/TestEndpointPluginContext.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact.plugin.endpointtest;
+
+
+/**
+ * extend mock endpoint plugin context
+ */
+public class TestEndpointPluginContext extends MockEndpointPluginContext {
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/invalid/InvalidPlugin.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/invalid/InvalidPlugin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact.plugin.invalid;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+
+import javax.ws.rs.Path;
+
+/**
+ * plugin doesn't actually do anything, just for tests
+ */
+@Plugin(type = "invalid")
+@Name("invalid")
+@Description("This is a Plugin with issues")
+public class InvalidPlugin {
+
+  @Path("ping")
+  public String callMe(String input) {
+    return "hello";
+  }
+
+  // dupliate endpoint "ping"
+  @Path("ping")
+  public String callMeAgain(String input) {
+    return "hello";
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/invalid2/InvalidPluginMethodParams.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/invalid2/InvalidPluginMethodParams.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact.plugin.invalid2;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.plugin.EndpointPluginContext;
+
+import javax.ws.rs.Path;
+
+/**
+ * plugin doesn't actually do anything, just for tests
+ */
+@Plugin(type = "invalid")
+@Name("invalidParams")
+@Description("This is a Plugin with invalid params for method")
+public class InvalidPluginMethodParams {
+
+  @Path("ping")
+  public String callMe(String input, EndpointPluginContext context, Long timestamp) {
+    return "hello";
+  }
+
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/invalid3/InvalidPluginMethodParamType.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/invalid3/InvalidPluginMethodParamType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact.plugin.invalid3;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.plugin.EndpointPluginContext;
+
+import javax.ws.rs.Path;
+
+/**
+ * plugin should fail deploy.
+ */
+@Plugin(type = "invalid")
+@Name("invalidParamType")
+@Description("This is a Plugin with invalid params for method")
+public class InvalidPluginMethodParamType {
+
+  @Path("ping")
+  public String callMe(String input, Long timestamp) {
+    return "hello";
+  }
+
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/p3/CallablePlugin.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/p3/CallablePlugin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact.plugin.p3;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+
+import java.util.concurrent.Callable;
+import javax.ws.rs.Path;
+
+/**
+ * this plugin should fail deploy
+ */
+@Plugin(type = "interactive")
+@Name("CallablePlugin")
+@Description("This is plugin3")
+public class CallablePlugin implements Callable {
+
+  @Path("ping")
+  public String callMe(String input) {
+    return "hello";
+  }
+
+  @Override
+  public Object call() throws Exception {
+    return "hi";
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/p4/CallingPlugin.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/p4/CallingPlugin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.runtime.artifact.plugin.p4;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.plugin.EndpointPluginContext;
+import co.cask.cdap.api.plugin.PluginProperties;
+
+import java.util.concurrent.Callable;
+import javax.ws.rs.Path;
+
+/**
+ * plugin doesn't actually do anything, just for tests
+ */
+@Plugin(type = "interactive")
+@Name("CallingPlugin")
+@Description("This is plugin4")
+public class CallingPlugin {
+
+  @Path("ping")
+  public String callMe(String input, EndpointPluginContext pluginContext)
+    throws Exception {
+
+    Class<? extends Callable> plugin3 =
+      pluginContext.loadPluginClass("interactive", "CallablePlugin", PluginProperties.builder().build());
+
+    return plugin3.newInstance().call() + " " + input;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/p5/PluginWithPojo.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/p5/PluginWithPojo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.runtime.artifact.plugin.p5;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.plugin.EndpointPluginContext;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.Path;
+
+/**
+ * plugin has endpoint to aggregate data
+ */
+@Plugin(type = "interactive")
+@Name("aggregator")
+@Description("This is Plugin that aggregates data")
+public class PluginWithPojo {
+
+  @Path("aggregate")
+  public Map<Long, Long> aggregateData(List<TestData> dataList, EndpointPluginContext pluginContext)
+    throws Exception {
+    Map<Long, Long> aggregateResult = new HashMap<>();
+    for (TestData data : dataList) {
+      long current =
+        aggregateResult.containsKey(data.getTimeStamp()) ? aggregateResult.get(data.getTimeStamp()) : 0;
+      aggregateResult.put(data.getTimeStamp(), current + data.getValue());
+    }
+    return aggregateResult;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/p5/TestData.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/plugin/p5/TestData.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.runtime.artifact.plugin.p5;
+
+/**
+ * timestamp and value
+ */
+public class TestData {
+  long timeStamp;
+  int value;
+
+  public TestData(long timeStamp, int value) {
+    this.timeStamp = timeStamp;
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  public long getTimeStamp() {
+    return timeStamp;
+  }
+
+
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/PluginClassDeserializer.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/PluginClassDeserializer.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -28,7 +29,10 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 
 import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A Gson deserializater for creating {@link PluginClass} object from external plugin config file.
@@ -53,11 +57,18 @@ public class PluginClassDeserializer implements JsonDeserializer<PluginClass> {
     String description = jsonObj.has("description") ? jsonObj.get("description").getAsString() : "";
     String className = getRequired(jsonObj, "className").getAsString();
 
+    JsonArray endpoints = getRequired(jsonObj, "endpoints").getAsJsonArray();
+    Set<String> endpointsSet = new HashSet<>();
+    Iterator<JsonElement> iterator = endpoints.iterator();
+    while (iterator.hasNext()) {
+      endpointsSet.add(iterator.next().getAsString());
+    }
+
     Map<String, PluginPropertyField> properties = jsonObj.has("properties")
       ? context.<Map<String, PluginPropertyField>>deserialize(jsonObj.get("properties"), PROPERTIES_TYPE)
       : ImmutableMap.<String, PluginPropertyField>of();
 
-    return new PluginClass(type, name, description, className, null, properties);
+    return new PluginClass(type, name, description, className, null, properties, endpointsSet);
   }
 
   private JsonElement getRequired(JsonObject jsonObj, String name) {


### PR DESCRIPTION
Implementation of app-fabric endpoint to hit plugin endpoint methods. 

Next steps:
1) Implementation of plugin methods listTables and getSchema for DBSource in Hydrator plugins repo.

JIRA : https://issues.cask.co/browse/CDAP-5152
Build : http://builds.cask.co/browse/CDAP-DUT3648-2