### PR TITLE
Feature/ui styling remove breadcrumbs breakpoint

### DIFF
--- a/cdap-ui/app/directives/breadcrumbs/breadcrumbs.less
+++ b/cdap-ui/app/directives/breadcrumbs/breadcrumbs.less
@@ -20,10 +20,10 @@
 
 body.theme-cdap {
   my-breadcrumbs, my-breadcrumb {
-    @media (max-width: @screen-sm-max) {
+    @media (max-width: @screen-xs-max) {
       display: none;
     }
-    @media (min-width: @screen-md-min) {
+    @media (min-width: @screen-sm-min) {
       background-color: white;
       border-bottom: 1px solid @panel-default-border;
       position: absolute;
@@ -39,107 +39,12 @@ body.theme-cdap {
         flex-wrap: nowrap;
         align-items: center;
         height: 40px;
-
-        li.dropdown {
-          &.open {
-            a.ns-dropdown-toggle:focus {
-              border-color: transparent;
-            }
-          }
-        }
       }
-      ul.nav {
-        margin: 0;
-        white-space: nowrap;
-        .order(1);
-        .open {
-          > a, > a:hover, > a:focus {
-            background-color: transparent;
-          }
-
-          ul.dropdown-menu {
-            max-width: 400px;
-            height: auto;
-            max-height: 290px;
-            min-width: 0;
-            background-color: white;
-            border-color: white;
-            padding: 10px 0;
-            margin-top: 1px;
-            .border-radius(4px);
-            .box-shadow(0 6px 12px rgba(0, 0, 0, 0.175));
-            overflow-x: hidden;
-            overflow-y: scroll;
-            @media (min-width: @screen-md-min) {
-              position: absolute;
-            }
-            > li {
-              background-color: white;
-              padding: 0;
-              &:focus {
-                outline: 0;
-              }
-              > a {
-                color: @cdap-header;
-                font-weight: 500;
-                background-color: white;
-                padding-right: 10px;
-                padding-left: 10px;
-                &:hover, &:focus {
-                  color: @cdap-orange;
-                }
-                &:focus {
-                  outline: 0;
-                }
-              }
-              i {
-                display: inline-block;
-                width: 13px;
-              }
-              .active {
-                color: #c4c4c4;
-                pointer-events: none;
-              }
-            }
-          }
-        }
-      }
-
-      a.ns-dropdown-toggle {
-        color: @cdap-gray;
-        cursor: pointer;
-        font-weight: 500;
-        padding: 1px 0 0;
-        position: relative;
-        top: -1px;
-        &:hover, &:focus {
-          background-color: transparent;
-        }
-        &:after {
-          content: url('@{img-path}/chevron_front.png');
-          overflow: hidden;
-          position: absolute;
-          top: 1px;
-          height: 40px;
-          z-index: 99;
-        }
-        > span {
-          line-height: 40px;
-          vertical-align: top;
-          &:first-child {
-            padding-right: 5px;
-          }
-          &:last-child {
-            margin-right: 7px;
-          }
-        }
-      }
-
       .breadcrumb {
         background-color: transparent;
         font-weight: 500;
         height: 40px;
-        .order(2);
+        .order(1);
         white-space: nowrap;
         > li {
           display: inline-block;

--- a/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
+++ b/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
@@ -163,7 +163,7 @@
             <span>{{ $state.params.namespace || 'Management' }}</span>
           </div>
           <div class="namespace-caret pull-right">
-            <span class="fa fa-angle-down pull-right"></span>
+            <span class="fa fa-angle-down"></span>
           </div>
         </div>
 

--- a/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
+++ b/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
@@ -162,7 +162,7 @@
           <div class="namespace-display">
             <span>{{ $state.params.namespace || 'Management' }}</span>
           </div>
-          <div class="namespace-caret">
+          <div class="namespace-caret pull-right">
             <span class="fa fa-angle-down pull-right"></span>
           </div>
         </div>

--- a/cdap-ui/app/directives/my-global-navbar/my-global-navbar.less
+++ b/cdap-ui/app/directives/my-global-navbar/my-global-navbar.less
@@ -126,10 +126,6 @@ my-global-navbar {
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      .namespace-caret {
-        display: inline-block;
-        width: 10%;
-      }
     }
   }
 

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -38,13 +38,7 @@ body {
   div.progress { margin: 1px; /* by default they have just margin-bottom: 20px */ }
 
   main.container {
-    // Temporary
-    // TODO: Remove or adjust based on final/approved program detail layout
     margin-top: 90px;
-    // padding-top: 1em;
-    @media (max-width: @screen-sm-max) {
-      margin-top: 75px;
-    }
     > div { margin-bottom: 80px; }
     .sidebar {
       ul li a {


### PR DESCRIPTION
*  Changes breakpoint for hiding/showing of breadcrumbs from 992px to 768px
*  Removes old namespace styling from breadcrumbs
*  Floats namespace dropdown caret to prevent positioning issues on smaller screens (VM-specific)

Local build:
![local bread](https://cloud.githubusercontent.com/assets/5335210/13655195/74a3e252-e612-11e5-9349-9c60c249bbd0.gif)
 
VM build (3.3.1 snapshot):
![vm bread](https://cloud.githubusercontent.com/assets/5335210/13655200/820c401a-e612-11e5-9437-d5d7609683c4.gif)
