### PR TITLE
Feature/proto remove guava

### DIFF
--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExplorePreparedStatementTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExplorePreparedStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -30,7 +30,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 /**
- *
+ * Tests for {@link ExplorePreparedStatement}.
  */
 public class ExplorePreparedStatementTest {
 
@@ -45,9 +45,9 @@ public class ExplorePreparedStatementTest {
                       (List<QueryResult>) Lists.<QueryResult>newArrayList())
     );
 
-
+    String ns = "ns1";
     ExplorePreparedStatement statement = new ExplorePreparedStatement(null, exploreClient,
-                                                                      "SELECT * FROM table WHERE id=?, name=?", "");
+                                                                      "SELECT * FROM table WHERE id=?, name=?", ns);
     statement.setInt(1, 100);
     try {
       statement.execute();
@@ -65,27 +65,27 @@ public class ExplorePreparedStatementTest {
     Assert.assertFalse(rs.isClosed());
     Assert.assertFalse(rs.next());
 
-    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name='?'", "");
+    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name='?'", ns);
     Assert.assertEquals("SELECT * FROM table WHERE name='?'", statement.updateSql());
 
-    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name='?', id=?", "");
+    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name='?', id=?", ns);
     statement.setInt(1, 100);
     Assert.assertEquals("SELECT * FROM table WHERE name='?', id=100", statement.updateSql());
 
-    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"?\", id=?", "");
+    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"?\", id=?", ns);
     statement.setInt(1, 100);
     Assert.assertEquals("SELECT * FROM table WHERE name=\"?\", id=100", statement.updateSql());
 
-    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"'?'\", id=?", "");
+    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"'?'\", id=?", ns);
     statement.setInt(1, 100);
     Assert.assertEquals("SELECT * FROM table WHERE name=\"'?'\", id=100", statement.updateSql());
 
-    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"'?\", id=?", "");
+    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"'?\", id=?", ns);
     statement.setInt(1, 100);
     Assert.assertEquals("SELECT * FROM table WHERE name=\"'?\", id=100", statement.updateSql());
 
     statement = new ExplorePreparedStatement(null, exploreClient,
-                                             "SELECT * FROM table WHERE name=\"\\\"?\\\"\", id=?", "");
+                                             "SELECT * FROM table WHERE name=\"\\\"?\\\"\", id=?", ns);
     statement.setInt(1, 100);
     Assert.assertEquals("SELECT * FROM table WHERE name=\"\\\"?\\\"\", id=100", statement.updateSql());
   }

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreResultSetTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreResultSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,9 +35,10 @@ import java.sql.Timestamp;
 import java.util.List;
 
 /**
- *
+ * Tests for {@link ExploreResultSet}.
  */
 public class ExploreResultSetTest {
+  private final String ns = "ns1";
   @Test
   public void testResultSet() throws Exception {
     ExploreClient exploreClient = new MockExploreClient(
@@ -79,9 +80,8 @@ public class ExploreResultSetTest {
         ))
     );
 
-    ResultSet resultSet = new ExploreResultSet(exploreClient.submit(Id.Namespace.from(""), "mock_query").get(),
-                                               new ExploreStatement(null, exploreClient, ""),
-                                               0);
+    ResultSet resultSet = new ExploreResultSet(exploreClient.submit(Id.Namespace.from(ns), "mock_query").get(),
+                                               new ExploreStatement(null, exploreClient, ns), 0);
     Assert.assertTrue(resultSet.next());
     Assert.assertEquals(resultSet.getObject(1), resultSet.getObject("column1"));
     Assert.assertEquals("value1", resultSet.getString(1));
@@ -121,9 +121,8 @@ public class ExploreResultSetTest {
         ))
     );
 
