### PR TITLE
fixes alert close button positioning/visibility

### DIFF
--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -39,8 +39,15 @@ body.theme-cdap {
   // --------------------------------------------------
 
   > div.alerts {
+    div.alert {
+      position: relative;
+    }
     button.close {
-      font-size: 34px;
+      font-size: 30px;
+      line-height: 1;
+      position: absolute;
+      top: 2px;
+      right: 15px;
     }
   }
   // Common styles


### PR DESCRIPTION
*  Changes positioning of alert close button to ensure it's always fully displayed in the alert ribbon

Local build:
![local-close](https://cloud.githubusercontent.com/assets/5335210/13652149/76cc6882-e5ff-11e5-84ca-6d431674d06c.gif)

VM Build (3.3.1 snapshot):
![vm-close](https://cloud.githubusercontent.com/assets/5335210/13652161/8343b84a-e5ff-11e5-9c6c-41653f9cadff.gif)
