### PR TITLE
(CDAP-5085) Removed the getDataset method from SparkExecutionContext

### DIFF
--- a/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
+++ b/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
 /**
  * Spark program execution context. User Spark program can interact with CDAP through this context.
  */
-public abstract class JavaSparkExecutionContext implements RuntimeContext {
+public abstract class JavaSparkExecutionContext implements RuntimeContext, DatasetContext {
 
   /**
    * @return The specification used to configure this {@link Spark} job instance.
@@ -57,14 +57,6 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext {
    * @return Time in milliseconds since epoch time (00:00:00 January 1, 1970 UTC).
    */
   public abstract long getLogicalStartTime();
-
-  /**
-   * Returns a {@link DatasetContext} to provide access to {@link Dataset}
-   * which can be passed in Spark program's closures.
-   *
-   * @return A {@link Serializable} {@link DatasetContext}
-   */
-  public abstract DatasetContext getDatasetContext();
 
   /**
    * Returns a {@link Serializable} {@link ServiceDiscoverer} for Service Discovery in Spark Program which can be

--- a/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
+++ b/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
 /**
   * Spark program execution context. User Spark program can interact with CDAP through this context.
   */
-trait SparkExecutionContext extends RuntimeContext {
+trait SparkExecutionContext extends RuntimeContext with DatasetContext {
 
   /**
     * @return The specification used to configure this Spark job instance.
@@ -46,14 +46,6 @@ trait SparkExecutionContext extends RuntimeContext {
     * @return Time in milliseconds since epoch time (00:00:00 January 1, 1970 UTC).
     */
   def getLogicalStartTime: Long
-
-  /**
-    * Returns a [[co.cask.cdap.api.data.DatasetContext]] to provide access to [[co.cask.cdap.api.dataset.Dataset]]
-    * which can be passed in Spark program's closures.
-    *
-    * @return A [[scala.Serializable]] [[co.cask.cdap.api.data.DatasetContext]]
-    */
-  def getDatasetContext : DatasetContext
 
   /**
     * Returns a [[scala.Serializable]] [[co.cask.cdap.api.ServiceDiscoverer]] for Service Discovery


### PR DESCRIPTION
- Direct dataset access inside closure doesn’t fit well in Spark execution model
  - Spark is meant to be functional, hence doing side-effect writes is not well defined
  - We want to provide read-only access to dataset, but that requires enhancement to the underlying DatasetFramework, which will be in future work.

- Also added a unit-test for SparkTransactionService to test transaction failure