### PR TITLE
CDAP-5117 Implementation to keep the local datasets based in the input runtime arguments.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -17,6 +17,8 @@ package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.common.RuntimeArguments;
+import co.cask.cdap.api.common.Scope;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.workflow.ScheduleProgramInfo;
@@ -468,6 +470,12 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
 
   private void deleteLocalDatasets() {
     for (Map.Entry<String, DatasetCreationSpec> instanceEntry : workflowSpec.getLocalDatasetSpecs().entrySet()) {
+      Map<String, String> datasetArguments = RuntimeArguments.extractScope(Scope.DATASET, instanceEntry.getKey(),
+                                                                           runtimeArgs);
+      if (Boolean.parseBoolean(datasetArguments.get("keep.local"))) {
+        continue;
+      }
+
       String localInstanceName = getLocalDatasetName(instanceEntry.getKey(), runId.getId());
       Id.DatasetInstance instanceId = Id.DatasetInstance.from(program.getNamespaceId(), localInstanceName);
       LOG.debug("Deleting Workflow local dataset instance: {}", localInstanceName);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -95,10 +95,10 @@ import java.io.OutputStreamWriter;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -442,13 +442,69 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
   @Test
   public void testWorkflowLocalDatasets() throws Exception {
     ApplicationManager applicationManager = deployApplication(testSpace, WorkflowAppWithLocalDatasets.class);
-    final WorkflowManager wfmanager = applicationManager.getWorkflowManager("WorkflowWithLocalDatasets");
+
+    // Execute Workflow without keeping the local datasets after run
+    Map<String, String> additionalParams = new HashMap<>();
+    String runId = executeWorkflow(applicationManager, additionalParams);
+    verifyWorkflowRun(runId, false, false);
+
+
+    additionalParams.put("dataset.wordcount.keep.local", "true");
+    runId = executeWorkflow(applicationManager, additionalParams);
+    verifyWorkflowRun(runId, true, false);
+
+    additionalParams.clear();
+    additionalParams.put("dataset.*.keep.local", "true");
+    runId = executeWorkflow(applicationManager, additionalParams);
+    verifyWorkflowRun(runId, true, true);
+  }
+
+  private void verifyWorkflowRun(String runId, boolean shouldKeepWordCountDataset, boolean shouldKeepCSVFilesetDataset)
+    throws Exception {
+
+    // Once the Workflow run is complete local datasets should not be available
+    DataSetManager<KeyValueTable> localKeyValueDataset = getDataset(testSpace,
+                                                                    WorkflowAppWithLocalDatasets.WORDCOUNT_DATASET
+                                                                      + "." + runId);
+
+    if (shouldKeepWordCountDataset) {
+      Assert.assertNotNull(localKeyValueDataset.get());
+    } else {
+      Assert.assertNull(localKeyValueDataset.get());
+    }
+
+    DataSetManager<FileSet> localFileSetDataset = getDataset(testSpace, WorkflowAppWithLocalDatasets.CSV_FILESET_DATASET
+      + "." + runId);
+
+    if (shouldKeepCSVFilesetDataset) {
+      Assert.assertNotNull(localFileSetDataset.get());
+    } else {
+      Assert.assertNull(localFileSetDataset.get());
+    }
+
+    // Dataset which is not local should still be available
+    DataSetManager<KeyValueTable> nonLocalKeyValueDataset = getDataset(testSpace,
+                                                                       WorkflowAppWithLocalDatasets.RESULT_DATASET);
+    Assert.assertEquals("6", Bytes.toString(nonLocalKeyValueDataset.get().read("UniqueWordCount")));
+
+    // There should not be any local copy of the non local dataset
+    nonLocalKeyValueDataset = getDataset(testSpace, WorkflowAppWithLocalDatasets.RESULT_DATASET + "." + runId);
+    Assert.assertNull(nonLocalKeyValueDataset.get());
+  }
+
+  private String executeWorkflow(ApplicationManager applicationManager, Map<String, String> additionalParams)
+    throws Exception {
+    WorkflowManager wfManager = applicationManager.getWorkflowManager(WorkflowAppWithLocalDatasets.WORKFLOW_NAME);
+    Map<String, String> runtimeArgs = new HashMap<>();
     File waitFile = new File(tmpFolder.newFolder(), "/wait.file");
     File doneFile = new File(tmpFolder.newFolder(), "/done.file");
 
-    wfmanager.start(ImmutableMap.of("input.path", "input", "output.path", "output",
-                                    "wait.file", waitFile.getAbsolutePath(),
-                                    "done.file", doneFile.getAbsolutePath()));
+    runtimeArgs.put("input.path", "input");
+    runtimeArgs.put("output.path", "output");
+    runtimeArgs.put("wait.file", waitFile.getAbsolutePath());
+    runtimeArgs.put("done.file", doneFile.getAbsolutePath());
+    runtimeArgs.putAll(additionalParams);
+    wfManager.start(runtimeArgs);
 
     // Wait till custom action in the Workflow is triggerred.
     while (!waitFile.exists()) {
@@ -456,7 +512,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     }
 
     // Now the Workflow should have RUNNING status. Get its runid.
-    List<RunRecord> history = wfmanager.getHistory(ProgramRunStatus.RUNNING);
+    List<RunRecord> history = wfManager.getHistory(ProgramRunStatus.RUNNING);
     Assert.assertEquals(1, history.size());
     String runId = history.get(0).getPid();
 
@@ -480,18 +536,9 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     doneFile.createNewFile();
 
     // Wait for workflow to finish
-    wfmanager.waitForFinish(1, TimeUnit.MINUTES);
+    wfManager.waitForFinish(1, TimeUnit.MINUTES);
 
-    // Once the Workflow run is complete local datasets should not be available
-    localDataset = getDataset(testSpace, WorkflowAppWithLocalDatasets.WORDCOUNT_DATASET + "." + runId);
-    Assert.assertNull(localDataset.get());
-
-    fileSetDataset = getDataset(testSpace, WorkflowAppWithLocalDatasets.CSV_FILESET_DATASET + "." + runId);
-    Assert.assertNull(fileSetDataset.get());
-
-    // Dataset which is not local should still be available
-    DataSetManager<KeyValueTable> dataset = getDataset(testSpace, WorkflowAppWithLocalDatasets.RESULT_DATASET);
-    Assert.assertEquals("6", Bytes.toString(dataset.get().read("UniqueWordCount")));
+    return runId;
   }
 
   @Category(XSlowTests.class)


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-5117

`WorkflowDriver` before deleting the local dataset checks the `dataset.<dataset_name>.keep.local` runtime argument.