### PR TITLE
Documentation Changes

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -36,7 +36,8 @@ Standalone and Distributed CDAP
 
 - Run selected test::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn -Dtest=TestClass,TestMore*Class,TestClassMethod#methodName -DfailIfNoTests=false test
+    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn -Dtest=TestClass,TestMore*Class,TestClassMethod#methodName \
+    -DfailIfNoTests=false test
 
 - Run App-Template tests::
 
@@ -50,11 +51,16 @@ Standalone and Distributed CDAP
 
 - Build Standalone distribution ZIP::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -pl cdap-standalone,cdap-app-templates/cdap-etl,cdap-app-templates/cdap-data-quality,cdap-examples -am -amd -DskipTests -P examples,templates,dist,release,unit-tests
+    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package \
+    -pl cdap-standalone,cdap-app-templates/cdap-etl,cdap-app-templates/cdap-data-quality,cdap-examples \
+    -am -amd -DskipTests -P examples,templates,dist,release,unit-tests
 
 - Build Standalone distribution ZIP with additional system artifacts::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -pl cdap-standalone,cdap-app-templates/cdap-etl,cdap-app-templates/cdap-data-quality,cdap-examples -am -amd -DskipTests -P examples,templates,dist,release,unit-tests -Dadditional.artifacts.dir=</path/to/additional/artifacts>
+    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package \
+    -pl cdap-standalone,cdap-app-templates/cdap-etl,cdap-app-templates/cdap-data-quality,cdap-examples \
+    -am -amd -DskipTests -P examples,templates,dist,release,unit-tests \
+    -Dadditional.artifacts.dir=</path/to/additional/artifacts>
 
   This will copy any .jar and .json files in any 'target' directories under the specified path to the artifacts directory.
 
@@ -62,21 +68,25 @@ Standalone and Distributed CDAP
 
     mvn clean package javadoc:javadoc -pl cdap-api -am -DskipTests -P release
     
-- Build the limited set of Javadocs, including the App Templates, used in documentation::
+- Build the limited set of Javadocs, including the ETL Application Templates, included in the CDAP documentation::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true && mvn clean site -DskipTests -P templates -DisOffline=false
+    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests \
+    -Dgpg.skip=true && mvn clean site -DskipTests -P templates -DisOffline=false
 
-- Build the complete set of Javadocs, for all modules (currently incomplete)::
+- Build the complete set of Javadocs, for all modules and examples::
 
-    MAVEN_OPTS="-Xmx1024m" mvn clean site -Dmaxmemory=1024m -DskipTests
-    
+    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests \
+    -Dgpg.skip=true && mvn clean javadoc:aggregate -DskipTests -P examples,templates -DisOffline=false
+
 - Build distributions (rpm, deb, tgz)::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -DskipTests -P examples,templates,dist,release,rpm-prepare,rpm,deb-prepare,deb,tgz,unit-tests
+    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -DskipTests \
+    -P examples,templates,dist,release,rpm-prepare,rpm,deb-prepare,deb,tgz,unit-tests
 
 - Build Cloudera Manager parcel::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -DskipTests -P templates,dist,tgz && ./cdap-distributions/bin/build_parcel.sh
+    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -DskipTests \
+    -P templates,dist,tgz && ./cdap-distributions/bin/build_parcel.sh
 
 - Show dependency tree::
 
@@ -114,7 +124,7 @@ Standalone and Distributed CDAP
 License and Trademarks
 ======================
 
-Copyright © 2014-2015 Cask Data, Inc.
+Copyright © 2014-2016 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 in compliance with the License. You may obtain a copy of the License at

--- a/cdap-authorization-dataset-plugin/pom.xml
+++ b/cdap-authorization-dataset-plugin/pom.xml
@@ -26,6 +26,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>cdap-authorization-dataset-plugin</artifactId>
+  <name>CDAP Authorization Dataset Plugin</name>
 
   <dependencies>
     <dependency>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -284,6 +284,24 @@
   </property>
 
 
+  <!-- Audit Configuration -->
+
+  <property>
+    <name>audit.enabled</name>
+    <value>false</value>
+    <description>
+      Determines whether to publish audit messages to Apache Kafka
+    </description>
+  </property>
+
+  <property>
+    <name>audit.kafka.topic</name>
+    <value>audit</value>
+    <description>
+      Apache Kafka topic name to which audit messages are published
+    </description>
+  </property>
+
   <!-- Datasets Configuration -->
 
   <property>
@@ -977,7 +995,7 @@
     <name>metadata.updates.kafka.topic</name>
     <value>cdap-metadata-updates</value>
     <description>
-      Apache Kafka topic to which metadata update notifications are published
+      Apache Kafka topic name to which metadata update notifications are published
     </description>
   </property>
 
@@ -1781,24 +1799,6 @@
     <value>60000</value>
     <description>
       Timeout in milliseconds for internal HTTP requests
