### PR TITLE
MultipleInputs for MapReduce

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Input.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Input.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.data.batch;
+
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.common.RuntimeArguments;
+import co.cask.cdap.api.data.format.FormatSpecification;
+import co.cask.cdap.api.data.stream.StreamBatchReadable;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.stream.StreamEventDecoder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Defines input to a program, such as MapReduce.
+ */
+public abstract class Input {
+
+  private final String name;
+
+  private String alias;
+
+  private Input(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @return an alias of the input, to be used as the input name instead of the actual name of the input (i.e. dataset
+   * name or stream name). Defaults to the actual name, in the case that no alias was set.
+   */
+  public String getAlias() {
+    return alias == null ? name : alias;
+  }
+
+  /**
+   * Sets an alias to be used as the input name.
+   *
+   * @param alias the alias to be set for this Input
+   * @return the Input being operated on
+   */
+  public Input alias(String alias) {
+    this.alias = alias;
+    return this;
+  }
+
+  /**
+   * Returns an Input defined by a dataset.
+   *
+   * @param datasetName the name of the input dataset
+   */
+  public static Input ofDataset(String datasetName) {
+    return ofDataset(datasetName, RuntimeArguments.NO_ARGUMENTS);
+  }
+
+  /**
+   * Returns an Input defined by a dataset.
+   *
+   * @param datasetName the name of the input dataset
+   * @param arguments the arguments to use when instantiating the dataset
+   */
+  public static Input ofDataset(String datasetName, Map<String, String> arguments) {
+    return ofDataset(datasetName, arguments, null);
+  }
+
+  /**
+   * Returns an Input defined by a dataset.
+   *
+   * @param datasetName the name of the input dataset
+   * @param splits the data selection splits. If null, will use the splits defined by the dataset.
+   */
+  public static Input ofDataset(String datasetName, @Nullable Iterable<? extends Split> splits) {
+    return ofDataset(datasetName, RuntimeArguments.NO_ARGUMENTS, splits);
+  }
+
+  /**
+   * Returns an Input defined by a dataset.
+   *
+   * @param datasetName the name of the input dataset
+   * @param arguments the arguments to use when instantiating the dataset
+   * @param splits the data selection splits. If null, will use the splits defined by the dataset.
+   */
+  public static Input ofDataset(String datasetName, Map<String, String> arguments,
+                                @Nullable Iterable<? extends Split> splits) {
+    return new DatasetInput(datasetName, arguments, splits);
+  }
+
+  /**
+   * Returns an Input defined by an InputFormatProvider.
+   *
+   * @param inputName the name of the input
+   */
+  public static Input of(String inputName, InputFormatProvider inputFormatProvider) {
+    return new InputFormatProviderInput(inputName, inputFormatProvider);
+  }
+
+  /**
+   * Returns an Input defined with the given stream name with all time range.
+   *
+   * @param streamName Name of the stream.
+   */
+  public static Input ofStream(String streamName) {
+    return ofStream(new StreamBatchReadable(streamName, 0, Long.MAX_VALUE));
+  }
+
+  /**
+   * Returns an Input defined by a stream with the given properties.
+   *
+   * @param streamName Name of the stream.
+   * @param startTime Start timestamp in milliseconds.
+   * @param endTime End timestamp in milliseconds.
+   */
+  public static Input ofStream(String streamName, long startTime, long endTime) {
+    return ofStream(new StreamBatchReadable(streamName, startTime, endTime));
+  }
+
+  /**
+   * Returns an Input defined by a stream with the given properties.
+   *
+   * @param streamName Name of the stream
+   * @param startTime Start timestamp in milliseconds (inclusive) of stream events provided to the job
+   * @param endTime End timestamp in milliseconds (exclusive) of stream events provided to the job
+   * @param decoderType The {@link StreamEventDecoder} class for decoding {@link StreamEvent}
+   */
+  public static Input ofStream(String streamName, long startTime,
+                               long endTime, Class<? extends StreamEventDecoder> decoderType) {
+    return ofStream(new StreamBatchReadable(streamName, startTime, endTime, decoderType));
+  }
+
+  /**
+   * Returns an Input defined by a stream with the given properties.
+   *
+   * @param streamName Name of the stream
+   * @param startTime Start timestamp in milliseconds (inclusive) of stream events provided to the job
+   * @param endTime End timestamp in milliseconds (exclusive) of stream events provided to the job
+   * @param bodyFormatSpec The {@link FormatSpecification} class for decoding {@link StreamEvent}
+   */
+  @Beta
+  public static Input ofStream(String streamName, long startTime,
+                               long endTime, FormatSpecification bodyFormatSpec) {
+    return ofStream(new StreamBatchReadable(streamName, startTime, endTime, bodyFormatSpec));
+  }
+
+  /**
+   * Returns an Input defined by a stream.
+   *
+   * @param streamBatchReadable specifies the stream to be used as input
+   */
+  private static Input ofStream(StreamBatchReadable streamBatchReadable) {
+    return new StreamInput(streamBatchReadable);
+  }
+
+  /**
+   * An implementation of {@link Input}, which defines a {@link co.cask.cdap.api.dataset.Dataset} as an input.
+   */
+  public static class DatasetInput extends Input {
+
+    private final Map<String, String> arguments;
+    private final List<Split> splits;
+
+    private DatasetInput(String name, Map<String, String> arguments, @Nullable Iterable<? extends Split> splits) {
+      super(name);
+      this.arguments = Collections.unmodifiableMap(new HashMap<>(arguments));
+      this.splits = copySplits(splits);
+    }
+
+    private List<Split> copySplits(@Nullable Iterable<? extends Split> splitsToCopy) {
+      if (splitsToCopy == null) {
+        return null;
+      }
+      List<Split> copiedSplits = new ArrayList<>();
+      for (Split split : splitsToCopy) {
+        copiedSplits.add(split);
+      }
+      return copiedSplits;
+    }
+
+    public Map<String, String> getArguments() {
+      return arguments;
+    }
+
+    @Nullable
+    public List<Split> getSplits() {
+      return splits;
+    }
+  }
+
+  /**
+   * An implementation of {@link Input}, which defines a {@link co.cask.cdap.api.data.stream.Stream} as an input.
+   */
+  public static class StreamInput extends Input {
+
+    private final StreamBatchReadable streamBatchReadable;
+
+    private StreamInput(StreamBatchReadable streamBatchReadable) {
+      super(streamBatchReadable.getStreamName());
+      this.streamBatchReadable = streamBatchReadable;
+    }
+
+    @Deprecated
+    public StreamBatchReadable getStreamBatchReadable() {
+      return streamBatchReadable;
+    }
+  }
+
+  /**
+   * An implementation of {@link Input}, which defines an {@link InputFormatProvider} as an input.
+   */
+  public static class InputFormatProviderInput extends Input {
+
+    private final InputFormatProvider inputFormatProvider;
+
+    private InputFormatProviderInput(String name, InputFormatProvider inputFormatProvider) {
+      super(name);
+      this.inputFormatProvider = inputFormatProvider;
+    }
+
+    public InputFormatProvider getInputFormatProvider() {
+      return inputFormatProvider;
+    }
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,10 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.api.data.stream;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.batch.BatchReadable;
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.batch.SplitReader;
 import co.cask.cdap.api.data.format.FormatSpecification;
@@ -47,12 +49,14 @@ import java.util.Map;
  * <pre><code>
  *   class MyMapReduce implements MapReduce {
  *       public void beforeSubmit(MapReduceContext context) {
- *         context.setInput(new StreamBatchReadable("mystream"));
+ *         context.addInput(Input.ofStream("mystream"));
  *       }
  *   }
  * </code></pre>
  *
+ * @deprecated as of version 3.4.0. Use {@link MapReduceContext#addInput(Input)}
  */
+@Deprecated
 public class StreamBatchReadable implements BatchReadable<Long, String> {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionBatchInput.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionBatchInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.dataset.lib.partitioned;
 
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.dataset.lib.DatasetStatePersistor;
 import co.cask.cdap.api.dataset.lib.Partition;
 import co.cask.cdap.api.dataset.lib.PartitionDetail;
@@ -74,8 +75,7 @@ public class PartitionBatchInput {
 
     Map<String, String> arguments = new HashMap<>();
     PartitionedFileSetArguments.addInputPartitions(arguments, consumedPartitions);
-
-    mapreduceContext.setInput((PartitionedFileSet) mapreduceContext.getDataset(partitionedFileSetName, arguments));
+    mapreduceContext.addInput(Input.ofDataset(partitionedFileSetName, arguments));
 
     return new BatchPartitionCommitter() {
       @Override

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.mapreduce;
 
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.internal.api.AbstractPluginConfigurable;
 
@@ -126,7 +127,11 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
 
   /**
    * Sets the name of the Dataset used as input for the {@link MapReduce}.
+   *
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
+   * in {@link #beforeSubmit}, instead.
    */
+  @Deprecated
   protected final void setInputDataset(String dataset) {
     configurer.setInputDataset(dataset);
   }
@@ -135,7 +140,10 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    * Uses Stream as input for the {@link MapReduce}.
    *
    * @param stream Name of the stream
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
+   *             in {@link #beforeSubmit}, instead.
    */
+  @Deprecated
   protected final void useStreamInput(String stream) {
     useStreamInput(new StreamBatchReadable(stream));
   }
@@ -145,7 +153,11 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    * {@link #useStreamInput(StreamBatchReadable) setInputStream(new StreamBatchReadable(stream, startTime, endTime))}.
    *
    * @see StreamBatchReadable
+   *
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
+   *             in {@link #beforeSubmit}, instead.
    */
+  @Deprecated
   protected final void useStreamInput(String stream, long startTime, long endTime) {
     useStreamInput(new StreamBatchReadable(stream, startTime, endTime));
   }
@@ -154,7 +166,11 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    * Uses Stream as input for the {@link MapReduce}.
    *
    * @see StreamBatchReadable
+   *
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
+   *             in {@link #beforeSubmit}, instead.
    */
+  @Deprecated
   protected final void useStreamInput(StreamBatchReadable streamBatchReadable) {
     configurer.setInputDataset(streamBatchReadable.toURI().toString());
   }
@@ -162,8 +178,8 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
   /**
    * Sets the name of the Dataset used as output for the {@link MapReduce}.
    *
-   * Deprecated as of 3.2.0. Use {@link MapReduceContext#addOutput(String datasetName)}
-   * in {@link #beforeSubmit}, instead.
+   * @deprecated as of 3.2.0. Use {@link MapReduceContext#addOutput(String datasetName)}
+   *             in {@link #beforeSubmit}, instead.
    */
   @Deprecated
   protected final void setOutputDataset(String dataset) {

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceConfigurer.java
@@ -19,6 +19,8 @@ package co.cask.cdap.api.mapreduce;
 import co.cask.cdap.api.DatasetConfigurer;
 import co.cask.cdap.api.ProgramConfigurer;
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.plugin.PluginConfigurer;
 
 /**
@@ -37,12 +39,20 @@ public interface MapReduceConfigurer extends DatasetConfigurer, ProgramConfigure
 
   /**
    * Sets the name of the dataset used as input for the {@link MapReduce}.
+   *
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
+   *             in beforeSubmit, instead.
    */
+  @Deprecated
   void setInputDataset(String dataset);
 
   /**
    * Sets the name of the dataset used as output for the {@link MapReduce}.
+   *
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addOutput(String)}
+   *             in beforeSubmit, instead.
    */
+  @Deprecated
   void setOutputDataset(String dataset);
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,6 +22,7 @@ import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.batch.BatchReadable;
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
@@ -60,58 +61,71 @@ public interface MapReduceContext
   <T> T getHadoopJob();
 
   /**
-   * Overrides the input configuration of this MapReduce job to use the specific stream.
+   * Overrides the input configuration of this MapReduce job to use the specific stream as the single input.
    *
    * @param stream the input stream.
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
    */
+  @Deprecated
   void setInput(StreamBatchReadable stream);
 
   /**
-   * Overrides the input configuration of this MapReduce job to use
-   * the specified dataset by its name.
+   * Overrides the input configuration of this MapReduce job to use the specified dataset by its name,
+   * as the single input.
    *
    * @param datasetName the name of the input dataset.
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
    */
+  @Deprecated
   void setInput(String datasetName);
 
   /**
-   * Overrides the input configuration of this MapReduce job to use
-   * the specified dataset by its name and arguments.
+   * Overrides the input configuration of this MapReduce job to use he specified dataset by its name and arguments,
+   * as the single input.
    *
    * @param datasetName the the name of the input dataset
    * @param arguments the arguments to use when instantiating the dataset
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
    */
+  @Deprecated
   void setInput(String datasetName, Map<String, String> arguments);
 
   /**
-   * Overrides the input configuration of this MapReduce job to use
-   * the specified dataset by its name and data selection splits.
+   * Overrides the input configuration of this MapReduce job to use the specified dataset by its name and data
+   * selection splits, as teh single input
    *
    * @param datasetName the name of the input dataset
    * @param splits the data selection splits
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
    */
+  @Deprecated
   void setInput(String datasetName, List<Split> splits);
 
   /**
-   * Overrides the input configuration of this MapReduce job to use
-   * the specified dataset by its name and arguments with the given data selection splits.
+   * Overrides the input configuration of this MapReduce job to use the specified dataset by its name and arguments
+   * with the given data selection splits, as the single input.
    *
    * @param datasetName the name of the input dataset
    * @param arguments the arguments to use when instantiating the dataset
    * @param splits the data selection splits
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
    */
+  @Deprecated
   void setInput(String datasetName, Map<String, String> arguments, List<Split> splits);
 
   /**
    * Overrides the input configuration of this MapReduce job to the one provided by the given
-   * {@link InputFormatProvider}.
+   * {@link InputFormatProvider}, as the single input.
    *
    * @param inputFormatProvider provider for InputFormat and configurations to be used
+   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
    */
+  @Deprecated
   void setInput(InputFormatProvider inputFormatProvider);
 
   /**
-   * Overrides the input configuration of this MapReduce job to read from the specified dataset instance.
+   * Overrides the input configuration of this MapReduce job to read from the specified dataset instance,
+   * as the single input.
    *
    * <p>
    * Currently, the dataset passed in must either be an {@link InputFormatProvider} or a {@link BatchReadable}.
@@ -128,6 +142,21 @@ public interface MapReduceContext
    */
   @Deprecated
   void setInput(String datasetName, Dataset dataset);
+
+  /**
+   * Updates the input configuration of this MapReduce job to use the specified {@link Input}.
+   * @param input the input to be used
+   * @throws IllegalStateException if called after any setInput methods.
+   */
+  void addInput(Input input);
+
+  /**
+   * Updates the input configuration of this MapReduce job to use the specified {@link Input}.
+   * @param input the input to be used
+   * @param mapperCls the mapper class to be used for the input
+   * @throws IllegalStateException if called after any setInput methods.
+   */
+  void addInput(Input input, Class<?> mapperCls);
 
   /**
    * Overrides the output configuration of this MapReduce job to write to the specified dataset by its name.

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
@@ -83,4 +83,11 @@ public interface MapReduceTaskContext<KEYOUT, VALUEOUT> extends RuntimeContext, 
    */
   @Nullable
   WorkflowToken getWorkflowToken();
+
+  /**
+   * Returns the name of the input configured for this task.
+   * Returns null, if this task is a Reducer or no inputs were configured through CDAP APIs.
+   */
+  @Nullable
+  String getInputName();
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -88,6 +88,7 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
 
   private MultipleOutputs multipleOutputs;
   private TaskInputOutputContext<?, ?, KEYOUT, VALUEOUT> context;
+  private String inputName;
 
   // keeps track of all tx-aware datasets to perform the transaction lifecycle for them. Note that
   // the transaction is already started, and it will be committed or aborted outside of this task.
@@ -170,6 +171,10 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
     this.context = context;
   }
 
+  public void setInputName(String inputName) {
+    this.inputName = inputName;
+  }
+
   /**
    * Closes the {@link MultipleOutputs} contained inside this context.
    */
@@ -196,6 +201,12 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
   @Nullable
   public WorkflowToken getWorkflowToken() {
     return workflowProgramInfo == null ? null : workflowProgramInfo.getWorkflowToken();
+  }
+
+  @Nullable
+  @Override
+  public String getInputName() {
+    return inputName;
   }
 
   @Nullable

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -89,7 +89,7 @@ public final class MapReduceContextConfig {
                   Map<String, String> localizedUserResources) {
     setRunId(context.getRunId().getId());
     setLogicalStartTime(context.getLogicalStartTime());
-    setWorkflowProgramInfo(context.getWorkflowProramInfo());
+    setWorkflowProgramInfo(context.getWorkflowProgramInfo());
     setPlugins(context.getPlugins());
     setArguments(context.getRuntimeArguments());
     setProgramJarURI(programJarURI);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.Admin;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
@@ -88,6 +89,12 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   @Override
   public WorkflowToken getWorkflowToken() {
     return delegate.getWorkflowToken();
+  }
+
+  @Nullable
+  @Override
+  public String getInputName() {
+    return delegate.getInputName();
   }
 
   @Override
@@ -199,6 +206,16 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
 
   @Override
   public void setInput(String datasetName, Dataset dataset) {
+    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
+  }
+
+  @Override
+  public void addInput(Input input) {
+    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
+  }
+
+  @Override
+  public void addInput(Input input, Class<?> mapperCls) {
     LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapperWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapperWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,9 +23,13 @@ import co.cask.cdap.common.lang.PropertyFieldSetter;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.internal.app.runtime.DataSetFieldSetter;
 import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
+import co.cask.cdap.internal.app.runtime.batch.dataset.input.TaggedInputSplit;
 import co.cask.cdap.internal.lang.Reflections;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.Mapper;
@@ -50,11 +54,21 @@ public class MapperWrapper extends Mapper {
   public static void wrap(Job job) {
     // NOTE: we don't use job.getMapperClass() as we don't need to load user class here
     Configuration conf = job.getConfiguration();
-    String mapClass = conf.get(MRJobConfig.MAP_CLASS_ATTR);
-    if (mapClass != null) {
-      conf.set(MapperWrapper.ATTR_MAPPER_CLASS, mapClass);
-      job.setMapperClass(MapperWrapper.class);
-    }
+    String mapClass = conf.get(MRJobConfig.MAP_CLASS_ATTR, Mapper.class.getName());
+    conf.set(MapperWrapper.ATTR_MAPPER_CLASS, mapClass);
+    job.setMapperClass(MapperWrapper.class);
+  }
+
+  /**
+   * Retrieves the class name of the wrapped mapper class from a Job's configuration.
+   *
+   * @param conf The conf from which to get the wrapped class.
+   * @return the class name of the wrapped Mapper class
+   */
+  public static String getWrappedMapper(Configuration conf) {
+    String wrappedMapperClassName = conf.get(MapperWrapper.ATTR_MAPPER_CLASS);
+    Preconditions.checkNotNull(wrappedMapperClassName, "Wrapped mapper class could not be found.");
+    return wrappedMapperClassName;
   }
 
   @SuppressWarnings("unchecked")
@@ -67,11 +81,15 @@ public class MapperWrapper extends Mapper {
 
     // this is a hook for periodic flushing of changes buffered by datasets (to avoid OOME)
     WrappedMapper.Context flushingContext = createAutoFlushingContext(context, basicMapReduceContext);
-    basicMapReduceContext.setHadoopContext(flushingContext);
 
-    String userMapper = context.getConfiguration().get(ATTR_MAPPER_CLASS);
+    basicMapReduceContext.setHadoopContext(flushingContext);
+    InputSplit inputSplit = context.getInputSplit();
+    if (inputSplit instanceof TaggedInputSplit) {
+      basicMapReduceContext.setInputName(((TaggedInputSplit) inputSplit).getName());
+    }
+
     ClassLoader programClassLoader = classLoader.getProgramClassLoader();
-    Mapper delegate = createMapperInstance(programClassLoader, userMapper);
+    Mapper delegate = createMapperInstance(programClassLoader, getWrappedMapper(context.getConfiguration()), context);
 
     // injecting runtime components, like datasets, etc.
     try {
@@ -154,11 +172,35 @@ public class MapperWrapper extends Mapper {
         }
         return result;
       }
+
+      @Override
+      public InputSplit getInputSplit() {
+        InputSplit inputSplit = super.getInputSplit();
+        if (inputSplit instanceof TaggedInputSplit) {
+          // expose the delegate InputSplit to the user
+          inputSplit = ((TaggedInputSplit) inputSplit).getInputSplit();
+        }
+        return inputSplit;
+      }
+
+      @Override
+      public Class<? extends InputFormat<?, ?>> getInputFormatClass() throws ClassNotFoundException {
+        InputSplit inputSplit = super.getInputSplit();
+        if (inputSplit instanceof TaggedInputSplit) {
+          // expose the delegate InputFormat to the user
+          return ((TaggedInputSplit) inputSplit).getInputFormatClass();
+        }
+        return super.getInputFormatClass();
+      }
     };
     return flushingContext;
   }
 
-  private Mapper createMapperInstance(ClassLoader classLoader, String userMapper) {
+  private Mapper createMapperInstance(ClassLoader classLoader, String userMapper, Context context) {
+    if (context.getInputSplit() instanceof TaggedInputSplit) {
+      // Find the delegate Mapper from the TaggedInputSplit.
+      userMapper = ((TaggedInputSplit) context.getInputSplit()).getMapperClassName();
+    }
     try {
       return (Mapper) classLoader.loadClass(userMapper).newInstance();
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/DelegatingInputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/DelegatingInputFormat.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import co.cask.cdap.common.conf.ConfigurationUtil;
+import co.cask.cdap.internal.app.runtime.batch.MapperWrapper;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * An {@link InputFormat} that delegates behavior of InputFormat to multiple other InputFormats.
+ *
+ * @see MultipleInputs#addInput(Job, String, String, Map, Class)
+ *
+ * @param <K> Type of key
+ * @param <V> Type of value
+ */
+public class DelegatingInputFormat<K, V> extends InputFormat<K, V> {
+
+  @SuppressWarnings("unchecked")
+  public List<InputSplit> getSplits(JobContext job) throws IOException, InterruptedException {
+    List<InputSplit> splits = new ArrayList<>();
+    Map<String, MultipleInputs.MapperInput> mapperInputMap = MultipleInputs.getInputMap(job.getConfiguration());
+
+    for (Map.Entry<String, MultipleInputs.MapperInput> mapperInputEntry : mapperInputMap.entrySet()) {
+      String inputName = mapperInputEntry.getKey();
+      MultipleInputs.MapperInput mapperInput = mapperInputEntry.getValue();
+      String mapperClassName = mapperInput.getMapperClassName();
+      Job jobCopy = new Job(job.getConfiguration());
+      Configuration confCopy = jobCopy.getConfiguration();
+
+      // set configuration specific for this input onto the jobCopy
+      ConfigurationUtil.setAll(mapperInput.getInputFormatConfiguration(), confCopy);
+
+      Class<?> inputFormatClass = confCopy.getClassByNameOrNull(mapperInput.getInputFormatClassName());
+      Preconditions.checkNotNull(inputFormatClass, "Class could not be found: ", mapperInput.getInputFormatClassName());
+      InputFormat inputFormat = (InputFormat) ReflectionUtils.newInstance(inputFormatClass, confCopy);
+
+      // Get splits for each input path and tag with InputFormat
+      // and Mapper types by wrapping in a TaggedInputSplit.
+      List<InputSplit> formatSplits = inputFormat.getSplits(jobCopy);
+      for (InputSplit split : formatSplits) {
+        splits.add(new TaggedInputSplit(inputName, split, confCopy, mapperInput.getInputFormatConfiguration(),
+                                        inputFormat.getClass(), mapperClassName));
+      }
+    }
+    return splits;
+  }
+
+  @Override
+  public RecordReader<K, V> createRecordReader(InputSplit split,
+                                               TaskAttemptContext context) throws IOException, InterruptedException {
+    TaggedInputSplit taggedInputSplit = (TaggedInputSplit) split;
+    ConfigurationUtil.setAll((taggedInputSplit).getInputConfigs(), context.getConfiguration());
+    return new DelegatingRecordReader<>(taggedInputSplit, context);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/DelegatingMapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/DelegatingMapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+
+import java.util.Map;
+
+/**
+ * A placeholder class that will be set on the {@link Job} when multiple mappers are to be used.
+ *
+ * @see MultipleInputs#addInput(Job, String, String, Map, Class)
+ */
+public class DelegatingMapper extends Mapper {
+
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/DelegatingRecordReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/DelegatingRecordReader.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import java.io.IOException;
+
+/**
+ * This is a delegating RecordReader, which delegates the functionality to the
+ * underlying record reader in {@link TaggedInputSplit}
+ *
+ * @param <K> Type of key
+ * @param <V> Type of value
+ */
+public class DelegatingRecordReader<K, V> extends RecordReader<K, V> {
+  private final RecordReader<K, V> originalRR;
+
+  /**
+   * Constructs the DelegatingRecordReader.
+   *
+   * @param taggedInputSplit TaggedInputSplit object
+   * @param context TaskAttemptContext object
+   *
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  @SuppressWarnings("unchecked")
+  public DelegatingRecordReader(TaggedInputSplit taggedInputSplit,
+                                TaskAttemptContext context) throws IOException, InterruptedException {
+    // Find the InputFormat and then the RecordReader from the TaggedInputSplit.
+    InputFormat<K, V> inputFormat = (InputFormat<K, V>) ReflectionUtils.newInstance(
+      taggedInputSplit.getInputFormatClass(), context.getConfiguration());
+    InputSplit inputSplit = taggedInputSplit.getInputSplit();
+    originalRR = inputFormat.createRecordReader(inputSplit, context);
+  }
+
+  @Override
+  public void close() throws IOException {
+    originalRR.close();
+  }
+
+  @Override
+  public K getCurrentKey() throws IOException, InterruptedException {
+    return originalRR.getCurrentKey();
+  }
+
+  @Override
+  public V getCurrentValue() throws IOException, InterruptedException {
+    return originalRR.getCurrentValue();
+  }
+
+  @Override
+  public float getProgress() throws IOException, InterruptedException {
+    return originalRR.getProgress();
+  }
+
+  @Override
+  public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+    InputSplit inputSplit = ((TaggedInputSplit) split).getInputSplit();
+    originalRR.initialize(inputSplit, context);
+  }
+
+  @Override
+  public boolean nextKeyValue() throws IOException, InterruptedException {
+    return originalRR.nextKeyValue();
+  }
+
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MapperInput.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MapperInput.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import co.cask.cdap.api.data.batch.InputFormatProvider;
+import org.apache.hadoop.mapreduce.Mapper;
+
+import javax.annotation.Nullable;
+
+/**
+ * Encapsulates {@link InputFormatProvider} and a {@link Mapper} to use for that input.
+ */
+public class MapperInput {
+  private final InputFormatProvider inputFormatProvider;
+  private final Class<? extends Mapper> mapper;
+
+  /**
+   * Creates an instance of MapperInput with the given InputFormatProvider.
+   */
+  public MapperInput(InputFormatProvider inputFormatProvider) {
+    this(inputFormatProvider, null);
+  }
+
+  /**
+   * Creates an instance of MapperInput with the given InputFormatProvider and specified Mapper class.
+   */
+  public MapperInput(InputFormatProvider inputFormatProvider, @Nullable Class<? extends Mapper> mapper) {
+    this.inputFormatProvider = inputFormatProvider;
+    this.mapper = mapper;
+  }
+
+  public InputFormatProvider getInputFormatProvider() {
+    return inputFormatProvider;
+  }
+
+  @Nullable
+  public Class<? extends Mapper> getMapper() {
+    return mapper;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultipleInputs.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultipleInputs.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.Mapper;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * This utility class supports MapReduce jobs that have multiple inputs with
+ * a different {@link InputFormat} and {@link Mapper} for each path
+ */
+public final class MultipleInputs {
+  private static final String INPUT_CONFIGS = "mapreduce.input.multipleinputs.inputs";
+
+  private static final Gson GSON = new GsonBuilder().enableComplexMapKeySerialization().create();
+  private static final Type STRING_MAPPER_INPUT_MAP_TYPE = new TypeToken<Map<String, MapperInput>>() { }.getType();
+
+  private MultipleInputs() {
+  }
+
+  /**
+   * Add a {@link Path} with a custom {@link InputFormat} and
+   * {@link Mapper} to the list of inputs for the map-reduce job.
+   *
+   * @param job The {@link Job}
+   * @param namedInput name of the input
+   * @param inputFormatClass the name of the InputFormat class to be used for this input
+   * @param inputConfigs the configurations to be used for this input
+   * @param mapperClass {@link Mapper} class to use for this path
+   */
+  @SuppressWarnings("unchecked")
+  public static void addInput(Job job, String namedInput, String inputFormatClass, Map<String, String> inputConfigs,
+                              Class<? extends Mapper> mapperClass) {
+    Configuration conf = job.getConfiguration();
+
+    Map<String, MapperInput> map = getInputMap(conf);
+    if (map.containsKey(namedInput)) {
+      throw new IllegalArgumentException("Input already exists with name: " + namedInput);
+    }
+    map.put(namedInput, new MapperInput(inputFormatClass, inputConfigs, mapperClass));
+    conf.set(INPUT_CONFIGS, GSON.toJson(map));
+
+    job.setInputFormatClass(DelegatingInputFormat.class);
+  }
+
+  /**
+   * @param conf the Configuration from which to deserialize the input configurations
+   * @return a mapping from input name to the MapperInput for that input
+   */
+  public static Map<String, MapperInput> getInputMap(Configuration conf) {
+    String mapString = conf.get(INPUT_CONFIGS);
+    if (mapString == null) {
+      return new HashMap<>();
+    }
+    return GSON.fromJson(mapString, STRING_MAPPER_INPUT_MAP_TYPE);
+  }
+
+  /**
+   * A simple POJO for encapsulating information for an input. We don't use
+   * {@link co.cask.cdap.internal.app.runtime.batch.dataset.input.MapperInput}, because that consists of an Interface,
+   * which doesn't serialize well.
+   */
+  public static final class MapperInput {
+    private final String inputFormatClassName;
+    private final Map<String, String> inputFormatConfiguration;
+    private final String mapperClassName;
+
+    public MapperInput(String inputFormatClassName, Map<String, String> inputFormatConfiguration,
+                       Class<? extends Mapper> mapper) {
+      this.inputFormatClassName = inputFormatClassName;
+      this.inputFormatConfiguration = inputFormatConfiguration;
+      this.mapperClassName = mapper.getName();
+    }
+
+    public String getInputFormatClassName() {
+      return inputFormatClassName;
+    }
+
+    public Map<String, String> getInputFormatConfiguration() {
+      return inputFormatConfiguration;
+    }
+
+    public String getMapperClassName() {
+      return mapperClassName;
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/TaggedInputSplit.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/TaggedInputSplit.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.serializer.Deserializer;
+import org.apache.hadoop.io.serializer.SerializationFactory;
+import org.apache.hadoop.io.serializer.Serializer;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.hadoop.util.StringInterner;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * An {@link InputSplit} that tags another InputSplit with extra data for use
+ * by {@link DelegatingInputFormat}s.
+ */
+public class TaggedInputSplit extends InputSplit implements Configurable, Writable {
+
+  private static final Gson GSON = new Gson();
+  private static final Type STRING_STRING_MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+
+  private String name;
+  private Class<? extends InputSplit> inputSplitClass;
+
+  private InputSplit inputSplit;
+
+  @SuppressWarnings("unchecked")
+  private Class<? extends InputFormat<?, ?>> inputFormatClass;
+
+  private String mapperClassName;
+
+  private Configuration conf;
+  private Map<String, String> inputConfigs;
+
+  public TaggedInputSplit() {
+  }
+
+  /**
+   * Creates a new TaggedInputSplit.
+   *
+   * @param name name of the InputSplit
+   * @param inputSplit The InputSplit to be tagged
+   * @param conf The configuration to use
+   * @param inputConfigs configurations to use for the InputFormat
+   * @param inputFormatClass The InputFormat class to use for this job
+   * @param mapperClassName The name of the Mapper class to use for this job
+   */
+  @SuppressWarnings("unchecked")
+  public TaggedInputSplit(String name, InputSplit inputSplit, Configuration conf,
+                          Map<String, String> inputConfigs,
+                          Class<? extends InputFormat> inputFormatClass,
+                          String mapperClassName) {
+    this.name = name;
+    this.inputSplitClass = inputSplit.getClass();
+    this.inputSplit = inputSplit;
+    this.conf = conf;
+    this.inputConfigs = inputConfigs;
+    this.inputFormatClass = (Class<? extends InputFormat<?, ?>>) inputFormatClass;
+    this.mapperClassName = mapperClassName;
+  }
+
+  /**
+   * Retrieves the name of this TaggedInputSplit.
+   *
+   * @return name of the TaggedInputSplit
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Retrieves the original InputSplit.
+   *
+   * @return The InputSplit that was tagged
+   */
+  public InputSplit getInputSplit() {
+    return inputSplit;
+  }
+
+  /**
+   * Retrieves the InputFormat class to use for this split.
+   *
+   * @return The InputFormat class to use
+   */
+  @SuppressWarnings("unchecked")
+  public Class<? extends InputFormat<?, ?>> getInputFormatClass() {
+    return inputFormatClass;
+  }
+
+  /**
+   * Retrieves the name of the Mapper class to use for this split.
+   *
+   * @return The name of the Mapper class to use
+   */
+  @SuppressWarnings("unchecked")
+  public String getMapperClassName() {
+    return mapperClassName;
+  }
+
+  @Override
+  public long getLength() throws IOException, InterruptedException {
+    return inputSplit.getLength();
+  }
+
+  @Override
+  public String[] getLocations() throws IOException, InterruptedException {
+    return inputSplit.getLocations();
+  }
+
+  Map<String, String> getInputConfigs() {
+    return inputConfigs;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    name = Text.readString(in);
+    inputSplitClass = (Class<? extends InputSplit>) readClass(in);
+    inputFormatClass = (Class<? extends InputFormat<?, ?>>) readClass(in);
+    mapperClassName = Text.readString(in);
+    inputConfigs = GSON.fromJson(Text.readString(in), STRING_STRING_MAP_TYPE);
+    inputSplit = ReflectionUtils.newInstance(inputSplitClass, conf);
+    SerializationFactory factory = new SerializationFactory(conf);
+    Deserializer deserializer = factory.getDeserializer(inputSplitClass);
+    deserializer.open((DataInputStream) in);
+    inputSplit = (InputSplit) deserializer.deserialize(inputSplit);
+  }
+
+  private Class<?> readClass(DataInput in) throws IOException {
+    String className = StringInterner.weakIntern(Text.readString(in));
+    try {
+      return conf.getClassByName(className);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("readObject can't find class", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void write(DataOutput out) throws IOException {
+    Text.writeString(out, name);
+    Text.writeString(out, inputSplitClass.getName());
+    Text.writeString(out, inputFormatClass.getName());
+    Text.writeString(out, mapperClassName);
+    Text.writeString(out, GSON.toJson(inputConfigs));
+    SerializationFactory factory = new SerializationFactory(conf);
+    Serializer serializer = factory.getSerializer(inputSplitClass);
+    serializer.open((DataOutputStream) out);
+    serializer.serialize(inputSplit);
+  }
+
+  @Override
+  public Configuration getConf() {
+    return conf;
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public String toString() {
+    return inputSplit.toString();
+  }
+
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithPartitionedFileSet.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithPartitionedFileSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,7 +24,6 @@ import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
-import com.google.common.base.Throwables;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
@@ -49,29 +48,25 @@ public class AppWithPartitionedFileSet extends AbstractApplication {
 
   @Override
   public void configure() {
-    try {
-      setName("AppWithMapReduceUsingFile");
-      setDescription("Application with MapReduce job using file as dataset");
-      createDataset(INPUT, "table");
-      createDataset(OUTPUT, "table");
+    setName("AppWithMapReduceUsingFile");
+    setDescription("Application with MapReduce job using file as dataset");
+    createDataset(INPUT, "table");
+    createDataset(OUTPUT, "table");
 
-      createDataset(PARTITIONED, "partitionedFileSet", PartitionedFileSetProperties.builder()
-        .setPartitioning(Partitioning.builder()
-                           .addStringField("type")
-                           .addLongField("time")
-                           .build())
-          // properties for file set
-        .setBasePath("partitioned")
-        .setInputFormat(TextInputFormat.class)
-        .setOutputFormat(TextOutputFormat.class)
-        .setOutputProperty(TextOutputFormat.SEPERATOR, SEPARATOR)
-          // don't configure properties for the Hive table - this is used in a context where explore is disabled
-        .build());
-      addMapReduce(new PartitionWriter());
-      addMapReduce(new PartitionReader());
-    } catch (Throwable t) {
-      throw Throwables.propagate(t);
-    }
+    createDataset(PARTITIONED, "partitionedFileSet", PartitionedFileSetProperties.builder()
+      .setPartitioning(Partitioning.builder()
+                         .addStringField("type")
+                         .addLongField("time")
+                         .build())
+        // properties for file set
+      .setBasePath("partitioned")
+      .setInputFormat(TextInputFormat.class)
+      .setOutputFormat(TextOutputFormat.class)
+      .setOutputProperty(TextOutputFormat.SEPERATOR, SEPARATOR)
+        // don't configure properties for the Hive table - this is used in a context where explore is disabled
+      .build());
+    addMapReduce(new PartitionWriter());
+    addMapReduce(new PartitionReader());
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithTimePartitionedFileSet.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithTimePartitionedFileSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,7 +27,6 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
@@ -53,25 +52,21 @@ public class AppWithTimePartitionedFileSet extends AbstractApplication {
 
   @Override
   public void configure() {
-    try {
-      setName("AppWithMapReduceUsingFile");
-      setDescription("Application with MapReduce job using file as dataset");
-      createDataset(INPUT, "table");
-      createDataset(OUTPUT, "table");
+    setName("AppWithMapReduceUsingFile");
+    setDescription("Application with MapReduce job using file as dataset");
+    createDataset(INPUT, "table");
+    createDataset(OUTPUT, "table");
 
-      createDataset(TIME_PARTITIONED, "timePartitionedFileSet", FileSetProperties.builder()
-        // properties for file set
-        .setBasePath("partitioned")
-        .setInputFormat(TextInputFormat.class)
-        .setOutputFormat(TextOutputFormat.class)
-        .setOutputProperty(TextOutputFormat.SEPERATOR, SEPARATOR)
-        // don't configure properties for the Hive table - this is used in a context where explore is disabled
-        .build());
-      addMapReduce(new PartitionWriter());
-      addMapReduce(new PartitionReader());
-    } catch (Throwable t) {
-      throw Throwables.propagate(t);
-    }
+    createDataset(TIME_PARTITIONED, "timePartitionedFileSet", FileSetProperties.builder()
+      // properties for file set
+      .setBasePath("partitioned")
+      .setInputFormat(TextInputFormat.class)
+      .setOutputFormat(TextOutputFormat.class)
+      .setOutputProperty(TextOutputFormat.SEPERATOR, SEPARATOR)
+      // don't configure properties for the Hive table - this is used in a context where explore is disabled
+      .build());
+    addMapReduce(new PartitionWriter());
+    addMapReduce(new PartitionReader());
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/DynamicPartitionerWithAvroTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/DynamicPartitionerWithAvroTest.java
@@ -69,7 +69,7 @@ public class DynamicPartitionerWithAvroTest extends MapReduceRunnerTestBase {
 
   @Test
   public void testDynamicPartitionerWithAvro() throws Exception {
-    final ApplicationWithPrograms app = deployApp(AppWithMapReduceUsingAvroDynamicPartitioner.class);
+    ApplicationWithPrograms app = deployApp(AppWithMapReduceUsingAvroDynamicPartitioner.class);
 
     final GenericRecord record1 = createRecord("bob", 95111);
     final GenericRecord record2 = createRecord("sally", 98123);
@@ -84,7 +84,7 @@ public class DynamicPartitionerWithAvroTest extends MapReduceRunnerTestBase {
     final PartitionKey key3 = PartitionKey.builder().addLongField("time", now).addIntField("zip", 84125).build();
     final Set<PartitionKey> expectedKeys = ImmutableSet.of(key1, key2, key3);
 
-    // write a value to the input kvTable
+    // write values to the input kvTable
     final KeyValueTable kvTable = datasetCache.getDataset(INPUT_DATASET);
     Transactions.createTransactionExecutor(txExecutorFactory, kvTable).execute(
       new TransactionExecutor.Subroutine() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/StreamDecoderDetectionTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/StreamDecoderDetectionTest.java
@@ -17,10 +17,10 @@
 package co.cask.cdap.internal.app.runtime.batch;
 
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data.stream.StreamInputFormat;
 import co.cask.cdap.data.stream.decoder.IdentityStreamEventDecoder;
 import co.cask.cdap.data.stream.decoder.TextStreamEventDecoder;
+import com.google.common.reflect.TypeToken;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
@@ -38,30 +38,35 @@ public class StreamDecoderDetectionTest {
 
   @Test
   public void testDecoderDetection() throws IOException {
-    // For testing purpose, we don't need all those parameters
     Configuration hConf = new Configuration();
-    MapReduceRuntimeService runtimeService = new MapReduceRuntimeService(null,
-      CConfiguration.create(), hConf, null, null, null, null, null, null, null, null);
 
     hConf.setClass(Job.MAP_CLASS_ATTR, IdentityMapper.class, Mapper.class);
-    StreamInputFormat.inferDecoderClass(hConf, runtimeService.getInputValueType(hConf, Void.class));
+    StreamInputFormat.inferDecoderClass(hConf, MapReduceRuntimeService.getInputValueType(hConf, Void.class,
+                                                                                         getMapperTypeToken(hConf)));
     Assert.assertSame(IdentityStreamEventDecoder.class, StreamInputFormat.getDecoderClass(hConf));
 
     hConf.setClass(Job.MAP_CLASS_ATTR, NoTypeMapper.class, Mapper.class);
-    StreamInputFormat.inferDecoderClass(hConf, runtimeService.getInputValueType(hConf, StreamEvent.class));
+    StreamInputFormat.inferDecoderClass(hConf, MapReduceRuntimeService.getInputValueType(hConf, StreamEvent.class,
+                                                                                         getMapperTypeToken(hConf)));
     Assert.assertSame(IdentityStreamEventDecoder.class, StreamInputFormat.getDecoderClass(hConf));
 
     hConf.setClass(Job.MAP_CLASS_ATTR, TextMapper.class, Mapper.class);
-    StreamInputFormat.inferDecoderClass(hConf, runtimeService.getInputValueType(hConf, Void.class));
+    StreamInputFormat.inferDecoderClass(hConf, MapReduceRuntimeService.getInputValueType(hConf, Void.class,
+                                                                                         getMapperTypeToken(hConf)));
     Assert.assertSame(TextStreamEventDecoder.class, StreamInputFormat.getDecoderClass(hConf));
 
     try {
       hConf.setClass(Job.MAP_CLASS_ATTR, InvalidTypeMapper.class, Mapper.class);
-      StreamInputFormat.inferDecoderClass(hConf, runtimeService.getInputValueType(hConf, Void.class));
+      StreamInputFormat.inferDecoderClass(hConf, MapReduceRuntimeService.getInputValueType(hConf, Void.class,
+                                                                                           getMapperTypeToken(hConf)));
       Assert.fail("Expected Exception");
     } catch (IllegalArgumentException e) {
       // Expected
     }
+  }
+
+  private TypeToken<?> getMapperTypeToken(Configuration hConf) {
+    return MapReduceRuntimeService.resolveClass(hConf, Job.MAP_CLASS_ATTR, Mapper.class);
   }
 
   public static final class IdentityMapper extends Mapper<LongWritable, StreamEvent, String, String> {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingInconsistentMappers.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingInconsistentMappers.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+
+/**
+ * App used to test that a MapReduce using multiple mappers must be of same output key/value types.
+ */
+public class AppWithMapReduceUsingInconsistentMappers extends AbstractApplication {
+
+  @Override
+  public void configure() {
+    setName("AppWithMapReduceUsingInconsistentMappers");
+    setDescription("Application with MapReduce jobs, to test Mapper type checking");
+    addMapReduce(new MapReduceWithConsistentMapperTypes());
+    addMapReduce(new MapReduceWithInconsistentMapperTypes());
+    addMapReduce(new MapReduceWithInconsistentMapperTypes2());
+    // the types of the datasets do not matter, because we never actually write or read to/from them
+    createDataset("input1", KeyValueTable.class);
+    createDataset("input2", KeyValueTable.class);
+    createDataset("output", KeyValueTable.class);
+  }
+
+  /**
+   * Performs no data operations, but simply runs to test mapper output type checking.
+   */
+  private abstract static class BaseMapReduce extends AbstractMapReduce {
+
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      // the inputs will be set in child classes
+
+      context.addOutput("output");
+
+      Job job = context.getHadoopJob();
+      job.setReducerClass(SomeReducer.class);
+    }
+  }
+
+  /**
+   * MapReduce job that has two mapper classes, both with the same output types.
+   */
+  public static final class MapReduceWithConsistentMapperTypes extends BaseMapReduce {
+
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      context.addInput(Input.ofDataset("input1"), OriginalMapper.class);
+      context.addInput(Input.ofDataset("input2"), ConsistentMapper.class);
+      super.beforeSubmit(context);
+    }
+  }
+
+  /**
+   * MapReduce job that has two mapper classes, each with different output types, both set through the CDAP APIs.
+   */
+  public static final class MapReduceWithInconsistentMapperTypes extends BaseMapReduce {
+
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      context.addInput(Input.ofDataset("input1"), OriginalMapper.class);
+      context.addInput(Input.ofDataset("input2"), InconsistentMapper.class);
+
+      Job job = context.getHadoopJob();
+      // none of the inputs default to the job-defined mapper, so an inconsistent mapper defined here gives no issue
+      job.setMapperClass(InconsistentMapper.class);
+      super.beforeSubmit(context);
+    }
+  }
+
+  /**
+   * MapReduce job that has two mapper classes, each with different output types (one set through CDAP APIs and one set
+   * directly on the job).
+   */
+  public static final class MapReduceWithInconsistentMapperTypes2 extends BaseMapReduce {
+
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      context.addInput(Input.ofDataset("input1"), OriginalMapper.class);
+      context.addInput(Input.ofDataset("input2"));
+
+
+      Job job = context.getHadoopJob();
+      job.setMapperClass(InconsistentMapper.class);
+      super.beforeSubmit(context);
+    }
+  }
+
+  /**
+   * Simple Mapper class.
+   */
+  public static class OriginalMapper extends Mapper<LongWritable, Text, LongWritable, Text> {
+
+  }
+
+  /**
+   * Mapper class that has output types, same as {@link OriginalMapper}.
+   */
+  public static class ConsistentMapper extends Mapper<LongWritable, Text, LongWritable, Text> {
+
+  }
+
+  /**
+   * Mapper class that has output types being different than {@link OriginalMapper}.
+   */
+  public static class InconsistentMapper extends Mapper<LongWritable, Text, IntWritable, Text> {
+
+  }
+
+  /**
+   * Simple Reducer class.
+   */
+  public static class SomeReducer extends Reducer<LongWritable, Text, String, String> {
+
+  }
+
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingMultipleInputs.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingMultipleInputs.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.dataset.lib.FileSetArguments;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * App used to test whether M/R can read and perform a join across multiple inputs.
+ */
+public class AppWithMapReduceUsingMultipleInputs extends AbstractApplication {
+
+  public static final String PURCHASES = "purchases";
+  public static final String CUSTOMERS = "customers";
+  public static final String OUTPUT_DATASET = "saturatedRecords";
+
+  @Override
+  public void configure() {
+    setName("AppWithMapReduceUsingMultipleInputs");
+    setDescription("Application with MapReduce job using multiple inputs");
+    addStream(PURCHASES);
+    createDataset(PURCHASES, "fileSet", FileSetProperties.builder()
+      .setInputFormat(TextInputFormat.class)
+      .build());
+    createDataset(CUSTOMERS, "fileSet", FileSetProperties.builder()
+      .setInputFormat(TextInputFormat.class)
+      .build());
+    createDataset(OUTPUT_DATASET, "fileSet", FileSetProperties.builder()
+      .setOutputFormat(TextOutputFormat.class)
+      .setOutputProperty(TextOutputFormat.SEPERATOR, " ")
+      .build());
+    addMapReduce(new ComputeSum());
+  }
+
+  /**
+   * Computes sum of a customer's spending, while also joining on a lookup table, to get more data.
+   */
+  public static final class ComputeSum extends AbstractMapReduce {
+
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      Map<String, String> inputArgs = new HashMap<>();
+      FileSetArguments.setInputPath(inputArgs, "inputFile");
+
+      // test using a stream with the same name, but aliasing it differently (so mapper gets the alias'd name)
+      context.addInput(Input.ofStream(PURCHASES).alias("streamPurchases"), StreamTestBatchMapper.class);
+      context.addInput(Input.ofDataset(PURCHASES, inputArgs), FileMapper.class);
+      // since we set a Mapper class on the job itself, omitting the mapper in the addInput call will default to that
+      context.addInput(Input.ofDataset(CUSTOMERS, inputArgs));
+
+      Map<String, String> outputArgs = new HashMap<>();
+      FileSetArguments.setOutputPath(outputArgs, "output");
+      context.addOutput(OUTPUT_DATASET, outputArgs);
+
+      Job job = context.getHadoopJob();
+      job.setMapperClass(FileMapper.class);
+      job.setReducerClass(FileReducer.class);
+    }
+  }
+
+  public static class StreamTestBatchMapper extends Mapper<LongWritable, BytesWritable, LongWritable, Text>
+    implements ProgramLifecycle<MapReduceTaskContext> {
+
+    @Override
+    protected void map(LongWritable key, BytesWritable value,
+                       Context context) throws IOException, InterruptedException {
+      String[] split = Bytes.toString(value.copyBytes()).split(" ");
+      // tag each record with the source as 'purchases', because we know this mapper is only used for that input
+      context.write(new LongWritable(Long.valueOf(split[0])), new Text("purchases " + split[1]));
+    }
+
+    @Override
+    public void initialize(MapReduceTaskContext context) throws Exception {
+      // we aliased the stream 'purchases' as 'streamPurchases'
+      Preconditions.checkArgument("streamPurchases".equals(context.getInputName()));
+    }
+
+    @Override
+    public void destroy() {
+      // no-op
+    }
+  }
+
+  public static class FileMapper extends Mapper<LongWritable, Text, LongWritable, Text>
+    implements ProgramLifecycle<MapReduceTaskContext> {
+
+    private String source;
+
+    @Override
+    public void initialize(MapReduceTaskContext context) throws Exception {
+      System.setProperty("mapper.initialized", "true");
+      source = context.getInputName();
+      Preconditions.checkNotNull(source);
+      Preconditions.checkArgument(PURCHASES.equals(source) || CUSTOMERS.equals(source));
+    }
+
+    @Override
+    public void destroy() {
+      System.setProperty("mapper.destroyed", "true");
+    }
+
+    @Override
+    protected void setup(Context context) throws IOException, InterruptedException {
+      // assert that the user gets FileInputSplit (as opposed to the TaggedInputSplit from the context
+      Preconditions.checkArgument(context.getInputSplit() instanceof FileSplit);
+      try {
+        // assert that the user gets the TextInputFormat, as opposed to the DelegatingInputFormat from the context
+        Preconditions.checkArgument(context.getInputFormatClass() == TextInputFormat.class);
+      } catch (ClassNotFoundException e) {
+        Throwables.propagate(e);
+      }
+    }
+
+    @Override
+    public void map(LongWritable key, Text data, Context context) throws IOException, InterruptedException {
+      String[] split = data.toString().split(" ");
+      // tag each record with the source, so the reducer is simpler
+      context.write(new LongWritable(Long.valueOf(split[0])), new Text(source + " " + split[1]));
+    }
+  }
+
+  public static class FileReducer extends Reducer<LongWritable, Text, String, String> {
+
+    @Override
+    public void reduce(LongWritable key, Iterable<Text> values,
+                       Context context) throws IOException, InterruptedException {
+      String name = null;
+      int totalSpend = 0;
+
+      for (Text value : values) {
+        String[] split = value.toString().split(" ");
+        String source = split[0];
+        String data = split[1];
+
+        if (PURCHASES.equals(source)) {
+          totalSpend += Integer.valueOf(data);
+        } else if (CUSTOMERS.equals(source)) {
+          name = data;
+        }
+      }
+      Preconditions.checkNotNull(name);
+      context.write(key.toString(), name + " " + totalSpend);
+    }
+  }
+
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MapReduceWithMultipleInputsTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MapReduceWithMultipleInputsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
+import co.cask.cdap.internal.app.runtime.batch.MapReduceRunnerTestBase;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.CharStreams;
+import org.apache.twill.filesystem.Location;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+/**
+ * Test case that tests ability to perform join across two datasets, using multiple inputs of a MapReduce job.
+ */
+public class MapReduceWithMultipleInputsTest extends MapReduceRunnerTestBase {
+
+  @Test
+  public void testSimpleJoin() throws Exception {
+    ApplicationWithPrograms app = deployApp(AppWithMapReduceUsingMultipleInputs.class);
+
+    final FileSet fileSet = datasetCache.getDataset(AppWithMapReduceUsingMultipleInputs.PURCHASES);
+    Location inputFile = fileSet.getBaseLocation().append("inputFile");
+    inputFile.createNew();
+
+    PrintWriter writer = new PrintWriter(inputFile.getOutputStream());
+    // the PURCHASES dataset consists of purchase records in the format: <customerId> <spend>
+    writer.println("1 20");
+    writer.println("1 25");
+    writer.println("1 30");
+    writer.println("2 5");
+    writer.close();
+
+    // write some of the purchases to the stream
+    writeToStream(AppWithMapReduceUsingMultipleInputs.PURCHASES, "2 13");
+    writeToStream(AppWithMapReduceUsingMultipleInputs.PURCHASES, "3 60");
+
+    FileSet fileSet2 = datasetCache.getDataset(AppWithMapReduceUsingMultipleInputs.CUSTOMERS);
+    inputFile = fileSet2.getBaseLocation().append("inputFile");
+    inputFile.createNew();
+
+    // the CUSTOMERS dataset consists of records in the format: <customerId> <customerName>
+    writer = new PrintWriter(inputFile.getOutputStream());
+    writer.println("1 Bob");
+    writer.println("2 Samuel");
+    writer.println("3 Joe");
+    writer.close();
+
+    // Using multiple inputs, this MapReduce will join on the two above datasets to get aggregate results.
+    // The records are expected to be in the form: <customerId> <customerName> <totalSpend>
+    runProgram(app, AppWithMapReduceUsingMultipleInputs.ComputeSum.class, new BasicArguments());
+    FileSet outputFileSet = datasetCache.getDataset(AppWithMapReduceUsingMultipleInputs.OUTPUT_DATASET);
+    // will only be 1 part file, due to the small amount of data
+    Location outputLocation = outputFileSet.getBaseLocation().append("output").append("part-r-00000");
+
+    List<String> lines = CharStreams.readLines(
+      CharStreams.newReaderSupplier(Locations.newInputSupplier(outputLocation), Charsets.UTF_8));
+
+    Assert.assertEquals(ImmutableList.of("1 Bob 75", "2 Samuel 18", "3 Joe 60"),
+                        lines);
+
+    // assert that the mapper was initialized and destroyed (this doesn't happen when using hadoop's MultipleOutputs).
+    Assert.assertEquals("true", System.getProperty("mapper.initialized"));
+    Assert.assertEquals("true", System.getProperty("mapper.destroyed"));
+  }
+
+  @Test
+  public void testMapperOutputTypeChecking() throws Exception {
+    final ApplicationWithPrograms app = deployApp(AppWithMapReduceUsingInconsistentMappers.class);
+
+    // the mapreduce with consistent mapper types will succeed
+    Assert.assertTrue(runProgram(app,
+                                 AppWithMapReduceUsingInconsistentMappers.MapReduceWithConsistentMapperTypes.class,
+                                 new BasicArguments()));
+
+    // the mapreduce with mapper classes of inconsistent output types will fail, whether the mappers are set through
+    // CDAP APIs or also directly on the job
+    Assert.assertFalse(runProgram(app,
+                                  AppWithMapReduceUsingInconsistentMappers.MapReduceWithInconsistentMapperTypes.class,
+                                  new BasicArguments()));
+
+    Assert.assertFalse(runProgram(app,
+                                  AppWithMapReduceUsingInconsistentMappers.MapReduceWithInconsistentMapperTypes2.class,
+                                  new BasicArguments()));
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultipleInputsTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultipleInputsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Tests for {@link MultipleInputs}.
+ */
+public class MultipleInputsTest {
+
+  @Test
+  public void testConfigurations() throws IOException, ClassNotFoundException {
+    Job job = Job.getInstance();
+
+    String inputName1 = "inputName1";
+    String inputFormatClass1 = TextInputFormat.class.getName();
+    Map<String, String> inputFormatConfigs1 = ImmutableMap.of("key1", "val1", "key2", "val2");
+    MultipleInputs.addInput(job, inputName1, inputFormatClass1, inputFormatConfigs1, job.getMapperClass());
+
+    Map<String, MultipleInputs.MapperInput> map = MultipleInputs.getInputMap(job.getConfiguration());
+
+    Assert.assertEquals(1, map.size());
+    Assert.assertEquals(inputName1, Iterables.getOnlyElement(map.keySet()));
+    Assert.assertEquals(inputFormatClass1, Iterables.getOnlyElement(map.values()).getInputFormatClassName());
+    Assert.assertEquals(inputFormatConfigs1, Iterables.getOnlyElement(map.values()).getInputFormatConfiguration());
+    Assert.assertEquals(job.getMapperClass().getName(), Iterables.getOnlyElement(map.values()).getMapperClassName());
+
+    Assert.assertEquals(DelegatingInputFormat.class, job.getInputFormatClass());
+
+    // now, test with two inputs in the configuration
+    String inputName2 = "inputName2";
+    String inputFormatClass2 = TextInputFormat.class.getName();
+    Map<String, String> inputFormatConfigs2 = ImmutableMap.of("some_key1", "some_val1", "some_key2", "some_val2");
+    MultipleInputs.addInput(job, inputName2, inputFormatClass2, inputFormatConfigs2, CustomMapper.class);
+
+    map = MultipleInputs.getInputMap(job.getConfiguration());
+
+    Assert.assertEquals(2, map.size());
+
+    MultipleInputs.MapperInput mapperInput1 = map.get(inputName1);
+    Assert.assertEquals(inputFormatClass1, mapperInput1.getInputFormatClassName());
+    Assert.assertEquals(inputFormatConfigs1, mapperInput1.getInputFormatConfiguration());
+    Assert.assertEquals(job.getMapperClass().getName(), mapperInput1.getMapperClassName());
+
+    MultipleInputs.MapperInput mapperInput2 = map.get(inputName2);
+    Assert.assertEquals(inputFormatClass2, mapperInput2.getInputFormatClassName());
+    Assert.assertEquals(inputFormatConfigs2, mapperInput2.getInputFormatConfiguration());
+    Assert.assertEquals(CustomMapper.class, job.getConfiguration().getClassByName(mapperInput2.getMapperClassName()));
+  }
+
+  public static final class CustomMapper extends Mapper {
+
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -117,8 +117,8 @@ public class SparkProgramRunnerTest {
   private static DynamicDatasetCache datasetCache;
   private static MetricStore metricStore;
 
-  final String testString1 = "persisted data";
-  final String testString2 = "distributed systems";
+  private static final String testString1 = "persisted data";
+  private static final String testString2 = "distributed systems";
 
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StopProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StopProgramsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -32,7 +32,7 @@ import java.io.PrintStream;
 import java.util.List;
 
 /**
- * Starts one or more programs in an application.
+ * Stops one or more programs in an application.
  */
 public class StopProgramsCommand extends BaseBatchCommand<BatchProgram> {
   private final ProgramClient programClient;

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/ConfigurationUtilTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/ConfigurationUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,35 +14,37 @@
  * the License.
  */
 
-package co.cask.cdap.internal.app.runtime.batch.dataset;
+package co.cask.cdap.common.conf;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.Job;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Map;
 
-public class MultipleOutputsTest {
+/**
+ * Tests for {@link ConfigurationUtil}.
+ */
+public class ConfigurationUtilTest {
 
   @Test
   public void testNamedConfigurations() throws IOException {
-    Job job = Job.getInstance(new Configuration());
+    org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
 
     Map<String, String> name1Config = ImmutableMap.of("key1", "value1",
                                                       "key2", "value2");
     Map<String, String> name2Config = ImmutableMap.of("name2key", "name2value");
     Map<String, String> emptyConfig = ImmutableMap.of();
 
-    MultipleOutputs.setNamedConfigurations(job, "name1", name1Config);
-    MultipleOutputs.setNamedConfigurations(job, "name2", name2Config);
-    MultipleOutputs.setNamedConfigurations(job, "emptyConfig", emptyConfig);
+    ConfigurationUtil.setNamedConfigurations(conf, "name1", name1Config);
+    ConfigurationUtil.setNamedConfigurations(conf, "name2", name2Config);
+    ConfigurationUtil.setNamedConfigurations(conf, "emptyConfig", emptyConfig);
 
 
-    Assert.assertEquals(name1Config, MultipleOutputs.getNamedConfigurations(job, "name1"));
-    Assert.assertEquals(name2Config, MultipleOutputs.getNamedConfigurations(job, "name2"));
-    Assert.assertEquals(emptyConfig, MultipleOutputs.getNamedConfigurations(job, "emptyConfig"));
+    Assert.assertEquals(name1Config, ConfigurationUtil.getNamedConfigurations(conf, "name1"));
+    Assert.assertEquals(name2Config, ConfigurationUtil.getNamedConfigurations(conf, "name2"));
+    Assert.assertEquals(emptyConfig, ConfigurationUtil.getNamedConfigurations(conf, "emptyConfig"));
   }
+
 }

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package co.cask.cdap.examples.fileset;
 
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import org.apache.hadoop.io.IntWritable;
@@ -40,7 +41,6 @@ public class WordCount extends AbstractMapReduce {
 
   @Override
   public void configure() {
-    setInputDataset("lines");
     setMapperResources(new Resources(1024));
     setReducerResources(new Resources(1024));
   }
@@ -51,6 +51,8 @@ public class WordCount extends AbstractMapReduce {
     job.setMapperClass(Tokenizer.class);
     job.setReducerClass(Counter.class);
     job.setNumReduceTasks(1);
+
+    context.addInput(Input.ofDataset("lines"));
     context.addOutput("counts");
   }
 

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -80,8 +80,8 @@ public class PurchaseApp extends AbstractApplication {
       "PurchaseHistoryWorkflow"
     );
 
+    createDataset("history", PurchaseHistoryStore.class, PurchaseHistoryStore.properties());
     try {
-      createDataset("history", PurchaseHistoryStore.class, PurchaseHistoryStore.properties());
       createDataset("purchases", ObjectMappedTable.class,
                     ObjectMappedTableProperties.builder().setType(Purchase.class).build());
     } catch (UnsupportedTypeException e) {
@@ -91,5 +91,8 @@ public class PurchaseApp extends AbstractApplication {
       // because PurchaseHistory and Purchase are actual classes.
       throw new RuntimeException(e);
     }
+    // create an 'oldPurchases' KeyValueTable, which stores Purchase events, but in JSON format in one column, instead
+    // of in an ObjectMappedTable
+    createDataset("oldPurchases", KeyValueTable.class);
   }
 }

--- a/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
+++ b/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/MapReduceStreamInputTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/MapReduceStreamInputTestRun.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
@@ -41,7 +43,6 @@ public class MapReduceStreamInputTestRun extends TestFrameworkTestBase {
 
   @Test
   public void test() throws Exception {
-
     ApplicationManager applicationManager = deployApplication(AppWithMapReduceUsingStream.class);
     Schema schema = new Schema.Parser().parse(AppWithMapReduceUsingStream.SCHEMA.toString());
     StreamManager streamManager = getStreamManager("mrStream");

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionConsumingTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionConsumingTestRun.java
@@ -14,20 +14,6 @@
  * the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package co.cask.cdap.partitioned;
 
 import co.cask.cdap.api.dataset.lib.PartitionDetail;


### PR DESCRIPTION
This implementation supports multiple inputs for a MapReduce job. I have updated `PurchaseHistoryBuilder` to show case one of the use cases (using two datasets as source, each with different format). I have also added a test case to showcase another use case (joining two datasets), using `AppWithMapReduceUsingMultipleInputs`.

At the core of it, there is a DelegatingMapper, which has an implementation of `getSplits()` which will call `getSplits()` to each of the delegate input formats, and return the concatenated list. Each of these returned splits is tagged with information specific to that particular input, for use by the Mapper that processes that split. The hadoop framework is then responsible for creating separate mapper instances for each of these lists.


https://issues.cask.co/browse/CDAP-3980
http://builds.cask.co/browse/CDAP-DUT3616