-    ResultSet resultSet = new ExploreResultSet(exploreClient.submit(Id.Namespace.from(""), "mock_query").get(),
-                                               new ExploreStatement(null, exploreClient, ""),
-                                               0);
+    ResultSet resultSet = new ExploreResultSet(exploreClient.submit(Id.Namespace.from(ns), "mock_query").get(),
+                                               new ExploreStatement(null, exploreClient, ns), 0);
     Assert.assertTrue(resultSet.next());
     Assert.assertEquals(1, resultSet.findColumn("column1"));
     Assert.assertEquals(1, resultSet.getObject("column1"));

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreStatementTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,32 +26,35 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.ResultSet;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- *
+ * Tests for {@link ExploreStatement}.
  */
 public class ExploreStatementTest {
 
   @Test
   public void executeTest() throws Exception {
+    List<ColumnDesc> columnDescriptions = Lists.newArrayList(new ColumnDesc("column1", "STRING", 1, ""));
+    List<QueryResult> queryResults = Lists.newArrayList();
     ExploreClient exploreClient = new MockExploreClient(
         ImmutableMap.of(
-          "mock_query_1", (List<ColumnDesc>) Lists.newArrayList(new ColumnDesc("column1", "STRING", 1, "")),
-          "mock_query_2", (List<ColumnDesc>) Lists.newArrayList(new ColumnDesc("column1", "STRING", 1, "")),
-          "mock_query_3", (List<ColumnDesc>) Lists.newArrayList(new ColumnDesc("column1", "STRING", 1, "")),
-          "mock_query_4", (List<ColumnDesc>) Lists.newArrayList(new ColumnDesc("column1", "STRING", 1, ""))
+          "mock_query_1", columnDescriptions,
+          "mock_query_2", columnDescriptions,
+          "mock_query_3", columnDescriptions,
+          "mock_query_4", columnDescriptions
         ),
         ImmutableMap.of(
-          "mock_query_1", (List<QueryResult>) Lists.<QueryResult>newArrayList(),
-          "mock_query_2", (List<QueryResult>) Lists.<QueryResult>newArrayList(),
-          "mock_query_3", (List<QueryResult>) Lists.<QueryResult>newArrayList(),
-          "mock_query_4", (List<QueryResult>) Lists.<QueryResult>newArrayList()
+          "mock_query_1", queryResults,
+          "mock_query_2", queryResults,
+          "mock_query_3", queryResults,
+          "mock_query_4", queryResults
           )
     );
 
     // Make sure an empty query still has a ResultSet associated to it
-    ExploreStatement statement = new ExploreStatement(null, exploreClient, "");
+    ExploreStatement statement = new ExploreStatement(null, exploreClient, "ns1");
     Assert.assertTrue(statement.execute("mock_query_1"));
     ResultSet rs = statement.getResultSet();
     Assert.assertNotNull(rs);

--- a/cdap-proto/pom.xml
+++ b/cdap-proto/pom.xml
@@ -37,10 +37,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ApplicationDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ApplicationDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,8 +21,8 @@ import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
-import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -94,7 +94,7 @@ public class ApplicationDetail {
   }
 
   public static ApplicationDetail fromSpec(ApplicationSpecification spec) {
-    List<ProgramRecord> programs = Lists.newArrayList();
+    List<ProgramRecord> programs = new ArrayList<>();
     for (ProgramSpecification programSpec : spec.getFlows().values()) {
       programs.add(new ProgramRecord(ProgramType.FLOW, spec.getName(),
                                      programSpec.getName(), programSpec.getDescription()));
@@ -120,12 +120,12 @@ public class ApplicationDetail {
                                      programSpec.getName(), programSpec.getDescription()));
     }
 
-    List<StreamDetail> streams = Lists.newArrayList();
+    List<StreamDetail> streams = new ArrayList<>();
     for (StreamSpecification streamSpec : spec.getStreams().values()) {
       streams.add(new StreamDetail(streamSpec.getName()));
     }
 
-    List<DatasetDetail> datasets = Lists.newArrayList();
+    List<DatasetDetail> datasets = new ArrayList<>();
     for (DatasetCreationSpec datasetSpec : spec.getDatasets().values()) {
       datasets.add(new DatasetDetail(datasetSpec.getInstanceName(), datasetSpec.getTypeName()));
     }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/BatchProgram.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/BatchProgram.java
@@ -16,8 +16,7 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Joiner;
-
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -60,7 +59,7 @@ public class BatchProgram {
       throw new IllegalArgumentException("'appId' must be specified.");
     }
     if (programType == null) {
-      throw new IllegalArgumentException("'programType' must be one of " + Joiner.on(",").join(ProgramType.values()));
+      throw new IllegalArgumentException("'programType' must be one of " + Arrays.toString(ProgramType.values()));
     }
     if (programId == null || programId.isEmpty()) {
       throw new IllegalArgumentException("'programId' must be specified.");

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ColumnDesc.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ColumnDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 /**
  * Represents a column inside a query result.
@@ -65,24 +65,24 @@ public class ColumnDesc {
 
     ColumnDesc that = (ColumnDesc) o;
 
-    return Objects.equal(this.name, that.name) &&
-      Objects.equal(this.type, that.type) &&
-      Objects.equal(this.position, that.position) &&
-      Objects.equal(this.comment, that.comment);
+    return Objects.equals(this.name, that.name) &&
+      Objects.equals(this.type, that.type) &&
+      Objects.equals(this.position, that.position) &&
+      Objects.equals(this.comment, that.comment);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(name, type, position, comment);
+    return Objects.hash(name, type, position, comment);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("name", name)
-      .add("type", type)
-      .add("position", position)
-      .add("comment", comment)
-      .toString();
+    return "ColumnDesc{" +
+      "name='" + name + '\'' +
+      ", type='" + type + '\'' +
+      ", position=" + position +
+      ", comment='" + comment + '\'' +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ConfigEntry.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ConfigEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 /**
  * Represents an entry in {@link org.apache.hadoop.conf.Configuration}
@@ -47,7 +47,7 @@ public final class ConfigEntry {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(name, value, source);
+    return Objects.hash(name, value, source);
   }
 
   @Override
@@ -59,13 +59,17 @@ public final class ConfigEntry {
       return false;
     }
     final ConfigEntry other = (ConfigEntry) obj;
-    return Objects.equal(this.name, other.name) &&
-      Objects.equal(this.value, other.value) &&
-      Objects.equal(this.source, other.source);
+    return Objects.equals(this.name, other.name) &&
+      Objects.equals(this.value, other.value) &&
+      Objects.equals(this.source, other.source);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("name", name).add("value", value).add("source", source).toString();
+    return "ConfigEntry{" +
+      "name='" + name + '\'' +
+      ", value='" + value + '\'' +
+      ", source='" + source + '\'' +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetInstanceConfiguration.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetInstanceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +16,7 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.collect.ImmutableMap;
-
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -37,7 +36,7 @@ public final class DatasetInstanceConfiguration {
   }
 
   public Map<String, String> getProperties() {
-    return properties == null ? ImmutableMap.<String, String>of() : properties;
+    return properties == null ? Collections.<String, String>emptyMap() : properties;
   }
 
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetModuleMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetModuleMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,11 +16,8 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
-import com.google.common.collect.Lists;
-
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -54,9 +51,9 @@ public class DatasetModuleMeta {
     this.name = name;
     this.className = className;
     this.jarLocation = jarLocation;
-    this.types = Collections.unmodifiableList(types);
-    this.usesModules = Collections.unmodifiableList(usesModules);
-    this.usedByModules = Lists.newArrayList();
+    this.types = Collections.unmodifiableList(new ArrayList<>(types));
+    this.usesModules = Collections.unmodifiableList(new ArrayList<>(usesModules));
+    this.usedByModules = new ArrayList<>();
   }
 
   /**
@@ -121,12 +118,13 @@ public class DatasetModuleMeta {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("name", name)
-      .add("className", className)
-      .add("jarLocation", jarLocation)
-      .add("usesModules", Joiner.on(",").skipNulls().join(usesModules))
-      .add("usedByModules", Joiner.on(",").skipNulls().join(usedByModules))
-      .toString();
+    return "DatasetModuleMeta{" +
+      "name='" + name + '\'' +
+      ", className='" + className + '\'' +
+      ", jarLocation=" + jarLocation +
+      ", types=" + types +
+      ", usesModules=" + usesModules +
+      ", usedByModules=" + usedByModules +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetSpecificationSummary.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetSpecificationSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,9 +17,9 @@
 package co.cask.cdap.proto;
 
 import co.cask.cdap.api.dataset.DatasetSpecification;
-import com.google.common.base.Objects;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Summary of a {@link DatasetSpecification}. This is returned by the dataset API when getting all dataset instances
@@ -60,23 +60,22 @@ public class DatasetSpecificationSummary {
 
     DatasetSpecificationSummary that = (DatasetSpecificationSummary) o;
 
-    return Objects.equal(name, that.name) &&
-      Objects.equal(type, that.type) &&
-      Objects.equal(properties, that.properties);
-  }
-
-  @Override
-  public String toString() {
-    final StringBuilder sb = new StringBuilder("DatasetSpecificationSummary{");
-    sb.append("name='").append(name).append('\'');
-    sb.append(", type='").append(type).append('\'');
-    sb.append(", properties=").append(properties);
-    sb.append('}');
-    return sb.toString();
+    return Objects.equals(name, that.name) &&
+      Objects.equals(type, that.type) &&
+      Objects.equals(properties, that.properties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(name, type, properties);
+    return Objects.hash(name, type, properties);
+  }
+
+  @Override
+  public String toString() {
+    return "DatasetSpecificationSummary{" +
+      "name='" + name + '\'' +
+      ", type='" + type + '\'' +
+      ", properties=" + properties +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetTypeMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetTypeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,9 +15,6 @@
  */
 
 package co.cask.cdap.proto;
-
-import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 
 import java.util.List;
 
@@ -56,9 +53,9 @@ public class DatasetTypeMeta {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("name", name)
-      .add("modules", Joiner.on(",").skipNulls().join(modules))
-      .toString();
+    return "DatasetTypeMeta{" +
+      "name='" + name + '\'' +
+      ", modules=" + modules +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DistributedProgramLiveInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DistributedProgramLiveInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +16,7 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -26,8 +25,8 @@ import java.util.List;
 public class DistributedProgramLiveInfo extends ProgramLiveInfo implements Containers {
 
   private final String yarnAppId;
-  private final List<Containers.ContainerInfo> containers = Lists.newArrayList();
-  private final List<String> services = Lists.newArrayList();
+  private final List<Containers.ContainerInfo> containers = new ArrayList<>();
+  private final List<String> services = new ArrayList<>();
 
   public DistributedProgramLiveInfo(Id.Program program, String yarnAppId) {
     super(program, "distributed");

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -37,9 +37,9 @@ import co.cask.cdap.proto.id.ScheduleId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.cdap.proto.id.SystemServiceId;
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Charsets;
-import com.google.common.base.Preconditions;
+
+import java.nio.charset.Charset;
+import java.util.regex.Pattern;
 
 /**
  * Contains collection of classes representing different types of Ids.
@@ -53,29 +53,26 @@ public abstract class Id implements EntityIdCompatible {
     return type.getSimpleName().toLowerCase();
   }
 
-  private static final CharMatcher namespaceMatcher =
-    CharMatcher.inRange('A', 'Z')
-    .or(CharMatcher.inRange('a', 'z'))
-    .or(CharMatcher.inRange('0', '9'))
-    .or(CharMatcher.is('_'));
+  // Only allow alphanumeric and _ character for namespace
+  private static final Pattern namespacePattern = Pattern.compile("[a-zA-Z0-9_]+");
   // Allow hyphens for other ids.
-  private static final CharMatcher idMatcher = namespaceMatcher.or(CharMatcher.is('-'));
+  private static final Pattern idPattern = Pattern.compile("[a-zA-Z0-9_-]+");
   // Allow '.' and '$' for dataset ids since they can be fully qualified class names
-  private static final CharMatcher datasetIdCharMatcher = idMatcher.or(CharMatcher.is('.')).or(CharMatcher.is('$'));
-
-  private static boolean isValidNamespaceId(String name) {
-    return namespaceMatcher.matchesAllOf(name);
-  }
+  private static final Pattern datasetIdPattern = Pattern.compile("[$\\.a-zA-Z0-9_-]+");
 
   private transient String toString;
   private transient Integer hashCode;
 
+  private static boolean isValidNamespaceId(String name) {
+    return namespacePattern.matcher(name).matches();
+  }
+
   private static boolean isValidId(String name) {
-    return idMatcher.matchesAllOf(name);
+    return idPattern.matcher(name).matches();
   }
 
   private static boolean isValidDatasetId(String datasetId) {
-    return datasetIdCharMatcher.matchesAllOf(datasetId);
+    return datasetIdPattern.matcher(datasetId).matches();
   }
 
   public String getIdType() {
@@ -137,7 +134,9 @@ public abstract class Id implements EntityIdCompatible {
     private final String id;
 
     private QueryHandle(String id) {
-      Preconditions.checkNotNull(id, "id cannot be null.");
+      if (id == null) {
+        throw new NullPointerException("id cannot be null.");
+      }
       this.id = id;
     }
 
@@ -165,7 +164,9 @@ public abstract class Id implements EntityIdCompatible {
     private final String id;
 
     private SystemService(String id) {
-      Preconditions.checkNotNull(id, "id cannot be null.");
+      if (id == null) {
+        throw new NullPointerException("id cannot be null.");
+      }
       this.id = id;
     }
 
@@ -198,8 +199,12 @@ public abstract class Id implements EntityIdCompatible {
     private final String id;
 
     public Namespace(String id) {
-      Preconditions.checkNotNull(id, "Namespace '" + id + "' cannot be null.");
-      Preconditions.checkArgument(isValidNamespaceId(id), "Namespace '" + id + "' has an incorrect format.");
+      if (id == null) {
+        throw new NullPointerException("Namespace cannot be null.");
+      }
+      if (!isValidNamespaceId(id)) {
+        throw new IllegalArgumentException("Namespace '" + id + "' has an incorrect format.");
+      }
       this.id = id;
     }
 
@@ -229,9 +234,15 @@ public abstract class Id implements EntityIdCompatible {
     private final String applicationId;
 
     public Application(final Namespace namespace, final String applicationId) {
-      Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
-      Preconditions.checkNotNull(applicationId, "Application cannot be null.");
-      Preconditions.checkArgument(isValidId(applicationId), "Invalid Application ID.");
+      if (namespace == null) {
+        throw new NullPointerException("Namespace cannot be null.");
+      }
+      if (applicationId == null) {
+        throw new NullPointerException("Application cannot be null.");
+      }
+      if (!isValidId(applicationId)) {
+        throw new IllegalArgumentException("Invalid Application ID.");
+      }
       this.namespace = namespace;
       this.applicationId = applicationId;
     }
@@ -314,9 +325,15 @@ public abstract class Id implements EntityIdCompatible {
     private final String id;
 
     public Program(Application application, ProgramType type, final String id) {
-      Preconditions.checkNotNull(application, "application cannot be null.");
-      Preconditions.checkNotNull(application, "type cannot be null.");
-      Preconditions.checkNotNull(id, "id cannot be null.");
+      if (application == null) {
+        throw new NullPointerException("Application cannot be null.");
+      }
+      if (type == null) {
+        throw new NullPointerException("Program type cannot be null.");
+      }
+      if (id == null) {
+        throw new NullPointerException("Program id cannot be null.");
+      }
       this.application = application;
       this.type = type;
       this.id = id;
@@ -468,8 +485,12 @@ public abstract class Id implements EntityIdCompatible {
       private final String id;
 
       private Flowlet(Flow flow, String id) {
-        Preconditions.checkArgument(flow != null, "flow cannot be null");
-        Preconditions.checkArgument(id != null, "id cannot be null");
+        if (flow == null) {
+          throw new IllegalArgumentException("flow cannot be null");
+        }
+        if (id == null) {
+          throw new IllegalArgumentException("id cannot be null");
+        }
         this.flow = flow;
         this.id = id;
       }
@@ -551,8 +572,12 @@ public abstract class Id implements EntityIdCompatible {
     private final String id;
 
     private Schedule(Application application, String id) {
-      Preconditions.checkArgument(application != null, "application cannot be null.");
-      Preconditions.checkArgument(id != null && !id.isEmpty(), "id cannot be null or empty.");
+      if (application == null) {
+        throw new IllegalArgumentException("application cannot be null");
+      }
+      if (id == null || id.isEmpty()) {
+        throw new IllegalArgumentException("id cannot be null or empty");
+      }
       this.application = application;
       this.id = id;
     }
@@ -619,13 +644,18 @@ public abstract class Id implements EntityIdCompatible {
     }
 
     private NotificationFeed(String namespace, String category, String name, String description) {
-      Preconditions.checkArgument(namespace != null && !namespace.isEmpty(),
-                                  "Namespace value cannot be null or empty.");
-      Preconditions.checkArgument(category != null && !category.isEmpty(),
-                                  "Category value cannot be null or empty.");
-      Preconditions.checkArgument(name != null && !name.isEmpty(), "Name value cannot be null or empty.");
-      Preconditions.checkArgument(isValidId(namespace) && isValidId(category) && isValidId(name),
-                                  "Namespace, category or name has a wrong format.");
+      if (namespace == null || namespace.isEmpty()) {
+        throw new IllegalArgumentException("Namespace value cannot be null or empty.");
+      }
+      if (category == null || category.isEmpty()) {
+        throw new IllegalArgumentException("Category value cannot be null or empty.");
+      }
+      if (name == null || name.isEmpty()) {
+        throw new IllegalArgumentException("Name value cannot be null or empty.");
+      }
+      if (!isValidId(namespace) || !isValidId(category) || !isValidId(name)) {
+        throw new IllegalArgumentException("Namespace, category or name has a wrong format.");
+      }
 
       this.namespace = Namespace.from(namespace);
       this.category = category;
@@ -734,11 +764,16 @@ public abstract class Id implements EntityIdCompatible {
     private transient byte[] idBytes;
 
     private Stream(final Namespace namespace, final String streamName) {
-      Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
-      Preconditions.checkNotNull(streamName, "Stream name cannot be null.");
-
-      Preconditions.checkArgument(isValidId(streamName), "Stream name can only contain alphanumeric, " +
-                                    "'-' and '_' characters: %s", streamName);
+      if (namespace == null) {
+        throw new NullPointerException("Namespace cannot be null.");
+      }
+      if (streamName == null) {
+        throw new IllegalArgumentException("Stream name cannot be null.");
+      }
+      if (!isValidId(streamName)) {
+        throw new IllegalArgumentException(String.format("Stream name can only contain alphanumeric, " +
+                                                           "'-' and '_' characters: %s", streamName));
+      }
 
       this.namespace = namespace;
       this.streamName = streamName;
@@ -760,7 +795,7 @@ public abstract class Id implements EntityIdCompatible {
 
     public byte[] toBytes() {
       if (idBytes == null) {
-        idBytes = toString().getBytes(Charsets.US_ASCII);
+        idBytes = toString().getBytes(Charset.forName("US-ASCII"));
       }
       return idBytes;
     }
@@ -789,9 +824,13 @@ public abstract class Id implements EntityIdCompatible {
       private final String id;
 
       public View(Stream stream, String id) {
-        Preconditions.checkNotNull(id, "ID cannot be null.");
-        Preconditions.checkArgument(isValidId(id), "ID can only contain alphanumeric, " +
-          "'-' and '_' characters: %s", id);
+        if (id == null) {
+          throw new NullPointerException("ID cannot be null.");
+        }
+        if (!isValidId(id)) {
+          throw new IllegalArgumentException(String.format("ID can only contain alphanumeric, " +
+                                                             "'-' and '_' characters: %s", id));
+        }
         this.stream = stream;
         this.id = id;
       }
@@ -848,10 +887,16 @@ public abstract class Id implements EntityIdCompatible {
     private final String typeName;
 
     private DatasetType(Namespace namespace, String typeName) {
-      Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
-      Preconditions.checkNotNull(typeName, "Dataset type name cannot be null.");
-      Preconditions.checkArgument(isValidDatasetId(typeName), "Invalid characters found in dataset type name '" +
-        typeName + "'. Allowed characters are ASCII letters, numbers, and _, -, ., or $.");
+      if (namespace == null) {
+        throw new NullPointerException("Namespace cannot be null.");
+      }
+      if (typeName == null) {
+        throw new NullPointerException("Dataset type name cannot be null.");
+      }
+      if (!isValidDatasetId(typeName)) {
+        throw new IllegalArgumentException("Invalid characters found in dataset type name '" + typeName +
+                                             "'. Allowed characters are ASCII letters, numbers, and _, -, ., or $.");
+      }
       this.namespace = namespace;
       this.typeName = typeName;
     }
@@ -899,10 +944,16 @@ public abstract class Id implements EntityIdCompatible {
     private final String moduleId;
 
     private DatasetModule(Namespace namespace, String moduleId) {
-      Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
-      Preconditions.checkNotNull(moduleId, "Dataset module id cannot be null.");
-      Preconditions.checkArgument(isValidDatasetId(moduleId), "Invalid characters found in dataset module Id. '" +
-        moduleId + "'. Module id can contain ASCII letters, numbers, and _, -, ., or $ characters.");
+      if (namespace == null) {
+        throw new NullPointerException("Namespace cannot be null.");
+      }
+      if (moduleId == null) {
+        throw new NullPointerException("Dataset module id cannot be null.");
+      }
+      if (!isValidDatasetId(moduleId)) {
+        throw new IllegalArgumentException("Invalid characters found in dataset module Id '" + moduleId +
+                                             "'. Allowed characters are ASCII letters, numbers, and _, -, ., or $.");
+      }
       this.namespace = namespace;
       this.moduleId = moduleId;
     }
@@ -945,10 +996,16 @@ public abstract class Id implements EntityIdCompatible {
     private final String instanceId;
 
     private DatasetInstance(Namespace namespace, String instanceId) {
-      Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
-      Preconditions.checkNotNull(instanceId, "Dataset instance id cannot be null.");
-      Preconditions.checkArgument(isValidDatasetId(instanceId), "Invalid characters found in dataset instance id. '" +
-        instanceId + "'. Instance id can contain ASCII letters, numbers, and _, -, ., or $.");
+      if (namespace == null) {
+        throw new NullPointerException("Namespace cannot be null.");
+      }
+      if (instanceId == null) {
+        throw new NullPointerException("Dataset instance id cannot be null.");
+      }
+      if (!isValidDatasetId(instanceId)) {
+        throw new IllegalArgumentException("Invalid characters found in dataset instance Id '" + instanceId +
+                                             "'. Allowed characters are ASCII letters, numbers, and _, -, ., or $.");
+      }
       this.namespace = namespace;
       this.instanceId = instanceId;
     }
@@ -992,11 +1049,21 @@ public abstract class Id implements EntityIdCompatible {
     private final ArtifactVersion version;
 
     public Artifact(Namespace namespace, String name, ArtifactVersion version) {
-      Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
-      Preconditions.checkNotNull(name, "Name cannot be null.");
-      Preconditions.checkArgument(isValidId(name), "Invalid artifact name.");
-      Preconditions.checkNotNull(version, "Version cannot be null.");
-      Preconditions.checkNotNull(version.getVersion(), "Invalid artifact version.");
+      if (namespace == null) {
+        throw new NullPointerException("Namespace cannot be null.");
+      }
+      if (name == null) {
+        throw new NullPointerException("Name cannot be null.");
+      }
+      if (!isValidId(name)) {
+        throw new IllegalArgumentException("Invalid artifact name.");
+      }
+      if (version == null) {
+        throw new NullPointerException("Version cannot be null.");
+      }
+      if (version.getVersion() == null) {
+        throw new NullPointerException("Invalid artifact version.");
+      }
       this.namespace = namespace;
       this.name = name;
       this.version = version;
@@ -1091,5 +1158,4 @@ public abstract class Id implements EntityIdCompatible {
       return new NamespacedArtifactId(namespace.getId(), name, version.getVersion());
     }
   }
-
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +16,9 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Objects;
 import com.google.gson.annotations.SerializedName;
+
+import java.util.Objects;
 
 /**
  * Represents the configuration of a namespace. This class needs to be GSON serializable.
@@ -44,7 +45,7 @@ public class NamespaceConfig {
       return false;
     }
     NamespaceConfig other = (NamespaceConfig) o;
-    return Objects.equal(schedulerQueueName, other.schedulerQueueName);
+    return Objects.equals(schedulerQueueName, other.schedulerQueueName);
   }
 
   @Override
@@ -54,8 +55,8 @@ public class NamespaceConfig {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-                  .add("scheduler.queue.name", schedulerQueueName)
-                  .toString();
+    return "NamespaceConfig{" +
+      "scheduler.queue.name='" + schedulerQueueName + '\'' +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +16,7 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
 /**
  * Represents metadata for namespaces
@@ -89,7 +88,9 @@ public final class NamespaceMeta {
     }
 
     public NamespaceMeta build() {
-      Preconditions.checkArgument(name != null, "Namespace id cannot be null.");
+      if (name == null) {
+        throw new IllegalArgumentException("Namespace id cannot be null.");
+      }
       if (description == null) {
         description = "";
       }
@@ -110,22 +111,22 @@ public final class NamespaceMeta {
       return false;
     }
     NamespaceMeta other = (NamespaceMeta) o;
-    return Objects.equal(name, other.name)
-      && Objects.equal(description, other.description)
-      && Objects.equal(config, other.config);
+    return Objects.equals(name, other.name)
+      && Objects.equals(description, other.description)
+      && Objects.equals(config, other.config);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(name, description, config);
+    return Objects.hash(name, description, config);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("name", name)
-      .add("description", description)
-      .add("config", getConfig())
-      .toString();
+    return "NamespaceMeta{" +
+      "name='" + name + '\'' +
+      ", description='" + description + '\'' +
+      ", config=" + getConfig() +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramType.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,7 +17,6 @@
 package co.cask.cdap.proto;
 
 import co.cask.cdap.api.schedule.SchedulableProgramType;
-import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.HashMap;
@@ -102,7 +101,7 @@ public enum ProgramType {
   private final int index;
   private final Parameters parameters;
 
-  private ProgramType(int type, Parameters parameters) {
+  ProgramType(int type, Parameters parameters) {
     this.index = type;
     this.parameters = parameters;
   }
@@ -167,9 +166,15 @@ public enum ProgramType {
 
     public Parameters(String prettyName, Boolean listable, String categoryName,
                       @Nullable SchedulableProgramType schedulableType) {
-      Preconditions.checkArgument(prettyName != null, "prettyName cannot be null");
-      Preconditions.checkArgument(listable != null, "listable cannot be null");
-      Preconditions.checkArgument(categoryName != null, "categoryName cannot be null");
+      if (prettyName == null) {
+        throw new IllegalArgumentException("prettyName cannot be null");
+      }
+      if (listable == null) {
+        throw new IllegalArgumentException("listable cannot be null");
+      }
+      if (categoryName == null) {
+        throw new IllegalArgumentException("categoryName cannot be null");
+      }
       this.prettyName = prettyName;
       this.listable = listable;
       this.categoryName = categoryName;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramTypes.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,8 +24,9 @@ import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.api.webapp.WebappSpecification;
 import co.cask.cdap.api.worker.WorkerSpecification;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
-import com.google.common.collect.ImmutableMap;
 
+import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 
 /**
@@ -34,15 +35,16 @@ import java.util.Map;
 public class ProgramTypes {
 
   private static final Map<Class<? extends ProgramSpecification>, ProgramType> specClassToProgramType =
-    ImmutableMap.<Class<? extends ProgramSpecification>, ProgramType>builder()
-      .put(FlowSpecification.class, ProgramType.FLOW)
-      .put(MapReduceSpecification.class, ProgramType.MAPREDUCE)
-      .put(SparkSpecification.class, ProgramType.SPARK)
-      .put(WorkflowSpecification.class, ProgramType.WORKFLOW)
-      .put(WebappSpecification.class, ProgramType.WEBAPP)
-      .put(ServiceSpecification.class, ProgramType.SERVICE)
-      .put(WorkerSpecification.class, ProgramType.WORKER)
-      .build();
+    new IdentityHashMap<>();
+  static {
+    specClassToProgramType.put(FlowSpecification.class, ProgramType.FLOW);
+    specClassToProgramType.put(MapReduceSpecification.class, ProgramType.MAPREDUCE);
+    specClassToProgramType.put(SparkSpecification.class, ProgramType.SPARK);
+    specClassToProgramType.put(WorkflowSpecification.class, ProgramType.WORKFLOW);
+    specClassToProgramType.put(WebappSpecification.class, ProgramType.WEBAPP);
+    specClassToProgramType.put(ServiceSpecification.class, ProgramType.SERVICE);
+    specClassToProgramType.put(WorkerSpecification.class, ProgramType.WORKER);
+  }
 
   /**
    * Maps from {@link ProgramSpecification} to {@link ProgramType}.

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/QueryHandle.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/QueryHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +16,7 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Objects;
-
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -55,9 +54,9 @@ public final class QueryHandle {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("id", handle)
-      .toString();
+    return "QueryHandle{" +
+      "handle='" + handle + '\'' +
+      '}';
   }
 
   @Override
@@ -71,11 +70,11 @@ public final class QueryHandle {
 
     QueryHandle that = (QueryHandle) o;
 
-    return Objects.equal(this.handle, that.handle);
+    return Objects.equals(this.handle, that.handle);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(handle);
+    return Objects.hash(handle);
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/QueryInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/QueryInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.primitives.Longs;
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -74,6 +73,6 @@ public class QueryInfo implements Comparable<QueryInfo> {
   @Override
   public int compareTo(QueryInfo queryInfo) {
     // descending.
-    return Longs.compare(queryInfo.getTimestamp(), getTimestamp());
+    return Long.valueOf(queryInfo.getTimestamp()).compareTo((getTimestamp()));
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/QueryResult.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/QueryResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,11 +16,10 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Objects;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Represents query result.
@@ -59,7 +58,7 @@ public class QueryResult {
         if (!Arrays.equals((byte[]) thisCol, (byte[]) thatCol)) {
           return false;
         }
-      } else if (!Objects.equal(thisCol, thatCol)) {
+      } else if (!Objects.equals(thisCol, thatCol)) {
         return false;
       }
     }
@@ -68,13 +67,13 @@ public class QueryResult {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(columns);
+    return Objects.hash(columns);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("columns", columns)
-      .toString();
+    return "QueryResult{" +
+      "columns=" + columns +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/QueryStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/QueryStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 /**
  * Represents the status of a submitted query operation.
@@ -43,10 +43,10 @@ public class QueryStatus {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("state", status)
-      .add("hasResults", hasResults)
-      .toString();
+    return "QueryStatus{" +
+      "status=" + status +
+      ", hasResults=" + hasResults +
+      '}';
   }
 
   @Override
@@ -60,13 +60,13 @@ public class QueryStatus {
 
     QueryStatus that = (QueryStatus) o;
 
-    return Objects.equal(this.status, that.status) &&
-      Objects.equal(this.hasResults, that.hasResults);
+    return Objects.equals(this.status, that.status) &&
+      Objects.equals(this.hasResults, that.hasResults);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(NO_OP, status, hasResults);
+    return Objects.hash(NO_OP, status, hasResults);
   }
 
   /**

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,11 +16,12 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Objects;
-import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -49,7 +50,8 @@ public class RunRecord {
     this.startTs = startTs;
     this.stopTs = stopTs;
     this.status = status;
-    this.properties = properties == null ? Maps.<String, String>newHashMap() : properties;
+    this.properties = properties == null ? Collections.<String, String>emptyMap() :
+      Collections.unmodifiableMap(new LinkedHashMap<>(properties));
   }
 
   public RunRecord(RunRecord otherRunRecord) {
@@ -89,26 +91,26 @@ public class RunRecord {
 
     RunRecord that = (RunRecord) o;
 
-    return Objects.equal(this.pid, that.pid) &&
-      Objects.equal(this.startTs, that.startTs) &&
-      Objects.equal(this.stopTs, that.stopTs) &&
-      Objects.equal(this.status, that.status) &&
-      Objects.equal(this.properties, that.properties);
+    return Objects.equals(this.pid, that.pid) &&
+      Objects.equals(this.startTs, that.startTs) &&
+      Objects.equals(this.stopTs, that.stopTs) &&
+      Objects.equals(this.status, that.status) &&
+      Objects.equals(this.properties, that.properties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(pid, startTs, stopTs, status, properties);
+    return Objects.hash(pid, startTs, stopTs, status, properties);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("pid", pid)
-      .add("startTs", startTs)
-      .add("stopTs", stopTs)
-      .add("status", status)
-      .add("properties", properties)
-      .toString();
+    return "RunRecord{" +
+      "pid='" + pid + '\'' +
+      ", startTs=" + startTs +
+      ", stopTs=" + stopTs +
+      ", status=" + status +
+      ", properties=" + properties +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/StreamProperties.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/StreamProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +16,9 @@
 package co.cask.cdap.proto;
 
 import co.cask.cdap.api.data.format.FormatSpecification;
-import com.google.common.base.Objects;
 import com.google.gson.annotations.SerializedName;
+
+import java.util.Objects;
 
 /**
  * Represents the properties of a stream.
@@ -69,22 +70,22 @@ public class StreamProperties {
 
     StreamProperties that = (StreamProperties) o;
 
-    return Objects.equal(ttl, that.ttl) &&
-      Objects.equal(format, that.format) &
-      Objects.equal(notificationThresholdMB, that.notificationThresholdMB);
+    return Objects.equals(ttl, that.ttl) &&
+      Objects.equals(format, that.format) &
+      Objects.equals(notificationThresholdMB, that.notificationThresholdMB);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(ttl, format, notificationThresholdMB);
+    return Objects.hash(ttl, format, notificationThresholdMB);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("ttl", ttl)
-      .add("format", format)
-      .add("notificationThresholdMB", notificationThresholdMB)
-      .toString();
+    return "StreamProperties{" +
+      "ttl=" + ttl +
+      ", format=" + format +
+      ", notificationThresholdMB=" + notificationThresholdMB +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/SystemServiceLiveInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/SystemServiceLiveInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,9 +16,8 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -30,7 +29,7 @@ public class SystemServiceLiveInfo {
   private final List<Containers.ContainerInfo> containers;
 
   public SystemServiceLiveInfo(List<Containers.ContainerInfo> containers) {
-    this.containers = ImmutableList.copyOf(containers);
+    this.containers = Collections.unmodifiableList(new ArrayList<>(containers));
   }
 
   @Nullable
@@ -46,7 +45,7 @@ public class SystemServiceLiveInfo {
    *
    */
   public static class Builder {
-    private final List<Containers.ContainerInfo> containers = Lists.newArrayList();
+    private final List<Containers.ContainerInfo> containers = new ArrayList<>();
 
     public Builder addContainer(Containers.ContainerInfo containerInfo) {
       containers.add(containerInfo);

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/TableInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/TableInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,12 +16,13 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Schema and other extended information about a Hive table.
@@ -90,7 +91,7 @@ public class TableInfo {
     this.lastAccessTime = lastAccessTime;
     this.retention = retention;
     this.partitionKeys = partitionKeys;
-    this.parameters = ImmutableMap.copyOf(parameters);
+    this.parameters = Collections.unmodifiableMap(new LinkedHashMap<>(parameters));
     this.tableType = tableType;
     this.schema = schema;
     this.location = location;
@@ -99,7 +100,7 @@ public class TableInfo {
     this.compressed = compressed;
     this.numBuckets = numBuckets;
     this.serde = serde;
-    this.serdeParameters = ImmutableMap.copyOf(serdeParameters);
+    this.serdeParameters = Collections.unmodifiableMap(new LinkedHashMap<>(serdeParameters));
     this.isBackedByDataset = isBackedByDataset;
   }
 
@@ -150,55 +151,55 @@ public class TableInfo {
 
     TableInfo that = (TableInfo) o;
 
-    return Objects.equal(this.tableName, that.tableName) &&
-      Objects.equal(this.dbName, that.dbName) &&
-      Objects.equal(this.owner, that.owner) &&
-      Objects.equal(this.creationTime, that.creationTime) &&
-      Objects.equal(this.lastAccessTime, that.lastAccessTime) &&
-      Objects.equal(this.retention, that.retention) &&
-      Objects.equal(this.partitionKeys, that.partitionKeys) &&
-      Objects.equal(this.parameters, that.parameters) &&
-      Objects.equal(this.tableType, that.tableType) &&
-      Objects.equal(this.schema, that.schema) &&
-      Objects.equal(this.location, that.location) &&
-      Objects.equal(this.inputFormat, that.inputFormat) &&
-      Objects.equal(this.outputFormat, that.outputFormat) &&
-      Objects.equal(this.compressed, that.compressed) &&
-      Objects.equal(this.numBuckets, that.numBuckets) &&
-      Objects.equal(this.serde, that.serde) &&
-      Objects.equal(this.serdeParameters, that.serdeParameters) &&
-      Objects.equal(this.isBackedByDataset, that.isBackedByDataset);
+    return Objects.equals(this.tableName, that.tableName) &&
+      Objects.equals(this.dbName, that.dbName) &&
+      Objects.equals(this.owner, that.owner) &&
+      Objects.equals(this.creationTime, that.creationTime) &&
+      Objects.equals(this.lastAccessTime, that.lastAccessTime) &&
+      Objects.equals(this.retention, that.retention) &&
+      Objects.equals(this.partitionKeys, that.partitionKeys) &&
+      Objects.equals(this.parameters, that.parameters) &&
+      Objects.equals(this.tableType, that.tableType) &&
+      Objects.equals(this.schema, that.schema) &&
+      Objects.equals(this.location, that.location) &&
+      Objects.equals(this.inputFormat, that.inputFormat) &&
+      Objects.equals(this.outputFormat, that.outputFormat) &&
+      Objects.equals(this.compressed, that.compressed) &&
+      Objects.equals(this.numBuckets, that.numBuckets) &&
+      Objects.equals(this.serde, that.serde) &&
+      Objects.equals(this.serdeParameters, that.serdeParameters) &&
+      Objects.equals(this.isBackedByDataset, that.isBackedByDataset);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(tableName, dbName, owner, creationTime, lastAccessTime, retention, partitionKeys,
-                            parameters, tableType, schema, location, inputFormat, outputFormat, compressed,
-                            numBuckets, serde, serdeParameters, isBackedByDataset);
+    return Objects.hash(tableName, dbName, owner, creationTime, lastAccessTime, retention, partitionKeys,
+                        parameters, tableType, schema, location, inputFormat, outputFormat, compressed,
+                        numBuckets, serde, serdeParameters, isBackedByDataset);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("tableName", tableName)
-      .add("dbName", dbName)
-      .add("owner", owner)
-      .add("creationTime", creationTime)
-      .add("lastAccessTime", lastAccessTime)
-      .add("retention", retention)
-      .add("partitionKeys", partitionKeys)
-      .add("parameters", parameters)
-      .add("tableType", tableType)
-      .add("schema", schema)
-      .add("location", location)
-      .add("inputFormat", inputFormat)
-      .add("outputFormat", outputFormat)
-      .add("compressed", compressed)
-      .add("numBuckets", numBuckets)
-      .add("serde", serde)
-      .add("serdeParameters", serdeParameters)
-      .add("isBackedByDataset", isBackedByDataset)
-      .toString();
+    return "TableInfo{" +
+      "tableName='" + tableName + '\'' +
+      ", dbName='" + dbName + '\'' +
+      ", owner='" + owner + '\'' +
+      ", creationTime=" + creationTime +
+      ", lastAccessTime=" + lastAccessTime +
+      ", retention=" + retention +
+      ", partitionKeys=" + partitionKeys +
+      ", parameters=" + parameters +
+      ", tableType='" + tableType + '\'' +
+      ", schema=" + schema +
+      ", location='" + location + '\'' +
+      ", inputFormat='" + inputFormat + '\'' +
+      ", outputFormat='" + outputFormat + '\'' +
+      ", compressed=" + compressed +
+      ", numBuckets=" + numBuckets +
+      ", serde='" + serde + '\'' +
+      ", serdeParameters=" + serdeParameters +
+      ", isBackedByDataset=" + isBackedByDataset +
+      '}';
   }
 
   /**
@@ -226,23 +227,23 @@ public class TableInfo {
 
       ColumnInfo that = (ColumnInfo) o;
 
-      return Objects.equal(this.name, that.name) &&
-        Objects.equal(this.type, that.type) &&
-        Objects.equal(this.comment, that.comment);
+      return Objects.equals(this.name, that.name) &&
+        Objects.equals(this.type, that.type) &&
+        Objects.equals(this.comment, that.comment);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(name, type, comment);
+      return Objects.hash(name, type, comment);
     }
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
-        .add("name", name)
-        .add("type", type)
-        .add("comment", comment)
-        .toString();
+      return "ColumnInfo{" +
+        "name='" + name + '\'' +
+        ", type='" + type + '\'' +
+        ", comment='" + comment + '\'' +
+        '}';
     }
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/TableNameInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/TableNameInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +16,9 @@
 
 package co.cask.cdap.proto;
 
-import com.google.common.base.Objects;
 import com.google.gson.annotations.SerializedName;
+
+import java.util.Objects;
 
 /**
  * Basic information about a Hive table.
@@ -53,12 +54,12 @@ public class TableNameInfo {
 
     TableNameInfo that = (TableNameInfo) o;
 
-    return Objects.equal(this.databaseName, that.databaseName)
-      && Objects.equal(this.tableName, that.tableName);
+    return Objects.equals(this.databaseName, that.databaseName)
+      && Objects.equals(this.tableName, that.tableName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(databaseName, tableName);
+    return Objects.hash(databaseName, tableName);
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowTokenDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowTokenDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,10 +18,11 @@ package co.cask.cdap.proto;
 import co.cask.cdap.api.workflow.NodeValue;
 import co.cask.cdap.api.workflow.Value;
 import co.cask.cdap.api.workflow.WorkflowToken;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -33,11 +34,19 @@ public class WorkflowTokenDetail {
   private final Map<String, List<NodeValueDetail>> tokenData;
 
   public WorkflowTokenDetail(Map<String, List<NodeValueDetail>> tokenData) {
-    this.tokenData = ImmutableMap.copyOf(tokenData);
+    this.tokenData = deepCopy(tokenData);
   }
 
   public Map<String, List<NodeValueDetail>> getTokenData() {
     return tokenData;
+  }
+
+  private static Map<String, List<NodeValueDetail>> deepCopy(Map<String, List<NodeValueDetail>> tokenData) {
+    Map<String, List<NodeValueDetail>> tokenDataCopy = new LinkedHashMap<>();
+    for (Map.Entry<String, List<NodeValueDetail>> entry : tokenData.entrySet()) {
+      tokenDataCopy.put(entry.getKey(), Collections.unmodifiableList(new ArrayList<>(entry.getValue())));
+    }
+    return Collections.unmodifiableMap(tokenDataCopy);
   }
 
   /**

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowTokenNodeDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowTokenNodeDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,9 +17,10 @@ package co.cask.cdap.proto;
 
 import co.cask.cdap.api.workflow.Value;
 import co.cask.cdap.api.workflow.WorkflowToken;
-import com.google.common.collect.ImmutableMap;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -30,7 +31,7 @@ public class WorkflowTokenNodeDetail {
   private final Map<String, String> tokenDataAtNode;
 
   public WorkflowTokenNodeDetail(Map<String, String> tokenDataAtNode) {
-    this.tokenDataAtNode = ImmutableMap.copyOf(tokenDataAtNode);
+    this.tokenDataAtNode = Collections.unmodifiableMap(new LinkedHashMap<>(tokenDataAtNode));
   }
 
   public Map<String, String> getTokenDataAtNode() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/AbstractSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/AbstractSpecificationCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,11 +15,8 @@
  */
 package co.cask.cdap.proto.codec;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.reflect.TypeParameter;
-import com.google.common.reflect.TypeToken;
+import co.cask.cdap.internal.guava.reflect.TypeParameter;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -27,6 +24,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,7 +48,7 @@ public abstract class AbstractSpecificationCodec<T> implements JsonSerializer<T>
                                                     Class<V> valueType) {
     Type type = new TypeToken<Map<String, V>>() { }.where(new TypeParameter<V>() { }, valueType).getType();
     Map<String, V> map = context.deserialize(json, type);
-    return map == null ? ImmutableMap.<String, V>of() : map;
+    return map == null ? Collections.<String, V>emptyMap() : map;
   }
 
   protected final <V> JsonElement serializeSet(Set<V> set, JsonSerializationContext context, Class<V> valueType) {
@@ -61,7 +59,7 @@ public abstract class AbstractSpecificationCodec<T> implements JsonSerializer<T>
   protected final <V> Set<V> deserializeSet(JsonElement json, JsonDeserializationContext context, Class<V> valueType) {
     Type type = new TypeToken<Set<V>>() { }.where(new TypeParameter<V>() { }, valueType).getType();
     Set<V> set = context.deserialize(json, type);
-    return set == null ? ImmutableSet.<V>of() : set;
+    return set == null ? Collections.<V>emptySet() : set;
   }
 
   protected final <V> JsonElement serializeList(List<V> list, JsonSerializationContext context, Class<V> valueType) {
@@ -73,6 +71,6 @@ public abstract class AbstractSpecificationCodec<T> implements JsonSerializer<T>
                                               JsonDeserializationContext context, Class<V> valueType) {
     Type type = new TypeToken<List<V>>() { }.where(new TypeParameter<V>() { }, valueType).getType();
     List<V> list = context.deserialize(json, type);
-    return list == null ? ImmutableList.<V>of() : list;
+    return list == null ? Collections.<V>emptyList() : list;
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/element/EntityType.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/element/EntityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -33,12 +33,12 @@ import co.cask.cdap.proto.id.ScheduleId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.cdap.proto.id.SystemServiceId;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -71,14 +71,14 @@ public enum EntityType {
   private static final Map<Class<? extends EntityId>, EntityType> byIdClass;
   private static final Map<Class<? extends Id>, EntityType> byOldIdClass;
   static {
-    ImmutableMap.Builder<Class<? extends EntityId>, EntityType> builder = ImmutableMap.builder();
-    ImmutableMap.Builder<Class<? extends Id>, EntityType> builderOld = ImmutableMap.builder();
+    Map<Class<? extends EntityId>, EntityType> byIdClassMap = new LinkedHashMap<>();
+    Map<Class<? extends Id>, EntityType> byOldIdClassMap = new LinkedHashMap<>();
     for (EntityType type : EntityType.values()) {
-      builder.put(type.getIdClass(), type);
-      builderOld.put(type.getOldIdClass(), type);
+      byIdClassMap.put(type.getIdClass(), type);
+      byOldIdClassMap.put(type.getOldIdClass(), type);
     }
-    byIdClass = builder.build();
-    byOldIdClass = builderOld.build();
+    byIdClass = Collections.unmodifiableMap(byIdClassMap);
+    byOldIdClass = Collections.unmodifiableMap(byOldIdClassMap);
   }
 
   private final Class<? extends EntityId> idClass;
@@ -121,8 +121,10 @@ public enum EntityType {
   public <T extends EntityId> T fromIdParts(Iterable<String> idParts) {
     try {
       return (T) fromIdParts.invoke(idParts);
+    } catch (RuntimeException t) {
+      throw t;
     } catch (Throwable t) {
-      throw Throwables.propagate(t);
+      throw new RuntimeException(t);
     }
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,8 +18,9 @@ package co.cask.cdap.proto.id;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -105,7 +106,7 @@ public class ApplicationId extends EntityId implements NamespacedId, ParentedId<
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, application);
+    return Collections.unmodifiableList(Arrays.asList(namespace, application));
   }
 
   public static ApplicationId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,9 @@ package co.cask.cdap.proto.id;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -76,7 +77,7 @@ public class DatasetId extends EntityId implements NamespacedId, ParentedId<Name
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, dataset);
+    return Collections.unmodifiableList(Arrays.asList(namespace, dataset));
   }
 
   public static DatasetId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetModuleId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetModuleId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,9 @@ package co.cask.cdap.proto.id;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -76,7 +77,7 @@ public class DatasetModuleId extends EntityId implements NamespacedId, ParentedI
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, module);
+    return Collections.unmodifiableList(Arrays.asList(namespace, module));
   }
 
   public static DatasetModuleId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetTypeId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetTypeId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,9 @@ package co.cask.cdap.proto.id;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -71,7 +72,7 @@ public class DatasetTypeId extends EntityId implements NamespacedId, ParentedId<
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, type);
+    return Collections.unmodifiableList(Arrays.asList(namespace, type));
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,12 +15,12 @@
  */
 package co.cask.cdap.proto.id;
 
-
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -94,7 +94,7 @@ public class FlowletId extends EntityId implements NamespacedId, ParentedId<Prog
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, application, flow, flowlet);
+    return Collections.unmodifiableList(Arrays.asList(namespace, application, flow, flowlet));
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletQueueId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletQueueId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,11 +15,11 @@
  */
 package co.cask.cdap.proto.id;
 
-
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -97,7 +97,7 @@ public class FlowletQueueId extends EntityId implements NamespacedId, ParentedId
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, application, flow, flowlet, queue);
+    return Collections.unmodifiableList(Arrays.asList(namespace, application, flow, flowlet, queue));
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespaceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespaceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,8 @@ package co.cask.cdap.proto.id;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -91,7 +91,7 @@ public class NamespaceId extends EntityId {
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace);
+    return Collections.singletonList(namespace);
   }
 
   public static NamespaceId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespacedArtifactId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespacedArtifactId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,9 @@ package co.cask.cdap.proto.id;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -86,7 +87,7 @@ public class NamespacedArtifactId extends EntityId implements NamespacedId, Pare
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, artifact, version);
+    return Collections.unmodifiableList(Arrays.asList(namespace, artifact, version));
   }
 
   public static NamespacedArtifactId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NotificationFeedId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NotificationFeedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,11 +15,11 @@
  */
 package co.cask.cdap.proto.id;
 
-
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -87,7 +87,7 @@ public class NotificationFeedId extends EntityId implements NamespacedId, Parent
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, category, feed);
+    return Collections.unmodifiableList(Arrays.asList(namespace, category, feed));
   }
 
   public static NotificationFeedId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,13 +15,12 @@
  */
 package co.cask.cdap.proto.id;
 
