### PR TITLE
CDAP-5186 add dag class to prepare for hydrator planner

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/Dag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/Dag.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.planner;
+
+import co.cask.cdap.etl.proto.Connection;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A DAG (directed acyclic graph).
+ */
+public class Dag {
+  private final Set<String> nodes;
+  private final Set<String> sources;
+  private final Set<String> sinks;
+  // stage -> outputs of that stage
+  private final SetMultimap<String, String> outgoingConnections;
+  // stage -> inputs for that stage
+  private final SetMultimap<String, String> incomingConnections;
+
+  public static Dag fromConnections(Collection<Connection> connections) {
+    SetMultimap<String, String> outgoingConnections = HashMultimap.create();
+    SetMultimap<String, String> incomingConnections = HashMultimap.create();
+    for (Connection connection : connections) {
+      outgoingConnections.put(connection.getFrom(), connection.getTo());
+      incomingConnections.put(connection.getTo(), connection.getFrom());
+    }
+    Dag dag = new Dag(outgoingConnections, incomingConnections);
+    dag.validate();
+    return dag;
+  }
+
+  public static Dag clone(Dag dag) {
+    return new Dag(dag.sources, dag.sinks, dag.outgoingConnections, dag.incomingConnections);
+  }
+
+  private Dag(SetMultimap<String, String> outgoingConnections,
+              SetMultimap<String, String> incomingConnections) {
+    this(calculateSources(outgoingConnections, incomingConnections),
+         calculateSinks(outgoingConnections, incomingConnections),
+         outgoingConnections, incomingConnections);
+  }
+
+  private Dag(Set<String> sources, Set<String> sinks,
+              SetMultimap<String, String> outgoingConnections,
+              SetMultimap<String, String> incomingConnections) {
+    Preconditions.checkArgument(!outgoingConnections.isEmpty(), "Cannot create a DAG without any connections");
+    Preconditions.checkArgument(!incomingConnections.isEmpty(), "Cannot create a DAG without any connections");
+    this.sources = new HashSet<>(sources);
+    this.sinks = new HashSet<>(sinks);
+    this.outgoingConnections = HashMultimap.create(outgoingConnections);
+    this.incomingConnections = HashMultimap.create(incomingConnections);
+    this.nodes = new HashSet<>();
+    nodes.addAll(outgoingConnections.keySet());
+    nodes.addAll(outgoingConnections.values());
+  }
+
+  /**
+   * Validate the DAG is a valid DAG without cycles, and no islands. This should only be called before any
+   * mutating operations like {@link #removeSource()} are called.
+   *
+   * @throws IllegalStateException if there is a cycle in the graph, or an island in the graph
+   */
+  void validate() {
+    // if there are no sources, we must have a cycle.
+    if (sources.isEmpty()) {
+      throw new IllegalStateException("DAG does not have any sources. Please remove cycles from the graph.");
+    }
+    // similarly, if there are no sinks, we must have a cycle
+    if (sinks.isEmpty()) {
+      throw new IllegalStateException("DAG does not have any sinks. Please remove cycles from the graph.");
+    }
+
+    // check for cycles
+    linearize();
+
+    // check for sections of the dag that are on an island by themselves
+
+    // source -> [ nodes accessible by the source ]
+    Map<String, Set<String>> nodesAccessibleBySources = new HashMap<>();
+    for (String source : sources) {
+      nodesAccessibleBySources.put(source, accessibleFrom(source));
+    }
+
+    // the algorithm is to keep an island and try to keep adding to it until we can't anymore.
+    // the island starts off as the nodes accessible by the first source
+    // we then loop through all other sources and add them to the island if they can access any node in the island.
+    // we stop if we ever loop through all other sources and can't add them to the island,
+    // or if the island has grown to include all sources.
+    Set<String> islandNodes = new HashSet<>();
+    // seed the island with the first source
+    Set<String> potentialIslandSources = new HashSet<>(sources);
+    String firstSource = potentialIslandSources.iterator().next();
+    islandNodes.addAll(nodesAccessibleBySources.get(firstSource));
+    potentialIslandSources.remove(firstSource);
+
+    while (!potentialIslandSources.isEmpty()) {
+      Set<String> sourcesAdded = new HashSet<>();
+      // for each source not yet a part of the island
+      for (String potentialIslandSource : potentialIslandSources) {
+        Set<String> accessibleBySource = nodesAccessibleBySources.get(potentialIslandSource);
+        // if that source can access the island in any way, add it to the island
+        if (!Sets.intersection(islandNodes, accessibleBySource).isEmpty()) {
+          islandNodes.addAll(accessibleBySource);
+          sourcesAdded.add(potentialIslandSource);
+        }
+      }
+      // if this is empty, no sources were added to the island. That means the island really is an island.
+      if (sourcesAdded.isEmpty()) {
+        throw new IllegalStateException(
+          String.format("Invalid DAG. Stages %s form an island (no other stages connect to them).",
+                        Joiner.on(',').join(islandNodes)));
+      }
+      potentialIslandSources.removeAll(sourcesAdded);
+    }
+  }
+
+  public Set<String> getNodes() {
+    return nodes;
+  }
+
+  public Set<String> getSources() {
+    return Collections.unmodifiableSet(sources);
+  }
+
+  public Set<String> getSinks() {
+    return Collections.unmodifiableSet(sinks);
+  }
+
+  public Set<String> getNodeOutputs(String node) {
+    return Collections.unmodifiableSet(outgoingConnections.get(node));
+  }
+
+  public Set<String> getNodeInputs(String node) {
+    return Collections.unmodifiableSet(incomingConnections.get(node));
+  }
+
+  /**
+   * Return all stages accessible from the specified stage.
+   *
+   * @param stage the stage to start at
+   * @return all stages accessible from that stage
+   */
+  public Set<String> accessibleFrom(String stage) {
+    return traverse(stage, new HashSet<String>(), new HashSet<String>());
+  }
+
+  /**
+   * Return all stages accessible from the specified stage, without going past any node in stopNodes.
+   *
+   * @param stage the stage to start at
+   * @param stopNodes set of nodes to stop traversal on
+   * @return all stages accessible from that stage
+   */
+  public Set<String> accessibleFrom(String stage, Set<String> stopNodes) {
+    return traverse(stage, new HashSet<String>(), stopNodes);
+  }
+
+  /**
+   * Return a subset of this dag starting from the specified stage.
+   * This is equivalent to calling {@link #subsetFrom(String, Set)} with an empty set for stop nodes
+   *
+   * @param stage the stage to start at
+   * @return a dag created from the nodes accessible from the specified stage
+   */
+  public Dag subsetFrom(String stage) {
+    return subsetFrom(stage, ImmutableSet.<String>of());
+  }
+
+  /**
+   * Return a subset of this dag starting from the specified stage, without going past any node in stopNodes.
+   * This is equivalent to taking the nodes from {@link #accessibleFrom(String, Set)} and building a dag from them.
+   *
+   * @param stage the stage to start at
+   * @param stopNodes set of nodes to stop traversal on
+   * @return a dag created from the nodes accessible from the specified stage
+   */
+  public Dag subsetFrom(String stage, Set<String> stopNodes) {
+    Set<String> nodes = accessibleFrom(stage, stopNodes);
+    Set<Connection> connections = new HashSet<>();
+    for (String node : nodes) {
+      for (String outputNode : outgoingConnections.get(node)) {
+        if (nodes.contains(outputNode)) {
+          connections.add(new Connection(node, outputNode));
+        }
+      }
+    }
+    return Dag.fromConnections(connections);
+  }
+
+  /**
+   * Inserts a node in front of the specified node.
+   *
+   * @param name the name of the new node
+   * @param inFrontOf the node to insert in front of
+   */
+  public void insertNode(String name, String inFrontOf) {
+    if (!nodes.contains(inFrontOf)) {
+      throw new IllegalArgumentException(
+        String.format("Cannot insert in front node %s because it does not exist.", inFrontOf));
+    }
+    if (!nodes.add(name)) {
+      throw new IllegalArgumentException(
+        String.format("Cannot insert node %s because it already exists.", name));
+    }
+
+    Set<String> inputs = incomingConnections.get(inFrontOf);
+    incomingConnections.putAll(name, inputs);
+    for (String input : inputs) {
+      outgoingConnections.get(input).remove(inFrontOf);
+      outgoingConnections.put(input, name);
+    }
+    outgoingConnections.put(name, inFrontOf);
+    incomingConnections.replaceValues(inFrontOf, ImmutableSet.of(name));
+  }
+
+  /**
+   * Remove a source from the dag. New sources will be re-calculated after the source is removed.
+   *
+   * @return the removed source, or null if there were no sources to remove.
+   */
+  public String removeSource() {
+    if (sources.isEmpty()) {
+      return null;
+    }
+    String source = sources.iterator().next();
+    removeNode(source);
+    return source;
+  }
+
+  /**
+   * Linearize the dag. The returned list guarantees that for each item in the list, that item has no path to an
+   * item that comes before it in the list. In the process, if a cycle is found, an exception will be thrown.
+   * This is a destructive operation and will result in an empty dag.
+   *
+   * @return the linearized dag
+   * @throws IllegalStateException if there is a cycle in the dag
+   */
+  public List<String> linearize() {
+    List<String> linearized = new ArrayList<>();
+
+    Dag copy = Dag.clone(this);
+    String removed;
+    while ((removed = copy.removeSource()) != null) {
+      linearized.add(removed);
+    }
+    if (copy.outgoingConnections.isEmpty()) {
+      return linearized;
+    }
+    // if we've run out of sources to remove, but there are still connections, that means there is a cycle.
+    // remove all sinks so we can print out where the cycle is.
+    do {
+      removed = copy.removeSink();
+    } while (removed != null);
+    Set<String> cycle = accessibleFrom(copy.outgoingConnections.keySet().iterator().next());
+    throw new IllegalStateException(
+      String.format("Invalid DAG. Stages %s form a cycle.", Joiner.on(',').join(cycle)));
+  }
+
+  /**
+   * Remove a specific node from the dag. Removing a node will remove all connections into the node and all
+   * connection coming out of the node. Removing a node will also re-compute the sources and sinks of the dag.
+   *
+   * @param node the node to remove
+   */
+  private void removeNode(String node) {
+    // for each node this output to: node -> outputNode
+    for (String outputNode : outgoingConnections.removeAll(node)) {
+      // remove the connection from this node to its output
+      incomingConnections.remove(outputNode, node);
+      // if the removal of that connection caused the output to become a source, add it as a source
+      if (incomingConnections.get(outputNode).isEmpty()) {
+        sources.add(outputNode);
+      }
+    }
+    // for each node that output to this node: inputNode -> node
+    for (String inputNode : incomingConnections.removeAll(node)) {
+      // remove the connection from the input node to this node
+      outgoingConnections.remove(inputNode, node);
+      // if the removal of that connection caused the input node to become a sink, add it as a sink
+      if (outgoingConnections.get(inputNode).isEmpty()) {
+        sinks.add(inputNode);
+      }
+    }
+    // in case this node we removed a source or a sink (or both).
+    sinks.remove(node);
+    sources.remove(node);
+  }
+
+  private Set<String> traverse(String stage, Set<String> alreadySeen, Set<String> stopNodes) {
+    if (!alreadySeen.add(stage)) {
+      return alreadySeen;
+    }
+    Collection<String> outputs = outgoingConnections.get(stage);
+    if (outputs.isEmpty()) {
+      return alreadySeen;
+    }
+    for (String output : outputs) {
+      if (stopNodes.contains(output)) {
+        alreadySeen.add(output);
+        continue;
+      }
+      alreadySeen.addAll(traverse(output, alreadySeen, stopNodes));
+    }
+    return alreadySeen;
+  }
+
+  private String removeSink() {
+    if (sinks.isEmpty()) {
+      return null;
+    }
+    String sink = sinks.iterator().next();
+    removeNode(sink);
+    return sink;
+  }
+
+  private static Set<String> calculateSources(Multimap<String, String> outgoingConnections,
+                                              Multimap<String, String> incomingConnections) {
+    Set<String> sources = new HashSet<>();
+    // a source is any stage that doesn't have any inputs but has at least one output
+    for (String stageWithOutput : outgoingConnections.keySet()) {
+      if (incomingConnections.get(stageWithOutput).isEmpty()) {
+        sources.add(stageWithOutput);
+      }
+    }
+    return sources;
+  }
+
+  private static Set<String> calculateSinks(Multimap<String, String> outgoingConnections,
+                                            Multimap<String, String> incomingConnections) {
+    Set<String> sinks = new HashSet<>();
+    // a sink is any stage that doesn't have any outputs but has at least one input
+    for (String stageWithInput : incomingConnections.keySet()) {
+      if (outgoingConnections.get(stageWithInput).isEmpty()) {
+        sinks.add(stageWithInput);
+      }
+    }
+    return sinks;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Dag that = (Dag) o;
+
+    return Objects.equals(nodes, that.nodes) &&
+      Objects.equals(sources, that.sources) &&
+      Objects.equals(sinks, that.sinks) &&
+      Objects.equals(outgoingConnections, that.outgoingConnections) &&
+      Objects.equals(incomingConnections, that.incomingConnections);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nodes, sources, sinks, outgoingConnections, incomingConnections);
+  }
+
+  @Override
+  public String toString() {
+    return "Dag{" +
+      "nodes=" + nodes +
+      ", sources=" + sources +
+      ", sinks=" + sinks +
+      ", outgoingConnections=" + outgoingConnections +
+      ", incomingConnections=" + incomingConnections +
+      '}';
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/Dag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/Dag.java
@@ -59,10 +59,6 @@ public class Dag {
     return dag;
   }
 
-  public static Dag clone(Dag dag) {
-    return new Dag(dag.sources, dag.sinks, dag.outgoingConnections, dag.incomingConnections);
-  }
-
   private Dag(SetMultimap<String, String> outgoingConnections,
               SetMultimap<String, String> incomingConnections) {
     this(calculateSources(outgoingConnections, incomingConnections),
@@ -137,7 +133,7 @@ public class Dag {
       // if this is empty, no sources were added to the island. That means the island really is an island.
       if (sourcesAdded.isEmpty()) {
         throw new IllegalStateException(
-          String.format("Invalid DAG. Stages %s form an island (no other stages connect to them).",
+          String.format("Invalid DAG. There is an island made up of stages %s (no other stages connect to them).",
                         Joiner.on(',').join(islandNodes)));
       }
       potentialIslandSources.removeAll(sourcesAdded);
@@ -268,7 +264,7 @@ public class Dag {
   public List<String> linearize() {
     List<String> linearized = new ArrayList<>();
 
-    Dag copy = Dag.clone(this);
+    Dag copy = new Dag(sources, sinks, outgoingConnections, incomingConnections);
     String removed;
     while ((removed = copy.removeSource()) != null) {
       linearized.add(removed);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpec.java
@@ -25,7 +25,8 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Specification for a pipeline.
+ * Specification for a pipeline. The application should get this from the {@link PipelineSpecGenerator} in order
+ * to ensure that the spec is validated and created correctly.
  *
  * This is like an {@link ETLConfig} but its stages contain additional information calculated at configure time of
  * the application, like input and output schemas of each stage and the artifact selected for each plugin.

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -62,6 +62,21 @@ public class PipelineSpecGenerator {
     this.errorDatasetProperties = errorDatasetProperties;
   }
 
+  /**
+   * Validate the user provided ETL config and generate a pipeline specification from it.
+   * It will also register all plugins used by the pipeline and create any error datasets used by the pipeline.
+   *
+   * A valid pipeline has the following properties:
+   *
+   * All stages in the pipeline have a unique name.
+   * Source stages have at least one output and no inputs.
+   * Sink stages have at least one input and no outputs.
+   * There are no cycles in the pipeline.
+   * All inputs into a stage have the same schema.
+   *
+   * @param config user provided ETL config
+   * @return the pipeline specification
+   */
   public PipelineSpec generateSpec(ETLConfig config) {
     // validate the config and determine the order we should configure the stages in.
     List<StageConnections> traversalOrder = validateConfig(config);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spec;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.etl.api.PipelineConfigurable;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.common.DefaultPipelineConfigurer;
+import co.cask.cdap.etl.planner.Dag;
+import co.cask.cdap.etl.proto.Connection;
+import co.cask.cdap.etl.proto.v2.ETLConfig;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import co.cask.cdap.etl.proto.v2.ETLStage;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This is run at application configure time to take an application config {@link ETLConfig} and call
+ * {@link PipelineConfigurable#configurePipeline(PipelineConfigurer)} on all plugins in the pipeline.
+ * This generates a {@link PipelineSpec} which the programs understand.
+ */
+public class PipelineSpecGenerator {
+  private final PluginConfigurer configurer;
+  private final Class<? extends Dataset> errorDatasetClass;
+  private final DatasetProperties errorDatasetProperties;
+  private final String sourcePluginType;
+  private final String sinkPluginType;
+
+  public PipelineSpecGenerator(PluginConfigurer configurer,
+                               String sourcePluginType,
+                               String sinkPluginType,
+                               Class<? extends Dataset> errorDatasetClass,
+                               DatasetProperties errorDatasetProperties) {
+    this.configurer = configurer;
+    this.sourcePluginType = sourcePluginType;
+    this.sinkPluginType = sinkPluginType;
+    this.errorDatasetClass = errorDatasetClass;
+    this.errorDatasetProperties = errorDatasetProperties;
+  }
+
+  public PipelineSpec generateSpec(ETLConfig config) {
+    // validate the config and determine the order we should configure the stages in.
+    List<StageConnections> traversalOrder = validateConfig(config);
+
+    Map<String, DefaultPipelineConfigurer> pluginConfigurers = new HashMap<>(traversalOrder.size());
+    for (StageConnections stageConnections : traversalOrder) {
+      String stageName = stageConnections.getStage().getName();
+      pluginConfigurers.put(stageName, new DefaultPipelineConfigurer(configurer, stageName));
+    }
+
+    // configure the stages in order and build up the stage specs
+    Set<StageSpec> stageSpecs = new HashSet<>(traversalOrder.size());
+    for (StageConnections stageConnections : traversalOrder) {
+      ETLStage stage = stageConnections.getStage();
+      String stageName = stage.getName();
+      DefaultPipelineConfigurer pluginConfigurer = pluginConfigurers.get(stageName);
+
+      StageSpec stageSpec = configureStage(stageConnections, pluginConfigurer);
+      Schema outputSchema = stageSpec.getOutputSchema();
+
+      // for each output, set their input schema to our output schema
+      for (String outputStageName : stageConnections.getOutputs()) {
+        pluginConfigurers.get(outputStageName).getStageConfigurer().setInputSchema(outputSchema);
+      }
+
+      stageSpecs.add(stageSpec);
+    }
+
+    Set<Connection> connections = new HashSet<>();
+    connections.addAll(config.getConnections());
+
+    return new PipelineSpec(stageSpecs, connections, config.getResources(), config.isStageLoggingEnabled());
+  }
+
+  /**
+   * Configures a stage and returns the spec for it.
+   *
+   * @param stageConnections the user provided configuration for the stage along with its connections
+   * @param pluginConfigurer configurer used to configure the stage
+   * @return the spec for the stage
+   */
+  private StageSpec configureStage(StageConnections stageConnections, DefaultPipelineConfigurer pluginConfigurer) {
+    ETLStage stage = stageConnections.getStage();
+    String stageName = stage.getName();
+    ETLPlugin stagePlugin = stage.getPlugin();
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(stagePlugin.getPluginSelector());
+    PipelineConfigurable plugin = configurer.usePlugin(stagePlugin.getType(),
+                                                       stagePlugin.getName(),
+                                                       stageName,
+                                                       stagePlugin.getPluginProperties(),
+                                                       pluginSelector);
+    if (plugin == null) {
+      throw new IllegalArgumentException(
+        String.format("No plugin of type %s and name %s could be found for stage %s.",
+                      stagePlugin.getType(), stagePlugin.getName(), stageName));
+    }
+
+    try {
+      plugin.configurePipeline(pluginConfigurer);
+    } catch (Exception e) {
+      throw new RuntimeException(
+        String.format("Exception while configuring plugin of type %s and name %s for stage %s: %s",
+                      stagePlugin.getType(), stagePlugin.getName(), stageName, e.getMessage()),
+        e);
+    }
+
+    if (!Strings.isNullOrEmpty(stage.getErrorDatasetName())) {
+      configurer.createDataset(stage.getErrorDatasetName(), errorDatasetClass, errorDatasetProperties);
+    }
+
+    Schema inputSchema = pluginConfigurer.getStageConfigurer().getInputSchema();
+    Schema outputSchema = pluginConfigurer.getStageConfigurer().getOutputSchema();
+
+    PluginSpec pluginSpec = new PluginSpec(stagePlugin.getType(),
+                                           stagePlugin.getName(),
+                                           stagePlugin.getProperties(),
+                                           pluginSelector.getSelectedArtifact());
+    return StageSpec.builder(stageName, pluginSpec)
+      .setErrorDatasetName(stage.getErrorDatasetName())
+      .setInputSchema(inputSchema)
+      .setOutputSchema(outputSchema)
+      .addInputs(stageConnections.getInputs())
+      .addOutputs(stageConnections.getOutputs())
+      .build();
+  }
+
+  /**
+   * Validate that this is a valid pipeline. A valid pipeline has the following properties:
+   *
+   * All stages in the pipeline have a unique name.
+   * Source stages have at least one output and no inputs.
+   * Sink stages have at least one input and no outputs.
+   * There are no cycles in the pipeline.
+   * All inputs into a stage have the same schema.
+   *
+   * Returns the stages in the order they should be configured to ensure that all input stages are configured
+   * before their output.
+   *
+   * @param config the user provided configuration
+   * @return the order to configure the stages in
+   * @throws IllegalArgumentException if the pipeline is invalid
+   */
+  private List<StageConnections> validateConfig(ETLConfig config) {
+    config.validate();
+    if (config.getStages().isEmpty()) {
+      throw new IllegalArgumentException("A pipeline must contain at least one stage.");
+    }
+
+    // check stage name uniqueness
+    Set<String> stageNames = new HashSet<>();
+    for (ETLStage stage : config.getStages()) {
+      if (!stageNames.add(stage.getName())) {
+        throw new IllegalArgumentException(
+          String.format("Invalid pipeline. Multiple stages are named %s. Please ensure all stage names are unique",
+                        stage.getName()));
+      }
+    }
+
+    // check that the from and to are names of actual stages
+    for (Connection connection : config.getConnections()) {
+      if (!stageNames.contains(connection.getFrom())) {
+        throw new IllegalArgumentException(
+          String.format("Invalid connection %s. %s is not a stage.", connection, connection.getFrom()));
+      }
+      if (!stageNames.contains(connection.getTo())) {
+        throw new IllegalArgumentException(
+          String.format("Invalid connection %s. %s is not a stage.", connection, connection.getTo()));
+      }
+    }
+
+    Dag dag = Dag.fromConnections(config.getConnections());
+
+    // check source plugins are sources in the dag
+    // check sink plugins are sinks in the dag
+    // check that other plugins are not sources or sinks in the dag
+    Map<String, StageConnections> stages = new HashMap<>();
+    for (ETLStage stage : config.getStages()) {
+      String stageName = stage.getName();
+      Set<String> stageInputs = dag.getNodeInputs(stageName);
+      Set<String> stageOutputs = dag.getNodeOutputs(stageName);
+
+      if (sourcePluginType.equals(stage.getPlugin().getType())) {
+        if (!stageInputs.isEmpty()) {
+          throw new IllegalArgumentException(
+            String.format("Source %s has incoming connections from %s. Sources cannot have any incoming connections.",
+                          stageName, Joiner.on(',').join(stageInputs)));
+        }
+      } else if (sinkPluginType.equals(stage.getPlugin().getType())) {
+        if (!stageOutputs.isEmpty()) {
+          throw new IllegalArgumentException(
+            String.format("Sink %s has outgoing connections to %s. Sinks cannot have any outgoing connections.",
+                          stageName, Joiner.on(',').join(stageOutputs)));
+        }
+      } else {
+        if (stageInputs.isEmpty()) {
+          throw new IllegalArgumentException(
+            String.format("Stage %s is unreachable, it has no incoming connections.", stageName));
+        }
+        if (stageOutputs.isEmpty()) {
+          throw new IllegalArgumentException(
+            String.format("Stage %s is a dead end, it has no outgoing connections.", stageName));
+        }
+      }
+      stages.put(stageName, new StageConnections(stage, stageInputs, stageOutputs));
+    }
+    if (dag.getSources().size() > 1) {
+      throw new IllegalArgumentException("Multiple sources are not allowed at this time.");
+    }
+
+    List<StageConnections> traversalOrder = new ArrayList<>(stages.size());
+    for (String stageName : dag.linearize()) {
+      traversalOrder.add(stages.get(stageName));
+    }
+
+    return traversalOrder;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/StageConnections.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/StageConnections.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spec;
+
+import co.cask.cdap.etl.proto.v2.ETLStage;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Class to hold a stage with its input and outputs.
+ */
+public class StageConnections {
+  private final ETLStage stage;
+  private final Set<String> inputs;
+  private final Set<String> outputs;
+
+  public StageConnections(ETLStage stage, Collection<String> inputs, Collection<String> outputs) {
+    this.stage = stage;
+    this.inputs = ImmutableSet.copyOf(inputs);
+    this.outputs = ImmutableSet.copyOf(outputs);
+  }
+
+
+  public ETLStage getStage() {
+    return stage;
+  }
+
+  public Set<String> getOutputs() {
+    return outputs;
+  }
+
+  public Set<String> getInputs() {
+    return inputs;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    StageConnections that = (StageConnections) o;
+
+    return Objects.equals(stage, that.stage) &&
+      Objects.equals(outputs, that.outputs) &&
+      Objects.equals(inputs, that.inputs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(stage, outputs, inputs);
+  }
+
+  @Override
+  public String toString() {
+    return "StageConnections{" +
+      "stage=" + stage +
+      ", outputs=" + outputs +
+      ", inputs=" + inputs +
+      '}';
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/TrackedPluginSelector.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/TrackedPluginSelector.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spec;
+
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginSelector;
+
+import java.util.Map;
+import java.util.SortedMap;
+
+/**
+ * Wrapper around {@link PluginSelector} that delegates to another selector but tracks which artifact it chose.
+ */
+public class TrackedPluginSelector extends PluginSelector {
+  private final PluginSelector delegate;
+  private ArtifactId selectedArtifact;
+
+  public TrackedPluginSelector(PluginSelector delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Map.Entry<ArtifactId, PluginClass> select(SortedMap<ArtifactId, PluginClass> plugins) {
+    Map.Entry<ArtifactId, PluginClass> selected = delegate.select(plugins);
+    selectedArtifact = selected.getKey();
+    return selected;
+  }
+
+  public ArtifactId getSelectedArtifact() {
+    return selectedArtifact;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/MockPluginConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/MockPluginConfigurer.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.api.plugin.PluginSelector;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import javax.annotation.Nullable;
+
+/**
+ * Mock {@link PluginConfigurer} for unit tests. No-op for dataset methods.
+ * Use the setter methods to populate the plugin objects that should be returned by the PluginConfigurer methods.
+ */
+public class MockPluginConfigurer implements PluginConfigurer {
+  private Map<Key, Value> plugins;
+
+  private static class Value {
+    private Object plugin;
+    private SortedMap<ArtifactId, PluginClass> artifacts;
+
+    public Value(Object plugin, Set<ArtifactId> artifacts) {
+      this.plugin = plugin;
+      this.artifacts = new TreeMap<>();
+      for (ArtifactId artifactId : artifacts) {
+        this.artifacts.put(artifactId, new PluginClass("type", "name", "desc", "clsname", "cfgfield",
+                                                       ImmutableMap.<String, PluginPropertyField>of()));
+      }
+    }
+  }
+
+  public MockPluginConfigurer() {
+    plugins = new HashMap<>();
+  }
+
+  public void addMockPlugin(String type, String name, Object plugin, Set<ArtifactId> artifacts) {
+    Key key = new Key(type, name);
+    Value value = new Value(plugin, artifacts);
+    plugins.put(key, value);
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String pluginType, String pluginName,
+                         String pluginId, PluginProperties properties) {
+    Value value = plugins.get(new Key(pluginType, pluginName));
+    if (value == null) {
+      return null;
+    }
+    return (T) value.plugin;
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String pluginType, String pluginName, String pluginId,
+                         PluginProperties properties, PluginSelector selector) {
+    Value value = plugins.get(new Key(pluginType, pluginName));
+    if (value == null) {
+      return null;
+    }
+    selector.select(value.artifacts);
+    return (T) value.plugin;
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String pluginType, String pluginName,
+                                     String pluginId, PluginProperties properties) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId,
+                                     PluginProperties properties, PluginSelector selector) {
+    return null;
+  }
+
+  @Override
+  public void addStream(Stream stream) {
+
+  }
+
+  @Override
+  public void addStream(String streamName) {
+
+  }
+
+  @Override
+  public void addDatasetModule(String moduleName, Class<? extends DatasetModule> moduleClass) {
+
+  }
+
+  @Override
+  public void addDatasetType(Class<? extends Dataset> datasetClass) {
+
+  }
+
+  @Override
+  public void createDataset(String datasetName, String typeName, DatasetProperties properties) {
+
+  }
+
+  @Override
+  public void createDataset(String datasetName, String typeName) {
+
+  }
+
+  @Override
+  public void createDataset(String datasetName, Class<? extends Dataset> datasetClass, DatasetProperties props) {
+
+  }
+
+  @Override
+  public void createDataset(String datasetName, Class<? extends Dataset> datasetClass) {
+
+  }
+
+  private static class Key {
+    private final String type;
+    private final String name;
+
+    public Key(String type, String name) {
+      this.type = type;
+      this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Key that = (Key) o;
+
+      return Objects.equals(type, that.type) && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(type, name);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.planner;
+
+import co.cask.cdap.etl.proto.Connection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ */
+public class DagTest {
+
+  @Test
+  public void testLinearize() {
+    // n1 -> n2 -> n3 -> n4
+    Dag dag = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n1", "n2"), new Connection("n2", "n3"), new Connection("n3", "n4")));
+    Assert.assertEquals(ImmutableList.of("n1", "n2", "n3", "n4"), dag.linearize());
+
+    /*
+             |--- n2 ---|
+        n1 --|          |-- n4
+             |--- n3 ---|
+     */
+    dag = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n1", "n2"),
+      new Connection("n1", "n3"),
+      new Connection("n2", "n4"),
+      new Connection("n3", "n4")));
+    // could be n1 -> n2 -> n3 -> n4
+    // or it could be n1 -> n3 -> n2 -> n4
+    List<String> linearized = dag.linearize();
+    Assert.assertEquals("n1", linearized.get(0));
+    Assert.assertEquals("n4", linearized.get(3));
+    assertBefore(linearized, "n1", "n2");
+    assertBefore(linearized, "n1", "n3");
+
+    /*
+        n1 --|
+             |--- n3
+        n2 --|
+     */
+    dag = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n1", "n3"),
+      new Connection("n2", "n3")));
+    // could be n1 -> n2 -> n3
+    // or it could be n2 -> n1 -> n3
+    linearized = dag.linearize();
+    Assert.assertEquals("n3", linearized.get(2));
+    assertBefore(linearized, "n1", "n3");
+    assertBefore(linearized, "n2", "n3");
+
+    /*
+                                     |--- n3
+             |--- n2 ----------------|
+        n1 --|       |               |--- n5
+             |--------- n4 ----------|
+             |              |        |
+             |---------------- n6 ---|
+
+        vertical arrows are pointing down
+     */
+    dag = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n1", "n2"),
+      new Connection("n1", "n4"),
+      new Connection("n1", "n6"),
+      new Connection("n2", "n3"),
+      new Connection("n2", "n4"),
+      new Connection("n2", "n5"),
+      new Connection("n4", "n3"),
+      new Connection("n4", "n5"),
+      new Connection("n4", "n6"),
+      new Connection("n6", "n3"),
+      new Connection("n6", "n5")));
+    linearized = dag.linearize();
+    Assert.assertEquals("n1", linearized.get(0));
+    Assert.assertEquals("n2", linearized.get(1));
+    Assert.assertEquals("n4", linearized.get(2));
+    Assert.assertEquals("n6", linearized.get(3));
+    assertBefore(linearized, "n6", "n3");
+    assertBefore(linearized, "n6", "n5");
+  }
+
+  private void assertBefore(List<String> list, String a, String b) {
+    int aIndex = list.indexOf(a);
+    int bIndex = list.indexOf(b);
+    Assert.assertTrue(aIndex < bIndex);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testCycle() {
+    /*
+             |---> n2 ----|
+             |      ^     v
+        n1 --|      |     n3 --> n5
+             |---> n4 <---|
+     */
+    Dag dag = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n1", "n2"),
+      new Connection("n2", "n3"),
+      new Connection("n3", "n4"),
+      new Connection("n4", "n2"),
+      new Connection("n3", "n5")));
+    dag.linearize();
+  }
+
+  @Test
+  public void testRemoveSource() {
+    /*
+             |--- n2 ---|
+        n1 --|          |-- n4
+             |--- n3 ---|
+     */
+    Dag dag = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n1", "n2"),
+      new Connection("n1", "n3"),
+      new Connection("n2", "n4"),
+      new Connection("n3", "n4")));
+    Assert.assertEquals("n1", dag.removeSource());
+    Assert.assertEquals(ImmutableSet.of("n2", "n3"), dag.getSources());
+
+    Set<String> removed = ImmutableSet.of(dag.removeSource(), dag.removeSource());
+    Assert.assertEquals(ImmutableSet.of("n2", "n3"), removed);
+    Assert.assertEquals(ImmutableSet.of("n4"), dag.getSources());
+    Assert.assertEquals("n4", dag.removeSource());
+    Assert.assertTrue(dag.getSources().isEmpty());
+    Assert.assertTrue(dag.getSinks().isEmpty());
+    Assert.assertNull(dag.removeSource());
+  }
+
+  @Test
+  public void testIslands() {
+    /*
+        n1 -- n2
+
+        n3 -- n4
+     */
+    try {
+      Dag.fromConnections(ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n3", "n4")));
+      Assert.fail();
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    /*
+        n1 -- n2
+              |
+              v
+        n3 -- n4
+              ^
+        n5----|   n6 -- n7
+     */
+    try {
+      Dag.fromConnections(ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n2", "n4"),
+        new Connection("n3", "n4"),
+        new Connection("n5", "n4"),
+        new Connection("n6", "n7")));
+      Assert.fail();
+    } catch (IllegalStateException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testAccessibleFrom() {
+    /*
+        n1 -- n2
+              |
+              v
+        n3 -- n4 --- n8
+              ^
+              |
+        n5-------- n6 -- n7
+     */
+    Dag dag = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n1", "n2"),
+      new Connection("n2", "n4"),
+      new Connection("n3", "n4"),
+      new Connection("n4", "n8"),
+      new Connection("n5", "n4"),
+      new Connection("n5", "n6"),
+      new Connection("n6", "n7")));
+    Assert.assertEquals(ImmutableSet.of("n1", "n2", "n4", "n8"), dag.accessibleFrom("n1"));
+    Assert.assertEquals(ImmutableSet.of("n2", "n4", "n8"), dag.accessibleFrom("n2"));
+    Assert.assertEquals(ImmutableSet.of("n3", "n4", "n8"), dag.accessibleFrom("n3"));
+    Assert.assertEquals(ImmutableSet.of("n4", "n8"), dag.accessibleFrom("n4"));
+    Assert.assertEquals(ImmutableSet.of("n5", "n4", "n8", "n6", "n7"), dag.accessibleFrom("n5"));
+    Assert.assertEquals(ImmutableSet.of("n6", "n7"), dag.accessibleFrom("n6"));
+    Assert.assertEquals(ImmutableSet.of("n7"), dag.accessibleFrom("n7"));
+    Assert.assertEquals(ImmutableSet.of("n8"), dag.accessibleFrom("n8"));
+
+    // this stop node isn't accessible from n5 anyway, shouldn't have any effect
+    Assert.assertEquals(ImmutableSet.of("n5", "n4", "n8", "n6", "n7"),
+                        dag.accessibleFrom("n5", ImmutableSet.of("n1")));
+    // these stop nodes cut off all paths, though the stop nodes themselves should show up in accessible set
+    Assert.assertEquals(ImmutableSet.of("n5", "n4", "n6"), dag.accessibleFrom("n5", ImmutableSet.of("n4", "n6")));
+    // these stop nodes cut off some paths
+    Assert.assertEquals(ImmutableSet.of("n5", "n4", "n6", "n7"),
+                        dag.accessibleFrom("n5", ImmutableSet.of("n4")));
+    // these stop nodes cut off some paths
+    Assert.assertEquals(ImmutableSet.of("n5", "n4", "n6", "n8"),
+                        dag.accessibleFrom("n5", ImmutableSet.of("n6", "n1")));
+  }
+
+  @Test
+  public void testSubset() {
+    /*
+        n1 -- n2
+              |
+              v
+        n3 -- n4 --- n8
+              ^
+              |
+        n5-------- n6 -- n7
+     */
+    Dag fulldag = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n1", "n2"),
+      new Connection("n2", "n4"),
+      new Connection("n3", "n4"),
+      new Connection("n4", "n8"),
+      new Connection("n5", "n4"),
+      new Connection("n5", "n6"),
+      new Connection("n6", "n7")));
+
+    Dag expected = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n1", "n2"),
+      new Connection("n2", "n4"),
+      new Connection("n4", "n8")));
+    Dag actual = fulldag.subsetFrom("n1");
+    Assert.assertEquals(expected, actual);
+
+    expected = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n2", "n4"),
+      new Connection("n4", "n8")));
+    actual = fulldag.subsetFrom("n2");
+    Assert.assertEquals(expected, actual);
+
+    expected = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n3", "n4"),
+      new Connection("n4", "n8")));
+    actual = fulldag.subsetFrom("n3");
+    Assert.assertEquals(expected, actual);
+
+    expected = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n4", "n8"),
+      new Connection("n5", "n4"),
+      new Connection("n5", "n6"),
+      new Connection("n6", "n7")));
+    actual = fulldag.subsetFrom("n5");
+    Assert.assertEquals(expected, actual);
+
+    expected = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n6", "n7")));
+    actual = fulldag.subsetFrom("n6");
+    Assert.assertEquals(expected, actual);
+
+    // test subsets with stop nodes
+    expected = Dag.fromConnections(ImmutableSet.of(new Connection("n1", "n2")));
+    actual = fulldag.subsetFrom("n1", ImmutableSet.of("n2"));
+    Assert.assertEquals(expected, actual);
+
+    expected = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n5", "n4"),
+      new Connection("n5", "n6")));
+    actual = fulldag.subsetFrom("n5", ImmutableSet.of("n4", "n6"));
+    Assert.assertEquals(expected, actual);
+
+
+    /*
+             |--- n2 ----------|
+             |                 |                              |-- n10
+        n1 --|--- n3 --- n5 ---|--- n6 --- n7 --- n8 --- n9 --|
+             |                 |                              |-- n11
+             |--- n4 ----------|
+
+     */
+    fulldag = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n1", "n2"),
+      new Connection("n1", "n3"),
+      new Connection("n1", "n4"),
+      new Connection("n2", "n6"),
+      new Connection("n3", "n5"),
+      new Connection("n4", "n6"),
+      new Connection("n5", "n6"),
+      new Connection("n6", "n7"),
+      new Connection("n7", "n8"),
+      new Connection("n8", "n9"),
+      new Connection("n9", "n10"),
+      new Connection("n9", "n11")));
+
+    expected = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n3", "n5"),
+      new Connection("n5", "n6"),
+      new Connection("n6", "n7"),
+      new Connection("n7", "n8"),
+      new Connection("n8", "n9")));
+    actual = fulldag.subsetFrom("n3", ImmutableSet.of("n4", "n9"));
+    Assert.assertEquals(expected, actual);
+
+    expected = Dag.fromConnections(ImmutableSet.of(
+      new Connection("n2", "n6"),
+      new Connection("n6", "n7"),
+      new Connection("n7", "n8")));
+    actual = fulldag.subsetFrom("n2", ImmutableSet.of("n4", "n8", "n1"));
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
@@ -161,6 +161,7 @@ public class DagTest {
       Assert.fail();
     } catch (IllegalStateException e) {
       // expected
+      Assert.assertTrue(e.getMessage().startsWith("Invalid DAG. There is an island"));
     }
 
     /*
@@ -181,6 +182,7 @@ public class DagTest {
       Assert.fail();
     } catch (IllegalStateException e) {
       // expected
+      Assert.assertTrue(e.getMessage().startsWith("Invalid DAG. There is an island"));
     }
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spec;
+
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.etl.api.PipelineConfigurable;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.common.MockPluginConfigurer;
+import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
+import co.cask.cdap.etl.proto.v2.ETLConfig;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import co.cask.cdap.etl.proto.v2.ETLStage;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tests for converting a {@link ETLConfig} into a {@link PipelineSpec}.
+ */
+public class PipelineSpecGeneratorTest {
+  private static final Schema SCHEMA_A = Schema.recordOf("a", Schema.Field.of("a", Schema.of(Schema.Type.STRING)));
+  private static final Schema SCHEMA_B = Schema.recordOf("b", Schema.Field.of("b", Schema.of(Schema.Type.STRING)));
+  private static final ETLPlugin MOCK_SOURCE =
+    new ETLPlugin("mocksource", BatchSource.PLUGIN_TYPE, ImmutableMap.<String, String>of(), null);
+  private static final ETLPlugin MOCK_TRANSFORM_A =
+    new ETLPlugin("mockA", Transform.PLUGIN_TYPE, ImmutableMap.<String, String>of(), null);
+  private static final ETLPlugin MOCK_TRANSFORM_B =
+    new ETLPlugin("mockB", Transform.PLUGIN_TYPE, ImmutableMap.<String, String>of(), null);
+  private static final ETLPlugin MOCK_SINK =
+    new ETLPlugin("mocksink", BatchSink.PLUGIN_TYPE, ImmutableMap.<String, String>of(), null);
+  private static final ArtifactId ARTIFACT_ID =
+    new ArtifactId("plugins", new ArtifactVersion("1.0.0"), ArtifactScope.USER);
+  private static PipelineSpecGenerator specGenerator;
+
+  @BeforeClass
+  public static void setupTests() {
+    // populate some mock plugins.
+    MockPluginConfigurer pluginConfigurer = new MockPluginConfigurer();
+    Set<ArtifactId> artifactIds = ImmutableSet.of(ARTIFACT_ID);
+    pluginConfigurer.addMockPlugin(BatchSource.PLUGIN_TYPE, "mocksource", new MockPlugin(SCHEMA_A), artifactIds);
+    pluginConfigurer.addMockPlugin(Transform.PLUGIN_TYPE, "mockA", new MockPlugin(SCHEMA_A), artifactIds);
+    pluginConfigurer.addMockPlugin(Transform.PLUGIN_TYPE, "mockB", new MockPlugin(SCHEMA_B), artifactIds);
+    pluginConfigurer.addMockPlugin(BatchSink.PLUGIN_TYPE, "mocksink", new MockPlugin(), artifactIds);
+
+    specGenerator = new PipelineSpecGenerator(pluginConfigurer, BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE,
+                                              FileSet.class, DatasetProperties.EMPTY);
+  }
+
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUniqueStageNames() {
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addConnection("source", "sink")
+      .build();
+    specGenerator.generateSpec(etlConfig);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConnectionWithMissingStage() {
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addConnection("source", "sink")
+      .addConnection("source", "stage2")
+      .build();
+    specGenerator.generateSpec(etlConfig);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConnectionIntoSource() {
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addStage(new ETLStage("transform", MOCK_TRANSFORM_A))
+      .addConnection("source", "sink")
+      .addConnection("transform", "source")
+      .build();
+    specGenerator.generateSpec(etlConfig);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConnectionOutOfSink() {
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addStage(new ETLStage("transform", MOCK_TRANSFORM_A))
+      .addConnection("source", "sink")
+      .addConnection("sink", "transform")
+      .build();
+    specGenerator.generateSpec(etlConfig);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUnreachableStage() {
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addStage(new ETLStage("transform", MOCK_TRANSFORM_A))
+      .addConnection("source", "sink")
+      .addConnection("transform", "sink")
+      .build();
+    specGenerator.generateSpec(etlConfig);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDeadEndStage() {
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addStage(new ETLStage("transform", MOCK_TRANSFORM_A))
+      .addConnection("source", "sink")
+      .addConnection("source", "transform")
+      .build();
+    specGenerator.generateSpec(etlConfig);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testCycle() {
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addStage(new ETLStage("t1", MOCK_TRANSFORM_A))
+      .addStage(new ETLStage("t2", MOCK_TRANSFORM_A))
+      .addConnection("source", "t1")
+      .addConnection("t1", "t2")
+      .addConnection("t2", "t1")
+      .addConnection("t2", "sink")
+      .build();
+    specGenerator.generateSpec(etlConfig);
+  }
+
+  @Test
+  public void testGenerateSpec() {
+    /*
+     *           ---- t1 ------------
+     *           |            |      |
+     * source ---             |      |--- t3 --- sink1
+     *           |            |      |
+     *           ------------ t2 --------------- sink2
+     *           |                        |
+     *           |                        |
+     *           -------------------------
+     */
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("sink1", MOCK_SINK))
+      .addStage(new ETLStage("sink2", MOCK_SINK))
+      .addStage(new ETLStage("t1", MOCK_TRANSFORM_A))
+      .addStage(new ETLStage("t2", MOCK_TRANSFORM_A))
+      .addStage(new ETLStage("t3", MOCK_TRANSFORM_B))
+      .addConnection("source", "t1")
+      .addConnection("source", "t2")
+      .addConnection("source", "sink2")
+      .addConnection("t1", "t2")
+      .addConnection("t1", "t3")
+      .addConnection("t1", "sink2")
+      .addConnection("t2", "sink2")
+      .addConnection("t2", "t3")
+      .addConnection("t3", "sink1")
+      .build();
+    // test the spec generated is correct, with the right input and output schemas and artifact information.
+    PipelineSpec actual = specGenerator.generateSpec(etlConfig);
+    Map<String, String> emptyMap = ImmutableMap.of();
+    Set<StageSpec> expectedStages = ImmutableSet.of(
+      StageSpec.builder("source", new PluginSpec(BatchSource.PLUGIN_TYPE, "mocksource", emptyMap, ARTIFACT_ID))
+        .setOutputSchema(SCHEMA_A)
+        .addOutputs("t1", "t2", "sink2")
+        .build(),
+      StageSpec.builder("sink1", new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", emptyMap, ARTIFACT_ID))
+        .setInputSchema(SCHEMA_B)
+        .addInputs("t3")
+        .build(),
+      StageSpec.builder("sink2", new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", emptyMap, ARTIFACT_ID))
+        .setInputSchema(SCHEMA_A)
+        .addInputs("t1", "t2", "source")
+        .build(),
+      StageSpec.builder("t1", new PluginSpec(Transform.PLUGIN_TYPE, "mockA", emptyMap, ARTIFACT_ID))
+        .setInputSchema(SCHEMA_A)
+        .setOutputSchema(SCHEMA_A)
+        .addInputs("source")
+        .addOutputs("t2", "t3", "sink2")
+        .build(),
+      StageSpec.builder("t2", new PluginSpec(Transform.PLUGIN_TYPE, "mockA", emptyMap, ARTIFACT_ID))
+        .setInputSchema(SCHEMA_A)
+        .setOutputSchema(SCHEMA_A)
+        .addInputs("source", "t1")
+        .addOutputs("t3", "sink2")
+        .build(),
+      StageSpec.builder("t3", new PluginSpec(Transform.PLUGIN_TYPE, "mockB", emptyMap, ARTIFACT_ID))
+        .setInputSchema(SCHEMA_A)
+        .setOutputSchema(SCHEMA_B)
+        .addInputs("t1", "t2")
+        .addOutputs("sink1")
+        .build()
+    );
+    PipelineSpec expected = new PipelineSpec(expectedStages, ImmutableSet.copyOf(etlConfig.getConnections()),
+                                             etlConfig.getResources(),
+                                             etlConfig.isStageLoggingEnabled());
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConflictingInputSchemas() {
+    /*
+     *           ---- transformA ----
+     *           |                  |
+     * source ---                   |--- sink
+     *           |                  |
+     *           ---- transformB ----
+     *
+     * sink gets schema A and schema B as input, should fail
+     */
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addStage(new ETLStage("tA", MOCK_TRANSFORM_A))
+      .addStage(new ETLStage("tB", MOCK_TRANSFORM_B))
+      .addConnection("source", "tA")
+      .addConnection("source", "tB")
+      .addConnection("tA", "sink")
+      .addConnection("tB", "sink")
+      .build();
+    specGenerator.generateSpec(etlConfig);
+  }
+
+  private static class MockPlugin implements PipelineConfigurable {
+    private final Schema schema;
+
+    public MockPlugin() {
+      this.schema = null;
+    }
+
+    public MockPlugin(Schema schema) {
+      this.schema = schema;
+    }
+
+    @Override
+    public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+      if (schema != null) {
+        pipelineConfigurer.getStageConfigurer().setOutputSchema(schema);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Extracts some of the logic in the
PipelineRegisterer into a Dag class which can be used to check
for cycles, linearize, etc. This class will be enhanced next to
include methods to help with pipeline planning.

Also uses the Dag class to validate the user provided ETLConfig and
generate a PipelineSpec.  The spec contains all information needed
to plan the pipeline execution.