### PR TITLE
Improvement to Admin Documentation of upgrades: show examples of CDAP version

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -227,10 +227,16 @@ if version:
 """ % {'version': version}
 
 if short_version:
+    previous_short_version = float(short_version) -0.1
     rst_epilog = rst_epilog + """
 .. |short-version| replace:: %(short_version)s
+.. |bold-short-version| replace:: **%(short_version)s**
 .. |literal-short-version| replace:: ``%(short_version)s``
-""" % {'short_version': short_version}
+.. |previous-short-version| replace:: %(previous_short_version)s
+.. |bold-previous-short-version| replace:: **%(previous_short_version)s**
+.. |literal-previous-short-version| replace:: ``%(previous_short_version)s``
+
+""" % {'short_version': short_version, 'previous_short_version': previous_short_version}
 
 if version_tuple:
     rst_epilog = rst_epilog + """

--- a/cdap-docs/admin-manual/source/upgrading/cloudera.rst
+++ b/cdap-docs/admin-manual/source/upgrading/cloudera.rst
@@ -17,7 +17,7 @@ Upgrading CDAP
 Upgrading CDAP Patch Release Versions
 -------------------------------------
 Upgrading between patch versions of CDAP refers to upgrading from one |short-version|\.x
-version to a higher |short-version| version.
+version to a higher |short-version|\.x version.
 When a new compatible CDAP parcel is released, it will be available via the Parcels page
 in the Cloudera Manager UI.
 
@@ -32,8 +32,8 @@ in the Cloudera Manager UI.
 
 Upgrading CDAP Major/Minor Release Versions
 -------------------------------------------
-Upgrading between major versions of CDAP (for example, from a 3.3.x version to |short-version|\.x)
-involves the additional steps of upgrading the
+Upgrading between major versions of CDAP (for example, from a |previous-short-version|\.x version 
+to |short-version|\.x) involves the additional steps of upgrading the
 CSD, and running the included CDAP Upgrade Tool. Upgrades between multiple Major/Minor
 versions must be done consecutively, and a version cannot be skipped unless otherwise
 noted.

--- a/cdap-docs/admin-manual/source/upgrading/cloudera.rst
+++ b/cdap-docs/admin-manual/source/upgrading/cloudera.rst
@@ -16,6 +16,8 @@ Upgrading CDAP
 
 Upgrading CDAP Patch Release Versions
 -------------------------------------
+Upgrading between patch versions of CDAP refers to upgrading from one |short-version|\.x
+version to a higher |short-version| version.
 When a new compatible CDAP parcel is released, it will be available via the Parcels page
 in the Cloudera Manager UI.
 
@@ -30,7 +32,8 @@ in the Cloudera Manager UI.
 
 Upgrading CDAP Major/Minor Release Versions
 -------------------------------------------
-Upgrading between major versions of CDAP involves the additional steps of upgrading the
+Upgrading between major versions of CDAP (for example, from a 3.3.x version to |short-version|\.x)
+involves the additional steps of upgrading the
 CSD, and running the included CDAP Upgrade Tool. Upgrades between multiple Major/Minor
 versions must be done consecutively, and a version cannot be skipped unless otherwise
 noted.

--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -18,8 +18,10 @@ to make sure the CDAP table definitions in HBase are up-to-date.
 These steps will stop CDAP, update the installation, run an upgrade tool for the table definitions,
 and then restart CDAP.
 
-**These steps will upgrade from CDAP** |bold-previous-short-version|\ **.x to** |bold-short-version|\ **.x.** If you are on an earlier version of CDAP,
-please follow the upgrade instructions for the earlier versions and upgrade first to |previous-short-version|\.x before proceeding.
+**These steps will upgrade from CDAP** |bold-previous-short-version|\ **.x to**
+|bold-short-version|\ **.x.** If you are on an earlier version of CDAP, please follow the
+upgrade instructions for the earlier versions and upgrade first to
+|previous-short-version|\.x before proceeding.
 
 .. highlight:: console
 

--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -18,8 +18,8 @@ to make sure the CDAP table definitions in HBase are up-to-date.
 These steps will stop CDAP, update the installation, run an upgrade tool for the table definitions,
 and then restart CDAP.
 
-**These steps will upgrade from CDAP 3.2.x to 3.3.x.** If you are on an earlier version of CDAP,
-please follow the upgrade instructions for the earlier versions and upgrade first to 3.2.x before proceeding.
+**These steps will upgrade from CDAP** |bold-previous-short-version|\ **.x to** |bold-short-version|\ **.x.** If you are on an earlier version of CDAP,
+please follow the upgrade instructions for the earlier versions and upgrade first to |previous-short-version|\.x before proceeding.
 
 .. highlight:: console
 


### PR DESCRIPTION
Add version examples, and make current examples independent of the version.
Adds reST "replacements" for the "short version", "previous short version", and bold and literal versions of each.

Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DOB142-1).

Pages of Interest:
- [Upgrading CDAP with CM](http://builds.cask.co/artifact/CDAP-DOB142/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/admin-manual/upgrading/cloudera.html#admin-upgrading-cloudera)
- [Upgrading CDAP using Packages](http://builds.cask.co/artifact/CDAP-DOB142/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/admin-manual/upgrading/packages.html)