-
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -68,7 +67,9 @@ public class ProgramId extends EntityId implements NamespacedId, ParentedId<Appl
   }
 
   public FlowletId flowlet(String flowlet) {
-    Preconditions.checkArgument(type == ProgramType.FLOW);
+    if (type != ProgramType.FLOW) {
+      throw new IllegalArgumentException("Expected program type for flowlet to be " + ProgramType.FLOW);
+    }
     return new FlowletId(namespace, application, program, flowlet);
   }
 
@@ -109,7 +110,9 @@ public class ProgramId extends EntityId implements NamespacedId, ParentedId<Appl
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, application, type.getPrettyName().toLowerCase(), program);
+    return Collections.unmodifiableList(
+      Arrays.asList(namespace, application, type.getPrettyName().toLowerCase(), program)
+    );
   }
 
   public static ProgramId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,12 +15,12 @@
  */
 package co.cask.cdap.proto.id;
 
-
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -102,7 +102,9 @@ public class ProgramRunId extends EntityId implements NamespacedId, ParentedId<P
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, application, type.getPrettyName().toLowerCase(), program, run);
+    return Collections.unmodifiableList(
+      Arrays.asList(namespace, application, type.getPrettyName().toLowerCase(), program, run)
+    );
   }
 
   public static ProgramRunId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/QueryId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/QueryId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,8 @@ package co.cask.cdap.proto.id;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -65,7 +65,7 @@ public class QueryId extends EntityId {
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(handle);
+    return Collections.singletonList(handle);
   }
 
   public static QueryId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ScheduleId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ScheduleId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,11 +15,11 @@
  */
 package co.cask.cdap.proto.id;
 
