### PR TITLE
[CDAP-5116] Reset left panel store on changing etl template type (prevents batch templates appear in realtime)

### DIFF
--- a/cdap-ui/app/features/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydrator/controllers/create/leftpanel-ctrl.js
@@ -67,6 +67,9 @@ class LeftPanelController {
     this.PluginActionsFactory.fetchSinks(params);
     this.PluginActionsFactory.fetchTemplates(params);
 
+    $scope.$on('$destroy', ()=> {
+      this.PluginActionsFactory.resetLeftPanelStore();
+    });
   }
 
   onLeftSidePanelItemClicked(event, node) {

--- a/cdap-ui/app/features/hydrator/services/create/actions/plugin-actions.js
+++ b/cdap-ui/app/features/hydrator/services/create/actions/plugin-actions.js
@@ -84,6 +84,9 @@ class PluginActionsFactory {
         });
 
   }
+  resetLeftPanelStore() {
+    this.dispatcher.dispatch('onLeftPanelStoreReset');
+  }
 }
 
 PluginActionsFactory.$inject = ['PluginsDispatcher', 'myPipelineApi', 'PluginConfigFactory', 'GLOBALS', 'mySettings'];

--- a/cdap-ui/app/features/hydrator/services/create/stores/left-panel-store.js
+++ b/cdap-ui/app/features/hydrator/services/create/stores/left-panel-store.js
@@ -92,6 +92,7 @@ class LeftPanelStore {
     pluginsDispatcher.register('onTransformsFetch', this.setTransforms.bind(this));
     pluginsDispatcher.register('onSinksFetch', this.setSinks.bind(this));
     pluginsDispatcher.register('onPluginTemplatesFetch', this.updatePluginTemplates.bind(this));
+    pluginsDispatcher.register('onLeftPanelStoreReset', this.setDefaults.bind(this));
   }
   setDefaults() {
     this.state = {


### PR DESCRIPTION
- Prevents ETL-Batch templates to appear in Realtime & vice versa
- Resets left panel every time the user leaves the studio (prevent momentarily showing batch plugins in realtime and then replacing it with realtime plugins)