-    </description>
-  </property>
-
-  <!-- Audit configuration -->
-
-  <property>
-    <name>audit.enabled</name>
-    <value>false</value>
-    <description>
-      Determines whether to publish audit messages
-    </description>
-  </property>
-
-  <property>
-    <name>audit.kafka.topic</name>
-    <value>audit</value>
-    <description>
-      Kafka topic to publish the audit messages
     </description>
   </property>
 

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -25,6 +25,7 @@ APIS="apis"
 BUILD_PDF="build-pdf"
 CDAP_DOCS="cdap-docs"
 HTML="html"
+HYDRATOR_PLUGINS="hydrator-plugins"
 INCLUDES="_includes"
 JAVADOCS="javadocs"
 LICENSES="licenses"
@@ -66,7 +67,7 @@ TARGET_PATH="${SCRIPT_PATH}/${TARGET}"
 SOURCE_PATH="${SCRIPT_PATH}/${SOURCE}"
 
 if [ "x${2}" == "x" ]; then
-  PROJECT_PATH="${SCRIPT_PATH}/../../"
+  PROJECT_PATH="${SCRIPT_PATH}/../.."
 else
   PROJECT_PATH="${SCRIPT_PATH}/../../../${2}"
 fi
@@ -227,7 +228,7 @@ function check_build_rst() {
   local current_directory=$(pwd)
   cd ${PROJECT_PATH}
   # check BUILD.rst for changes
-  BUILD_RST_PATH="${PROJECT_PATH}${BUILD_RST}"
+  BUILD_RST_PATH="${PROJECT_PATH}/${BUILD_RST}"
   test_an_include "${BUILD_RST_HASH}" "${BUILD_RST_PATH}" "${BUILD_RST_HASH_LOCATION}"
   echo
   cd ${current_directory}
@@ -351,6 +352,7 @@ function display_version() {
   echo "GIT_BRANCH: ${GIT_BRANCH}"
   echo "GIT_BRANCH_TYPE: ${GIT_BRANCH_TYPE}"
   echo "GIT_BRANCH_PARENT: ${GIT_BRANCH_PARENT}"
+  echo "GIT_BRANCH_CDAP_HYDRATOR: ${GIT_BRANCH_CDAP_HYDRATOR}"
 }
 
 function clear_messages_set_messages_file() {

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="b6f3b12d1bf35f4b068412cb88334fc7"
+DEFAULT_XML_MD5_HASH="9d9ce5b185a4085b09e7b0021938eb3e"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -43,16 +43,19 @@ function usage() {
   echo "    docs-outer        Dirty build of HTML with docs.cask.co code, skipping re-building inner doc, zipping, and Javadocs"
   echo "    docs              Dirty build of HTML with docs.cask.co code, skipping zipping and Javadocs"
   echo 
-  echo "    docs-github  Clean build of HTML and Javadocs, zipped, for placing on GitHub"
-  echo "    docs-web     Clean build of HTML and Javadocs, zipped, for placing on docs.cask.co webserver"
+  echo "    docs-github       Clean build of HTML and Javadocs, zipped, for placing on GitHub"
+  echo "    docs-web          Clean build of HTML and Javadocs, zipped, for placing on docs.cask.co webserver"
   echo 
-  echo "    clean         Clean up any previous build's target directories"
-  echo "    docs-cli      Build CLI documentation"
-  echo "    javadocs      Build Javadocs used in documentation"
-  echo "    javadocs-all  Build Javadocs for all modules"
-  echo "    licenses      Clean build of License Dependency PDFs"
-  echo "    sdk           Build CDAP SDK"
-  echo "    version       Print the version information"
+  echo "    clean             Clean up any previous build's target directories"
+  echo "    docs-cli          Build CLI documentation"
+  echo "    javadocs          Build Javadocs used in documentation"
+  echo "    javadocs-all      Build Javadocs for all modules"
+  echo "    licenses          Clean build of License Dependency PDFs"
+  echo "    sdk               Build CDAP SDK (includes the Hydrator plugins if Hydrator plugins source is at"
+  echo "                        '${HYDRATOR_PLUGINS_PATH}'"
+  echo "                        or the environment variable 'HYDRATOR_PLUGINS_PATH' has been set)"
+  echo 
+  echo "    version           Print the version information"
   echo 
   echo "  with"
   echo "    source    Path to ${PROJECT} source, if not '${PROJECT_PATH}'"
@@ -69,9 +72,12 @@ function error_usage() {
 
 function set_project_path() {
   if [ "x${ARG_2}" == "x" ]; then
-    PROJECT_PATH="${SCRIPT_PATH}/../"
+    PROJECT_PATH="${SCRIPT_PATH}/.."
   else
     PROJECT_PATH="${SCRIPT_PATH}/../../${ARG_2}"
+  fi
+  if [[ "x${HYDRATOR_PLUGINS_PATH}" == "x" ]]; then
+    HYDRATOR_PLUGINS_PATH="${PROJECT_PATH}/../${HYDRATOR_PLUGINS}"
   fi
 }
 
@@ -454,10 +460,36 @@ function build_license_dependency_pdfs() {
 }
 
 function build_standalone() {
+  local add_artifacts=""
+  if [ -d ${HYDRATOR_PLUGINS_PATH} ]; then
+    build_hydrator_plugins
+    local errors=$?
+    if [ "${errors}" == "0" ]; then
+      add_artifacts="-Dadditional.artifacts.dir=${HYDRATOR_PLUGINS_PATH}"
+    fi
+  else
+    echo "No HYDRATOR_PLUGINS_PATH at ${HYDRATOR_PLUGINS_PATH}"
+  fi
   set_mvn_environment
-  MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -pl cdap-standalone,cdap-app-templates/cdap-etl,cdap-app-templates/cdap-data-quality,cdap-examples -am -amd -DskipTests -P examples,templates,dist,release,unit-tests
+  MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package \
+  -pl cdap-standalone,cdap-app-templates/cdap-etl,cdap-app-templates/cdap-data-quality,cdap-examples \
+  -am -amd -DskipTests -P examples,templates,dist,release,unit-tests ${add_artifacts}
 }
 
+function build_hydrator_plugins() {
+  local errors=0
+  set_mvn_environment
+  if [ -d ${HYDRATOR_PLUGINS_PATH} ]; then
+    cd ${HYDRATOR_PLUGINS_PATH}
+    echo "HYDRATOR_PLUGINS_PATH: ${HYDRATOR_PLUGINS_PATH}"
+    mvn clean package -DskipTests
+    errors=$?
+  else
+    echo "No HYDRATOR_PLUGINS_PATH at ${HYDRATOR_PLUGINS_PATH}"
+  fi
+  return ${errors}
+}
+  
 function print_version() {
   cd ${SCRIPT_PATH}/developers-manual
   ./build.sh display-version ${ARG_2} 

--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -23,10 +23,9 @@
 # Targets for both a limited and complete set of javadocs
 # Targets not included in usage are intended for internal usage by script
 
+source ../vars
 source ../_common/common-build.sh
 
-CDAP_CLIENTS_RELEASE_VERSION="1.2.0"
-CDAP_INGEST_RELEASE_VERSION="1.3.0"
 CHECK_INCLUDES=${TRUE}
 
 function download_readme_file_and_test() {

--- a/cdap-docs/reference-manual/build.sh
+++ b/cdap-docs/reference-manual/build.sh
@@ -23,6 +23,7 @@
 # Targets for both a limited and complete set of javadocs
 # Targets not included in usage are intended for internal usage by script
 
+source ../vars
 source ../_common/common-build.sh
 
 function build_extras() {

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -23,10 +23,15 @@ MANUALS="introduction developers-manual cdap-apps admin-manual integrations exam
 # BUILD.rst
 BUILD_RST="BUILD.rst"
 BUILD_RST_HASH_LOCATION="cdap-docs/vars"
-BUILD_RST_HASH="99c0076f03dae5c014417a00d5e04b5e"
+BUILD_RST_HASH="6b6124e34febf8ff1259e923ce29b5f9"
 
 # This needs to be explicitly set as Git has trouble identifying it.
 GIT_BRANCH_PARENT="develop"
 
 # Used by cdap-apps for Hydrator documentation
 GIT_BRANCH_CDAP_HYDRATOR="develop"
+
+# Used by developers-manual
+CDAP_CLIENTS_RELEASE_VERSION="1.2.0"
+CDAP_INGEST_RELEASE_VERSION="1.3.0"
+ 

--- a/pom.xml
+++ b/pom.xml
@@ -1739,6 +1739,7 @@
               <artifactId>maven-javadoc-plugin</artifactId>
               <version>2.9.1</version>
               <configuration>
+                <stylesheetfile>cdap-distributions/src/javadoc/stylesheet.css</stylesheetfile>
                 <bottom>
                   <![CDATA[Copyright &#169; {currentYear} <a href="http://cask.co" target="_blank">Cask Data, Inc.</a> Licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache License, Version 2.0</a>.]]>
                 </bottom>


### PR DESCRIPTION
- Adds a target to BUILD.rst for the complete build (all-module) of the Javadocs that works.
- Re-formats BUILD.rst to not have excessively long lines.
- Adds a stylesheet to the pom.xml that is used by the complete (all-module) Javadoc build.
- Adds a name to the cdap-authorization-plugin so that the mvn build doesn't look like it's missing something.
- Moves two doc build parameters to the vars file so they are easier to find.
- Updates the SDK build target of the docs build.sh script to include the building of the hydrator plugins, if they are available.
- Corrected paths in the build.sh script that were incorrect (they had a trailing "/")
- Updated cdap-default.xml: moved "Audit Configuration" to correct alphabetical location and updated descriptions to be consistent with others.

- New Documentation [Appendix page: Audit Configuration](http://builds.cask.co/artifact/CDAP-DOB145/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/admin-manual/appendices/cdap-site.html#audit)

Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DOB145-1)