-
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -86,7 +86,7 @@ public class ScheduleId extends EntityId implements NamespacedId, ParentedId<App
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, application, schedule);
+    return Collections.unmodifiableList(Arrays.asList(namespace, application, schedule));
   }
 
   public static ScheduleId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,9 @@ package co.cask.cdap.proto.id;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -76,7 +77,7 @@ public class StreamId extends EntityId implements NamespacedId, ParentedId<Names
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, stream);
+    return Collections.unmodifiableList(Arrays.asList(namespace, stream));
   }
 
   public static StreamId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,9 @@ package co.cask.cdap.proto.id;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -85,7 +86,7 @@ public class StreamViewId extends EntityId implements NamespacedId, ParentedId<S
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(namespace, stream);
+    return Collections.unmodifiableList(Arrays.asList(namespace, stream, view));
   }
 
   public static StreamViewId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/SystemServiceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/SystemServiceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,8 @@ package co.cask.cdap.proto.id;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -65,7 +65,7 @@ public class SystemServiceId extends EntityId {
 
   @Override
   protected Iterable<String> toIdParts() {
-    return ImmutableList.of(service);
+    return Collections.singletonList(service);
   }
 
   public static SystemServiceId fromString(String string) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataRecord.java
@@ -17,9 +17,8 @@
 package co.cask.cdap.proto.metadata;
 
 import co.cask.cdap.proto.Id;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -38,7 +37,7 @@ public class MetadataRecord {
    * Returns an empty {@link MetadataRecord} in the specified {@link MetadataScope}.
    */
   public MetadataRecord(Id.NamespacedId entityId, MetadataScope scope) {
-    this(entityId, scope, ImmutableMap.<String, String>of(), ImmutableSet.<String>of());
+    this(entityId, scope, Collections.<String, String>emptyMap(), Collections.<String>emptySet());
   }
 
   /**

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/lineage/LineageRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/lineage/LineageRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,9 +16,9 @@
 
 package co.cask.cdap.proto.metadata.lineage;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -37,9 +37,9 @@ public class LineageRecord {
                        Map<String, DataRecord> data) {
     this.start = start;
     this.end = end;
-    this.relations = ImmutableSet.copyOf(relations);
-    this.programs = ImmutableMap.copyOf(programs);
-    this.data = ImmutableMap.copyOf(data);
+    this.relations = Collections.unmodifiableSet(new LinkedHashSet<>(relations));
+    this.programs = Collections.unmodifiableMap(new LinkedHashMap<>(programs));
+    this.data = Collections.unmodifiableMap(new LinkedHashMap<>(data));
   }
 
   public long getStart() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/lineage/RelationRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/lineage/RelationRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +16,8 @@
 
 package co.cask.cdap.proto.metadata.lineage;
 
-import com.google.common.collect.ImmutableSet;
-
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -35,8 +35,8 @@ public class RelationRecord {
     this.data = data;
     this.program = program;
     this.access = access;
-    this.runs = ImmutableSet.copyOf(runs);
-    this.components = ImmutableSet.copyOf(components);
+    this.runs = Collections.unmodifiableSet(new LinkedHashSet<>(runs));
+    this.components = Collections.unmodifiableSet(new LinkedHashSet<>(components));
   }
 
   public String getData() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/AuthorizationRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/AuthorizationRequest.java
@@ -18,9 +18,9 @@ package co.cask.cdap.proto.security;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.proto.id.EntityId;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -35,10 +35,12 @@ public class AuthorizationRequest {
   private final Set<Action> actions;
 
   protected AuthorizationRequest(EntityId entity, @Nullable Principal principal, @Nullable Set<Action> actions) {
-    Preconditions.checkArgument(entity != null, "entity is required");
+    if (entity == null) {
+      throw new IllegalArgumentException("entity is required");
+    }
     this.entity = entity;
     this.principal = principal;
-    this.actions = (actions != null) ? Sets.newHashSet(actions) : null;
+    this.actions = (actions != null) ? Collections.unmodifiableSet(new LinkedHashSet<>(actions)) : null;
   }
 
   public EntityId getEntity() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/CheckAuthorizedRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/CheckAuthorizedRequest.java
@@ -18,7 +18,6 @@ package co.cask.cdap.proto.security;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.proto.id.EntityId;
-import com.google.common.base.Preconditions;
 
 import java.util.Set;
 
@@ -30,7 +29,11 @@ public class CheckAuthorizedRequest extends AuthorizationRequest {
 
   public CheckAuthorizedRequest(EntityId entity, Principal principal, Set<Action> actions) {
     super(entity, principal, actions);
-    Preconditions.checkArgument(principal != null, "principal is required");
-    Preconditions.checkArgument(actions != null, "actions is required");
+    if (principal == null) {
+      throw new IllegalArgumentException("principal is required");
+    }
+    if (actions == null) {
+      throw new IllegalArgumentException("actions is required");
+    }
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/GrantRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/GrantRequest.java
@@ -18,7 +18,6 @@ package co.cask.cdap.proto.security;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.proto.id.EntityId;
-import com.google.common.base.Preconditions;
 
 import java.util.Set;
 
@@ -30,7 +29,11 @@ public class GrantRequest extends AuthorizationRequest {
 
   public GrantRequest(EntityId entity, Principal principal, Set<Action> actions) {
     super(entity, principal, actions);
-    Preconditions.checkArgument(principal != null, "principal is required");
-    Preconditions.checkArgument(actions != null, "actions is required");
+    if (principal == null) {
+      throw new IllegalArgumentException("principal is required");
+    }
+    if (actions == null) {
+      throw new IllegalArgumentException("actions is required");
+    }
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/RevokeRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/RevokeRequest.java
@@ -18,7 +18,6 @@ package co.cask.cdap.proto.security;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.proto.id.EntityId;
-import com.google.common.base.Preconditions;
 
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -31,7 +30,8 @@ public class RevokeRequest extends AuthorizationRequest {
 
   public RevokeRequest(EntityId entity, @Nullable Principal principal, @Nullable Set<Action> actions) {
     super(entity, principal, actions);
-    Preconditions.checkArgument(actions == null || (principal != null),
-                                "Principal is required when actions is provided");
+    if (actions != null && principal == null) {
+      throw new IllegalArgumentException("Principal is required when actions is provided");
+    }
   }
 }

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/audit/AuditMessageTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/audit/AuditMessageTest.java
@@ -25,14 +25,17 @@ import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.metadata.MetadataScope;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  *
@@ -87,19 +90,35 @@ public class AuditMessageTest {
         "\"SYSTEM\":{\"properties\":{\"sk\":\"sv\"},\"tags\":[]}}," +
         "\"additions\":{\"SYSTEM\":{\"properties\":{\"sk\":\"sv\"},\"tags\":[\"t1\",\"t2\"]}}," +
         "\"deletions\":{\"USER\":{\"properties\":{\"uk\":\"uv\"},\"tags\":[\"ut1\"]}}}}";
-    Map<MetadataScope, MetadataAuditRecord> previous = ImmutableMap.of(MetadataScope.USER,
-                                                                  new MetadataAuditRecord(ImmutableMap.of("uk", "uv",
-                                                                                                     "uk1", "uv2"),
-                                                                                     ImmutableSet.of("ut1", "ut2")),
-                                                                  MetadataScope.SYSTEM,
-                                                                  new MetadataAuditRecord(ImmutableMap.of("sk", "sv"),
-                                                                                     ImmutableSet.<String>of()));
-    Map<MetadataScope, MetadataAuditRecord> additions = ImmutableMap.of(MetadataScope.SYSTEM,
-                                                                  new MetadataAuditRecord(ImmutableMap.of("sk", "sv"),
-                                                                                     ImmutableSet.of("t1", "t2")));
-    Map<MetadataScope, MetadataAuditRecord> deletions = ImmutableMap.of(MetadataScope.USER,
-                                                                  new MetadataAuditRecord(ImmutableMap.of("uk", "uv"),
-                                                                                     ImmutableSet.of("ut1")));
+    Map<String, String> userProperties = new HashMap<>();
+    userProperties.put("uk", "uv");
+    userProperties.put("uk1", "uv2");
+    Map<String, String> systemProperties = new HashMap<>();
+    systemProperties.put("sk", "sv");
+    Set<String> userTags = new LinkedHashSet<>();
+    userTags.add("ut1");
+    userTags.add("ut2");
+    Map<MetadataScope, MetadataAuditRecord> previous = new LinkedHashMap<>();
+    previous.put(MetadataScope.USER, new MetadataAuditRecord(Collections.unmodifiableMap(userProperties),
+                                                             Collections.unmodifiableSet(userTags)));
+    previous.put(MetadataScope.SYSTEM, new MetadataAuditRecord(Collections.unmodifiableMap(systemProperties),
+                                                               Collections.unmodifiableSet(
+                                                                 new LinkedHashSet<String>())));
+    Map<String, String> sysPropertiesAdded = new HashMap<>();
+    sysPropertiesAdded.put("sk", "sv");
+    Set<String> systemTagsAdded = new LinkedHashSet<>();
+    systemTagsAdded.add("t1");
+    systemTagsAdded.add("t2");
+    Map<MetadataScope, MetadataAuditRecord> additions = new HashMap<>();
+    additions.put(MetadataScope.SYSTEM, new MetadataAuditRecord(Collections.unmodifiableMap(sysPropertiesAdded),
+                                                                Collections.unmodifiableSet(systemTagsAdded)));
+    Map<String, String> userPropertiesDeleted = new HashMap<>();
+    userPropertiesDeleted.put("uk", "uv");
+    Set<String> userTagsDeleted = new LinkedHashSet<>();
+    userTagsDeleted.add("ut1");
+    Map<MetadataScope, MetadataAuditRecord> deletions = new HashMap<>();
+    deletions.put(MetadataScope.USER, new MetadataAuditRecord(Collections.unmodifiableMap(userPropertiesDeleted),
+                                                              Collections.unmodifiableSet(userTagsDeleted)));
     AuditMessage metadataChange =
       new AuditMessage(3000L, Ids.namespace("ns1").app("app1"), "user1", AuditType.METADATA_CHANGE,
                        new MetadataPayload(previous, additions, deletions));

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/codec/NamespacedIdCodecTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/codec/NamespacedIdCodecTest.java
@@ -20,13 +20,13 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -78,8 +78,12 @@ public class NamespacedIdCodecTest {
 
   @Test
   public void testWithMetadataRecord() {
-    Map<String, String> properties = ImmutableMap.of("key1", "value1", "k1", "v1");
-    Set<String> tags = ImmutableSet.of("tag1", "t1");
+    Map<String, String> properties = new HashMap<>();
+    properties.put("key1", "value1");
+    properties.put("k1", "v1");
+    Set<String> tags = new LinkedHashSet<>();
+    tags.add("tag1");
+    tags.add("t1");
     // verify with Id.Application
     MetadataRecord appRecord = new MetadataRecord(app, MetadataScope.USER, properties, tags);
     String appRecordJson = GSON.toJson(appRecord);

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,19 +19,19 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
 import co.cask.cdap.proto.codec.IdTypeAdapter;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- *
+ * Tests for {@link EntityId}.
  */
 public class EntityIdTest {
 
@@ -40,106 +40,108 @@ public class EntityIdTest {
     .registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter())
     .create();
 
-  private final List<? extends EntityId> ids = ImmutableList.<EntityId>builder()
-    .add(Ids.namespace("foo"))
-    .add(Ids.namespace("foo").artifact("art", "1.2.3"))
-    .add(Ids.namespace("foo").dataset("zoo"))
-    .add(Ids.namespace("foo").datasetModule("moo"))
-    .add(Ids.namespace("foo").datasetType("typ"))
-    .add(Ids.namespace("foo").stream("t"))
-    .add(Ids.namespace("foo").app("app"))
-    .add(Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo"))
-    .add(Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").run("run1"))
-    .add(Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").flowlet("flol"))
-    .add(Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").flowlet("flol").queue("q"))
-    .add(Ids.namespace("foo").app("app").flow("flo"))
-    .add(Ids.namespace("foo").app("app").workflow("flo"))
-    .add(Ids.namespace("foo").app("app").mr("flo"))
-    .add(Ids.namespace("foo").app("app").spark("flo"))
-    .add(Ids.namespace("foo").app("app").worker("flo"))
-    .add(Ids.namespace("foo").app("app").service("flo"))
+  private static final List<EntityId> ids = new ArrayList<>();
+  static {
+    ids.add(Ids.namespace("foo"));
+    ids.add(Ids.namespace("foo").artifact("art", "1.2.3"));
+    ids.add(Ids.namespace("foo").dataset("zoo"));
+    ids.add(Ids.namespace("foo").datasetModule("moo"));
+    ids.add(Ids.namespace("foo").datasetType("typ"));
+    ids.add(Ids.namespace("foo").stream("t"));
+    ids.add(Ids.namespace("foo").app("app"));
+    ids.add(Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo"));
+    ids.add(Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").run("run1"));
+    ids.add(Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").flowlet("flol"));
+    ids.add(Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").flowlet("flol").queue("q"));
+    ids.add(Ids.namespace("foo").app("app").flow("flo"));
+    ids.add(Ids.namespace("foo").app("app").workflow("flo"));
+    ids.add(Ids.namespace("foo").app("app").mr("flo"));
+    ids.add(Ids.namespace("foo").app("app").spark("flo"));
+    ids.add(Ids.namespace("foo").app("app").worker("flo"));
+    ids.add(Ids.namespace("foo").app("app").service("flo"));
     // components mostly the same
-    .add(Ids.namespace("zzz"))
-    .add(Ids.namespace("zzz").artifact("zzz", "1.2.3"))
-    .add(Ids.namespace("zzz").dataset("zzz"))
-    .add(Ids.namespace("zzz").datasetModule("zzz"))
-    .add(Ids.namespace("zzz").datasetType("zzz"))
-    .add(Ids.namespace("zzz").stream("zzz"))
-    .add(Ids.namespace("zzz").app("zzz"))
-    .add(Ids.namespace("zzz").app("zzz").program(ProgramType.FLOW, "zzz"))
-    .add(Ids.namespace("zzz").app("zzz").program(ProgramType.FLOW, "zzz").run("zzz"))
-    .add(Ids.namespace("zzz").app("zzz").program(ProgramType.FLOW, "zzz").flowlet("zzz"))
-    .add(Ids.namespace("zzz").app("zzz").program(ProgramType.FLOW, "zzz").flowlet("zzz").queue("zzz"))
-    .add(Ids.namespace("zzz").app("zzz").flow("zzz"))
-    .add(Ids.namespace("zzz").app("zzz").workflow("zzz"))
-    .add(Ids.namespace("zzz").app("zzz").mr("zzz"))
-    .add(Ids.namespace("zzz").app("zzz").spark("zzz"))
-    .add(Ids.namespace("zzz").app("zzz").worker("zzz"))
-    .add(Ids.namespace("zzz").app("zzz").service("zzz"))
-    .build();
+    ids.add(Ids.namespace("zzz"));
+    ids.add(Ids.namespace("zzz").artifact("zzz", "1.2.3"));
+    ids.add(Ids.namespace("zzz").dataset("zzz"));
+    ids.add(Ids.namespace("zzz").datasetModule("zzz"));
+    ids.add(Ids.namespace("zzz").datasetType("zzz"));
+    ids.add(Ids.namespace("zzz").stream("zzz"));
+    ids.add(Ids.namespace("zzz").app("zzz"));
+    ids.add(Ids.namespace("zzz").app("zzz").program(ProgramType.FLOW, "zzz"));
+    ids.add(Ids.namespace("zzz").app("zzz").program(ProgramType.FLOW, "zzz").run("zzz"));
+    ids.add(Ids.namespace("zzz").app("zzz").program(ProgramType.FLOW, "zzz").flowlet("zzz"));
+    ids.add(Ids.namespace("zzz").app("zzz").program(ProgramType.FLOW, "zzz").flowlet("zzz").queue("zzz"));
+    ids.add(Ids.namespace("zzz").app("zzz").flow("zzz"));
+    ids.add(Ids.namespace("zzz").app("zzz").workflow("zzz"));
+    ids.add(Ids.namespace("zzz").app("zzz").mr("zzz"));
+    ids.add(Ids.namespace("zzz").app("zzz").spark("zzz"));
+    ids.add(Ids.namespace("zzz").app("zzz").worker("zzz"));
+    ids.add(Ids.namespace("zzz").app("zzz").service("zzz"));
+  }
 
   /**
    * To maintain backwards compatibility, don't change this.
    */
-  private final Map<? extends EntityId, String> idsToString = ImmutableMap.<EntityId, String>builder()
-    .put(Ids.namespace("foo"), "namespace:foo")
-    .put(Ids.namespace("foo").artifact("art", "1.2.3"), "artifact:foo.art.1.2.3")
-    .put(Ids.namespace("foo").dataset("zoo"), "dataset:foo.zoo")
-    .put(Ids.namespace("foo").datasetModule("moo"), "dataset_module:foo.moo")
-    .put(Ids.namespace("foo").datasetType("typ"), "dataset_type:foo.typ")
-    .put(Ids.namespace("foo").stream("sdf"), "stream:foo.sdf")
-    .put(Ids.namespace("foo").app("app"), "application:foo.app")
-    .put(Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo"), "program:foo.app.flow.flo")
-    .put(
-      Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").run("run1"),
-      "program_run:foo.app.flow.flo.run1")
-    .put(
-      Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").flowlet("flol"),
-      "flowlet:foo.app.flo.flol")
-    .put(
-      Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").flowlet("flol").queue("q"),
-      "flowlet_queue:foo.app.flo.flol.q")
-    .build();
-
-  /**
-   * To maintain backwards compatibility, don't change this.
-   */
-  private final Map<? extends EntityId, String> idsToJson =
-    ImmutableMap.<EntityId, String>builder()
-      .put(Ids.namespace("foo"), "{\"namespace\":\"foo\",\"entity\":\"NAMESPACE\"}")
-      .put(
-        Ids.namespace("foo").artifact("art", "1.2.3"),
-        "{\"namespace\":\"foo\",\"artifact\":\"art\",\"version\":\"1.2.3\",\"entity\":\"ARTIFACT\"}")
-      .put(
-        Ids.namespace("foo").dataset("zoo"),
-        "{\"namespace\":\"foo\",\"dataset\":\"zoo\",\"entity\":\"DATASET\"}")
-      .put(
-        Ids.namespace("foo").datasetModule("moo"),
-        "{\"namespace\":\"foo\",\"module\":\"moo\",\"entity\":\"DATASET_MODULE\"}")
-      .put(
-        Ids.namespace("foo").datasetType("typ"),
-        "{\"namespace\":\"foo\",\"type\":\"typ\",\"entity\":\"DATASET_TYPE\"}")
-      .put(
-        Ids.namespace("foo").stream("t"),
-        "{\"namespace\":\"foo\",\"stream\":\"t\",\"entity\":\"STREAM\"}")
-      .put(
-        Ids.namespace("foo").app("app"),
-        "{\"namespace\":\"foo\",\"application\":\"app\",\"entity\":\"APPLICATION\"}")
-      .put(
-        Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo"),
-        "{\"namespace\":\"foo\",\"application\":\"app\",\"type\":\"Flow\",\"program\":\"flo\",\"entity\":\"PROGRAM\"}")
-      .put(
+  private static final Map<EntityId, String> idsToString = new HashMap<>();
+  static {
+    idsToString.put(Ids.namespace("foo"), "namespace:foo");
+    idsToString.put(Ids.namespace("foo").artifact("art", "1.2.3"), "artifact:foo.art.1.2.3");
+    idsToString.put(Ids.namespace("foo").dataset("zoo"), "dataset:foo.zoo");
+    idsToString.put(Ids.namespace("foo").datasetModule("moo"), "dataset_module:foo.moo");
+    idsToString.put(Ids.namespace("foo").datasetType("typ"), "dataset_type:foo.typ");
+    idsToString.put(Ids.namespace("foo").stream("sdf"), "stream:foo.sdf");
+    idsToString.put(Ids.namespace("foo").app("app"), "application:foo.app");
+    idsToString.put(Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo"), "program:foo.app.flow.flo");
+    idsToString.put(
         Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").run("run1"),
-        "{\"namespace\":\"foo\",\"application\":\"app\",\"type\":\"Flow\",\"program\":\"flo\"," +
-          "\"run\":\"run1\",\"entity\":\"PROGRAM_RUN\"}")
-      .put(
+        "program_run:foo.app.flow.flo.run1");
+    idsToString.put(
         Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").flowlet("flol"),
-        "{\"namespace\":\"foo\",\"application\":\"app\",\"flow\":\"flo\",\"flowlet\":\"flol\",\"entity\":\"FLOWLET\"}")
-      .put(
+        "flowlet:foo.app.flo.flol");
+    idsToString.put(
         Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").flowlet("flol").queue("q"),
-        "{\"namespace\":\"foo\",\"application\":\"app\",\"flow\":\"flo\"," +
-          "\"flowlet\":\"flol\",\"queue\":\"q\",\"entity\":\"FLOWLET_QUEUE\"}")
-      .build();
+        "flowlet_queue:foo.app.flo.flol.q");
+  }
+
+  /**
+   * To maintain backwards compatibility, don't change this.
+   */
+  private static final Map<EntityId, String> idsToJson = new HashMap<>();
+  static {
+    idsToJson.put(Ids.namespace("foo"), "{\"namespace\":\"foo\",\"entity\":\"NAMESPACE\"}");
+    idsToJson.put(
+      Ids.namespace("foo").artifact("art", "1.2.3"),
+      "{\"namespace\":\"foo\",\"artifact\":\"art\",\"version\":\"1.2.3\",\"entity\":\"ARTIFACT\"}");
+    idsToJson.put(
+      Ids.namespace("foo").dataset("zoo"),
+      "{\"namespace\":\"foo\",\"dataset\":\"zoo\",\"entity\":\"DATASET\"}");
+    idsToJson.put(
+      Ids.namespace("foo").datasetModule("moo"),
+      "{\"namespace\":\"foo\",\"module\":\"moo\",\"entity\":\"DATASET_MODULE\"}");
+    idsToJson.put(
+      Ids.namespace("foo").datasetType("typ"),
+      "{\"namespace\":\"foo\",\"type\":\"typ\",\"entity\":\"DATASET_TYPE\"}");
+    idsToJson.put(
+      Ids.namespace("foo").stream("t"),
+      "{\"namespace\":\"foo\",\"stream\":\"t\",\"entity\":\"STREAM\"}");
+    idsToJson.put(
+      Ids.namespace("foo").app("app"),
+      "{\"namespace\":\"foo\",\"application\":\"app\",\"entity\":\"APPLICATION\"}");
+    idsToJson.put(
+      Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo"),
+      "{\"namespace\":\"foo\",\"application\":\"app\",\"type\":\"Flow\",\"program\":\"flo\",\"entity\":\"PROGRAM\"}");
+    idsToJson.put(
+      Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").run("run1"),
+      "{\"namespace\":\"foo\",\"application\":\"app\",\"type\":\"Flow\",\"program\":\"flo\"," +
+        "\"run\":\"run1\",\"entity\":\"PROGRAM_RUN\"}");
+    idsToJson.put(
+      Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").flowlet("flol"),
+      "{\"namespace\":\"foo\",\"application\":\"app\",\"flow\":\"flo\",\"flowlet\":\"flol\",\"entity\":\"FLOWLET\"}");
+    idsToJson.put(
+      Ids.namespace("foo").app("app").program(ProgramType.FLOW, "flo").flowlet("flol").queue("q"),
+      "{\"namespace\":\"foo\",\"application\":\"app\",\"flow\":\"flo\"," +
+        "\"flowlet\":\"flol\",\"queue\":\"q\",\"entity\":\"FLOWLET_QUEUE\"}");
+  }
 
   @Test
   public void testToFromString() {
@@ -215,9 +217,13 @@ public class EntityIdTest {
     ApplicationId app = namespace.app("bar");
     ProgramId program = app.flow("foo");
 
-    Assert.assertEquals(ImmutableList.of(namespace), ImmutableList.copyOf(namespace.getHierarchy()));
-    Assert.assertEquals(ImmutableList.of(namespace, app), ImmutableList.copyOf(app.getHierarchy()));
-    Assert.assertEquals(ImmutableList.of(namespace, app, program), ImmutableList.copyOf(program.getHierarchy()));
+    List<EntityId> expectedHierarchy = new ArrayList<>();
+    expectedHierarchy.add(namespace);
+    Assert.assertEquals(expectedHierarchy, namespace.getHierarchy());
+    expectedHierarchy.add(app);
+    Assert.assertEquals(expectedHierarchy, app.getHierarchy());
+    expectedHierarchy.add(program);
+    Assert.assertEquals(expectedHierarchy, program.getHierarchy());
   }
 
   @Test

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/security/CheckAuthorizedRequestTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/security/CheckAuthorizedRequestTest.java
@@ -17,9 +17,12 @@
 package co.cask.cdap.proto.security;
 
 import co.cask.cdap.proto.id.Ids;
-import com.google.common.collect.ImmutableSet;
+
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Tests for {@link CheckAuthorizedRequest}.
@@ -29,7 +32,9 @@ public class CheckAuthorizedRequestTest {
   @Test
   public void testValidation() {
     Principal bob = new Principal("bob", Principal.PrincipalType.USER);
-    new CheckAuthorizedRequest(Ids.namespace("foo"), bob, ImmutableSet.of(Action.READ));
+    Set<Action> actions = new LinkedHashSet<>();
+    actions.add(Action.READ);
+    new CheckAuthorizedRequest(Ids.namespace("foo"), bob, actions);
 
     try {
       new CheckAuthorizedRequest(Ids.namespace("foo"), null, null);
@@ -46,14 +51,14 @@ public class CheckAuthorizedRequestTest {
     }
 
     try {
-      new CheckAuthorizedRequest(Ids.namespace("foo"), null, ImmutableSet.of(Action.READ));
+      new CheckAuthorizedRequest(Ids.namespace("foo"), null, actions);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // expected
     }
 
     try {
-      new CheckAuthorizedRequest(null, bob, ImmutableSet.of(Action.READ));
+      new CheckAuthorizedRequest(null, bob, actions);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // expected

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/security/GrantRequestTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/security/GrantRequestTest.java
@@ -17,9 +17,11 @@
 package co.cask.cdap.proto.security;
 
 import co.cask.cdap.proto.id.Ids;
-import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Tests for {@link GrantRequest}.
@@ -29,7 +31,9 @@ public class GrantRequestTest {
   @Test
   public void testValidation() {
     Principal bob = new Principal("bob", Principal.PrincipalType.USER);
-    new GrantRequest(Ids.namespace("foo"), bob, ImmutableSet.of(Action.READ));
+    Set<Action> actions = new LinkedHashSet<>();
+    actions.add(Action.READ);
+    new GrantRequest(Ids.namespace("foo"), bob, actions);
 
     try {
       new GrantRequest(Ids.namespace("foo"), null, null);
@@ -46,14 +50,14 @@ public class GrantRequestTest {
     }
 
     try {
-      new GrantRequest(Ids.namespace("foo"), null, ImmutableSet.of(Action.READ));
+      new GrantRequest(Ids.namespace("foo"), null, actions);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // expected
     }
 
     try {
-      new GrantRequest(null, bob, ImmutableSet.of(Action.READ));
+      new GrantRequest(null, bob, actions);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // expected

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/security/RevokeRequestTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/security/RevokeRequestTest.java
@@ -17,9 +17,11 @@
 package co.cask.cdap.proto.security;
 
 import co.cask.cdap.proto.id.Ids;
-import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Tests for {@link RevokeRequest}.
@@ -29,19 +31,21 @@ public class RevokeRequestTest {
   @Test
   public void testValidation() {
     Principal bob = new Principal("bob", Principal.PrincipalType.USER);
-    new RevokeRequest(Ids.namespace("foo"), bob, ImmutableSet.of(Action.READ));
+    Set<Action> actions = new LinkedHashSet<>();
+    actions.add(Action.READ);
+    new RevokeRequest(Ids.namespace("foo"), bob, actions);
     new RevokeRequest(Ids.namespace("foo"), bob, null);
     new RevokeRequest(Ids.namespace("foo"), null, null);
 
     try {
-      new RevokeRequest(Ids.namespace("foo"), null, ImmutableSet.of(Action.READ));
+      new RevokeRequest(Ids.namespace("foo"), null, actions);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // expected
     }
 
     try {
-      new RevokeRequest(null, null, ImmutableSet.of(Action.READ));
+      new RevokeRequest(null, null, actions);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // expected


### PR DESCRIPTION
This PR removes usages of the guava ``collect`` package. It also replaces usages of guava ``Objects`` with Java ``Objects``. Also removes usages of ``Throwables`` and ``Longs`` classes from guava.

Pending, and in a later PR:
``Joiner``, ``Splitter``, ``Preconditions``, ``CharMatcher``, ``Charsets``, ``TypeParameter``, ``TypeToken``

Jira: [CDAP-5207](https://issues.cask.co/browse/CDAP-5207)
Build: http://builds.cask.co/browse/CDAP-DUT3665