### PR TITLE
CDAP-5186 add planner dags

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ConnectorDag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ConnectorDag.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.planner;
+
+import co.cask.cdap.etl.proto.Connection;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * A special DAG that can insert connector nodes into a normal dag based on some rules.
+ * A connector node is a boundary at which the dag can be split into smaller dags.
+ */
+public class ConnectorDag extends Dag {
+  private final Set<String> reduceNodes;
+  private final Set<String> connectors;
+
+  public ConnectorDag(Collection<Connection> connections) {
+    this(connections, ImmutableSet.<String>of());
+  }
+
+  public ConnectorDag(Collection<Connection> connections, Set<String> reduceNodes) {
+    this(connections, reduceNodes, ImmutableSet.<String>of());
+  }
+
+  public ConnectorDag(Collection<Connection> connections, Set<String> reduceNodes, Set<String> connectors) {
+    super(connections);
+    this.reduceNodes = ImmutableSet.copyOf(reduceNodes);
+    this.connectors = new HashSet<>(connectors);
+  }
+
+  /**
+   * Insert connector nodes into the dag.
+   *
+   * A connector node is a boundary at which the pipeline can be split into sub dags.
+   * It is treated as a sink within one subdag and as a source in another subdag.
+   * A connector is inserted in front of a reduce node (aggregator plugin type, etc)
+   * when there is a path from some source to one or more reduce nodes or sinks.
+   * This is required because in a single mapper, we can't write to both a sink and do a reduce.
+   * We also can't reduce on multiple keys in the same mapper.
+   * A connector is also inserted in front of any node if the inputs into the node come from multiple sources.
+   * A connector is also inserted in front of a reduce node that has another reduce node as its input.
+   *
+   * @return the connectors added
+   */
+  public Set<String> insertConnectors() {
+    // none of this is particularly efficient, but this should never be a bottleneck
+    // unless we're dealing with very very large dags
+
+    // node to insert in front of -> new connector node
+    Set<String> addedAlready = new HashSet<>();
+
+    // first pass, find sections of the dag where a source is writing to both a sink and a reduce node
+    // or to multiple reduce nodes. a connector counts as both a source and a sink.
+    for (String node : linearize()) {
+      if (!sources.contains(node) && !connectors.contains(node)) {
+        continue;
+      }
+
+      Set<String> accessibleByNode = accessibleFrom(node, Sets.union(connectors, reduceNodes));
+      Set<String> sinksAndReduceNodes = Sets.intersection(accessibleByNode, Sets.union(sinks, reduceNodes));
+      // don't count this node
+      sinksAndReduceNodes = Sets.difference(sinksAndReduceNodes, ImmutableSet.of(node));
+
+      if (sinksAndReduceNodes.size() > 1) {
+        for (String reduceNodeConnector : Sets.intersection(sinksAndReduceNodes, reduceNodes)) {
+          addConnectorInFrontOf(reduceNodeConnector, addedAlready);
+        }
+      }
+    }
+
+    // next pass, find nodes that have input from multiple sources and add them to the connectors set.
+    // a connector counts as a source
+
+    // traverse the graph and keep track of sources that have a path to each node
+    // mapping of node -> sources that have a path to the node.
+    // a connector node is considered a source
+    SetMultimap<String, String> nodeSources = HashMultimap.create();
+    for (String source : sources) {
+      nodeSources.put(source, source);
+    }
+    for (String connector : connectors) {
+      nodeSources.put(connector, connector);
+    }
+    for (String node : linearize()) {
+      if (sinks.contains(node)) {
+        continue;
+      }
+      Set<String> connectedSources = nodeSources.get(node);
+      // if more than one source is connected to this node, then this node is a connector.
+      // keep track of it, and wipe its node sources to just contain itself
+      if (connectedSources.size() > 1) {
+        addConnectorInFrontOf(node, addedAlready);
+        connectedSources = new HashSet<>();
+        connectedSources.add(node);
+        nodeSources.replaceValues(node, connectedSources);
+      }
+      for (String nodeOutput : getNodeOutputs(node)) {
+        // don't propagate to connectors, since they are counted as source and replace any inputs they may have
+        if (connectors.contains(nodeOutput)) {
+          continue;
+        }
+        // propagate sources connected to me to all my outputs
+        nodeSources.putAll(nodeOutput, connectedSources);
+      }
+    }
+
+    // next pass, find reduce nodes that are connected to other reduce nodes
+    for (String reduceNode : reduceNodes) {
+      Set<String> accessibleByNode = accessibleFrom(reduceNode, Sets.union(connectors, reduceNodes));
+      Set<String> accessibleReduceNodes = Sets.intersection(accessibleByNode, reduceNodes);
+
+      // Sets.difference because we don't want to add ourselves
+      accessibleReduceNodes = Sets.difference(accessibleReduceNodes, ImmutableSet.of(reduceNode));
+      for (String accessibleReduceNode : Sets.difference(accessibleReduceNodes, ImmutableSet.of(reduceNode))) {
+        addConnectorInFrontOf(accessibleReduceNode, addedAlready);
+      }
+    }
+
+    return addedAlready;
+  }
+
+  public Set<String> getConnectors() {
+    return connectors;
+  }
+
+  /**
+   * Split this dag into multiple dags. Each connector is used as a split point where it is a sink of one dag and the
+   * source of another dag.
+   *
+   * @return list of dags split on connectors.
+   */
+  public List<Dag> splitOnConnectors() {
+    List<Dag> dags = new ArrayList<>();
+    for (String source : sources) {
+      dags.add(subsetFrom(source, connectors));
+    }
+    for (String connector : connectors) {
+      dags.add(subsetFrom(connector, connectors));
+    }
+
+    return dags;
+  }
+
+  private void addConnectorInFrontOf(String inFrontOf, Set<String> addedAlready) {
+    if (!addedAlready.add(inFrontOf)) {
+      return;
+    }
+
+    String connectorName = inFrontOf + ".connector";
+    if (nodes.contains(connectorName)) {
+      connectorName += UUID.randomUUID().toString();
+    }
+    insertNode(connectorName, inFrontOf);
+    connectors.add(connectorName);
+  }
+  /**
+   * Inserts a node in front of the specified node.
+   *
+   * @param name the name of the new node
+   * @param inFrontOf the node to insert in front of
+   */
+  private void insertNode(String name, String inFrontOf) {
+    if (!nodes.contains(inFrontOf)) {
+      throw new IllegalArgumentException(
+        String.format("Cannot insert in front node %s because it does not exist.", inFrontOf));
+    }
+    if (!nodes.add(name)) {
+      throw new IllegalArgumentException(
+        String.format("Cannot insert node %s because it already exists.", name));
+    }
+
+    Set<String> inputs = incomingConnections.get(inFrontOf);
+    incomingConnections.putAll(name, inputs);
+    for (String input : inputs) {
+      outgoingConnections.remove(input, inFrontOf);
+      outgoingConnections.put(input, name);
+    }
+    outgoingConnections.put(name, inFrontOf);
+    incomingConnections.replaceValues(inFrontOf, ImmutableSet.of(name));
+  }
+
+  @Override
+  public String toString() {
+    return "ConnectorDag{" +
+      "reduceNodes=" + reduceNodes +
+      ", connectors=" + connectors +
+      "} " + super.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    ConnectorDag that = (ConnectorDag) o;
+
+    return Objects.equals(reduceNodes, that.reduceNodes) &&
+      Objects.equals(connectors, that.connectors);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), reduceNodes, connectors);
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ControlDag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ControlDag.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.planner;
+
+import co.cask.cdap.etl.proto.Connection;
+import com.google.common.base.Joiner;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multiset;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+
+/**
+ * A DAG (directed acyclic graph) where edges represent a happens-before relationship.
+ * In these types of scenarios, certain edges may be redundant and can be removed.
+ * This simplifies the dag into something that is much easier to work with if it needs
+ * to be used as a fork-join type of dag for workflow execution.
+ */
+public class ControlDag extends Dag {
+  private static final Set<String> EMPTY = ImmutableSet.of();
+  private final Multiset<String> nodeVisits;
+
+  public ControlDag(Collection<Connection> connections) {
+    super(connections);
+    this.nodeVisits = HashMultiset.create();
+  }
+
+  /**
+   * Record that this node was visited.
+   *
+   * @param node node that was visited
+   * @return the number of times this node was visited, including the visit from this call
+   */
+  public int visit(String node) {
+    nodeVisits.add(node);
+    return nodeVisits.count(node);
+  }
+
+  /**
+   * Resets the number of times each node was visited back to 0.
+   */
+  public void resetVisitCounts() {
+    nodeVisits.clear();
+  }
+
+  /**
+   * Flattens the control dag to remove connections between branches of different forks, which would
+   * make the dag unusable in pure fork-join workflows.
+   *
+   * For example the following dag is not a fork-join dag:
+   *
+   *      |--> n2 -------|
+   *      |              |--> n5
+   *      |--> n3 -------|
+   *  n1--|           |
+   *      |           v
+   *      |--> n4 --> n6
+   *
+   *  There are many ways to turn this a fork-join while still respecting all happens-before relationships,
+   *  but for simplicity we'll use an algorithm that doesn't have any nested forks and will turn the above into:
+   *
+   *       |--> n2 --|
+   *       |         |               |--> n5 --|
+   *  n1 --|--> n3 --|--> n2.n3.n4 --|         |--> n5.n6
+   *       |         |               |--> n6 --|
+   *       |--> n4 --|
+   *
+   *  The algorithm is to insert a join node whenever it sees a fork. Every time there is a fork, we will follow
+   *  each branch to its endpoint (a node that forks, merges, or is a sink), then insert a join node that each
+   *  branch endpoint connects to.
+   */
+  public void flatten() {
+    trim();
+    String source;
+    // if we have multiple sources, insert a fork node as the new source
+    if (sources.size() > 1) {
+      // copy to avoid concurrent modification
+      Set<String> sourcesCopy = new HashSet<>(sources);
+      String newId = generateJoinNodeName(sourcesCopy);
+      addNode(newId, EMPTY, sourcesCopy);
+      source = newId;
+    } else {
+      source = sources.iterator().next();
+    }
+
+    flattenFrom(source);
+  }
+
+  private void flattenFrom(String node) {
+    Set<String> outputs = outgoingConnections.get(node);
+    if (outputs.isEmpty()) {
+      return;
+    }
+
+    if (outputs.size() == 1) {
+      flattenFrom(outputs.iterator().next());
+      return;
+    }
+
+    Multimap<String, String> branchEndpointOutputs = HashMultimap.create();
+    // can't just use branchEndpointOutputs.keySet(),
+    // because that won't track branch endpoints that had no output (sinks)
+    Set<String> branchEndpoints = new HashSet<>();
+    if (outputs.size() > 1) {
+      for (String output : outputs) {
+        String branchEndpoint = findBranchEnd(output);
+        branchEndpoints.add(branchEndpoint);
+        branchEndpointOutputs.putAll(branchEndpoint, outgoingConnections.get(branchEndpoint));
+      }
+    }
+    // if all the branch endpoints connect to a single node, there is no need to add a join node
+    Set<String> endpointOutputs = new HashSet<>(branchEndpointOutputs.values());
+    if (endpointOutputs.size() == 1) {
+      flattenFrom(endpointOutputs.iterator().next());
+      return;
+    }
+
+    // add a connection from each branch endpoint to a newly added join node
+    // then move all outgoing connections from each branch endpoint so that they are coming out of the new join node
+    String newJoinNode = generateJoinNodeName(branchEndpoints);
+    addNode(newJoinNode, branchEndpoints, endpointOutputs);
+    // remove the outgoing connections from endpoints that aren't going to our new join node
+    for (Map.Entry<String, String> endpointEntry : branchEndpointOutputs.entries()) {
+      removeConnection(endpointEntry.getKey(), endpointEntry.getValue());
+    }
+    /*
+       have to trim again due to reshuffling of nodes. For example, if we have:
+
+                      |--> n3
+            |--> n2 --|
+            |         |--> n4
+       n1 --|              |
+            |              v
+            |--> n5 -----> n6
+
+       after we insert the new join node we'll have:
+
+            |--> n2 --|           |--> n3
+            |         |           |
+       n1 --|         |--> join --|--> n4
+            |         |           |    |
+            |--> n5 --|           |    v
+                                  |--> n6
+
+       and we need to remove the connection from join -> n6, otherwise the algorithm will get messed up
+     */
+    trim();
+
+    // then keep flattening from the new join node
+    flattenFrom(newJoinNode);
+  }
+
+  // go down a branch until we find a node with multiple outputs, a node with multiple inputs, or a sink
+  private String findBranchEnd(String node) {
+    Set<String> outputs = outgoingConnections.get(node);
+    // if this is a sink, or if this is a fork on a branch
+    if (outputs.isEmpty() || outputs.size() > 1) {
+      return node;
+    }
+    // if the next node is a join node
+    String output = outputs.iterator().next();
+    if (incomingConnections.get(output).size() > 1) {
+      return node;
+    }
+    // otherwise keep going down this branch
+    return findBranchEnd(output);
+  }
+
+  /**
+   * Returns the number of paths from the start node to the stop node.
+   * The number of paths from a node to itself is 1.
+   *
+   * @param start the node to start from
+   * @param stop the node to end at
+   * @return the number of paths from the start node to the stop node
+   */
+  private int numPaths(String start, String stop) {
+    if (start.equals(stop)) {
+      return 1;
+    }
+    int count = 0;
+    for (String output : getNodeOutputs(start)) {
+      count += numPaths(output, stop);
+    }
+    return count;
+  }
+
+  /**
+   * Trims any redundant control connections.
+   *
+   * For example:
+   *   n1 ------> n2
+   *       |      |
+   *       |      v
+   *       |----> n3
+   * has a redundant edge n1 -> n3, because the edge from n2 -> n3 already enforces n1 -> n3.
+   * The approach is look at each node (call it nodeB). For each input into nodeB (call it nodeA),
+   * if there is another path from nodeA to nodeB besides the direct edge, we can remove the edge nodeA -> nodeB.
+   *
+   * @return number of connections removed.
+   */
+  public int trim() {
+    int numRemoved = 0;
+    for (String node : nodes) {
+      Set<Connection> toRemove = new HashSet<>();
+      for (String nodeInput : getNodeInputs(node)) {
+        if (numPaths(nodeInput, node) > 1) {
+          toRemove.add(new Connection(nodeInput, node));
+        }
+      }
+      for (Connection conn : toRemove) {
+        removeConnection(conn.getFrom(), conn.getTo());
+      }
+      numRemoved += toRemove.size();
+    }
+    return numRemoved;
+  }
+
+  /**
+   * Add a node with the following outputs and inputs
+   */
+  private void addNode(String node, Collection<String> inputs, Collection<String> outputs) {
+    nodes.add(node);
+    for (String output : outputs) {
+      outgoingConnections.put(node, output);
+      incomingConnections.put(output, node);
+      sources.remove(output);
+    }
+    for (String input : inputs) {
+      incomingConnections.put(node, input);
+      outgoingConnections.put(input, node);
+      sinks.remove(input);
+    }
+    if (outputs.isEmpty()) {
+      sinks.add(node);
+    }
+    if (inputs.isEmpty()) {
+      sources.add(node);
+    }
+  }
+
+  private String generateJoinNodeName(Set<String> inputs) {
+    // using sorted sets to guarantee the name is deterministic
+    String name = Joiner.on('.').join(new TreeSet<>(inputs));
+    if (nodes.contains(name)) {
+      name += UUID.randomUUID().toString();
+    }
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    ControlDag that = (ControlDag) o;
+
+    return Objects.equals(nodeVisits, that.nodeVisits);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), nodeVisits);
+  }
+
+  @Override
+  public String toString() {
+    return "ControlDag{" +
+      "nodeVisits=" + nodeVisits +
+      "} " + super.toString();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ControlDag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ControlDag.java
@@ -92,6 +92,11 @@ public class ControlDag extends Dag {
    *  branch endpoint connects to.
    */
   public void flatten() {
+    // this should never be the case, as it should be checked when the dag is created.
+    if (sources.isEmpty()) {
+      throw new IllegalStateException("There are no sources in the graph, which means there is a cycle.");
+    }
+
     trim();
     String source;
     // if we have multiple sources, insert a fork node as the new source
@@ -123,13 +128,12 @@ public class ControlDag extends Dag {
     // can't just use branchEndpointOutputs.keySet(),
     // because that won't track branch endpoints that had no output (sinks)
     Set<String> branchEndpoints = new HashSet<>();
-    if (outputs.size() > 1) {
-      for (String output : outputs) {
-        String branchEndpoint = findBranchEnd(output);
-        branchEndpoints.add(branchEndpoint);
-        branchEndpointOutputs.putAll(branchEndpoint, outgoingConnections.get(branchEndpoint));
-      }
+    for (String output : outputs) {
+      String branchEndpoint = findBranchEnd(output);
+      branchEndpoints.add(branchEndpoint);
+      branchEndpointOutputs.putAll(branchEndpoint, outgoingConnections.get(branchEndpoint));
     }
+
     // if all the branch endpoints connect to a single node, there is no need to add a join node
     Set<String> endpointOutputs = new HashSet<>(branchEndpointOutputs.values());
     if (endpointOutputs.size() == 1) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/Dag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/Dag.java
@@ -21,7 +21,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 
@@ -39,45 +38,37 @@ import java.util.Set;
  * A DAG (directed acyclic graph).
  */
 public class Dag {
-  private final Set<String> nodes;
-  private final Set<String> sources;
-  private final Set<String> sinks;
+  protected final Set<String> nodes;
+  protected final Set<String> sources;
+  protected final Set<String> sinks;
   // stage -> outputs of that stage
-  private final SetMultimap<String, String> outgoingConnections;
+  protected final SetMultimap<String, String> outgoingConnections;
   // stage -> inputs for that stage
-  private final SetMultimap<String, String> incomingConnections;
+  protected final SetMultimap<String, String> incomingConnections;
 
-  public static Dag fromConnections(Collection<Connection> connections) {
-    SetMultimap<String, String> outgoingConnections = HashMultimap.create();
-    SetMultimap<String, String> incomingConnections = HashMultimap.create();
+  public Dag(Collection<Connection> connections) {
+    Preconditions.checkArgument(!connections.isEmpty(), "Cannot create a DAG without any connections");
+    this.outgoingConnections = HashMultimap.create();
+    this.incomingConnections = HashMultimap.create();
     for (Connection connection : connections) {
       outgoingConnections.put(connection.getFrom(), connection.getTo());
       incomingConnections.put(connection.getTo(), connection.getFrom());
     }
-    Dag dag = new Dag(outgoingConnections, incomingConnections);
-    dag.validate();
-    return dag;
+    this.sources = new HashSet<>();
+    this.sinks = new HashSet<>();
+    this.nodes = new HashSet<>();
+    init();
+    validate();
   }
 
   private Dag(SetMultimap<String, String> outgoingConnections,
               SetMultimap<String, String> incomingConnections) {
-    this(calculateSources(outgoingConnections, incomingConnections),
-         calculateSinks(outgoingConnections, incomingConnections),
-         outgoingConnections, incomingConnections);
-  }
-
-  private Dag(Set<String> sources, Set<String> sinks,
-              SetMultimap<String, String> outgoingConnections,
-              SetMultimap<String, String> incomingConnections) {
-    Preconditions.checkArgument(!outgoingConnections.isEmpty(), "Cannot create a DAG without any connections");
-    Preconditions.checkArgument(!incomingConnections.isEmpty(), "Cannot create a DAG without any connections");
-    this.sources = new HashSet<>(sources);
-    this.sinks = new HashSet<>(sinks);
     this.outgoingConnections = HashMultimap.create(outgoingConnections);
     this.incomingConnections = HashMultimap.create(incomingConnections);
+    this.sources = new HashSet<>();
+    this.sinks = new HashSet<>();
     this.nodes = new HashSet<>();
-    nodes.addAll(outgoingConnections.keySet());
-    nodes.addAll(outgoingConnections.values());
+    init();
   }
 
   /**
@@ -210,47 +201,7 @@ public class Dag {
         }
       }
     }
-    return Dag.fromConnections(connections);
-  }
-
-  /**
-   * Inserts a node in front of the specified node.
-   *
-   * @param name the name of the new node
-   * @param inFrontOf the node to insert in front of
-   */
-  public void insertNode(String name, String inFrontOf) {
-    if (!nodes.contains(inFrontOf)) {
-      throw new IllegalArgumentException(
-        String.format("Cannot insert in front node %s because it does not exist.", inFrontOf));
-    }
-    if (!nodes.add(name)) {
-      throw new IllegalArgumentException(
-        String.format("Cannot insert node %s because it already exists.", name));
-    }
-
-    Set<String> inputs = incomingConnections.get(inFrontOf);
-    incomingConnections.putAll(name, inputs);
-    for (String input : inputs) {
-      outgoingConnections.get(input).remove(inFrontOf);
-      outgoingConnections.put(input, name);
-    }
-    outgoingConnections.put(name, inFrontOf);
-    incomingConnections.replaceValues(inFrontOf, ImmutableSet.of(name));
-  }
-
-  /**
-   * Remove a source from the dag. New sources will be re-calculated after the source is removed.
-   *
-   * @return the removed source, or null if there were no sources to remove.
-   */
-  public String removeSource() {
-    if (sources.isEmpty()) {
-      return null;
-    }
-    String source = sources.iterator().next();
-    removeNode(source);
-    return source;
+    return new Dag(connections);
   }
 
   /**
@@ -264,7 +215,7 @@ public class Dag {
   public List<String> linearize() {
     List<String> linearized = new ArrayList<>();
 
-    Dag copy = new Dag(sources, sinks, outgoingConnections, incomingConnections);
+    Dag copy = new Dag(outgoingConnections, incomingConnections);
     String removed;
     while ((removed = copy.removeSource()) != null) {
       linearized.add(removed);
@@ -280,6 +231,29 @@ public class Dag {
     Set<String> cycle = accessibleFrom(copy.outgoingConnections.keySet().iterator().next());
     throw new IllegalStateException(
       String.format("Invalid DAG. Stages %s form a cycle.", Joiner.on(',').join(cycle)));
+  }
+
+  /**
+   * Remove a source from the dag. New sources will be re-calculated after the source is removed.
+   *
+   * @return the removed source, or null if there were no sources to remove.
+   */
+  protected String removeSource() {
+    if (sources.isEmpty()) {
+      return null;
+    }
+    String source = sources.iterator().next();
+    removeNode(source);
+    return source;
+  }
+
+  /**
+   * Remove the specified connection. Does not check that the connection actually exists.
+   * It is possible to break apart the dag with this call.
+   */
+  protected void removeConnection(String from, String to) {
+    outgoingConnections.remove(from, to);
+    incomingConnections.remove(to, from);
   }
 
   /**
@@ -339,28 +313,20 @@ public class Dag {
     return sink;
   }
 
-  private static Set<String> calculateSources(Multimap<String, String> outgoingConnections,
-                                              Multimap<String, String> incomingConnections) {
-    Set<String> sources = new HashSet<>();
-    // a source is any stage that doesn't have any inputs but has at least one output
-    for (String stageWithOutput : outgoingConnections.keySet()) {
-      if (incomingConnections.get(stageWithOutput).isEmpty()) {
-        sources.add(stageWithOutput);
+  private void init() {
+    nodes.clear();
+    sources.clear();
+    sinks.clear();
+    nodes.addAll(outgoingConnections.keySet());
+    nodes.addAll(outgoingConnections.values());
+    for (String node : nodes) {
+      if (outgoingConnections.get(node).isEmpty()) {
+        sinks.add(node);
+      }
+      if (incomingConnections.get(node).isEmpty()) {
+        sources.add(node);
       }
     }
-    return sources;
-  }
-
-  private static Set<String> calculateSinks(Multimap<String, String> outgoingConnections,
-                                            Multimap<String, String> incomingConnections) {
-    Set<String> sinks = new HashSet<>();
-    // a sink is any stage that doesn't have any outputs but has at least one input
-    for (String stageWithInput : incomingConnections.keySet()) {
-      if (outgoingConnections.get(stageWithInput).isEmpty()) {
-        sinks.add(stageWithInput);
-      }
-    }
-    return sinks;
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/Dag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/Dag.java
@@ -88,7 +88,7 @@ public class Dag {
     }
 
     // check for cycles
-    linearize();
+    getTopologicalOrder();
 
     // check for sections of the dag that are on an island by themselves
 
@@ -205,14 +205,16 @@ public class Dag {
   }
 
   /**
-   * Linearize the dag. The returned list guarantees that for each item in the list, that item has no path to an
+   * Get the dag in topological order.
+   * The returned list guarantees that for each item in the list, that item has no path to an
    * item that comes before it in the list. In the process, if a cycle is found, an exception will be thrown.
-   * This is a destructive operation and will result in an empty dag.
+   * Topological sort means we pop off a source from the dag, re-calculate sources, and continue until there
+   * are no more nodes left. Popping will be done on a copy of the dag so that this is not a destructive operation.
    *
-   * @return the linearized dag
+   * @return the dag in topological order
    * @throws IllegalStateException if there is a cycle in the dag
    */
-  public List<String> linearize() {
+  public List<String> getTopologicalOrder() {
     List<String> linearized = new ArrayList<>();
 
     Dag copy = new Dag(outgoingConnections, incomingConnections);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlan.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlan.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.planner;
+
+import co.cask.cdap.etl.common.PipelinePhase;
+import co.cask.cdap.etl.proto.Connection;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Plan for a logical pipeline.
+ */
+public class PipelinePlan {
+  private final Map<String, PipelinePhase> phases;
+  private final Set<Connection> phaseConnections;
+
+  public PipelinePlan(Map<String, PipelinePhase> phases, Collection<Connection> phaseConnections) {
+    this.phases = ImmutableMap.copyOf(phases);
+    this.phaseConnections = ImmutableSet.copyOf(phaseConnections);
+  }
+
+  public Map<String, PipelinePhase> getPhases() {
+    return phases;
+  }
+
+  public Set<Connection> getPhaseConnections() {
+    return phaseConnections;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PipelinePlan that = (PipelinePlan) o;
+
+    return Objects.equals(phases, that.phases) &&
+      Objects.equals(phaseConnections, that.phaseConnections);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(phases, phaseConnections);
+  }
+
+  @Override
+  public String toString() {
+    return "PipelinePlan{" +
+      "phases=" + phases +
+      ", phaseConnections=" + phaseConnections +
+      '}';
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
@@ -47,7 +47,8 @@ public class PipelinePlanner {
   }
 
   /**
-   * Create an execution plan for the given logical pipeline.
+   * Create an execution plan for the given logical pipeline. This is used for batch pipelines.
+   * Though it may eventually be useful to mark windowing points for realtime pipelines.
    *
    * A plan consists of one or more phases, with connections between phases.
    * A connection between a phase indicates control flow, and not necessarily
@@ -135,7 +136,7 @@ public class PipelinePlanner {
     StageInfo source = null;
     StageInfo aggregator = null;
 
-    for (String stageName : dag.linearize()) {
+    for (String stageName : dag.getTopologicalOrder()) {
       Set<String> outputs = dag.getNodeOutputs(stageName);
       if (!outputs.isEmpty()) {
         connections.put(stageName, dag.getNodeOutputs(stageName));

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.planner;
+
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.common.PipelinePhase;
+import co.cask.cdap.etl.proto.Connection;
+import co.cask.cdap.etl.spec.PipelineSpec;
+import co.cask.cdap.etl.spec.StageSpec;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Takes a {@link PipelineSpec} and creates an execution plan from it.
+ */
+public class PipelinePlanner {
+  private final Set<String> reduceTypes;
+
+  public PipelinePlanner(Set<String> reduceTypes) {
+    this.reduceTypes = ImmutableSet.copyOf(reduceTypes);
+  }
+
+  /**
+   * Create an execution plan for the given logical pipeline.
+   *
+   * A plan consists of one or more phases, with connections between phases.
+   * A connection between a phase indicates control flow, and not necessarily
+   * data flow. This class assumes that it receives a valid pipeline spec.
+   * That is, the pipeline has no cycles, all its nodes have unique names,
+   * sources don't have any input, sinks don't have any output,
+   * everything else has both an input and an output, etc.
+   *
+   * We start by inserting connector nodes into the logical dag,
+   * which are used to mark boundaries between mapreduce jobs.
+   * Each connector represents a node where we will need to write to a local dataset.
+   *
+   * Next, the logical pipeline is broken up into phases,
+   * using the connectors as sinks in one phase, and a source in another.
+   * After this point, connections between phases do not indicate data flow, but control flow.
+   *
+   * @param spec the pipeline spec, representing a logical pipeline
+   * @return the execution plan
+   */
+  public PipelinePlan plan(PipelineSpec spec) {
+    // go through the stages and examine their plugin type to determine which stages are reduce stages
+    Set<String> reduceNodes = new HashSet<>();
+    Map<String, StageSpec> specs = new HashMap<>();
+    for (StageSpec stage : spec.getStages()) {
+      if (reduceTypes.contains(stage.getPlugin().getType())) {
+        reduceNodes.add(stage.getName());
+      }
+      specs.put(stage.getName(), stage);
+    }
+
+    // insert connector stages into the logical pipeline
+    ConnectorDag cdag = new ConnectorDag(spec.getConnections(), reduceNodes);
+    cdag.insertConnectors();
+    Set<String> connectorNodes = cdag.getConnectors();
+
+    // now split the logical pipeline into pipeline phases, using the connectors as split points
+    Map<String, Dag> subdags = new HashMap<>();
+    // assign some name to each subdag
+    for (Dag subdag : cdag.splitOnConnectors()) {
+      String name = getPhaseName(subdag.getSources(), subdag.getSinks());
+      subdags.put(name, subdag);
+    }
+
+    // build connections between phases
+    Set<Connection> phaseConnections = new HashSet<>();
+    for (Map.Entry<String, Dag> subdagEntry1 : subdags.entrySet()) {
+      String dag1Name = subdagEntry1.getKey();
+      Dag dag1 = subdagEntry1.getValue();
+
+      for (Map.Entry<String, Dag> subdagEntry2: subdags.entrySet()) {
+        String dag2Name = subdagEntry2.getKey();
+        Dag dag2 = subdagEntry2.getValue();
+        if (dag1Name.equals(dag2Name)) {
+          continue;
+        }
+
+        // if dag1 has any sinks that are a source in dag2, add a connection between the dags
+        if (Sets.intersection(dag1.getSinks(), dag2.getSources()).size() > 0) {
+          phaseConnections.add(new Connection(dag1Name, dag2Name));
+        }
+      }
+    }
+
+    // convert to objects the programs expect.
+    Map<String, PipelinePhase> phases = new HashMap<>();
+    for (Map.Entry<String, Dag> dagEntry : subdags.entrySet()) {
+      phases.put(dagEntry.getKey(), dagToPipeline(dagEntry.getValue(), connectorNodes, specs));
+    }
+    return new PipelinePlan(phases, phaseConnections);
+  }
+
+  /**
+   * Converts a Dag into a PipelinePhase, using what we know about the plugin type of each node in the dag.
+   * The PipelinePhase is what programs will take as input, and keeps track of sources, transforms, sinks, etc.
+   *
+   * @param dag the dag to convert
+   * @param connectors connector nodes across all dags
+   * @param specs specifications for every stage
+   * @return the converted dag
+   */
+  private PipelinePhase dagToPipeline(Dag dag, Set<String> connectors, Map<String, StageSpec> specs) {
+    Set<StageInfo> sinks = new HashSet<>();
+    Set<StageInfo> transforms = new HashSet<>();
+    Map<String, Set<String>> connections = new HashMap<>();
+    StageInfo source = null;
+    StageInfo aggregator = null;
+
+    for (String stageName : dag.linearize()) {
+      Set<String> outputs = dag.getNodeOutputs(stageName);
+      if (!outputs.isEmpty()) {
+        connections.put(stageName, dag.getNodeOutputs(stageName));
+      }
+
+      // if its a connector, figure out if its a source or a sink
+      if (connectors.contains(stageName)) {
+        StageInfo stageInfo = new StageInfo(stageName, null, true);
+        if (dag.getSources().contains(stageName)) {
+          source = stageInfo;
+        } else {
+          sinks.add(stageInfo);
+        }
+        continue;
+      }
+
+      StageSpec spec = specs.get(stageName);
+      String pluginType = spec.getPlugin().getType();
+
+      StageInfo stageInfo = new StageInfo(stageName, spec.getErrorDatasetName(), connectors.contains(stageName));
+      if (BatchSink.PLUGIN_TYPE.equals(pluginType)) {
+        sinks.add(stageInfo);
+      } else if (Transform.PLUGIN_TYPE.equals(pluginType)) {
+        transforms.add(stageInfo);
+      } else if (BatchSource.PLUGIN_TYPE.equals(pluginType)) {
+        if (source != null) {
+          // should never happen
+          throw new IllegalStateException(String.format(
+            "There was an error during pipeline planning. " +
+              "A pipeline phase should not have multiple sources, but %s and %s are in the same phase.",
+            source.getName(), stageName));
+        }
+        source = stageInfo;
+      } else if ("aggregator".equals(pluginType)) {
+        if (aggregator != null) {
+          // should never happen
+          throw new IllegalStateException(String.format(
+            "There was an error during pipeline planning. " +
+              "A pipeline phase should not have multiple aggregators, but %s and %s are in the same phase.",
+            aggregator.getName(), stageName));
+        }
+        aggregator = stageInfo;
+      } else {
+        // should never happen
+        throw new IllegalStateException(
+          String.format("Stage %s uses an unknown plugin type %s", stageName, pluginType));
+      }
+    }
+
+    return new PipelinePhase(source, aggregator, sinks, transforms, connections);
+  }
+
+  @VisibleForTesting
+  static String getPhaseName(Set<String> sources, Set<String> sinks) {
+    // using sorted sets to guarantee the name is deterministic
+    return Joiner.on('.').join(new TreeSet<>(sources)) +
+      ".to." +
+      Joiner.on('.').join(new TreeSet<>(sinks));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
@@ -17,8 +17,6 @@
 package co.cask.cdap.etl.planner;
 
 import co.cask.cdap.etl.api.Transform;
-import co.cask.cdap.etl.api.batch.BatchSink;
-import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.common.PipelinePhase;
 import co.cask.cdap.etl.proto.Connection;
 import co.cask.cdap.etl.spec.PipelineSpec;
@@ -38,9 +36,13 @@ import java.util.TreeSet;
  * Takes a {@link PipelineSpec} and creates an execution plan from it.
  */
 public class PipelinePlanner {
+  private final String sourceType;
+  private final String sinkType;
   private final Set<String> reduceTypes;
 
-  public PipelinePlanner(Set<String> reduceTypes) {
+  public PipelinePlanner(String sourceType, String sinkType, Set<String> reduceTypes) {
+    this.sourceType = sourceType;
+    this.sinkType = sinkType;
     this.reduceTypes = ImmutableSet.copyOf(reduceTypes);
   }
 
@@ -154,11 +156,11 @@ public class PipelinePlanner {
       String pluginType = spec.getPlugin().getType();
 
       StageInfo stageInfo = new StageInfo(stageName, spec.getErrorDatasetName(), connectors.contains(stageName));
-      if (BatchSink.PLUGIN_TYPE.equals(pluginType)) {
+      if (sinkType.equals(pluginType)) {
         sinks.add(stageInfo);
       } else if (Transform.PLUGIN_TYPE.equals(pluginType)) {
         transforms.add(stageInfo);
-      } else if (BatchSource.PLUGIN_TYPE.equals(pluginType)) {
+      } else if (sourceType.equals(pluginType)) {
         if (source != null) {
           // should never happen
           throw new IllegalStateException(String.format(

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -207,7 +207,7 @@ public class PipelineSpecGenerator {
       }
     }
 
-    Dag dag = Dag.fromConnections(config.getConnections());
+    Dag dag = new Dag(config.getConnections());
 
     // check source plugins are sources in the dag
     // check sink plugins are sinks in the dag

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -247,7 +247,7 @@ public class PipelineSpecGenerator {
     }
 
     List<StageConnections> traversalOrder = new ArrayList<>(stages.size());
-    for (String stageName : dag.linearize()) {
+    for (String stageName : dag.getTopologicalOrder()) {
       traversalOrder.add(stages.get(stageName));
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/ConnectorDagTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/ConnectorDagTest.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.planner;
+
+import co.cask.cdap.etl.proto.Connection;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ */
+public class ConnectorDagTest {
+
+  @Test
+  public void testMergeConnectors() {
+    /*
+        n1 --|
+             |--- n3
+        n2 --|
+     */
+    ConnectorDag cdag = new ConnectorDag(
+      ImmutableSet.of(new Connection("n1", "n3"), new Connection("n2", "n3")));
+    cdag.insertConnectors();
+    // n3 is not a connector because it is a sink
+    Assert.assertTrue(cdag.getConnectors().isEmpty());
+
+    /*
+        n1 --|
+             |--- n3 --- n4
+        n2 --|
+     */
+    cdag = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n3"),
+        new Connection("n2", "n3"),
+        new Connection("n3", "n4")));
+    cdag.insertConnectors();
+    // n3 should have a connector inserted in front of it
+    ConnectorDag expected = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n3.connector"),
+        new Connection("n2", "n3.connector"),
+        new Connection("n3", "n4"),
+        new Connection("n3.connector", "n3")),
+      ImmutableSet.<String>of(), ImmutableSet.of("n3.connector"));
+    Assert.assertEquals(expected, cdag);
+
+
+    /*
+        n1 --|
+             |--- n4 ---|
+        n2 --|          |-- n6 --- n9
+             |--- n5 ---|
+        n3 --|     |
+                   |------ n7 ---- n10
+                   |        |
+                   |------------ n8 -- n11
+     */
+    cdag = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n4"),
+        new Connection("n1", "n5"),
+        new Connection("n2", "n4"),
+        new Connection("n2", "n5"),
+        new Connection("n3", "n4"),
+        new Connection("n3", "n5"),
+        new Connection("n4", "n6"),
+        new Connection("n5", "n6"),
+        new Connection("n5", "n7"),
+        new Connection("n5", "n8"),
+        new Connection("n6", "n9"),
+        new Connection("n7", "n8"),
+        new Connection("n7", "n10"),
+        new Connection("n8", "n11")));
+    cdag.insertConnectors();
+    // n4 and n5 should have connectors in front since they have multiple inputs
+    // n6 should also since it has input from n4 and n5
+    // n7 should not since its only input is n5
+    // n8 also should not since its input is n5 and n7, but n7 comes from n5.
+    expected = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n4.connector"),
+        new Connection("n1", "n5.connector"),
+        new Connection("n2", "n4.connector"),
+        new Connection("n2", "n5.connector"),
+        new Connection("n3", "n4.connector"),
+        new Connection("n3", "n5.connector"),
+        new Connection("n4", "n6.connector"),
+        new Connection("n5", "n6.connector"),
+        new Connection("n5", "n7"),
+        new Connection("n5", "n8"),
+        new Connection("n6", "n9"),
+        new Connection("n7", "n8"),
+        new Connection("n7", "n10"),
+        new Connection("n8", "n11"),
+        new Connection("n6.connector", "n6"),
+        new Connection("n5.connector", "n5"),
+        new Connection("n4.connector", "n4")),
+      ImmutableSet.<String>of(),
+      ImmutableSet.of("n4.connector", "n5.connector", "n6.connector"));
+    Assert.assertEquals(expected, cdag);
+  }
+
+  @Test
+  public void testReduceNodeConnectors() {
+    /*
+             |--- n2
+        n1 --|
+             |--- n3(r) --- n4
+     */
+    // n3 is a reduce node, which means n1 is writing to a sink (n2) and a stop node (n3),
+    // so n3 should have a connector inserted in front of it
+    ConnectorDag cdag = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n3", "n4")),
+      ImmutableSet.of("n3"));
+    cdag.insertConnectors();
+    ConnectorDag expected = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3.connector"),
+        new Connection("n3", "n4"),
+        new Connection("n3.connector", "n3")),
+      ImmutableSet.of("n3"),
+      ImmutableSet.of("n3.connector"));
+    Assert.assertEquals(expected, cdag);
+
+    /*
+             |--- n2
+        n1 --|
+             |--- n3 --- n4
+     */
+    // the same graph as above, but n3 is not a reduce node. In this scenario, nothing is a connector
+    cdag = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n3", "n4")));
+    cdag.insertConnectors();
+    Assert.assertTrue(cdag.getConnectors().isEmpty());
+
+    /*
+        n1 --- n2(r) --- n3(r) --- n4(r) --- n5
+
+        in this example, n3 and n4 should have connectors
+     */
+    cdag = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n2", "n3"),
+        new Connection("n3", "n4"),
+        new Connection("n4", "n5")),
+      ImmutableSet.of("n2", "n3", "n4"));
+    cdag.insertConnectors();
+    expected = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n2", "n3.connector"),
+        new Connection("n3", "n4.connector"),
+        new Connection("n4.connector", "n4"),
+        new Connection("n4", "n5"),
+        new Connection("n3.connector", "n3")),
+      ImmutableSet.of("n2", "n3", "n4"),
+      ImmutableSet.of("n3.connector", "n4.connector"));
+    Assert.assertEquals(expected, cdag);
+
+    /*
+                       |-- n3(r) -- n4
+        n1 --- n2(r) --|
+                       |-- n5 -- n6(r) -- n7
+
+        in this example, n3 and n6 should have connectors
+     */
+    cdag = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n2", "n3"),
+        new Connection("n2", "n5"),
+        new Connection("n3", "n4"),
+        new Connection("n5", "n6"),
+        new Connection("n6", "n7")),
+      ImmutableSet.of("n2", "n3", "n6"));
+    cdag.insertConnectors();
+    expected = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n2", "n3.connector"),
+        new Connection("n2", "n5"),
+        new Connection("n3", "n4"),
+        new Connection("n5", "n6.connector"),
+        new Connection("n6", "n7"),
+        new Connection("n3.connector", "n3"),
+        new Connection("n6.connector", "n6")),
+      ImmutableSet.of("n2", "n3", "n6"),
+      ImmutableSet.of("n3.connector", "n6.connector"));
+    Assert.assertEquals(expected, cdag);
+
+    /*
+             |--- n2(r) ----------|
+             |                    |                                    |-- n10
+        n1 --|--- n3(r) --- n5 ---|--- n6 --- n7(r) --- n8 --- n9(r) --|
+             |                    |                                    |-- n11
+             |--- n4(r) ----------|
+
+        in this example, n2, n3, n4, n6, and n9 should all have connectors
+        n2, n3, n4 all have connectors because n1 is writing to multiple reduce nodes
+        n6 has a connector since it has inputs from multiple sources
+        n9 has a connector because it is connected to reduce node n7
+     */
+    cdag = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n1", "n4"),
+        new Connection("n2", "n6"),
+        new Connection("n3", "n5"),
+        new Connection("n4", "n6"),
+        new Connection("n5", "n6"),
+        new Connection("n6", "n7"),
+        new Connection("n7", "n8"),
+        new Connection("n8", "n9"),
+        new Connection("n9", "n10"),
+        new Connection("n9", "n11")),
+      ImmutableSet.of("n2", "n3", "n4", "n7", "n9"));
+    cdag.insertConnectors();
+    expected = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2.connector"),
+        new Connection("n1", "n3.connector"),
+        new Connection("n1", "n4.connector"),
+        new Connection("n2", "n6.connector"),
+        new Connection("n3", "n5"),
+        new Connection("n4", "n6.connector"),
+        new Connection("n5", "n6.connector"),
+        new Connection("n6", "n7"),
+        new Connection("n7", "n8"),
+        new Connection("n8", "n9.connector"),
+        new Connection("n9", "n10"),
+        new Connection("n9", "n11"),
+        new Connection("n2.connector", "n2"),
+        new Connection("n3.connector", "n3"),
+        new Connection("n4.connector", "n4"),
+        new Connection("n6.connector", "n6"),
+        new Connection("n9.connector", "n9")),
+      ImmutableSet.of("n2", "n3", "n4", "n7", "n9"),
+      ImmutableSet.of("n2.connector", "n3.connector", "n4.connector", "n6.connector", "n9.connector"));
+    Assert.assertEquals(expected, cdag);
+  }
+
+  @Test
+  public void testSplitDag() {
+    /*
+             |--- n2(r) ----------|
+             |                    |                                    |-- n10
+        n1 --|--- n3(r) --- n5 ---|--- n6 --- n7(r) --- n8 --- n9(r) --|
+             |                    |                                    |-- n11
+             |--- n4(r) ----------|
+
+        in this example, n2, n3, n4, n6, and n9 should all have connectors
+        n2, n3, n4 all have connectors because n1 is writing to multiple reduce nodes
+        n6 has a connector since it has inputs from multiple sources
+        n9 has a connector because it is connected to reduce node n7
+     */
+    ConnectorDag cdag = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n1", "n4"),
+        new Connection("n2", "n6"),
+        new Connection("n3", "n5"),
+        new Connection("n4", "n6"),
+        new Connection("n5", "n6"),
+        new Connection("n6", "n7"),
+        new Connection("n7", "n8"),
+        new Connection("n8", "n9"),
+        new Connection("n9", "n10"),
+        new Connection("n9", "n11")),
+      ImmutableSet.of("n2", "n3", "n4", "n7", "n9"));
+    cdag.insertConnectors();
+    Set<Dag> actual = new HashSet<>(cdag.splitOnConnectors());
+    // dag_source_sink(s)
+    Dag dag1 = new Dag(
+      ImmutableSet.of(
+        new Connection("n1", "n2.connector"),
+        new Connection("n1", "n3.connector"),
+        new Connection("n1", "n4.connector")));
+    Dag dag2 = new Dag(
+      ImmutableSet.of(
+        new Connection("n2.connector", "n2"),
+        new Connection("n2", "n6.connector")));
+    Dag dag3 = new Dag(
+      ImmutableSet.of(
+        new Connection("n3.connector", "n3"),
+        new Connection("n3", "n5"),
+        new Connection("n5", "n6.connector")));
+    Dag dag4 = new Dag(
+      ImmutableSet.of(
+        new Connection("n4.connector", "n4"),
+        new Connection("n4", "n6.connector")));
+    Dag dag5 = new Dag(
+      ImmutableSet.of(
+        new Connection("n6.connector", "n6"),
+        new Connection("n6", "n7"),
+        new Connection("n7", "n8"),
+        new Connection("n8", "n9.connector")));
+    Dag dag6 = new Dag(
+      ImmutableSet.of(
+        new Connection("n9.connector", "n9"),
+        new Connection("n9", "n10"),
+        new Connection("n9", "n11")));
+    Set<Dag> expected = ImmutableSet.of(dag1, dag2, dag3, dag4, dag5, dag6);
+    Assert.assertEquals(expected, actual);
+
+
+    /*
+             |---> n2(r)
+             |      |
+        n1 --|      |
+             |      v
+             |---> n3(r) ---> n4
+
+        n2 and n3 should have connectors inserted in front of them to become:
+
+             |---> n2.connector ---> n2(r)
+             |                        |
+        n1 --|                        |
+             |                        v
+             |-------------------> n3.connector ---> n3(r) ---> n4
+     */
+    cdag = new ConnectorDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n2", "n3"),
+        new Connection("n3", "n4")),
+      ImmutableSet.of("n2", "n3"));
+    cdag.insertConnectors();
+    actual = new HashSet<>(cdag.splitOnConnectors());
+
+    /*
+             |--> n2.connector
+        n1 --|
+             |--> n3.connector
+     */
+    dag1 = new Dag(ImmutableSet.of(
+      new Connection("n1", "n2.connector"),
+      new Connection("n1", "n3.connector")));
+    /*
+        n2.connector --> n2 --> n3.connector
+     */
+    dag2 = new Dag(ImmutableSet.of(
+      new Connection("n2.connector", "n2"),
+      new Connection("n2", "n3.connector")));
+    /*
+        n3.connector --> n3 --> n4
+     */
+    dag3 = new Dag(ImmutableSet.of(
+      new Connection("n3.connector", "n3"),
+      new Connection("n3", "n4")));
+    expected = ImmutableSet.of(dag1, dag2, dag3);
+    Assert.assertEquals(expected, actual);
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/ControlDagTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/ControlDagTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.planner;
+
+import co.cask.cdap.etl.proto.Connection;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class ControlDagTest {
+
+  @Test
+  public void testNoOpTrim() {
+    /*
+                           |--> n4
+        n1 --> n2 --> n3 --|
+                           |--> n5
+     */
+    ControlDag cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n3", "n4"),
+        new Connection("n3", "n5")));
+    Assert.assertEquals(0, cdag.trim());
+
+    /*
+             |--> n2 --|
+        n1 --|         |--> n4
+             |--> n3 --|
+     */
+    cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n2", "n4"),
+        new Connection("n3", "n4")));
+    Assert.assertEquals(0, cdag.trim());
+
+    /*
+                |--> n2 --|
+             |--|         |
+             |  |--> n3 --|--> n5
+        n1 --|            |
+             |-----> n4---|
+     */
+    cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n1", "n4"),
+        new Connection("n2", "n5"),
+        new Connection("n3", "n5"),
+        new Connection("n4", "n5")));
+    Assert.assertEquals(0, cdag.trim());
+  }
+
+  @Test
+  public void testTrim() {
+    /*
+             |--> n2 --|
+        n1 --|         v
+             |-------> n3
+     */
+    ControlDag cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n2", "n3")));
+    /*
+        trims down to:
+        n1 --> n2 --> n3
+     */
+    Assert.assertEquals(1, cdag.trim());
+    ControlDag expected = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n2", "n3")));
+    Assert.assertEquals(expected, cdag);
+
+    /*
+                       |--> n3 --|
+             |--> n2 --|         |--> n5
+             |         |--> n4 --|    ^
+        n1 --|              |         |
+             |              v         |
+             |--> n6 -----> n7 -------|
+     */
+    cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n6"),
+        new Connection("n2", "n3"),
+        new Connection("n2", "n4"),
+        new Connection("n3", "n5"),
+        new Connection("n4", "n5"),
+        new Connection("n4", "n7"),
+        new Connection("n6", "n7"),
+        new Connection("n7", "n5")));
+    /*
+       trims down to:
+                       |--> n3 --> n5
+             |--> n2 --|           ^
+             |         |--> n4     |
+        n1 --|              |      |
+             |              v      |
+             |--> n6 -----> n7 ----|
+     */
+    Assert.assertEquals(1, cdag.trim());
+    expected = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n6"),
+        new Connection("n2", "n3"),
+        new Connection("n2", "n4"),
+        new Connection("n3", "n5"),
+        new Connection("n4", "n7"),
+        new Connection("n6", "n7"),
+        new Connection("n7", "n5")));
+    Assert.assertEquals(expected, cdag);
+
+    /*
+             |--> n2 --> n3 ------------
+        n1 --|           |      |      |
+             |           v      v      |
+             |---------> n4 --> n5 ----|
+             |           |             v
+             |-----------------------> n6
+     */
+    cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n4"),
+        new Connection("n1", "n6"),
+        new Connection("n2", "n3"),
+        new Connection("n3", "n4"),
+        new Connection("n3", "n5"),
+        new Connection("n3", "n6"),
+        new Connection("n4", "n5"),
+        new Connection("n4", "n6"),
+        new Connection("n5", "n6")));
+    /*
+       trims down to:
+        n1 --> n2 --> n3 --> n4 --> n5 --> n6
+     */
+    Assert.assertEquals(5, cdag.trim());
+    expected = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n2", "n3"),
+        new Connection("n3", "n4"),
+        new Connection("n4", "n5"),
+        new Connection("n5", "n6")));
+    Assert.assertEquals(expected, cdag);
+  }
+
+  @Test
+  public void testFlattenNoOp() {
+    /*
+        n1 --> n2 --> n3
+     */
+    ControlDag cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n2", "n3")));
+    cdag.flatten();
+    ControlDag expected = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n2", "n3")));
+    Assert.assertEquals(expected, cdag);
+
+    /*
+             |--> n2 --|
+             |         |         |--> n6 --|
+        n1 --|--> n3 --|--> n5 --|         |--> n8
+             |         |         |--> n7 --|
+             |--> n4 --|
+     */
+    cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n1", "n4"),
+        new Connection("n2", "n5"),
+        new Connection("n3", "n5"),
+        new Connection("n4", "n5"),
+        new Connection("n5", "n6"),
+        new Connection("n5", "n7"),
+        new Connection("n6", "n8"),
+        new Connection("n7", "n8")));
+    cdag.flatten();
+    expected = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n1", "n4"),
+        new Connection("n2", "n5"),
+        new Connection("n3", "n5"),
+        new Connection("n4", "n5"),
+        new Connection("n5", "n6"),
+        new Connection("n5", "n7"),
+        new Connection("n6", "n8"),
+        new Connection("n7", "n8")));
+    Assert.assertEquals(expected, cdag);
+  }
+
+  @Test
+  public void testMultiSourceFlatten() {
+    /*
+        n1 --|
+             |--> n3
+        n2 --|
+     */
+    ControlDag cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n3"),
+        new Connection("n2", "n3")));
+    cdag.flatten();
+    ControlDag expected = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1.n2", "n1"),
+        new Connection("n1.n2", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n2", "n3")));
+    Assert.assertEquals(expected, cdag);
+  }
+
+  @Test
+  public void testFlatten() {
+    /*
+                      |--> n3
+            |--> n2 --|
+            |         |--> n4
+       n1 --|
+            |
+            |--> n5
+     */
+    ControlDag cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n5"),
+        new Connection("n2", "n3"),
+        new Connection("n2", "n4")));
+    cdag.flatten();
+    /*
+            |--> n2 --|             |--> n3 --|
+       n1 --|         |--> n2.n5 -->|         |--> n3.n4
+            |--> n5 --|             |--> n4 --|
+     */
+    ControlDag expected = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n5"),
+        new Connection("n2", "n2.n5"),
+        new Connection("n5", "n2.n5"),
+        new Connection("n2.n5", "n3"),
+        new Connection("n2.n5", "n4"),
+        new Connection("n3", "n3.n4"),
+        new Connection("n4", "n3.n4")));
+    Assert.assertEquals(expected, cdag);
+
+    /*
+                      |--> n3
+            |--> n2 --|
+            |         |--> n4
+       n1 --|              |
+            |              v
+            |--> n5 -----> n6
+     */
+    cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n5"),
+        new Connection("n2", "n3"),
+        new Connection("n2", "n4"),
+        new Connection("n4", "n6"),
+        new Connection("n5", "n6")));
+    cdag.flatten();
+    /*
+
+
+            |--> n2 --|
+            |         |            |--> n3 ---------|
+       n1 --|         |--> n2.n5 --|                |--> n3.n6
+            |         |            |--> n4 --> n6 --|
+            |--> n5 --|
+     */
+    expected = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n5"),
+        new Connection("n2", "n2.n5"),
+        new Connection("n5", "n2.n5"),
+        new Connection("n2.n5", "n3"),
+        new Connection("n2.n5", "n4"),
+        new Connection("n4", "n6"),
+        new Connection("n3", "n3.n6"),
+        new Connection("n6", "n3.n6")));
+    Assert.assertEquals(expected, cdag);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
@@ -30,11 +30,11 @@ import java.util.Set;
 public class DagTest {
 
   @Test
-  public void testLinearize() {
+  public void testTopologicalOrder() {
     // n1 -> n2 -> n3 -> n4
     Dag dag = new Dag(ImmutableSet.of(
       new Connection("n1", "n2"), new Connection("n2", "n3"), new Connection("n3", "n4")));
-    Assert.assertEquals(ImmutableList.of("n1", "n2", "n3", "n4"), dag.linearize());
+    Assert.assertEquals(ImmutableList.of("n1", "n2", "n3", "n4"), dag.getTopologicalOrder());
 
     /*
              |--- n2 ---|
@@ -48,7 +48,7 @@ public class DagTest {
       new Connection("n3", "n4")));
     // could be n1 -> n2 -> n3 -> n4
     // or it could be n1 -> n3 -> n2 -> n4
-    List<String> linearized = dag.linearize();
+    List<String> linearized = dag.getTopologicalOrder();
     Assert.assertEquals("n1", linearized.get(0));
     Assert.assertEquals("n4", linearized.get(3));
     assertBefore(linearized, "n1", "n2");
@@ -64,7 +64,7 @@ public class DagTest {
       new Connection("n2", "n3")));
     // could be n1 -> n2 -> n3
     // or it could be n2 -> n1 -> n3
-    linearized = dag.linearize();
+    linearized = dag.getTopologicalOrder();
     Assert.assertEquals("n3", linearized.get(2));
     assertBefore(linearized, "n1", "n3");
     assertBefore(linearized, "n2", "n3");
@@ -91,7 +91,7 @@ public class DagTest {
       new Connection("n4", "n6"),
       new Connection("n6", "n3"),
       new Connection("n6", "n5")));
-    linearized = dag.linearize();
+    linearized = dag.getTopologicalOrder();
     Assert.assertEquals("n1", linearized.get(0));
     Assert.assertEquals("n2", linearized.get(1));
     Assert.assertEquals("n4", linearized.get(2));
@@ -120,7 +120,7 @@ public class DagTest {
       new Connection("n3", "n4"),
       new Connection("n4", "n2"),
       new Connection("n3", "n5")));
-    dag.linearize();
+    dag.getTopologicalOrder();
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
@@ -32,7 +32,7 @@ public class DagTest {
   @Test
   public void testLinearize() {
     // n1 -> n2 -> n3 -> n4
-    Dag dag = Dag.fromConnections(ImmutableSet.of(
+    Dag dag = new Dag(ImmutableSet.of(
       new Connection("n1", "n2"), new Connection("n2", "n3"), new Connection("n3", "n4")));
     Assert.assertEquals(ImmutableList.of("n1", "n2", "n3", "n4"), dag.linearize());
 
@@ -41,7 +41,7 @@ public class DagTest {
         n1 --|          |-- n4
              |--- n3 ---|
      */
-    dag = Dag.fromConnections(ImmutableSet.of(
+    dag = new Dag(ImmutableSet.of(
       new Connection("n1", "n2"),
       new Connection("n1", "n3"),
       new Connection("n2", "n4"),
@@ -59,7 +59,7 @@ public class DagTest {
              |--- n3
         n2 --|
      */
-    dag = Dag.fromConnections(ImmutableSet.of(
+    dag = new Dag(ImmutableSet.of(
       new Connection("n1", "n3"),
       new Connection("n2", "n3")));
     // could be n1 -> n2 -> n3
@@ -79,7 +79,7 @@ public class DagTest {
 
         vertical arrows are pointing down
      */
-    dag = Dag.fromConnections(ImmutableSet.of(
+    dag = new Dag(ImmutableSet.of(
       new Connection("n1", "n2"),
       new Connection("n1", "n4"),
       new Connection("n1", "n6"),
@@ -114,7 +114,7 @@ public class DagTest {
         n1 --|      |     n3 --> n5
              |---> n4 <---|
      */
-    Dag dag = Dag.fromConnections(ImmutableSet.of(
+    Dag dag = new Dag(ImmutableSet.of(
       new Connection("n1", "n2"),
       new Connection("n2", "n3"),
       new Connection("n3", "n4"),
@@ -130,7 +130,7 @@ public class DagTest {
         n1 --|          |-- n4
              |--- n3 ---|
      */
-    Dag dag = Dag.fromConnections(ImmutableSet.of(
+    Dag dag = new Dag(ImmutableSet.of(
       new Connection("n1", "n2"),
       new Connection("n1", "n3"),
       new Connection("n2", "n4"),
@@ -155,7 +155,7 @@ public class DagTest {
         n3 -- n4
      */
     try {
-      Dag.fromConnections(ImmutableSet.of(
+      new Dag(ImmutableSet.of(
         new Connection("n1", "n2"),
         new Connection("n3", "n4")));
       Assert.fail();
@@ -173,7 +173,7 @@ public class DagTest {
         n5----|   n6 -- n7
      */
     try {
-      Dag.fromConnections(ImmutableSet.of(
+      new Dag(ImmutableSet.of(
         new Connection("n1", "n2"),
         new Connection("n2", "n4"),
         new Connection("n3", "n4"),
@@ -197,7 +197,7 @@ public class DagTest {
               |
         n5-------- n6 -- n7
      */
-    Dag dag = Dag.fromConnections(ImmutableSet.of(
+    Dag dag = new Dag(ImmutableSet.of(
       new Connection("n1", "n2"),
       new Connection("n2", "n4"),
       new Connection("n3", "n4"),
@@ -238,7 +238,7 @@ public class DagTest {
               |
         n5-------- n6 -- n7
      */
-    Dag fulldag = Dag.fromConnections(ImmutableSet.of(
+    Dag fulldag = new Dag(ImmutableSet.of(
       new Connection("n1", "n2"),
       new Connection("n2", "n4"),
       new Connection("n3", "n4"),
@@ -247,26 +247,26 @@ public class DagTest {
       new Connection("n5", "n6"),
       new Connection("n6", "n7")));
 
-    Dag expected = Dag.fromConnections(ImmutableSet.of(
+    Dag expected = new Dag(ImmutableSet.of(
       new Connection("n1", "n2"),
       new Connection("n2", "n4"),
       new Connection("n4", "n8")));
     Dag actual = fulldag.subsetFrom("n1");
     Assert.assertEquals(expected, actual);
 
-    expected = Dag.fromConnections(ImmutableSet.of(
+    expected = new Dag(ImmutableSet.of(
       new Connection("n2", "n4"),
       new Connection("n4", "n8")));
     actual = fulldag.subsetFrom("n2");
     Assert.assertEquals(expected, actual);
 
-    expected = Dag.fromConnections(ImmutableSet.of(
+    expected = new Dag(ImmutableSet.of(
       new Connection("n3", "n4"),
       new Connection("n4", "n8")));
     actual = fulldag.subsetFrom("n3");
     Assert.assertEquals(expected, actual);
 
-    expected = Dag.fromConnections(ImmutableSet.of(
+    expected = new Dag(ImmutableSet.of(
       new Connection("n4", "n8"),
       new Connection("n5", "n4"),
       new Connection("n5", "n6"),
@@ -274,17 +274,17 @@ public class DagTest {
     actual = fulldag.subsetFrom("n5");
     Assert.assertEquals(expected, actual);
 
-    expected = Dag.fromConnections(ImmutableSet.of(
+    expected = new Dag(ImmutableSet.of(
       new Connection("n6", "n7")));
     actual = fulldag.subsetFrom("n6");
     Assert.assertEquals(expected, actual);
 
     // test subsets with stop nodes
-    expected = Dag.fromConnections(ImmutableSet.of(new Connection("n1", "n2")));
+    expected = new Dag(ImmutableSet.of(new Connection("n1", "n2")));
     actual = fulldag.subsetFrom("n1", ImmutableSet.of("n2"));
     Assert.assertEquals(expected, actual);
 
-    expected = Dag.fromConnections(ImmutableSet.of(
+    expected = new Dag(ImmutableSet.of(
       new Connection("n5", "n4"),
       new Connection("n5", "n6")));
     actual = fulldag.subsetFrom("n5", ImmutableSet.of("n4", "n6"));
@@ -299,7 +299,7 @@ public class DagTest {
              |--- n4 ----------|
 
      */
-    fulldag = Dag.fromConnections(ImmutableSet.of(
+    fulldag = new Dag(ImmutableSet.of(
       new Connection("n1", "n2"),
       new Connection("n1", "n3"),
       new Connection("n1", "n4"),
@@ -313,7 +313,7 @@ public class DagTest {
       new Connection("n9", "n10"),
       new Connection("n9", "n11")));
 
-    expected = Dag.fromConnections(ImmutableSet.of(
+    expected = new Dag(ImmutableSet.of(
       new Connection("n3", "n5"),
       new Connection("n5", "n6"),
       new Connection("n6", "n7"),
@@ -322,7 +322,7 @@ public class DagTest {
     actual = fulldag.subsetFrom("n3", ImmutableSet.of("n4", "n9"));
     Assert.assertEquals(expected, actual);
 
-    expected = Dag.fromConnections(ImmutableSet.of(
+    expected = new Dag(ImmutableSet.of(
       new Connection("n2", "n6"),
       new Connection("n6", "n7"),
       new Connection("n7", "n8")));

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/PipelinePlannerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/PipelinePlannerTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.planner;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.common.PipelinePhase;
+import co.cask.cdap.etl.proto.Connection;
+import co.cask.cdap.etl.spec.PipelineSpec;
+import co.cask.cdap.etl.spec.PluginSpec;
+import co.cask.cdap.etl.spec.StageSpec;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ */
+public class PipelinePlannerTest {
+  private static final String AGGREGATOR = "aggregator";
+
+  @Test
+  public void testGeneratePlan() {
+    /*
+             |--- n2(r) ----------|
+             |                    |                                    |-- n10
+        n1 --|--- n3(r) --- n5 ---|--- n6 --- n7(r) --- n8 --- n9(r) --|
+             |                    |                                    |-- n11
+             |--- n4(r) ----------|
+     */
+    // create the spec for this pipeline
+    ArtifactId artifactId = new ArtifactId("dummy", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM);
+    Map<String, String> empty = ImmutableMap.of();
+    PluginSpec sourcePlugin = new PluginSpec(BatchSource.PLUGIN_TYPE, "mock", empty, artifactId);
+    PluginSpec reducePlugin = new PluginSpec(AGGREGATOR, "mock", empty, artifactId);
+    PluginSpec transformPlugin = new PluginSpec(Transform.PLUGIN_TYPE, "mock", empty, artifactId);
+    PluginSpec sinkPlugin = new PluginSpec(BatchSink.PLUGIN_TYPE, "mock", empty, artifactId);
+    Schema schema = Schema.recordOf("stuff", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+    Set<StageSpec> stageSpecs = ImmutableSet.of(
+      StageSpec.builder("n1", sourcePlugin)
+        .setOutputSchema(schema)
+        .addOutputs("n2", "n3", "n4")
+        .build(),
+      StageSpec.builder("n2", reducePlugin)
+        .setInputSchema(schema)
+        .setOutputSchema(schema)
+        .addInputs("n1")
+        .addOutputs("n6")
+        .build(),
+      StageSpec.builder("n3", reducePlugin)
+        .setInputSchema(schema)
+        .setOutputSchema(schema)
+        .addInputs("n1")
+        .addOutputs("n5")
+        .build(),
+      StageSpec.builder("n4", reducePlugin)
+        .setInputSchema(schema)
+        .setOutputSchema(schema)
+        .addInputs("n1")
+        .addOutputs("n6")
+        .build(),
+      StageSpec.builder("n5", transformPlugin)
+        .setInputSchema(schema)
+        .setOutputSchema(schema)
+        .addInputs("n3")
+        .addOutputs("n6")
+        .build(),
+      StageSpec.builder("n6", transformPlugin)
+        .setInputSchema(schema)
+        .setOutputSchema(schema)
+        .addInputs("n2", "n5", "n4")
+        .addOutputs("n7")
+        .build(),
+      StageSpec.builder("n7", reducePlugin)
+        .setInputSchema(schema)
+        .setOutputSchema(schema)
+        .addInputs("n6")
+        .addOutputs("n8")
+        .build(),
+      StageSpec.builder("n8", transformPlugin)
+        .setInputSchema(schema)
+        .setOutputSchema(schema)
+        .addInputs("n7")
+        .addOutputs("n9")
+        .build(),
+      StageSpec.builder("n9", reducePlugin)
+        .setInputSchema(schema)
+        .setOutputSchema(schema)
+        .addInputs("n8")
+        .addOutputs("n10", "n11")
+        .build(),
+      StageSpec.builder("n10", sinkPlugin)
+        .setInputSchema(schema)
+        .addInputs("n9")
+        .build(),
+      StageSpec.builder("n11", sinkPlugin)
+        .setInputSchema(schema)
+        .addInputs("n9")
+        .build()
+    );
+    Set<Connection> connections = ImmutableSet.of(
+      new Connection("n1", "n2"),
+      new Connection("n1", "n3"),
+      new Connection("n1", "n4"),
+      new Connection("n2", "n6"),
+      new Connection("n3", "n5"),
+      new Connection("n4", "n6"),
+      new Connection("n5", "n6"),
+      new Connection("n6", "n7"),
+      new Connection("n7", "n8"),
+      new Connection("n8", "n9"),
+      new Connection("n9", "n10"),
+      new Connection("n9", "n11")
+    );
+
+    PipelinePlanner planner = new PipelinePlanner(ImmutableSet.of(AGGREGATOR));
+    PipelineSpec pipelineSpec = new PipelineSpec(stageSpecs, connections, new Resources(), true);
+
+    Map<String, PipelinePhase> phases = new HashMap<>();
+    /*
+             |--- n2.connector
+             |
+        n1 --|--- n3.connector
+             |
+             |--- n4.connector
+     */
+    PipelinePhase phase1 = new PipelinePhase(
+      new StageInfo("n1", null, false),
+      null,
+      ImmutableSet.of(
+        new StageInfo("n2.connector", null, true),
+        new StageInfo("n3.connector", null, true),
+        new StageInfo("n4.connector", null, true)
+      ),
+      ImmutableSet.<StageInfo>of(),
+      ImmutableMap.<String, Set<String>>of(
+        "n1", ImmutableSet.of("n2.connector", "n3.connector", "n4.connector")
+      )
+    );
+    String phase1Name = getPhaseName("n1", "n2.connector", "n3.connector", "n4.connector");
+    phases.put(phase1Name, phase1);
+
+    /*
+        phase2:
+        n2.connector --- n2(r) --- n6.connector
+     */
+    PipelinePhase phase2 = new PipelinePhase(
+      new StageInfo("n2.connector", null, true),
+      new StageInfo("n2", null, false),
+      ImmutableSet.of(new StageInfo("n6.connector", null, true)),
+      ImmutableSet.<StageInfo>of(),
+      ImmutableMap.<String, Set<String>>of(
+        "n2.connector", ImmutableSet.of("n2"),
+        "n2", ImmutableSet.of("n6.connector")
+      )
+    );
+    String phase2Name = getPhaseName("n2.connector", "n6.connector");
+    phases.put(phase2Name, phase2);
+
+    /*
+        phase3:
+        n3.connector --- n3(r) --- n5 --- n6.connector
+     */
+    PipelinePhase phase3 = new PipelinePhase(
+      new StageInfo("n3.connector", null, true),
+      new StageInfo("n3", null, false),
+      ImmutableSet.of(new StageInfo("n6.connector", null, true)),
+      ImmutableSet.of(new StageInfo("n5", null, false)),
+      ImmutableMap.<String, Set<String>>of(
+        "n3.connector", ImmutableSet.of("n3"),
+        "n3", ImmutableSet.of("n5"),
+        "n5", ImmutableSet.of("n6.connector")
+      )
+    );
+    String phase3Name = getPhaseName("n3.connector", "n6.connector");
+    phases.put(phase3Name, phase3);
+
+    /*
+        phase4:
+        n4.connector --- n4(r) --- n6.connector
+     */
+    PipelinePhase phase4 = new PipelinePhase(
+      new StageInfo("n4.connector", null, true),
+      new StageInfo("n4", null, false),
+      ImmutableSet.of(new StageInfo("n6.connector", null, true)),
+      ImmutableSet.<StageInfo>of(),
+      ImmutableMap.<String, Set<String>>of(
+        "n4.connector", ImmutableSet.of("n4"),
+        "n4", ImmutableSet.of("n6.connector")
+      )
+    );
+    String phase4Name = getPhaseName("n4.connector", "n6.connector");
+    phases.put(phase4Name, phase4);
+
+    /*
+        phase5:
+        n6.connector --- n6 --- n7(r) --- n8 --- n9.connector
+     */
+    PipelinePhase phase5 = new PipelinePhase(
+      new StageInfo("n6.connector", null, true),
+      new StageInfo("n7", null, false),
+      ImmutableSet.of(new StageInfo("n9.connector", null, true)),
+      ImmutableSet.of(new StageInfo("n6", null, false), new StageInfo("n8", null, false)),
+      ImmutableMap.<String, Set<String>>of(
+        "n6.connector", ImmutableSet.of("n6"),
+        "n6", ImmutableSet.of("n7"),
+        "n7", ImmutableSet.of("n8"),
+        "n8", ImmutableSet.of("n9.connector")
+      )
+    );
+    String phase5Name = getPhaseName("n6.connector", "n9.connector");
+    phases.put(phase5Name, phase5);
+
+    /*
+        phase6:
+                                 |-- n10
+        n9.connector --- n9(r) --|
+                                 |-- n11
+     */
+    PipelinePhase phase6 = new PipelinePhase(
+      new StageInfo("n9.connector", null, true),
+      new StageInfo("n9", null, false),
+      ImmutableSet.of(new StageInfo("n10", null, false), new StageInfo("n11", null, false)),
+      ImmutableSet.<StageInfo>of(),
+      ImmutableMap.<String, Set<String>>of(
+        "n9.connector", ImmutableSet.of("n9"),
+        "n9", ImmutableSet.of("n10", "n11")
+      )
+    );
+    String phase6Name = getPhaseName("n9.connector", "n10", "n11");
+    phases.put(phase6Name, phase6);
+
+    Set<Connection> phaseConnections = new HashSet<>();
+    phaseConnections.add(new Connection(phase1Name, phase2Name));
+    phaseConnections.add(new Connection(phase1Name, phase3Name));
+    phaseConnections.add(new Connection(phase1Name, phase4Name));
+    phaseConnections.add(new Connection(phase2Name, phase5Name));
+    phaseConnections.add(new Connection(phase3Name, phase5Name));
+    phaseConnections.add(new Connection(phase4Name, phase5Name));
+    phaseConnections.add(new Connection(phase5Name, phase6Name));
+
+    PipelinePlan expected = new PipelinePlan(phases, phaseConnections);
+    PipelinePlan actual = planner.plan(pipelineSpec);
+    Assert.assertEquals(expected, actual);
+  }
+
+  private static String getPhaseName(String source, String... sinks) {
+    Set<String> sources = ImmutableSet.of(source);
+    Set<String> sinkNames = new HashSet<>();
+    Collections.addAll(sinkNames, sinks);
+    return PipelinePlanner.getPhaseName(sources, sinkNames);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/PipelinePlannerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/PipelinePlannerTest.java
@@ -139,7 +139,8 @@ public class PipelinePlannerTest {
       new Connection("n9", "n11")
     );
 
-    PipelinePlanner planner = new PipelinePlanner(ImmutableSet.of(AGGREGATOR));
+    PipelinePlanner planner = new PipelinePlanner(BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE,
+                                                  ImmutableSet.of(AGGREGATOR));
     PipelineSpec pipelineSpec = new PipelineSpec(stageSpecs, connections, new Resources(), true);
 
     Map<String, PipelinePhase> phases = new HashMap<>();


### PR DESCRIPTION
Also adds a ConnectorDag class that helps with splitting a dag into
multiple dags based on special knowledge about certain types of
nodes. The ConnectorDag takes a normal dag as input as well as a
set of reduce nodes. Reduce nodes basically map to plugins in the
pipeline that would require a reduce step in the mapreduce program.
The ConnectorDag uses this information to mark certain nodes in the
dag as connector nodes, which is a node that the dag can be split
on to create multiple sub-dags. Each connector node will translate
into a local dataset source and sink that will be used as temporary
storage linking mapreduce programs. This is used by the PipelinePlanner
to create one or more phases to be executed in the workflow.

Also adds a ControlDag class that is used to transform an arbitrary
data flow type of dag into a fork-join dag usable by workflow. It
moves phases around to accomplish this, while maintaining all
happens-before relationships. It can then be used by a workflow at
configure time.