### PR TITLE
Fix documentation build

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -107,10 +107,6 @@ WEB="web"
 GOOGLE_TAG_MANAGER_CODE_GITHUB="GTM-PBZ3JL"
 GITHUB="github"
 
-# BUILD.rst
-BUILD_RST="BUILD.rst"
-BUILD_RST_HASH="cb6279ac3ecd199cdfa2f6e914403f69"
-
 
 function usage() {
   echo "Build script for '${PROJECT_CAPS}' docs"
@@ -232,7 +228,7 @@ function check_build_rst() {
   cd ${PROJECT_PATH}
   # check BUILD.rst for changes
   BUILD_RST_PATH="${PROJECT_PATH}${BUILD_RST}"
-  test_an_include "${BUILD_RST_HASH}" "${BUILD_RST_PATH}"
+  test_an_include "${BUILD_RST_HASH}" "${BUILD_RST_PATH}" "${BUILD_RST_HASH_LOCATION}"
   echo
   cd ${current_directory}
 }
@@ -267,6 +263,7 @@ function test_an_include() {
   # Uses md5 hashes to monitor if any files have changed.
   local md5_hash=${1}
   local target=${2}
+  local location=${3}
   local new_md5_hash
   local m
   local m_display  
@@ -281,12 +278,15 @@ function test_an_include() {
     fi
   
     if [[ "${new_md5_hash}" == "${NOT_FOUND_HASH}" ]]; then
-      m="${WARNING} ${RED_BOLD}${file_name} not found!${NO_COLOR} "  
-      m="${m}\nfile: ${target}"  
+      m="${WARNING} ${RED_BOLD}${file_name} not found!${NO_COLOR}"
+      m="${m}\nfile: ${target}"
     elif [[ "${new_md5_hash}" != "${md5_hash}" ]]; then
-      m="${WARNING} ${RED_BOLD}${file_name} has changed! Compare files and update hash!${NO_COLOR} "   
-      m="${m}\nfile: ${target}"   
-      m="${m}\nOld MD5 Hash: ${md5_hash} New MD5 Hash: ${new_md5_hash}"   
+      m="${WARNING} ${RED_BOLD}${file_name} has changed! Compare files and update hash!${NO_COLOR}"
+      m="${m}\nfile: ${target}"
+      m="${m}\nOld MD5 Hash: ${md5_hash} New MD5 Hash: ${new_md5_hash}"
+      if [[ "x${location}" != "x" ]]; then
+        m="${m}\nHash location: ${location}"
+      fi
     fi
   else  
     m="No target is set for test_an_include"

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -174,11 +174,12 @@ function build_docs() {
     clean_targets
   fi
   clear_messages_set_messages_file
-  
+  if [ "${javadocs}" != "${WITH}" ]; then
+    check_build_rst
+  fi
   if [ "${doc_type}" != "${DOCS_OUTER}" ]; then
     run_command docs-first-pass ${source_path}
   fi
-  
   if [ "${doc_type}" == "${DOCS}" -o "${doc_type}" == "${DOCS_OUTER}" ]; then
     build_docs_outer_level ${source_path}
     copy_docs_inner_level

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -174,13 +174,13 @@ function build_docs() {
     clean_targets
   fi
   clear_messages_set_messages_file
-  if [ "${javadocs}" != "${WITH}" ]; then
-    check_build_rst
-  fi
   if [ "${doc_type}" != "${DOCS_OUTER}" ]; then
     run_command docs-first-pass ${source_path}
   fi
   if [ "${doc_type}" == "${DOCS}" -o "${doc_type}" == "${DOCS_OUTER}" ]; then
+    if [ "${javadocs}" != "${WITH}" ]; then
+      check_build_rst
+    fi
     build_docs_outer_level ${source_path}
     copy_docs_inner_level
   else
@@ -188,6 +188,8 @@ function build_docs() {
   fi
   if [ "${javadocs}" == "${WITH}" ]; then
     run_command javadocs
+  else
+    check_build_rst
   fi
   if [ "${doc_type}" == "${GITHUB}" -o "${doc_type}" == "${GITHUB_ONLY}" ]; then
     run_command docs-github-part ${source_path}

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -23,7 +23,7 @@ MANUALS="introduction developers-manual cdap-apps admin-manual integrations exam
 # BUILD.rst
 BUILD_RST="BUILD.rst"
 BUILD_RST_HASH_LOCATION="cdap-docs/vars"
-# BUILD_RST_HASH="99c0076f03dae5c014417a00d5e04b5e"
+BUILD_RST_HASH="99c0076f03dae5c014417a00d5e04b5e"
 
 # This needs to be explicitly set as Git has trouble identifying it.
 GIT_BRANCH_PARENT="develop"

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -20,6 +20,11 @@ WITH_JAVADOCS="$WITHOUT"
 
 MANUALS="introduction developers-manual cdap-apps admin-manual integrations examples-manual reference-manual faqs"
 
+# BUILD.rst
+BUILD_RST="BUILD.rst"
+BUILD_RST_HASH_LOCATION="cdap-docs/vars"
+BUILD_RST_HASH="cb6279ac3ecd199cdfa2f6e914403f69"
+
 # This needs to be explicitly set as Git has trouble identifying it.
 GIT_BRANCH_PARENT="develop"
 

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -23,7 +23,7 @@ MANUALS="introduction developers-manual cdap-apps admin-manual integrations exam
 # BUILD.rst
 BUILD_RST="BUILD.rst"
 BUILD_RST_HASH_LOCATION="cdap-docs/vars"
-BUILD_RST_HASH="cb6279ac3ecd199cdfa2f6e914403f69"
+BUILD_RST_HASH="99c0076f03dae5c014417a00d5e04b5e"
 
 # This needs to be explicitly set as Git has trouble identifying it.
 GIT_BRANCH_PARENT="develop"

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -23,7 +23,7 @@ MANUALS="introduction developers-manual cdap-apps admin-manual integrations exam
 # BUILD.rst
 BUILD_RST="BUILD.rst"
 BUILD_RST_HASH_LOCATION="cdap-docs/vars"
-BUILD_RST_HASH="99c0076f03dae5c014417a00d5e04b5e"
+# BUILD_RST_HASH="99c0076f03dae5c014417a00d5e04b5e"
 
 # This needs to be explicitly set as Git has trouble identifying it.
 GIT_BRANCH_PARENT="develop"


### PR DESCRIPTION
This fixes the documentation build so that the same warnings that come from a full build (including Javadocs) appear in a Quick Build. Otherwise, we end up with the situation where you run a Quick Build to check the doc build, it passes, only to find that the nightly "build & deploy" fails because the two runs aren't testing the exact same set of hashes. This adds the additional hash in the Javadoc runs.

This adds the test of the `BUILD.rst` hash to all other builds, with an appropriate error message. It moves the hash to the `vars` file where it will be easier to find and change, and adds that to the message that is produced.

You can see the results [here](http://builds.cask.co/browse/CDAP-DOB143-2/log).

A successful [Quick Build 3](http://builds.cask.co/browse/CDAP-DOB143-3) after correcting the hash.