### PR TITLE
(CDAP-5212) Deprecated cdap-common's UnauthorizedException in favor o…

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/console/ConsoleClient.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/console/ConsoleClient.java
@@ -18,7 +18,7 @@ package co.cask.cdap.etl.tool.console;
 
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
 import co.cask.common.http.ObjectResponse;
@@ -90,7 +90,7 @@ public class ConsoleClient {
     this.restClient = new RESTClient(config);
   }
 
-  public JsonObject get() throws IOException, UnauthorizedException {
+  public JsonObject get() throws IOException, UnauthenticatedException {
     URL url = config.resolveURLV3("/configuration/user");
     HttpRequest request = HttpRequest.get(url).build();
 
@@ -98,7 +98,7 @@ public class ConsoleClient {
     return ObjectResponse.fromJsonBody(response, JsonObject.class).getResponseObject();
   }
 
-  public void set(JsonObject val) throws IOException, UnauthorizedException {
+  public void set(JsonObject val) throws IOException, UnauthenticatedException {
     URL url = config.resolveURLV3("/configuration/user");
     HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(val)).build();
 

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -36,7 +36,7 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.config.ConnectionConfig;
 import co.cask.cdap.common.DatasetTypeNotFoundException;
 import co.cask.cdap.common.ProgramNotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.DatasetTypeMeta;
@@ -658,7 +658,7 @@ public class CLIMainTest {
   }
 
   protected void assertProgramStatus(ProgramClient programClient, Id.Program programId, String programStatus, int tries)
-    throws IOException, ProgramNotFoundException, UnauthorizedException {
+    throws IOException, ProgramNotFoundException, UnauthenticatedException {
 
     String status;
     int numTries = 0;
@@ -675,7 +675,7 @@ public class CLIMainTest {
   }
 
   protected void assertProgramStatus(ProgramClient programClient, Id.Program programId, String programStatus)
-    throws IOException, ProgramNotFoundException, UnauthorizedException {
+    throws IOException, ProgramNotFoundException, UnauthenticatedException {
 
     assertProgramStatus(programClient, programId, programStatus, 180);
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
@@ -25,7 +25,7 @@ import co.cask.cdap.client.MetaClient;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.config.ConnectionConfig;
 import co.cask.cdap.client.exception.DisconnectedException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.security.authentication.client.AccessToken;
 import co.cask.cdap.security.authentication.client.AuthenticationClient;
@@ -173,7 +173,7 @@ public class CLIConfig implements TableRendererConfig {
 
   private void checkConnection(ClientConfig baseClientConfig,
                                ConnectionConfig connectionInfo,
-                               AccessToken accessToken) throws IOException, UnauthorizedException {
+                               AccessToken accessToken) throws IOException, UnauthenticatedException {
     ClientConfig clientConfig = new ClientConfig.Builder(baseClientConfig)
       .setConnectionConfig(connectionInfo)
       .setAccessToken(accessToken)
@@ -202,11 +202,11 @@ public class CLIConfig implements TableRendererConfig {
     try {
       UserAccessToken savedToken = getSavedAccessToken(connectionInfo.getHostname());
       if (savedToken == null) {
-        throw new UnauthorizedException();
+        throw new UnauthenticatedException();
       }
       checkConnection(clientConfig, connectionInfo, savedToken.getAccessToken());
       return savedToken;
-    } catch (UnauthorizedException ignored) {
+    } catch (UnauthenticatedException ignored) {
       // access token invalid - fall through to try acquiring token manually
     }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/AbstractGetPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/AbstractGetPreferencesCommand.java
@@ -21,7 +21,7 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.client.PreferencesClient;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Joiner;
 
@@ -60,7 +60,7 @@ public abstract class AbstractGetPreferencesCommand extends AbstractCommand {
   }
 
   private Map<String, String> parsePreferences(String[] programIdParts)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     switch(type) {
       case INSTANCE:

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowTokenCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowTokenCommand.java
@@ -26,7 +26,7 @@ import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.WorkflowClient;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.WorkflowTokenDetail;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
@@ -98,7 +98,7 @@ public class GetWorkflowTokenCommand extends AbstractCommand {
   }
 
   private Table getWorkflowToken(Id.Run runId, WorkflowToken.Scope workflowTokenScope,
-                                 String key) throws UnauthorizedException, IOException, NotFoundException {
+                                 String key) throws UnauthenticatedException, IOException, NotFoundException {
     WorkflowTokenDetail workflowToken = workflowClient.getWorkflowToken(runId, workflowTokenScope, key);
     List<Map.Entry<String, List<WorkflowTokenDetail.NodeValueDetail>>> tokenKeys = new ArrayList<>();
     tokenKeys.addAll(workflowToken.getTokenData().entrySet());
@@ -115,7 +115,7 @@ public class GetWorkflowTokenCommand extends AbstractCommand {
   }
 
   private Table getWorkflowToken(Id.Run runId, WorkflowToken.Scope workflowTokenScope, String key,
-                                 String nodeName) throws UnauthorizedException, IOException, NotFoundException {
+                                 String nodeName) throws UnauthenticatedException, IOException, NotFoundException {
     WorkflowTokenNodeDetail workflowToken = workflowClient.getWorkflowTokenAtNode(runId, nodeName,
                                                                                   workflowTokenScope, key);
     List<Map.Entry<String, String>> tokenKeys = new ArrayList<>();

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/BaseBatchCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/BaseBatchCommand.java
@@ -24,7 +24,7 @@ import co.cask.cdap.cli.english.Fragment;
 import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.common.ApplicationNotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.BatchProgram;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
@@ -70,7 +70,7 @@ public abstract class BaseBatchCommand<T extends BatchProgram> extends AbstractA
    * Reads arguments to get app id, program types, and list of input programs.
    */
   protected Args<T> readArgs(Arguments arguments)
-    throws ApplicationNotFoundException, UnauthorizedException, IOException {
+    throws ApplicationNotFoundException, UnauthenticatedException, IOException {
 
     String appName = arguments.get(ArgumentName.APP.getName());
     Id.Application appId = Id.Application.from(cliConfig.getCurrentNamespace(), appName);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/CheckActionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/CheckActionCommand.java
@@ -20,7 +20,7 @@ import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.client.AuthorizationClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
@@ -53,7 +53,7 @@ public class CheckActionCommand extends AbstractAuthCommand {
     try {
       client.authorized(entity, principal, action);
       output.printf("Principal %s is authorized to perform action %s on entity %s\n", principal, action, entity);
-    } catch (UnauthorizedException e) {
+    } catch (UnauthenticatedException e) {
       output.printf("Principal %s is not authorized to perform action %s on entity %s\n", principal, action, entity);
     }
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/AppIdCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/AppIdCompleter.java
@@ -19,7 +19,7 @@ package co.cask.cdap.cli.completer.element;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.completer.StringsCompleter;
 import co.cask.cdap.client.ApplicationClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.ApplicationRecord;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
@@ -48,7 +48,7 @@ public class AppIdCompleter extends StringsCompleter {
           return appIds;
         } catch (IOException e) {
           return Lists.newArrayList();
-        } catch (UnauthorizedException e) {
+        } catch (UnauthenticatedException e) {
           return Lists.newArrayList();
         }
       }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/DatasetModuleNameCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/DatasetModuleNameCompleter.java
@@ -19,7 +19,7 @@ package co.cask.cdap.cli.completer.element;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.completer.StringsCompleter;
 import co.cask.cdap.client.DatasetModuleClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
@@ -54,7 +54,7 @@ public class DatasetModuleNameCompleter extends StringsCompleter {
           );
         } catch (IOException e) {
           return Lists.newArrayList();
-        } catch (UnauthorizedException e) {
+        } catch (UnauthenticatedException e) {
           return Lists.newArrayList();
         }
       }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/DatasetNameCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/DatasetNameCompleter.java
@@ -19,7 +19,7 @@ package co.cask.cdap.cli.completer.element;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.completer.StringsCompleter;
 import co.cask.cdap.client.DatasetClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
@@ -56,7 +56,7 @@ public class DatasetNameCompleter extends StringsCompleter {
           );
         } catch (IOException e) {
           return Lists.newArrayList();
-        } catch (UnauthorizedException e) {
+        } catch (UnauthenticatedException e) {
           return Lists.newArrayList();
         }
       }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/DatasetTypeNameCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/DatasetTypeNameCompleter.java
@@ -19,7 +19,7 @@ package co.cask.cdap.cli.completer.element;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.completer.StringsCompleter;
 import co.cask.cdap.client.DatasetTypeClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
@@ -54,7 +54,7 @@ public class DatasetTypeNameCompleter extends StringsCompleter {
           );
         } catch (IOException e) {
           return Lists.newArrayList();
-        } catch (UnauthorizedException e) {
+        } catch (UnauthenticatedException e) {
           return Lists.newArrayList();
         }
       }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpEndpointPrefixCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpEndpointPrefixCompleter.java
@@ -22,7 +22,7 @@ import co.cask.cdap.cli.ProgramIdArgument;
 import co.cask.cdap.cli.util.ArgumentParser;
 import co.cask.cdap.client.ServiceClient;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.common.cli.completers.PrefixCompleter;
 import com.google.common.collect.Lists;
@@ -76,7 +76,7 @@ public class HttpEndpointPrefixCompleter extends PrefixCompleter {
           httpEndpoints.add(endpoint.getPath());
         }
       }
-    } catch (IOException | NotFoundException | UnauthorizedException ignored) {
+    } catch (IOException | NotFoundException | UnauthenticatedException ignored) {
     }
     return httpEndpoints;
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpMethodPrefixCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpMethodPrefixCompleter.java
@@ -22,7 +22,7 @@ import co.cask.cdap.cli.ProgramIdArgument;
 import co.cask.cdap.cli.util.ArgumentParser;
 import co.cask.cdap.client.ServiceClient;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.common.cli.completers.PrefixCompleter;
 import com.google.common.collect.Lists;
@@ -76,7 +76,7 @@ public class HttpMethodPrefixCompleter extends PrefixCompleter {
           httpMethods.add(method);
         }
       }
-    } catch (IOException | UnauthorizedException | NotFoundException ignored) {
+    } catch (IOException | UnauthenticatedException | NotFoundException ignored) {
     }
     return httpMethods;
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/ProgramIdCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/ProgramIdCompleter.java
@@ -19,7 +19,7 @@ package co.cask.cdap.cli.completer.element;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.completer.StringsCompleter;
 import co.cask.cdap.client.ApplicationClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Supplier;
@@ -49,7 +49,7 @@ public class ProgramIdCompleter extends StringsCompleter {
           return programIds;
         } catch (IOException e) {
           return Lists.newArrayList();
-        } catch (UnauthorizedException e) {
+        } catch (UnauthenticatedException e) {
           return Lists.newArrayList();
         }
       }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/StreamIdCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/StreamIdCompleter.java
@@ -19,7 +19,7 @@ package co.cask.cdap.cli.completer.element;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.completer.StringsCompleter;
 import co.cask.cdap.client.StreamClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.StreamDetail;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
@@ -53,7 +53,7 @@ public class StreamIdCompleter extends StringsCompleter {
           );
         } catch (IOException e) {
           return Lists.newArrayList();
-        } catch (UnauthorizedException e) {
+        } catch (UnauthenticatedException e) {
           return Lists.newArrayList();
         }
       }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/AbstractAuthCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/AbstractAuthCommand.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.cli.util;
 
 import co.cask.cdap.cli.CLIConfig;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
 
@@ -38,7 +38,7 @@ public abstract class AbstractAuthCommand implements Command {
   public void execute(Arguments arguments, PrintStream printStream) throws Exception {
     try {
       perform(arguments, printStream);
-    } catch (UnauthorizedException e) {
+    } catch (UnauthenticatedException e) {
       cliConfig.updateAccessToken(printStream);
       perform(arguments, printStream);
     }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetaClientAvailableTest.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetaClientAvailableTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.client;
 
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.config.ConnectionConfig;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
 import co.cask.http.NettyHttpService;
@@ -80,13 +80,13 @@ public class MetaClientAvailableTest {
   }
 
   @Test
-  public void testAvailable() throws IOException, UnauthorizedException {
+  public void testAvailable() throws IOException, UnauthenticatedException {
     handler.setResponse(HttpResponseStatus.OK, "OK.\n");
     metaClient.ping();
   }
 
   @Test
-  public void testUnavailable() throws IOException, UnauthorizedException {
+  public void testUnavailable() throws IOException, UnauthenticatedException {
     try {
       fakeMetaClient.ping();
       Assert.fail();
@@ -96,7 +96,7 @@ public class MetaClientAvailableTest {
   }
 
   @Test
-  public void testWrongCode() throws UnauthorizedException {
+  public void testWrongCode() throws UnauthenticatedException {
     try {
       handler.setResponse(HttpResponseStatus.CONFLICT, "HI");
       metaClient.ping();
@@ -109,7 +109,7 @@ public class MetaClientAvailableTest {
   }
 
   @Test
-  public void testWrongBody() throws UnauthorizedException {
+  public void testWrongBody() throws UnauthenticatedException {
     try {
       handler.setResponse(HttpResponseStatus.OK, "???");
       metaClient.ping();

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetaClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetaClientTestRun.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.client;
 
 import co.cask.cdap.client.common.ClientTestBase;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.ConfigEntry;
 import co.cask.cdap.proto.Version;
@@ -38,7 +38,7 @@ import java.util.Map;
 public class MetaClientTestRun extends ClientTestBase {
 
   @Test
-  public void testAll() throws IOException, UnauthorizedException {
+  public void testAll() throws IOException, UnauthenticatedException {
     MetaClient metaClient = new MetaClient(clientConfig);
     metaClient.ping();
 

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
@@ -20,7 +20,7 @@ import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import org.junit.Assert;
@@ -170,7 +170,7 @@ public class NamespaceClientTestRun extends ClientTestBase {
     }
   }
 
-  private void waitForNamespaceCreation(Id.Namespace namespace) throws IOException, UnauthorizedException,
+  private void waitForNamespaceCreation(Id.Namespace namespace) throws IOException, UnauthenticatedException,
     InterruptedException {
     int count = 0;
     while (count < 10) {

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamClientTestRun.java
@@ -21,9 +21,8 @@ import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.common.BadRequestException;
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.StreamNotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.StreamProperties;
@@ -88,7 +87,7 @@ public class StreamClientTestRun extends ClientTestBase {
    */
   @Test
   public void testStreamEvents() throws IOException, BadRequestException,
-    StreamNotFoundException, UnauthorizedException {
+    StreamNotFoundException, UnauthenticatedException {
 
     Id.Stream streamId = Id.Stream.from(namespaceId, "testEvents");
     streamClient.create(streamId);

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
@@ -23,7 +23,7 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.config.ConnectionConfig;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.ProgramNotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
@@ -87,7 +87,7 @@ public abstract class ClientTestBase {
   }
 
   protected void assertFlowletInstances(ProgramClient programClient, Id.Flow.Flowlet flowlet, int numInstances)
-    throws IOException, NotFoundException, UnauthorizedException {
+    throws IOException, NotFoundException, UnauthenticatedException {
 
     int actualInstances;
     int numTries = 0;
@@ -100,19 +100,19 @@ public abstract class ClientTestBase {
   }
 
   protected void assertProgramRunning(ProgramClient programClient, Id.Program program)
-    throws IOException, ProgramNotFoundException, UnauthorizedException, InterruptedException {
+    throws IOException, ProgramNotFoundException, UnauthenticatedException, InterruptedException {
 
     assertProgramStatus(programClient, program, "RUNNING");
   }
 
   protected void assertProgramStopped(ProgramClient programClient, Id.Program program)
-    throws IOException, ProgramNotFoundException, UnauthorizedException, InterruptedException {
+    throws IOException, ProgramNotFoundException, UnauthenticatedException, InterruptedException {
 
     assertProgramStatus(programClient, program, "STOPPED");
   }
 
   protected void assertProgramStatus(ProgramClient programClient, Id.Program program, String programStatus)
-    throws IOException, ProgramNotFoundException, UnauthorizedException, InterruptedException {
+    throws IOException, ProgramNotFoundException, UnauthenticatedException, InterruptedException {
 
     try {
       programClient.waitForStatus(program, programStatus, 60, TimeUnit.SECONDS);

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/util/RESTClientTest.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/util/RESTClientTest.java
@@ -18,7 +18,7 @@
 package co.cask.cdap.client.util;
 
 import co.cask.cdap.client.config.ClientConfig;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.security.authentication.client.AccessToken;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
@@ -86,7 +86,7 @@ public class RESTClientTest {
     verifyResponse(response, only(200), any(), only("Access token received: " + ACCESS_TOKEN));
   }
 
-  @Test(expected = UnauthorizedException.class)
+  @Test(expected = UnauthenticatedException.class)
   public void testPostUnauthorizedWithAccessToken() throws Exception {
     URL url = getBaseURI().resolve("/api/testPostAuth").toURL();
     HttpRequest request = HttpRequest.post(url).build();
@@ -101,7 +101,7 @@ public class RESTClientTest {
     verifyResponse(response, only(200), any(), only("Access token received: " + ACCESS_TOKEN));
   }
 
-  @Test(expected = UnauthorizedException.class)
+  @Test(expected = UnauthenticatedException.class)
   public void testPutUnauthorizedWithAccessToken() throws Exception {
     URL url = getBaseURI().resolve("/api/testPutAuth").toURL();
     HttpRequest request = HttpRequest.put(url).build();
@@ -116,7 +116,7 @@ public class RESTClientTest {
     verifyResponse(response, only(200), any(), only("Access token received: " + ACCESS_TOKEN));
   }
 
-  @Test(expected = UnauthorizedException.class)
+  @Test(expected = UnauthenticatedException.class)
   public void testGetUnauthorizedWithAccessToken() throws Exception {
     URL url = getBaseURI().resolve("/api/testGetAuth").toURL();
     HttpRequest request = HttpRequest.get(url).build();
@@ -131,7 +131,7 @@ public class RESTClientTest {
     verifyResponse(response, only(200), any(), only("Access token received: " + ACCESS_TOKEN));
   }
 
-  @Test(expected = UnauthorizedException.class)
+  @Test(expected = UnauthenticatedException.class)
   public void testDeleteUnauthorizedWithAccessToken() throws Exception {
     URL url = getBaseURI().resolve("/api/testDeleteAuth").toURL();
     HttpRequest request = HttpRequest.delete(url).build();

--- a/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
@@ -23,7 +23,7 @@ import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.ApplicationNotFoundException;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.ApplicationRecord;
@@ -88,9 +88,9 @@ public class ApplicationClient {
    * @param namespace the namespace to list applications from
    * @return list of {@link ApplicationRecord ApplicationRecords}.
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public List<ApplicationRecord> list(Id.Namespace namespace) throws IOException, UnauthorizedException {
+  public List<ApplicationRecord> list(Id.Namespace namespace) throws IOException, UnauthenticatedException {
     HttpResponse response = restClient.execute(HttpMethod.GET,
                                                config.resolveNamespacedURLV3(namespace, "apps"),
                                                config.getAccessToken());
@@ -106,11 +106,11 @@ public class ApplicationClient {
    * @param artifactVersion the version of the artifact to filter by. If null, no filtering will be done
    * @return list of {@link ApplicationRecord ApplicationRecords}.
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ApplicationRecord> list(Id.Namespace namespace,
                                       @Nullable String artifactName,
-                                      @Nullable String artifactVersion) throws IOException, UnauthorizedException {
+                                      @Nullable String artifactVersion) throws IOException, UnauthenticatedException {
     Set<String> names = new HashSet<>();
     if (artifactName != null) {
       names.add(artifactName);
@@ -127,11 +127,11 @@ public class ApplicationClient {
    * @param artifactVersion the version of the artifact to filter by. If null, no filtering will be done
    * @return list of {@link ApplicationRecord ApplicationRecords}.
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ApplicationRecord> list(Id.Namespace namespace,
                                       Set<String> artifactNames,
-                                      @Nullable String artifactVersion) throws IOException, UnauthorizedException {
+                                      @Nullable String artifactVersion) throws IOException, UnauthenticatedException {
     if (artifactNames.isEmpty() && artifactVersion == null) {
       return list(namespace);
     }
@@ -159,10 +159,10 @@ public class ApplicationClient {
    * @return details about the specified application
    * @throws ApplicationNotFoundException if the application with the given ID was not found
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public ApplicationDetail get(Id.Application appId)
-    throws ApplicationNotFoundException, IOException, UnauthorizedException {
+    throws ApplicationNotFoundException, IOException, UnauthenticatedException {
 
     HttpResponse response = restClient.execute(HttpMethod.GET,
       config.resolveNamespacedURLV3(appId.getNamespace(), "apps/" + appId.getId()),
@@ -180,9 +180,9 @@ public class ApplicationClient {
    * @param app the application to delete
    * @throws ApplicationNotFoundException if the application with the given ID was not found
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void delete(Id.Application app) throws ApplicationNotFoundException, IOException, UnauthorizedException {
+  public void delete(Id.Application app) throws ApplicationNotFoundException, IOException, UnauthenticatedException {
     HttpResponse response = restClient.execute(HttpMethod.DELETE,
                                                config.resolveNamespacedURLV3(app.getNamespace(), "apps/" + app.getId()),
                                                config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
@@ -195,9 +195,9 @@ public class ApplicationClient {
    * Deletes all applications in a namespace.
    *
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void deleteAll(Id.Namespace namespace) throws IOException, UnauthorizedException {
+  public void deleteAll(Id.Namespace namespace) throws IOException, UnauthenticatedException {
     restClient.execute(HttpMethod.DELETE, config.resolveNamespacedURLV3(namespace, "apps"), config.getAccessToken());
   }
 
@@ -207,9 +207,9 @@ public class ApplicationClient {
    * @param app the application to check
    * @return true if the application exists
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public boolean exists(Id.Application app) throws IOException, UnauthorizedException {
+  public boolean exists(Id.Application app) throws IOException, UnauthenticatedException {
     HttpResponse response = restClient.execute(HttpMethod.GET,
                                                config.resolveNamespacedURLV3(app.getNamespace(), "apps/" + app.getId()),
                                                config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
@@ -223,12 +223,12 @@ public class ApplicationClient {
    * @param timeout time to wait before timing out
    * @param timeoutUnit time unit of timeout
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws TimeoutException if the application was not yet deployed before {@code timeout} milliseconds
    * @throws InterruptedException if interrupted while waiting
    */
   public void waitForDeployed(final Id.Application app, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthorizedException, TimeoutException, InterruptedException {
+    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
 
     try {
       Tasks.waitFor(true, new Callable<Boolean>() {
@@ -238,7 +238,7 @@ public class ApplicationClient {
         }
       }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthorizedException.class);
+      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
     }
   }
 
@@ -249,12 +249,12 @@ public class ApplicationClient {
    * @param timeout time to wait before timing out
    * @param timeoutUnit time unit of timeout
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws TimeoutException if the application was not yet deleted before {@code timeout} milliseconds
    * @throws InterruptedException if interrupted while waiting
    */
   public void waitForDeleted(final Id.Application app, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthorizedException, TimeoutException, InterruptedException {
+    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
 
     try {
       Tasks.waitFor(false, new Callable<Boolean>() {
@@ -264,7 +264,7 @@ public class ApplicationClient {
         }
       }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthorizedException.class);
+      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
     }
   }
 
@@ -274,7 +274,7 @@ public class ApplicationClient {
    * @param jarFile jar file of the application to deploy
    * @throws IOException if a network error occurred
    */
-  public void deploy(Id.Namespace namespace, File jarFile) throws IOException, UnauthorizedException {
+  public void deploy(Id.Namespace namespace, File jarFile) throws IOException, UnauthenticatedException {
     Map<String, String> headers = ImmutableMap.of("X-Archive-Name", jarFile.getName());
     deployApp(namespace, jarFile, headers);
   }
@@ -286,9 +286,10 @@ public class ApplicationClient {
    * @param jarFile jar file of the application to deploy
    * @param appConfig serialized application configuration
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void deploy(Id.Namespace namespace, File jarFile, String appConfig) throws IOException, UnauthorizedException {
+  public void deploy(Id.Namespace namespace, File jarFile,
+                     String appConfig) throws IOException, UnauthenticatedException {
     Map<String, String> headers = ImmutableMap.of("X-Archive-Name", jarFile.getName(),
                                                   "X-App-Config", appConfig);
     deployApp(namespace, jarFile, headers);
@@ -301,9 +302,10 @@ public class ApplicationClient {
    * @param jarFile jar file of the application to deploy
    * @param appConfig application configuration object
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void deploy(Id.Namespace namespace, File jarFile, Config appConfig) throws IOException, UnauthorizedException {
+  public void deploy(Id.Namespace namespace, File jarFile,
+                     Config appConfig) throws IOException, UnauthenticatedException {
     deploy(namespace, jarFile, GSON.toJson(appConfig));
   }
 
@@ -313,10 +315,10 @@ public class ApplicationClient {
    * @param appId the id of the application to add
    * @param createRequest the request body, which contains the artifact to use and any application config
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void deploy(Id.Application appId,
-                     AppRequest<?> createRequest) throws IOException, UnauthorizedException {
+                     AppRequest<?> createRequest) throws IOException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(appId.getNamespace(), "apps/" + appId.getId());
     HttpRequest request = HttpRequest.put(url)
       .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
@@ -331,12 +333,12 @@ public class ApplicationClient {
    * @param appId the id of the application to update
    * @param updateRequest the request to update the application with
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the app or requested artifact could not be found
    * @throws BadRequestException if the request is invalid
    */
   public void update(Id.Application appId, AppRequest<?> updateRequest)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
 
     URL url = config.resolveNamespacedURLV3(appId.getNamespace(), String.format("apps/%s/update", appId.getId()));
     HttpRequest request = HttpRequest.post(url)
@@ -355,7 +357,7 @@ public class ApplicationClient {
   }
 
   private void deployApp(Id.Namespace namespace, File jarFile, Map<String, String> headers)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(namespace, "apps");
     HttpRequest request = HttpRequest.post(url)
       .addHeaders(headers)
@@ -370,10 +372,10 @@ public class ApplicationClient {
    * @param programType type of the programs to list
    * @return list of {@link ProgramRecord}s
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ProgramRecord> listAllPrograms(Id.Namespace namespace, ProgramType programType)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     Preconditions.checkArgument(programType.isListable());
 
@@ -392,10 +394,10 @@ public class ApplicationClient {
    *
    * @return list of {@link ProgramRecord}s
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public Map<ProgramType, List<ProgramRecord>> listAllPrograms(Id.Namespace namespace)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     ImmutableMap.Builder<ProgramType, List<ProgramRecord>> allPrograms = ImmutableMap.builder();
     for (ProgramType programType : ProgramType.values()) {
@@ -416,10 +418,10 @@ public class ApplicationClient {
    * @return list of {@link ProgramRecord}s
    * @throws ApplicationNotFoundException if the application with the given ID was not found
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ProgramRecord> listPrograms(Id.Application app, ProgramType programType)
-    throws ApplicationNotFoundException, IOException, UnauthorizedException {
+    throws ApplicationNotFoundException, IOException, UnauthenticatedException {
 
     Preconditions.checkArgument(programType.isListable());
 
@@ -439,10 +441,10 @@ public class ApplicationClient {
    * @return Map of {@link ProgramType} to list of {@link ProgramRecord}s
    * @throws ApplicationNotFoundException if the application with the given ID was not found
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public Map<ProgramType, List<ProgramRecord>> listProgramsByType(Id.Application app)
-    throws ApplicationNotFoundException, IOException, UnauthorizedException {
+    throws ApplicationNotFoundException, IOException, UnauthenticatedException {
 
     Map<ProgramType, List<ProgramRecord>> result = Maps.newHashMap();
     for (ProgramType type : ProgramType.values()) {
@@ -461,10 +463,10 @@ public class ApplicationClient {
    * @return List of all {@link ProgramRecord}s
    * @throws ApplicationNotFoundException if the application with the given ID was not found
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ProgramRecord> listPrograms(Id.Application app)
-    throws ApplicationNotFoundException, IOException, UnauthorizedException {
+    throws ApplicationNotFoundException, IOException, UnauthenticatedException {
 
     String path = String.format("apps/%s", app.getId());
     URL url = config.resolveNamespacedURLV3(app.getNamespace(), path);

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -27,7 +27,7 @@ import co.cask.cdap.common.ArtifactNotFoundException;
 import co.cask.cdap.common.ArtifactRangeNotFoundException;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ApplicationClassInfo;
@@ -51,7 +51,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -94,11 +93,11 @@ public class ArtifactClient {
    * @param namespace the namespace to list artifacts in
    * @return list of {@link ArtifactSummary}
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the namespace could not be found
    */
   public List<ArtifactSummary> list(Id.Namespace namespace)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
     return list(namespace, null);
   }
 
@@ -109,11 +108,11 @@ public class ArtifactClient {
    * @param scope the scope of the artifacts to get. If null, both user and system artifacts are listed
    * @return list of {@link ArtifactSummary}
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the namespace could not be found
    */
   public List<ArtifactSummary> list(Id.Namespace namespace, @Nullable ArtifactScope scope)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     URL url = scope == null ? config.resolveNamespacedURLV3(namespace, "artifacts") :
       config.resolveNamespacedURLV3(namespace, String.format("artifacts?scope=%s", scope.name()));
@@ -133,11 +132,11 @@ public class ArtifactClient {
    * @param artifactName the name of the artifact
    * @return list of {@link ArtifactSummary}
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ArtifactNotFoundException if the given artifact does not exist
    */
   public List<ArtifactSummary> listVersions(Id.Namespace namespace, String artifactName)
-    throws UnauthorizedException, IOException, ArtifactNotFoundException {
+    throws UnauthenticatedException, IOException, ArtifactNotFoundException {
     return listVersions(namespace, artifactName, null);
   }
 
@@ -149,11 +148,11 @@ public class ArtifactClient {
    * @param scope the scope of artifacts to get. If none is given, the scope defaults to the user scope
    * @return list of {@link ArtifactSummary}
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ArtifactNotFoundException if the given artifact does not exist
    */
   public List<ArtifactSummary> listVersions(Id.Namespace namespace, String artifactName, @Nullable ArtifactScope scope)
-    throws UnauthorizedException, IOException, ArtifactNotFoundException {
+    throws UnauthenticatedException, IOException, ArtifactNotFoundException {
 
     URL url = scope == null ? config.resolveNamespacedURLV3(namespace, String.format("artifacts/%s", artifactName)) :
       config.resolveNamespacedURLV3(namespace, String.format("artifacts/%s?scope=%s", artifactName, scope.name()));
@@ -172,11 +171,11 @@ public class ArtifactClient {
    * @param artifactId the id of the artifact to get
    * @return information about the given artifact
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ArtifactNotFoundException if the given artifact does not exist
    */
   public ArtifactInfo getArtifactInfo(Id.Artifact artifactId)
-    throws IOException, UnauthorizedException, ArtifactNotFoundException {
+    throws IOException, UnauthenticatedException, ArtifactNotFoundException {
     return getArtifactInfo(artifactId, ArtifactScope.USER);
   }
 
@@ -187,11 +186,11 @@ public class ArtifactClient {
    * @param scope the scope of the artifact
    * @return information about the given artifact
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ArtifactNotFoundException if the given artifact does not exist
    */
   public ArtifactInfo getArtifactInfo(Id.Artifact artifactId, ArtifactScope scope)
-    throws IOException, UnauthorizedException, ArtifactNotFoundException {
+    throws IOException, UnauthenticatedException, ArtifactNotFoundException {
 
     String path = String.format("artifacts/%s/versions/%s?scope=%s",
       artifactId.getName(), artifactId.getVersion().getVersion(), scope.name());
@@ -211,10 +210,10 @@ public class ArtifactClient {
    * @param namespace the namespace to list application classes from
    * @return summaries of all application classes in the given namespace, including classes from system artifacts
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ApplicationClassSummary> getApplicationClasses(Id.Namespace namespace)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
     return getApplicationClasses(namespace, (ArtifactScope) null);
   }
 
@@ -226,11 +225,11 @@ public class ArtifactClient {
    * @param scope the scope to list application classes in. If null, classes from all scopes are returned
    * @return summaries of all application classes in the given namespace, including classes from system artifacts
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ApplicationClassSummary> getApplicationClasses(Id.Namespace namespace,
                                                              @Nullable ArtifactScope scope)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     String path = scope == null ? "classes/apps" : String.format("classes/apps?scope=%s", scope.name());
     URL url = config.resolveNamespacedURLV3(namespace, path);
@@ -246,10 +245,10 @@ public class ArtifactClient {
    * @param namespace the namespace to list application classes from
    * @return summaries of all application classes in the given namespace, including classes from system artifacts
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ApplicationClassInfo> getApplicationClasses(Id.Namespace namespace, String className)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
     return getApplicationClasses(namespace, className, ArtifactScope.USER);
   }
 
@@ -260,10 +259,10 @@ public class ArtifactClient {
    * @param scope the scope to list application classes in
    * @return summaries of all application classes in the given namespace, including classes from system artifacts
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ApplicationClassInfo> getApplicationClasses(Id.Namespace namespace, String className, ArtifactScope scope)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     String path = String.format("classes/apps/%s?scope=%s", className, scope.name());
     URL url = config.resolveNamespacedURLV3(namespace, path);
@@ -280,10 +279,10 @@ public class ArtifactClient {
    * @return list of plugin types available to the given artifact.
    * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<String> getPluginTypes(Id.Artifact artifactId)
-    throws IOException, UnauthorizedException, ArtifactNotFoundException {
+    throws IOException, UnauthenticatedException, ArtifactNotFoundException {
     return getPluginTypes(artifactId, ArtifactScope.USER);
   }
 
@@ -295,10 +294,10 @@ public class ArtifactClient {
    * @return list of plugin types available to the given artifact.
    * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<String> getPluginTypes(Id.Artifact artifactId, ArtifactScope scope)
-    throws IOException, UnauthorizedException, ArtifactNotFoundException {
+    throws IOException, UnauthenticatedException, ArtifactNotFoundException {
 
     String path = String.format("artifacts/%s/versions/%s/extensions?scope=%s",
       artifactId.getName(), artifactId.getVersion().getVersion(), scope.name());
@@ -320,10 +319,10 @@ public class ArtifactClient {
    * @return list of {@link PluginSummary}
    * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<PluginSummary> getPluginSummaries(Id.Artifact artifactId, String pluginType)
-    throws IOException, UnauthorizedException, ArtifactNotFoundException {
+    throws IOException, UnauthenticatedException, ArtifactNotFoundException {
     return getPluginSummaries(artifactId, pluginType, ArtifactScope.USER);
   }
 
@@ -336,10 +335,10 @@ public class ArtifactClient {
    * @return list of {@link PluginSummary}
    * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<PluginSummary> getPluginSummaries(Id.Artifact artifactId, String pluginType, ArtifactScope scope)
-    throws IOException, UnauthorizedException, ArtifactNotFoundException {
+    throws IOException, UnauthenticatedException, ArtifactNotFoundException {
 
     String path = String.format("artifacts/%s/versions/%s/extensions/%s?scope=%s",
       artifactId.getName(), artifactId.getVersion().getVersion(), pluginType, scope.name());
@@ -362,10 +361,10 @@ public class ArtifactClient {
    * @return list of {@link PluginInfo}
    * @throws NotFoundException if the given artifact does not exist or plugins for that artifact do not exist
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<PluginInfo> getPluginInfo(Id.Artifact artifactId, String pluginType, String pluginName)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
     return getPluginInfo(artifactId, pluginType, pluginName, ArtifactScope.USER);
   }
 
@@ -379,11 +378,11 @@ public class ArtifactClient {
    * @return list of {@link PluginInfo}
    * @throws NotFoundException if the given artifact does not exist or plugins for that artifact do not exist
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<PluginInfo> getPluginInfo(Id.Artifact artifactId, String pluginType, String pluginName,
                                         ArtifactScope scope)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     String path = String.format("artifacts/%s/versions/%s/extensions/%s/plugins/%s?scope=%s",
       artifactId.getName(), artifactId.getVersion().getVersion(), pluginType, pluginName, scope.name());
@@ -407,11 +406,11 @@ public class ArtifactClient {
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
    * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void add(Id.Artifact artifactId, @Nullable Set<ArtifactRange> parentArtifacts,
                   InputSupplier<? extends InputStream> artifactContents)
-    throws UnauthorizedException, BadRequestException, ArtifactRangeNotFoundException,
+    throws UnauthenticatedException, BadRequestException, ArtifactRangeNotFoundException,
     ArtifactAlreadyExistsException, IOException {
 
     add(artifactId.getNamespace(), artifactId.getName(), artifactContents,
@@ -430,13 +429,13 @@ public class ArtifactClient {
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
    * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void add(Id.Namespace namespace, String artifactName,
                   InputSupplier<? extends InputStream> artifactContents,
                   @Nullable String artifactVersion)
     throws ArtifactAlreadyExistsException, BadRequestException, IOException,
-    UnauthorizedException, ArtifactRangeNotFoundException {
+    UnauthenticatedException, ArtifactRangeNotFoundException {
 
     add(namespace, artifactName, artifactContents, artifactVersion, null, null);
   }
@@ -454,12 +453,12 @@ public class ArtifactClient {
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
    * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void add(Id.Namespace namespace, String artifactName, InputSupplier<? extends InputStream> artifactContents,
                   @Nullable String artifactVersion, @Nullable Set<ArtifactRange> parentArtifacts)
     throws ArtifactAlreadyExistsException, BadRequestException, IOException,
-    UnauthorizedException, ArtifactRangeNotFoundException {
+    UnauthenticatedException, ArtifactRangeNotFoundException {
 
     add(namespace, artifactName, artifactContents, artifactVersion, parentArtifacts, null);
   }
@@ -481,7 +480,7 @@ public class ArtifactClient {
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
    * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void add(Id.Namespace namespace, String artifactName,
                   InputSupplier<? extends InputStream> artifactContents,
@@ -489,7 +488,7 @@ public class ArtifactClient {
                   @Nullable Set<ArtifactRange> parentArtifacts,
                   @Nullable Set<PluginClass> additionalPlugins)
     throws ArtifactAlreadyExistsException, BadRequestException, IOException,
-    UnauthorizedException, ArtifactRangeNotFoundException {
+    UnauthenticatedException, ArtifactRangeNotFoundException {
 
     URL url = config.resolveNamespacedURLV3(namespace, String.format("artifacts/%s", artifactName));
     HttpRequest.Builder requestBuilder = HttpRequest.post(url);
@@ -524,9 +523,9 @@ public class ArtifactClient {
    *
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void delete(Id.Artifact artifactId) throws IOException, UnauthorizedException, BadRequestException {
+  public void delete(Id.Artifact artifactId) throws IOException, UnauthenticatedException, BadRequestException {
     URL url = config.resolveNamespacedURLV3(artifactId.getNamespace(),
       String.format("artifacts/%s/versions/%s", artifactId.getName(), artifactId.getVersion().getVersion()));
 
@@ -546,12 +545,12 @@ public class ArtifactClient {
    * @param artifactId the artifact to add properties to
    * @param properties the properties to add
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ArtifactNotFoundException if the artifact does not exist
    * @throws IOException if a network error occurred
    */
   public void writeProperties(Id.Artifact artifactId, Map<String, String> properties)
-    throws IOException, UnauthorizedException, ArtifactNotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, ArtifactNotFoundException, BadRequestException {
     String path = String.format("artifacts/%s/versions/%s/properties",
                                 artifactId.getName(),
                                 artifactId.getVersion().getVersion());
@@ -575,12 +574,12 @@ public class ArtifactClient {
    *
    * @param artifactId the artifact to delete properties from
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ArtifactNotFoundException if the artifact does not exist
    * @throws IOException if a network error occurred
    */
   public void deleteProperties(Id.Artifact artifactId)
-    throws IOException, UnauthorizedException, ArtifactNotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, ArtifactNotFoundException, BadRequestException {
     String path = String.format("artifacts/%s/versions/%s/properties",
                                 artifactId.getName(),
                                 artifactId.getVersion().getVersion());
@@ -607,12 +606,12 @@ public class ArtifactClient {
    * @param key the property key to write
    * @param value the property value to write
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ArtifactNotFoundException if the artifact does not exist
    * @throws IOException if a network error occurred
    */
   public void writeProperty(Id.Artifact artifactId, String key, String value)
-    throws IOException, UnauthorizedException, ArtifactNotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, ArtifactNotFoundException, BadRequestException {
     String path = String.format("artifacts/%s/versions/%s/properties/%s",
                                 artifactId.getName(),
                                 artifactId.getVersion().getVersion(),
@@ -638,12 +637,12 @@ public class ArtifactClient {
    * @param artifactId the artifact to delete a property from
    * @param key the property to delete
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ArtifactNotFoundException if the artifact does not exist
    * @throws IOException if a network error occurred
    */
   public void deleteProperty(Id.Artifact artifactId, String key)
-    throws IOException, UnauthorizedException, ArtifactNotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, ArtifactNotFoundException, BadRequestException {
     String path = String.format("artifacts/%s/versions/%s/properties/%s",
                                 artifactId.getName(),
                                 artifactId.getVersion().getVersion(),

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetClient.java
@@ -23,7 +23,7 @@ import co.cask.cdap.common.DatasetAlreadyExistsException;
 import co.cask.cdap.common.DatasetNotFoundException;
 import co.cask.cdap.common.DatasetTypeNotFoundException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetMeta;
@@ -76,9 +76,9 @@ public class DatasetClient {
    *
    * @return list of {@link DatasetSpecificationSummary}.
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public List<DatasetSpecificationSummary> list(Id.Namespace namespace) throws IOException, UnauthorizedException {
+  public List<DatasetSpecificationSummary> list(Id.Namespace namespace) throws IOException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(namespace, "data/datasets");
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response,
@@ -93,10 +93,10 @@ public class DatasetClient {
    * @return a {@link DatasetSpecificationSummary}.
    * @throws NotFoundException if the dataset is not found
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public DatasetMeta get(Id.DatasetInstance instance)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     URL url = config.resolveNamespacedURLV3(instance.getNamespace(),
                                             String.format("data/datasets/%s", instance.getId()));
@@ -115,10 +115,10 @@ public class DatasetClient {
    * @throws DatasetTypeNotFoundException if the desired dataset type was not found
    * @throws DatasetAlreadyExistsException if a dataset by the same name already exists
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void create(Id.DatasetInstance instance, DatasetInstanceConfiguration properties)
-    throws DatasetTypeNotFoundException, DatasetAlreadyExistsException, IOException, UnauthorizedException {
+    throws DatasetTypeNotFoundException, DatasetAlreadyExistsException, IOException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(instance.getNamespace(),
                                             String.format("data/datasets/%s", instance.getId()));
@@ -141,10 +141,10 @@ public class DatasetClient {
    * @throws DatasetTypeNotFoundException if the desired dataset type was not found
    * @throws DatasetAlreadyExistsException if a dataset by the same name already exists
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void create(Id.DatasetInstance instance, String typeName)
-    throws DatasetTypeNotFoundException, DatasetAlreadyExistsException, IOException, UnauthorizedException {
+    throws DatasetTypeNotFoundException, DatasetAlreadyExistsException, IOException, UnauthenticatedException {
     create(instance, new DatasetInstanceConfiguration(typeName, ImmutableMap.<String, String>of()));
   }
 
@@ -155,10 +155,10 @@ public class DatasetClient {
    * @param properties properties to set
    * @throws NotFoundException if the dataset is not found
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void update(Id.DatasetInstance instance, Map<String, String> properties)
-    throws NotFoundException, IOException, UnauthorizedException {
+    throws NotFoundException, IOException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(instance.getNamespace(),
                                             String.format("data/datasets/%s/properties", instance.getId()));
     HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(properties)).build();
@@ -177,10 +177,10 @@ public class DatasetClient {
    * @param properties properties to set
    * @throws NotFoundException if the dataset is not found
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void updateExisting(Id.DatasetInstance instance, Map<String, String> properties)
-    throws NotFoundException, IOException, UnauthorizedException {
+    throws NotFoundException, IOException, UnauthenticatedException {
 
     DatasetMeta meta = get(instance);
     Map<String, String> existingProperties = meta.getSpec().getProperties();
@@ -198,9 +198,10 @@ public class DatasetClient {
    * @param instance the dataset to delete
    * @throws DatasetNotFoundException if the dataset with the specified name could not be found
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void delete(Id.DatasetInstance instance) throws DatasetNotFoundException, IOException, UnauthorizedException {
+  public void delete(Id.DatasetInstance instance)
+    throws DatasetNotFoundException, IOException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(instance.getNamespace(),
                                             String.format("data/datasets/%s", instance.getId()));
     HttpResponse response = restClient.execute(HttpMethod.DELETE, url, config.getAccessToken(),
@@ -216,9 +217,9 @@ public class DatasetClient {
    * @param instance the dataset to check
    * @return true if the dataset exists
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public boolean exists(Id.DatasetInstance instance) throws IOException, UnauthorizedException {
+  public boolean exists(Id.DatasetInstance instance) throws IOException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(instance.getNamespace(),
                                             String.format("data/datasets/%s", instance.getId()));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
@@ -233,12 +234,12 @@ public class DatasetClient {
    * @param timeout time to wait before timing out
    * @param timeoutUnit time unit of timeout
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws TimeoutException if the dataset was not yet existent before {@code timeout} milliseconds
    * @throws InterruptedException if interrupted while waiting
    */
   public void waitForExists(final Id.DatasetInstance instance, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthorizedException, TimeoutException, InterruptedException {
+    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
 
     try {
       Tasks.waitFor(true, new Callable<Boolean>() {
@@ -248,7 +249,7 @@ public class DatasetClient {
         }
       }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthorizedException.class);
+      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
     }
   }
 
@@ -259,12 +260,12 @@ public class DatasetClient {
    * @param timeout time to wait before timing out
    * @param timeoutUnit time unit of timeout
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws TimeoutException if the dataset was not yet deleted before {@code timeout} milliseconds
    * @throws InterruptedException if interrupted while waiting
    */
   public void waitForDeleted(final Id.DatasetInstance instance, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthorizedException, TimeoutException, InterruptedException {
+    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
 
     try {
       Tasks.waitFor(false, new Callable<Boolean>() {
@@ -274,7 +275,7 @@ public class DatasetClient {
         }
       }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthorizedException.class);
+      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
     }
   }
 
@@ -283,9 +284,9 @@ public class DatasetClient {
    *
    * @param instance the dataset to truncate
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void truncate(Id.DatasetInstance instance) throws IOException, UnauthorizedException {
+  public void truncate(Id.DatasetInstance instance) throws IOException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(instance.getNamespace(),
                                             String.format("data/datasets/%s/admin/truncate", instance.getId()));
     restClient.execute(HttpMethod.POST, url, config.getAccessToken());
@@ -297,7 +298,7 @@ public class DatasetClient {
    * @return the properties as a map
    */
   public Map<String, String> getProperties(Id.DatasetInstance instance)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
     URL url = config.resolveNamespacedURLV3(instance.getNamespace(),
                                             String.format("data/datasets/%s/properties", instance.getId()));
     HttpRequest request = HttpRequest.get(url).build();

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetTypeClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetTypeClient.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.DatasetTypeNotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
@@ -64,9 +64,9 @@ public class DatasetTypeClient {
    *
    * @return list of {@link DatasetTypeMeta}s.
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public List<DatasetTypeMeta> list(Id.Namespace namespace) throws IOException, UnauthorizedException {
+  public List<DatasetTypeMeta> list(Id.Namespace namespace) throws IOException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(namespace, "data/types");
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, new TypeToken<List<DatasetTypeMeta>>() { }).getResponseObject();
@@ -79,10 +79,10 @@ public class DatasetTypeClient {
    * @return {@link DatasetTypeMeta} of the dataset type
    * @throws DatasetTypeNotFoundException if the dataset type could not be found
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public DatasetTypeMeta get(Id.DatasetType type)
-    throws DatasetTypeNotFoundException, IOException, UnauthorizedException {
+    throws DatasetTypeNotFoundException, IOException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(type.getNamespace(), String.format("data/types/%s", type.getId()));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
@@ -100,10 +100,10 @@ public class DatasetTypeClient {
    * @param type the dataset type to check
    * @return true if the dataset type exists
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public boolean exists(Id.DatasetType type)
-    throws DatasetTypeNotFoundException, IOException, UnauthorizedException {
+    throws DatasetTypeNotFoundException, IOException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(type.getNamespace(), String.format("data/types/%s", type.getId()));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -117,12 +117,12 @@ public class DatasetTypeClient {
    * @param timeout time to wait before timing out
    * @param timeoutUnit time unit of timeout
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws TimeoutException if the dataset type was not yet existent before {@code timeout} milliseconds
    * @throws InterruptedException if interrupted while waiting
    */
   public void waitForExists(final Id.DatasetType type, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthorizedException, TimeoutException, InterruptedException {
+    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
 
     try {
       Tasks.waitFor(true, new Callable<Boolean>() {
@@ -132,7 +132,7 @@ public class DatasetTypeClient {
         }
       }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthorizedException.class);
+      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
     }
   }
 
@@ -143,12 +143,12 @@ public class DatasetTypeClient {
    * @param timeout time to wait before timing out
    * @param timeoutUnit time unit of timeout
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws TimeoutException if the dataset type was not yet deleted before {@code timeout} milliseconds
    * @throws InterruptedException if interrupted while waiting
    */
   public void waitForDeleted(final Id.DatasetType type, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthorizedException, TimeoutException, InterruptedException {
+    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
 
     try {
       Tasks.waitFor(false, new Callable<Boolean>() {
@@ -158,7 +158,7 @@ public class DatasetTypeClient {
         }
       }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthorizedException.class);
+      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
     }
   }
 

--- a/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
@@ -20,7 +20,7 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
@@ -68,7 +68,7 @@ public class LineageClient {
    */
   public LineageRecord getLineage(Id.DatasetInstance datasetInstance, long startTime, long endTime,
                                   @Nullable Integer levels)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getLineage(datasetInstance, Long.toString(startTime), Long.toString(endTime), levels);
   }
 
@@ -83,7 +83,7 @@ public class LineageClient {
    */
   public LineageRecord getLineage(Id.DatasetInstance datasetInstance, String startTime, String endTime,
                                   @Nullable Integer levels)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     String path = String.format("datasets/%s/lineage?start=%s&end=%s", datasetInstance.getId(),
                                 URLEncoder.encode(startTime, "UTF-8"), URLEncoder.encode(endTime, "UTF-8"));
     if (levels != null) {
@@ -102,7 +102,7 @@ public class LineageClient {
    * @return {@link LineageRecord} for the specified stream.
    */
   public LineageRecord getLineage(Id.Stream streamId, long startTime, long endTime, @Nullable Integer levels)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getLineage(streamId, Long.toString(startTime), Long.toString(endTime), levels);
   }
 
@@ -116,7 +116,7 @@ public class LineageClient {
    * @return {@link LineageRecord} for the specified stream.
    */
   public LineageRecord getLineage(Id.Stream streamId, String startTime, String endTime, @Nullable Integer levels)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     String path = String.format("streams/%s/lineage?start=%s&end=%s", streamId.getId(),
                                 URLEncoder.encode(startTime, "UTF-8"), URLEncoder.encode(endTime, "UTF-8"));
     if (levels != null) {
@@ -126,7 +126,7 @@ public class LineageClient {
   }
 
   private LineageRecord getLineage(Id.NamespacedId namespacedId, String path)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     URL lineageURL = config.resolveNamespacedURLV3(namespacedId.getNamespace(), path);
     HttpResponse response = restClient.execute(HttpRequest.get(lineageURL).build(),
                                                config.getAccessToken(),

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetaClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetaClient.java
@@ -19,7 +19,7 @@ package co.cask.cdap.client;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.ConfigEntry;
 import co.cask.cdap.proto.Version;
 import co.cask.common.http.HttpMethod;
@@ -53,7 +53,7 @@ public class MetaClient {
     this(config, new RESTClient(config));
   }
 
-  public void ping() throws IOException, UnauthorizedException {
+  public void ping() throws IOException, UnauthenticatedException {
     HttpResponse response = restClient.execute(
       HttpMethod.GET, config.resolveURLNoVersion("ping"), config.getAccessToken());
     if (!Objects.equals(response.getResponseBodyAsString(), "OK.\n")) {
@@ -61,20 +61,20 @@ public class MetaClient {
     }
   }
 
-  public Version getVersion() throws IOException, UnauthorizedException {
+  public Version getVersion() throws IOException, UnauthenticatedException {
     HttpResponse response = restClient.execute(HttpMethod.GET, config.resolveURL("version"), config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, Version.class).getResponseObject();
   }
 
-  public Map<String, ConfigEntry> getCDAPConfig() throws IOException, UnauthorizedException {
+  public Map<String, ConfigEntry> getCDAPConfig() throws IOException, UnauthenticatedException {
     return getConfig("config/cdap");
   }
 
-  public Map<String, ConfigEntry> getHadoopConfig() throws IOException, UnauthorizedException {
+  public Map<String, ConfigEntry> getHadoopConfig() throws IOException, UnauthenticatedException {
     return getConfig("config/hadoop");
   }
 
-  private Map<String, ConfigEntry> getConfig(String url) throws IOException, UnauthorizedException {
+  private Map<String, ConfigEntry> getConfig(String url) throws IOException, UnauthenticatedException {
     HttpResponse response = restClient.execute(HttpMethod.GET, config.resolveURL(url), config.getAccessToken());
     List<ConfigEntry> responseObject =
       ObjectResponse.fromJsonBody(response, new TypeToken<List<ConfigEntry>>() { }).getResponseObject();

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
@@ -20,7 +20,7 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
 import co.cask.cdap.proto.metadata.MetadataRecord;
@@ -79,7 +79,7 @@ public class MetadataClient {
    */
   public Set<MetadataSearchResultRecord> searchMetadata(Id.Namespace namespace, String query,
                                                         @Nullable MetadataSearchTargetType target)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     String path = String.format("metadata/search?query=%s", query);
     if (target != null) {
@@ -97,7 +97,7 @@ public class MetadataClient {
    * @return The metadata for the entity.
    */
   public Set<MetadataRecord> getMetadata(Id id)
-    throws UnauthorizedException, BadRequestException, NotFoundException, IOException {
+    throws UnauthenticatedException, BadRequestException, NotFoundException, IOException {
     return getMetadata(id, null);
   }
 
@@ -108,7 +108,7 @@ public class MetadataClient {
    * @return The metadata for the entity.
    */
   public Set<MetadataRecord> getMetadata(Id id, @Nullable MetadataScope scope)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
 
     if (id instanceof Id.Application) {
       return getMetadata((Id.Application) id, scope);
@@ -135,7 +135,7 @@ public class MetadataClient {
    * @return The metadata properties for the entity.
    */
   public Map<String, String> getProperties(Id id)
-    throws UnauthorizedException, BadRequestException, NotFoundException, IOException {
+    throws UnauthenticatedException, BadRequestException, NotFoundException, IOException {
     return getProperties(id, null);
   }
 
@@ -146,7 +146,7 @@ public class MetadataClient {
    * @return The metadata properties for the entity.
    */
   public Map<String, String> getProperties(Id id, @Nullable MetadataScope scope)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
 
     if (id instanceof Id.Application) {
       return getProperties((Id.Application) id, scope);
@@ -170,7 +170,8 @@ public class MetadataClient {
    * {@link MetadataScope#USER}
    * @return The metadata tags for the entity.
    */
-  public Set<String> getTags(Id id) throws UnauthorizedException, BadRequestException, NotFoundException, IOException {
+  public Set<String> getTags(Id id)
+    throws UnauthenticatedException, BadRequestException, NotFoundException, IOException {
     return getTags(id, null);
   }
 
@@ -181,7 +182,7 @@ public class MetadataClient {
    * @return The metadata tags for the entity.
    */
   public Set<String> getTags(Id id, @Nullable MetadataScope scope)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
 
     if (id instanceof Id.Application) {
       return getTags((Id.Application) id, scope);
@@ -205,7 +206,7 @@ public class MetadataClient {
    * @param properties the metadata properties
    */
   public void addProperties(Id id, Map<String, String> properties)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
 
     if (id instanceof Id.Application) {
       addProperties((Id.Application) id, properties);
@@ -229,7 +230,7 @@ public class MetadataClient {
    * @param tags the metadata tags
    */
   public void addTags(Id id, Set<String> tags)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
 
     if (id instanceof Id.Application) {
       addTags((Id.Application) id, tags);
@@ -252,7 +253,7 @@ public class MetadataClient {
    * @param id the entity for which to remove metadata
    */
   public void removeMetadata(Id id)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
 
     if (id instanceof Id.Application) {
       removeMetadata((Id.Application) id);
@@ -275,7 +276,7 @@ public class MetadataClient {
    * @param id the entity for which to remove metadata properties
    */
   public void removeProperties(Id id)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
 
     if (id instanceof Id.Application) {
       removeProperties((Id.Application) id);
@@ -298,7 +299,7 @@ public class MetadataClient {
    * @param id the entity for which to remove metadata tags
    */
   public void removeTags(Id id)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
 
     if (id instanceof Id.Application) {
       removeTags((Id.Application) id);
@@ -322,7 +323,7 @@ public class MetadataClient {
    * @param property the property to remove
    */
   public void removeProperty(Id id, String property)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
 
     if (id instanceof Id.Application) {
       removeProperty((Id.Application) id, property);
@@ -346,7 +347,7 @@ public class MetadataClient {
    * @param tag the tag to remove
    */
   public void removeTag(Id id, String tag)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
 
     if (id instanceof Id.Application) {
       removeTag((Id.Application) id, tag);
@@ -372,7 +373,7 @@ public class MetadataClient {
    * @return The metadata for the application.
    */
   public Set<MetadataRecord> getMetadata(Id.Application appId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return doGetMetadata(appId, constructPath(appId), scope);
   }
 
@@ -381,7 +382,7 @@ public class MetadataClient {
    * @return The metadata for the artifact.
    */
   public Set<MetadataRecord> getMetadata(Id.Artifact artifactId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return doGetMetadata(artifactId, constructPath(artifactId), scope);
   }
 
@@ -390,7 +391,7 @@ public class MetadataClient {
    * @return The metadata for the dataset.
    */
   public Set<MetadataRecord> getMetadata(Id.DatasetInstance datasetInstance, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return doGetMetadata(datasetInstance, constructPath(datasetInstance), scope);
   }
 
@@ -399,7 +400,7 @@ public class MetadataClient {
    * @return The metadata for the stream.
    */
   public Set<MetadataRecord> getMetadata(Id.Stream streamId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return doGetMetadata(streamId, constructPath(streamId), scope);
   }
 
@@ -408,7 +409,7 @@ public class MetadataClient {
    * @return The metadata for the view.
    */
   public Set<MetadataRecord> getMetadata(Id.Stream.View viewId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return doGetMetadata(viewId, constructPath(viewId), scope);
   }
 
@@ -417,7 +418,7 @@ public class MetadataClient {
    * @return The metadata for the program.
    */
   public Set<MetadataRecord> getMetadata(Id.Program programId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return doGetMetadata(programId, constructPath(programId), scope);
   }
 
@@ -426,18 +427,18 @@ public class MetadataClient {
    * @return The metadata for the run.
    */
   public Set<MetadataRecord> getMetadata(Id.Run runId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return doGetMetadata(runId, constructPath(runId));
   }
 
   private Set<MetadataRecord> doGetMetadata(Id.NamespacedId namespacedId, String entityPath)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
     return doGetMetadata(namespacedId, entityPath, null);
   }
 
   private Set<MetadataRecord> doGetMetadata(Id.NamespacedId namespacedId, String entityPath,
                                             @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata", entityPath);
     path = scope == null ? path : String.format("%s?scope=%s", path, scope);
     HttpResponse response = makeRequest(namespacedId, path, HttpMethod.GET);
@@ -451,7 +452,7 @@ public class MetadataClient {
    * @return The metadata properties for the application.
    */
   public Map<String, String> getProperties(Id.Application appId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getProperties(appId, constructPath(appId), scope);
   }
 
@@ -462,7 +463,7 @@ public class MetadataClient {
    * @return The metadata properties for the artifact.
    */
   public Map<String, String> getProperties(Id.Artifact artifactId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getProperties(artifactId, constructPath(artifactId), scope);
   }
 
@@ -473,7 +474,7 @@ public class MetadataClient {
    * @return The metadata properties for the dataset.
    */
   public Map<String, String> getProperties(Id.DatasetInstance datasetInstance, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getProperties(datasetInstance, constructPath(datasetInstance), scope);
   }
 
@@ -484,7 +485,7 @@ public class MetadataClient {
    * @return The metadata properties for the stream.
    */
   public Map<String, String> getProperties(Id.Stream streamId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getProperties(streamId, constructPath(streamId), scope);
   }
 
@@ -495,7 +496,7 @@ public class MetadataClient {
    * @return The metadata properties for the view.
    */
   public Map<String, String> getProperties(Id.Stream.View viewId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getProperties(viewId, constructPath(viewId), scope);
   }
 
@@ -506,13 +507,13 @@ public class MetadataClient {
    * @return The metadata properties for the program.
    */
   public Map<String, String> getProperties(Id.Program programId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getProperties(programId, constructPath(programId), scope);
   }
 
   private Map<String, String> getProperties(Id.NamespacedId namespacedId, String entityPath,
                                             @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/properties", entityPath);
     path = scope == null ? path : String.format("%s?scope=%s", path, scope);
     HttpResponse response = makeRequest(namespacedId, path, HttpMethod.GET);
@@ -526,7 +527,7 @@ public class MetadataClient {
    * @return The metadata tags for the application.
    */
   public Set<String> getTags(Id.Application appId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getTags(appId, constructPath(appId), scope);
   }
 
@@ -537,7 +538,7 @@ public class MetadataClient {
    * @return The metadata tags for the artifact.
    */
   public Set<String> getTags(Id.Artifact artifactId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getTags(artifactId, constructPath(artifactId), scope);
   }
 
@@ -548,7 +549,7 @@ public class MetadataClient {
    * @return The metadata tags for the dataset.
    */
   public Set<String> getTags(Id.DatasetInstance datasetInstance, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getTags(datasetInstance, constructPath(datasetInstance), scope);
   }
 
@@ -559,7 +560,7 @@ public class MetadataClient {
    * @return The metadata tags for the stream.
    */
   public Set<String> getTags(Id.Stream streamId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getTags(streamId, constructPath(streamId), scope);
   }
 
@@ -570,7 +571,7 @@ public class MetadataClient {
    * @return The metadata tags for the view.
    */
   public Set<String> getTags(Id.Stream.View viewId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getTags(viewId, constructPath(viewId), scope);
   }
 
@@ -581,12 +582,12 @@ public class MetadataClient {
    * @return The metadata tags for the program.
    */
   public Set<String> getTags(Id.Program programId, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     return getTags(programId, constructPath(programId), scope);
   }
 
   private Set<String> getTags(Id.NamespacedId namespacedId, String entityPath, @Nullable MetadataScope scope)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/tags", entityPath);
     path = scope == null ? path : String.format("%s?scope=%s", path, scope);
     HttpResponse response = makeRequest(namespacedId, path, HttpMethod.GET);
@@ -600,7 +601,7 @@ public class MetadataClient {
    * @param tags tags to be added
    */
   public void addTags(Id.Application appId, Set<String> tags)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addTags(appId, constructPath(appId), tags);
   }
 
@@ -611,7 +612,7 @@ public class MetadataClient {
    * @param tags tags to be added
    */
   public void addTags(Id.Artifact artifactId, Set<String> tags)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addTags(artifactId, constructPath(artifactId), tags);
   }
 
@@ -622,7 +623,7 @@ public class MetadataClient {
    * @param tags tags to be added
    */
   public void addTags(Id.DatasetInstance datasetInstance, Set<String> tags)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addTags(datasetInstance, constructPath(datasetInstance), tags);
   }
 
@@ -633,7 +634,7 @@ public class MetadataClient {
    * @param tags tags to be added
    */
   public void addTags(Id.Stream streamId, Set<String> tags)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addTags(streamId, constructPath(streamId), tags);
   }
 
@@ -644,7 +645,7 @@ public class MetadataClient {
    * @param tags tags to be added
    */
   public void addTags(Id.Stream.View viewId, Set<String> tags)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addTags(viewId, constructPath(viewId), tags);
   }
 
@@ -655,12 +656,12 @@ public class MetadataClient {
    * @param tags tags to be added
    */
   public void addTags(Id.Program programId, Set<String> tags)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addTags(programId, constructPath(programId), tags);
   }
 
   private void addTags(Id.NamespacedId namespacedId, String entityPath, Set<String> tags)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/tags", entityPath);
     makeRequest(namespacedId, path, HttpMethod.POST, GSON.toJson(tags));
   }
@@ -672,7 +673,7 @@ public class MetadataClient {
    * @param properties properties to be added
    */
   public void addProperties(Id.Application appId, Map<String, String> properties)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addProperties(appId, constructPath(appId), properties);
   }
 
@@ -683,7 +684,7 @@ public class MetadataClient {
    * @param properties properties to be added
    */
   public void addProperties(Id.Artifact artifactId, Map<String, String> properties)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addProperties(artifactId, constructPath(artifactId), properties);
   }
 
@@ -694,7 +695,7 @@ public class MetadataClient {
    * @param properties properties to be added
    */
   public void addProperties(Id.DatasetInstance datasetInstance, Map<String, String> properties)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addProperties(datasetInstance, constructPath(datasetInstance), properties);
   }
 
@@ -705,7 +706,7 @@ public class MetadataClient {
    * @param properties properties to be added
    */
   public void addProperties(Id.Stream streamId, Map<String, String> properties)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addProperties(streamId, constructPath(streamId), properties);
   }
 
@@ -716,7 +717,7 @@ public class MetadataClient {
    * @param properties properties to be added
    */
   public void addProperties(Id.Stream.View viewId, Map<String, String> properties)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addProperties(viewId, constructPath(viewId), properties);
   }
 
@@ -727,12 +728,12 @@ public class MetadataClient {
    * @param properties properties to be added
    */
   public void addProperties(Id.Program programId, Map<String, String> properties)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     addProperties(programId, constructPath(programId), properties);
   }
 
   private void addProperties(Id.NamespacedId namespacedId, String entityPath, Map<String, String> properties)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/properties", entityPath);
     makeRequest(namespacedId, path, HttpMethod.POST, GSON.toJson(properties));
   }
@@ -744,7 +745,7 @@ public class MetadataClient {
    * @param propertyToRemove property to be removed
    */
   public void removeProperty(Id.Application appId, String propertyToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperty(appId, constructPath(appId), propertyToRemove);
   }
 
@@ -755,7 +756,7 @@ public class MetadataClient {
    * @param propertyToRemove property to be removed
    */
   public void removeProperty(Id.Artifact artifactId, String propertyToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperty(artifactId, constructPath(artifactId), propertyToRemove);
   }
 
@@ -766,7 +767,7 @@ public class MetadataClient {
    * @param propertyToRemove property to be removed
    */
   public void removeProperty(Id.DatasetInstance datasetInstance, String propertyToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperty(datasetInstance, constructPath(datasetInstance), propertyToRemove);
   }
 
@@ -777,7 +778,7 @@ public class MetadataClient {
    * @param propertyToRemove property to be removed
    */
   public void removeProperty(Id.Stream streamId, String propertyToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperty(streamId, constructPath(streamId), propertyToRemove);
   }
 
@@ -788,7 +789,7 @@ public class MetadataClient {
    * @param propertyToRemove property to be removed
    */
   public void removeProperty(Id.Stream.View viewId, String propertyToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperty(viewId, constructPath(viewId), propertyToRemove);
   }
 
@@ -799,12 +800,12 @@ public class MetadataClient {
    * @param propertyToRemove property to be removed
    */
   public void removeProperty(Id.Program programId, String propertyToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperty(programId, constructPath(programId), propertyToRemove);
   }
 
   private void removeProperty(Id.NamespacedId namespacedId, String entityPath, String propertyToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/properties/%s", entityPath, propertyToRemove);
     makeRequest(namespacedId, path, HttpMethod.DELETE);
   }
@@ -816,7 +817,7 @@ public class MetadataClient {
    * @param appId app to remove properties from
    */
   public void removeProperties(Id.Application appId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperties(appId, constructPath(appId));
   }
 
@@ -826,7 +827,7 @@ public class MetadataClient {
    * @param artifactId artifact to remove properties from
    */
   public void removeProperties(Id.Artifact artifactId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperties(artifactId, constructPath(artifactId));
   }
 
@@ -836,7 +837,7 @@ public class MetadataClient {
    * @param datasetInstance dataset to remove properties from
    */
   public void removeProperties(Id.DatasetInstance datasetInstance)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperties(datasetInstance, constructPath(datasetInstance));
   }
 
@@ -846,7 +847,7 @@ public class MetadataClient {
    * @param streamId stream to remove properties from
    */
   public void removeProperties(Id.Stream streamId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperties(streamId, constructPath(streamId));
   }
 
@@ -856,7 +857,7 @@ public class MetadataClient {
    * @param viewId view to remove properties from
    */
   public void removeProperties(Id.Stream.View viewId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperties(viewId, constructPath(viewId));
   }
 
@@ -866,12 +867,12 @@ public class MetadataClient {
    * @param programId program to remove properties from
    */
   public void removeProperties(Id.Program programId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeProperties(programId, constructPath(programId));
   }
 
   private void removeProperties(Id.NamespacedId namespacedId, String entityPath)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/properties", entityPath);
     makeRequest(namespacedId, path, HttpMethod.DELETE);
   }
@@ -883,7 +884,7 @@ public class MetadataClient {
    * @param tagToRemove tag to be removed
    */
   public void removeTag(Id.Application appId, String tagToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTag(appId, constructPath(appId), tagToRemove);
   }
 
@@ -894,7 +895,7 @@ public class MetadataClient {
    * @param tagToRemove tag to be removed
    */
   public void removeTag(Id.Artifact artifactId, String tagToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTag(artifactId, constructPath(artifactId), tagToRemove);
   }
 
@@ -906,7 +907,7 @@ public class MetadataClient {
    * @param tagToRemove tag to be removed
    */
   public void removeTag(Id.DatasetInstance datasetInstance, String tagToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTag(datasetInstance, constructPath(datasetInstance), tagToRemove);
   }
 
@@ -917,7 +918,7 @@ public class MetadataClient {
    * @param tagToRemove tag to be removed
    */
   public void removeTag(Id.Stream streamId, String tagToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTag(streamId, constructPath(streamId), tagToRemove);
   }
 
@@ -928,7 +929,7 @@ public class MetadataClient {
    * @param tagToRemove tag to be removed
    */
   public void removeTag(Id.Stream.View viewId, String tagToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTag(viewId, constructPath(viewId), tagToRemove);
   }
 
@@ -939,12 +940,12 @@ public class MetadataClient {
    * @param tagToRemove tag to be removed
    */
   public void removeTag(Id.Program programId, String tagToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTag(programId, constructPath(programId), tagToRemove);
   }
 
   private void removeTag(Id.NamespacedId namespacedId, String entityPath, String tagToRemove)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/tags/%s", entityPath, tagToRemove);
     makeRequest(namespacedId, path, HttpMethod.DELETE);
   }
@@ -955,7 +956,7 @@ public class MetadataClient {
    * @param appId app to remove tags from
    */
   public void removeTags(Id.Application appId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTags(appId, constructPath(appId));
   }
 
@@ -965,7 +966,7 @@ public class MetadataClient {
    * @param artifactId artifact to remove tags from
    */
   public void removeTags(Id.Artifact artifactId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTags(artifactId, constructPath(artifactId));
   }
 
@@ -975,7 +976,7 @@ public class MetadataClient {
    * @param datasetInstance dataset to remove tags from
    */
   public void removeTags(Id.DatasetInstance datasetInstance)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTags(datasetInstance, constructPath(datasetInstance));
   }
 
@@ -985,7 +986,7 @@ public class MetadataClient {
    * @param streamId stream to remove tags from
    */
   public void removeTags(Id.Stream streamId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTags(streamId, constructPath(streamId));
   }
 
@@ -995,7 +996,7 @@ public class MetadataClient {
    * @param viewId view to remove tags from
    */
   public void removeTags(Id.Stream.View viewId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTags(viewId, constructPath(viewId));
   }
 
@@ -1005,12 +1006,12 @@ public class MetadataClient {
    * @param programId program to remove tags from
    */
   public void removeTags(Id.Program programId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeTags(programId, constructPath(programId));
   }
 
   private void removeTags(Id.NamespacedId namespacedId, String entityPath)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/tags", entityPath);
     makeRequest(namespacedId, path, HttpMethod.DELETE);
   }
@@ -1021,7 +1022,7 @@ public class MetadataClient {
   * @param appId app to remove metadata from
   */
   public void removeMetadata(Id.Application appId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeMetadata(appId, constructPath(appId));
   }
 
@@ -1031,7 +1032,7 @@ public class MetadataClient {
    * @param artifactId artifact to remove metadata from
    */
   public void removeMetadata(Id.Artifact artifactId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeMetadata(artifactId, constructPath(artifactId));
   }
 
@@ -1041,7 +1042,7 @@ public class MetadataClient {
    * @param datasetInstance dataset to remove metadata from
    */
   public void removeMetadata(Id.DatasetInstance datasetInstance)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeMetadata(datasetInstance, constructPath(datasetInstance));
   }
 
@@ -1051,7 +1052,7 @@ public class MetadataClient {
    * @param streamId stream to remove metadata from
    */
   public void removeMetadata(Id.Stream streamId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeMetadata(streamId, constructPath(streamId));
   }
 
@@ -1061,7 +1062,7 @@ public class MetadataClient {
    * @param viewId view to remove metadata from
    */
   public void removeMetadata(Id.Stream.View viewId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeMetadata(viewId, constructPath(viewId));
   }
 
@@ -1071,25 +1072,25 @@ public class MetadataClient {
    * @param programId program to remove metadata from
    */
   public void removeMetadata(Id.Program programId)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     removeMetadata(programId, constructPath(programId));
   }
 
   private void removeMetadata(Id.NamespacedId namespacedId, String entityPath)
-    throws UnauthorizedException, BadRequestException, NotFoundException, IOException {
+    throws UnauthenticatedException, BadRequestException, NotFoundException, IOException {
     String path = String.format("%s/metadata", entityPath);
     makeRequest(namespacedId, path, HttpMethod.DELETE);
   }
 
   private HttpResponse makeRequest(Id.NamespacedId namespacedId, String path, HttpMethod httpMethod)
-    throws NotFoundException, BadRequestException, UnauthorizedException, IOException {
+    throws NotFoundException, BadRequestException, UnauthenticatedException, IOException {
     return makeRequest(namespacedId, path, httpMethod, null);
   }
 
   // makes a request and throws BadRequestException or NotFoundException, as appropriate
   private HttpResponse makeRequest(Id.NamespacedId namespacedId, String path,
                                    HttpMethod httpMethod, @Nullable String body)
-    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException {
     URL url = config.resolveNamespacedURLV3(namespacedId.getNamespace(), path);
     HttpRequest.Builder builder = HttpRequest.builder(httpMethod, url);
     if (body != null) {

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetricsClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetricsClient.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.metrics.MetricsTags;
 import co.cask.cdap.proto.Id;
@@ -77,10 +77,10 @@ public class MetricsClient {
    * @param tags the tags to match
    * @return the metrics matching the given tags
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<MetricTagValue> searchTags(Map<String, String> tags)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     List<String> queryParts = Lists.newArrayList();
     queryParts.add("target=tag");
@@ -99,10 +99,10 @@ public class MetricsClient {
    * @param tags the tags to match
    * @return the metrics matching the given tags
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<String> searchMetrics(Map<String, String> tags)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     List<String> queryParts = Lists.newArrayList();
     queryParts.add("target=metric");
@@ -122,10 +122,10 @@ public class MetricsClient {
    * @param metric names of the metric
    * @return values of the metrics
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public MetricQueryResult query(Map<String, String> tags, String metric)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
     return query(tags, ImmutableList.of(metric), ImmutableList.<String>of(), ImmutableMap.<String, String>of());
   }
 
@@ -137,11 +137,11 @@ public class MetricsClient {
    * @param groupBys groupBys for the request
    * @return values of the metrics
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public MetricQueryResult query(Map<String, String> tags, List<String> metrics, List<String> groupBys,
                                  @Nullable String start, @Nullable String end)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     Map<String, String> timeRangeParams = Maps.newHashMap();
     if (start != null) {
@@ -161,12 +161,12 @@ public class MetricsClient {
    * @param groupBys groupBys for the request
    * @return values of the metrics
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   // TODO: take in query object shared by MetricsHandler
   public MetricQueryResult query(Map<String, String> tags, List<String> metrics, List<String> groupBys,
                                  @Nullable Map<String, String> timeRangeParams)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     List<String> queryParts = Lists.newArrayList();
     queryParts.add("target=tag");

--- a/cdap-client/src/main/java/co/cask/cdap/client/MonitorClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MonitorClient.java
@@ -22,7 +22,7 @@ import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.ServiceNotEnabledException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.Instances;
 import co.cask.cdap.proto.SystemServiceLiveInfo;
@@ -68,10 +68,10 @@ public class MonitorClient {
    * @param serviceName Name of the system service
    * @return live info of the system service
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public SystemServiceLiveInfo getSystemServiceLiveInfo(String serviceName)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     Id.SystemService systemService = Id.SystemService.from(serviceName);
     URL url = config.resolveURLV3(String.format("system/services/%s/live-info", serviceName));
@@ -89,9 +89,9 @@ public class MonitorClient {
    *
    * @return list of {@link SystemServiceMeta}s.
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public List<SystemServiceMeta> listSystemServices() throws IOException, UnauthorizedException {
+  public List<SystemServiceMeta> listSystemServices() throws IOException, UnauthenticatedException {
     URL url = config.resolveURL("system/services");
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, new TypeToken<List<SystemServiceMeta>>() { }).getResponseObject();
@@ -105,10 +105,10 @@ public class MonitorClient {
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the system service with the specified name could not be found
    * @throws BadRequestException if the operation was not valid for the system service
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public String getSystemServiceStatus(String serviceName)
-    throws IOException, NotFoundException, BadRequestException, UnauthorizedException {
+    throws IOException, NotFoundException, BadRequestException, UnauthenticatedException {
 
     Id.SystemService systemService = Id.SystemService.from(serviceName);
     URL url = config.resolveURL(String.format("system/services/%s/status", serviceName));
@@ -130,9 +130,9 @@ public class MonitorClient {
    *
    * @return map from service name to service status
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public Map<String, String> getAllSystemServiceStatus() throws IOException, UnauthorizedException {
+  public Map<String, String> getAllSystemServiceStatus() throws IOException, UnauthenticatedException {
     URL url = config.resolveURL("system/services/status");
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, new TypeToken<Map<String, String>>() { }).getResponseObject();
@@ -141,9 +141,9 @@ public class MonitorClient {
   /**
    * @return true if all system services' status is 'OK'; false otherwise
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public boolean allSystemServicesOk() throws IOException, UnauthorizedException {
+  public boolean allSystemServicesOk() throws IOException, UnauthenticatedException {
     for (String status : getAllSystemServiceStatus().values()) {
       if (!"OK".equals(status)) {
         return false;
@@ -159,10 +159,10 @@ public class MonitorClient {
    * @param instances number of instances the system service is running on
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the system service with the specified name was not found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void setSystemServiceInstances(String serviceName, int instances)
-    throws IOException, NotFoundException, BadRequestException, UnauthorizedException {
+    throws IOException, NotFoundException, BadRequestException, UnauthenticatedException {
 
     Id.SystemService systemService = Id.SystemService.from(serviceName);
     URL url = config.resolveURL(String.format("system/services/%s/instances", serviceName));
@@ -185,10 +185,10 @@ public class MonitorClient {
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the system service with the specified name was not found
    * @throws ServiceNotEnabledException if the system service is not currently enabled
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public int getSystemServiceInstances(String serviceName)
-    throws IOException, NotFoundException, ServiceNotEnabledException, UnauthorizedException {
+    throws IOException, NotFoundException, ServiceNotEnabledException, UnauthenticatedException {
 
     Id.SystemService systemService = Id.SystemService.from(serviceName);
     URL url = config.resolveURL(String.format("system/services/%s/instances", serviceName));

--- a/cdap-client/src/main/java/co/cask/cdap/client/NamespaceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/NamespaceClient.java
@@ -19,7 +19,7 @@ package co.cask.cdap.client;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.namespace.AbstractNamespaceClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -51,7 +51,7 @@ public class NamespaceClient extends AbstractNamespaceClient {
   }
 
   @Override
-  protected HttpResponse execute(HttpRequest request) throws IOException, UnauthorizedException {
+  protected HttpResponse execute(HttpRequest request) throws IOException, UnauthenticatedException {
     // the allowed codes are the ones that AbstractNamespaceClient expects to be able to handle
     return restClient.execute(request, config.getAccessToken(),
                               HttpURLConnection.HTTP_BAD_REQUEST,

--- a/cdap-client/src/main/java/co/cask/cdap/client/PreferencesClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/PreferencesClient.java
@@ -22,7 +22,7 @@ import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.ApplicationNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.ProgramNotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpResponse;
@@ -62,9 +62,9 @@ public class PreferencesClient {
    *
    * @return map of key-value pairs
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public Map<String, String> getInstancePreferences() throws IOException, UnauthorizedException {
+  public Map<String, String> getInstancePreferences() throws IOException, UnauthenticatedException {
     URL url = config.resolveURLV3("preferences");
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, new TypeToken<Map<String, String>>() { }).getResponseObject();
@@ -75,9 +75,9 @@ public class PreferencesClient {
    *
    * @param preferences map of key-value pairs
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void setInstancePreferences(Map<String, String> preferences) throws IOException, UnauthorizedException {
+  public void setInstancePreferences(Map<String, String> preferences) throws IOException, UnauthenticatedException {
     URL url = config.resolveURLV3("preferences");
     restClient.execute(HttpMethod.PUT, url, GSON.toJson(preferences), null, config.getAccessToken());
   }
@@ -86,9 +86,9 @@ public class PreferencesClient {
    * Deletes Preferences at the Instance Level.
    *
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void deleteInstancePreferences() throws IOException, UnauthorizedException {
+  public void deleteInstancePreferences() throws IOException, UnauthenticatedException {
     URL url = config.resolveURLV3("preferences");
     restClient.execute(HttpMethod.DELETE, url, config.getAccessToken());
   }
@@ -100,11 +100,11 @@ public class PreferencesClient {
    * @param resolved Set to True if collapsed/resolved properties are desired
    * @return map of key-value pairs
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the requested namespace is not found
    */
   public Map<String, String> getNamespacePreferences(Id.Namespace namespace, boolean resolved)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     String res = Boolean.toString(resolved);
     URL url = config.resolveURLV3(String.format("namespaces/%s/preferences?resolved=%s",
@@ -123,11 +123,11 @@ public class PreferencesClient {
    * @param namespace Namespace Id
    * @param preferences map of key-value pairs
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the requested namespace is not found
    */
   public void setNamespacePreferences(Id.Namespace namespace, Map<String, String> preferences) throws IOException,
-    UnauthorizedException, NotFoundException {
+    UnauthenticatedException, NotFoundException {
     URL url = config.resolveURLV3(String.format("namespaces/%s/preferences", namespace.getId()));
     HttpResponse response = restClient.execute(HttpMethod.PUT, url, GSON.toJson(preferences), null,
                                                config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
@@ -141,11 +141,11 @@ public class PreferencesClient {
    *
    * @param namespace Namespace Id
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the requested namespace is not found
    */
   public void deleteNamespacePreferences(Id.Namespace namespace)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     URL url = config.resolveURLV3(String.format("namespaces/%s/preferences", namespace.getId()));
     HttpResponse response = restClient.execute(HttpMethod.DELETE, url, config.getAccessToken(),
@@ -162,11 +162,11 @@ public class PreferencesClient {
    * @param resolved Set to True if collapsed/resolved properties are desired
    * @return map of key-value pairs
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ApplicationNotFoundException if the requested application is not found
    */
   public Map<String, String> getApplicationPreferences(Id.Application application, boolean resolved)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     String res = Boolean.toString(resolved);
     URL url = config.resolveURLV3(String.format("namespaces/%s/apps/%s/preferences?resolved=%s",
@@ -185,11 +185,11 @@ public class PreferencesClient {
    * @param application Application Id
    * @param preferences map of key-value pairs
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the requested application or namespace is not found
    */
   public void setApplicationPreferences(Id.Application application, Map<String, String> preferences)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     URL url = config.resolveURLV3(String.format("namespaces/%s/apps/%s/preferences",
                                                 application.getNamespaceId(), application.getId()));
@@ -205,11 +205,11 @@ public class PreferencesClient {
    *
    * @param application Application Id
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the request application or namespace is not found
    */
   public void deleteApplicationPreferences(Id.Application application)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     URL url = config.resolveURLV3(String.format("namespaces/%s/apps/%s/preferences",
                                                 application.getNamespaceId(), application.getId()));
@@ -227,11 +227,11 @@ public class PreferencesClient {
    * @param resolved Set to True if collapsed/resolved properties are desired
    * @return map of key-value pairs
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ProgramNotFoundException if the requested program is not found
    */
   public Map<String, String> getProgramPreferences(Id.Program program, boolean resolved)
-    throws IOException, UnauthorizedException, ProgramNotFoundException {
+    throws IOException, UnauthenticatedException, ProgramNotFoundException {
 
     String res = Boolean.toString(resolved);
     URL url = config.resolveURLV3(String.format("namespaces/%s/apps/%s/%s/%s/preferences?resolved=%s",
@@ -251,11 +251,11 @@ public class PreferencesClient {
    * @param program Program Id
    * @param preferences map of key-value pairs
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ProgramNotFoundException if the requested program is not found
    */
   public void setProgramPreferences(Id.Program program, Map<String, String> preferences)
-    throws IOException, UnauthorizedException, ProgramNotFoundException {
+    throws IOException, UnauthenticatedException, ProgramNotFoundException {
     URL url = config.resolveURLV3(String.format("/namespaces/%s/apps/%s/%s/%s/preferences",
                                                 program.getNamespaceId(), program.getApplicationId(),
                                                 program.getType().getCategoryName(), program.getId()));
@@ -271,11 +271,11 @@ public class PreferencesClient {
    *
    * @param program Program Id
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ProgramNotFoundException if the requested program is not found
    */
   public void deleteProgramPreferences(Id.Program program)
-    throws IOException, UnauthorizedException, ProgramNotFoundException {
+    throws IOException, UnauthenticatedException, ProgramNotFoundException {
 
     URL url = config.resolveURLV3(String.format("namespaces/%s/apps/%s/%s/%s/preferences",
                                                 program.getNamespaceId(), program.getApplicationId(),

--- a/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
@@ -23,7 +23,7 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.ProgramNotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
 import co.cask.cdap.common.utils.Tasks;
@@ -104,10 +104,10 @@ public class ProgramClient {
    * @param runtimeArgs runtime arguments to pass to the program
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void start(Id.Program program, boolean debug, @Nullable Map<String, String> runtimeArgs)
-    throws IOException, ProgramNotFoundException, UnauthorizedException {
+    throws IOException, ProgramNotFoundException, UnauthenticatedException {
 
     String action = debug ? "debug" : "start";
     String path = String.format("apps/%s/%s/%s/%s",
@@ -133,10 +133,10 @@ public class ProgramClient {
    * @param program the program to start
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void start(Id.Program program, boolean debug)
-    throws IOException, ProgramNotFoundException, UnauthorizedException {
+    throws IOException, ProgramNotFoundException, UnauthenticatedException {
 
     start(program, debug, null);
   }
@@ -147,9 +147,9 @@ public class ProgramClient {
    * @param program the program to start
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void start(Id.Program program) throws IOException, ProgramNotFoundException, UnauthorizedException {
+  public void start(Id.Program program) throws IOException, ProgramNotFoundException, UnauthenticatedException {
     start(program, false, null);
   }
 
@@ -160,10 +160,10 @@ public class ProgramClient {
    * @param programs the programs to start, including any runtime arguments to start them with
    * @return the result of starting each program
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<BatchProgramResult> start(Id.Namespace namespace, List<BatchProgramStart> programs)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(namespace, "start");
     HttpRequest request = HttpRequest.builder(HttpMethod.POST, url)
@@ -180,9 +180,9 @@ public class ProgramClient {
    * @param program the program to stop
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void stop(Id.Program program) throws IOException, ProgramNotFoundException, UnauthorizedException {
+  public void stop(Id.Program program) throws IOException, ProgramNotFoundException, UnauthenticatedException {
     String path = String.format("apps/%s/%s/%s/stop",
                                 program.getApplicationId(), program.getType().getCategoryName(), program.getId());
     URL url = config.resolveNamespacedURLV3(program.getNamespace(), path);
@@ -200,10 +200,10 @@ public class ProgramClient {
    * @param programs the programs to stop
    * @return the result of stopping each program
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<BatchProgramResult> stop(Id.Namespace namespace, List<BatchProgram> programs)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(namespace, "stop");
     HttpRequest request = HttpRequest.builder(HttpMethod.POST, url)
@@ -218,12 +218,12 @@ public class ProgramClient {
    * Stops all currently running programs.
    *
    * @throws IOException
-   * @throws UnauthorizedException
+   * @throws UnauthenticatedException
    * @throws InterruptedException
    * @throws TimeoutException
    */
   public void stopAll(Id.Namespace namespace)
-    throws IOException, UnauthorizedException, InterruptedException, TimeoutException {
+    throws IOException, UnauthenticatedException, InterruptedException, TimeoutException {
 
     Map<ProgramType, List<ProgramRecord>> allPrograms = applicationClient.listAllPrograms(namespace);
     for (Map.Entry<ProgramType, List<ProgramRecord>> entry : allPrograms.entrySet()) {
@@ -252,10 +252,10 @@ public class ProgramClient {
    * @return the status of the program (e.g. STOPPED, STARTING, RUNNING)
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public String getStatus(Id.Program program)
-    throws IOException, ProgramNotFoundException, UnauthorizedException {
+    throws IOException, ProgramNotFoundException, UnauthenticatedException {
 
     String path = String.format("apps/%s/%s/%s/status",
                                 program.getApplicationId(), program.getType().getCategoryName(), program.getId());
@@ -279,7 +279,7 @@ public class ProgramClient {
    * @return the status of each program
    */
   public List<BatchProgramStatus> getStatus(Id.Namespace namespace, List<BatchProgram> programs)
-    throws IOException, UnauthorizedException {
+    throws IOException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(namespace, "status");
 
@@ -298,12 +298,12 @@ public class ProgramClient {
    * @param timeout how long to wait in milliseconds until timing out
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws TimeoutException if the program did not achieve the desired program status before the timeout
    * @throws InterruptedException if interrupted while waiting for the desired program status
    */
   public void waitForStatus(final Id.Program program, String status, long timeout, TimeUnit timeoutUnit)
-    throws UnauthorizedException, IOException, ProgramNotFoundException,
+    throws UnauthenticatedException, IOException, ProgramNotFoundException,
     TimeoutException, InterruptedException {
 
     try {
@@ -314,7 +314,7 @@ public class ProgramClient {
         }
       }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), UnauthorizedException.class);
+      Throwables.propagateIfPossible(e.getCause(), UnauthenticatedException.class);
       Throwables.propagateIfPossible(e.getCause(), ProgramNotFoundException.class);
       Throwables.propagateIfPossible(e.getCause(), IOException.class);
     }
@@ -328,10 +328,10 @@ public class ProgramClient {
    * @return {@link ProgramLiveInfo} of the program
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public DistributedProgramLiveInfo getLiveInfo(Id.Program program)
-    throws IOException, ProgramNotFoundException, UnauthorizedException {
+    throws IOException, ProgramNotFoundException, UnauthenticatedException {
 
     String path = String.format("apps/%s/%s/%s/live-info",
                                 program.getApplicationId(), program.getType().getCategoryName(), program.getId());
@@ -352,10 +352,10 @@ public class ProgramClient {
    * @return number of instances that the flowlet is currently running on
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application, flow, or flowlet could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public int getFlowletInstances(Id.Flow.Flowlet flowlet)
-    throws IOException, NotFoundException, UnauthorizedException {
+    throws IOException, NotFoundException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(flowlet.getNamespace(),
                                             String.format("apps/%s/flows/%s/flowlets/%s/instances",
@@ -378,10 +378,10 @@ public class ProgramClient {
    * @param instances number of instances for the flowlet to run on
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application, flow, or flowlet could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void setFlowletInstances(Id.Flow.Flowlet flowlet, int instances)
-    throws IOException, NotFoundException, UnauthorizedException {
+    throws IOException, NotFoundException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(flowlet.getNamespace(),
                                             String.format("apps/%s/flows/%s/flowlets/%s/instances",
@@ -403,10 +403,10 @@ public class ProgramClient {
    * @return number of instances that the worker is currently running on
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application or worker could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public int getWorkerInstances(Id.Worker worker) throws IOException, NotFoundException,
-    UnauthorizedException {
+    UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(worker.getNamespace(),
                                             String.format("apps/%s/workers/%s/instances",
                                                           worker.getApplicationId(), worker.getId()));
@@ -424,10 +424,10 @@ public class ProgramClient {
    * @param instances number of instances for the worker to run on
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application or worker could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void setWorkerInstances(Id.Worker worker, int instances) throws IOException, NotFoundException,
-    UnauthorizedException {
+    UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(worker.getNamespace(),
                                             String.format("apps/%s/workers/%s/instances",
@@ -447,9 +447,9 @@ public class ProgramClient {
    * @return number of instances of the service handler
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application or service could not found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public int getServiceInstances(Id.Service service) throws IOException, NotFoundException, UnauthorizedException {
+  public int getServiceInstances(Id.Service service) throws IOException, NotFoundException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(service.getNamespace(),
                                             String.format("apps/%s/services/%s/instances",
                                                           service.getApplicationId(),
@@ -469,10 +469,10 @@ public class ProgramClient {
    * @param instances number of instances for the service
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application or service could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void setServiceInstances(Id.Service service, int instances)
-    throws IOException, NotFoundException, UnauthorizedException {
+    throws IOException, NotFoundException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(service.getNamespace(),
                                             String.format("apps/%s/services/%s/instances",
@@ -493,10 +493,10 @@ public class ProgramClient {
    * @return list of {@link WorkflowActionNode} currently running for the given runid
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application, workflow, or runid could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<WorkflowActionNode> getWorkflowCurrent(Id.Application appId, String workflowId, String runId)
-    throws IOException, NotFoundException, UnauthorizedException {
+    throws IOException, NotFoundException, UnauthenticatedException {
     String path = String.format("/apps/%s/workflows/%s/runs/%s/current", appId.getId(), workflowId, runId);
     URL url = config.resolveNamespacedURLV3(appId.getNamespace(), path);
 
@@ -521,11 +521,11 @@ public class ProgramClient {
    * @return the run records of the program
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application or program could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<RunRecord> getProgramRuns(Id.Program program, String state,
                                         long startTime, long endTime, int limit)
-    throws IOException, NotFoundException, UnauthorizedException {
+    throws IOException, NotFoundException, UnauthenticatedException {
 
     String queryParams = String.format("%s=%s&%s=%d&%s=%d&%s=%d",
                                        Constants.AppFabric.QUERY_PARAM_STATUS, state,
@@ -555,10 +555,10 @@ public class ProgramClient {
    * @return the run records of the program
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application or program could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<RunRecord> getAllProgramRuns(Id.Program program, long startTime, long endTime, int limit)
-    throws IOException, NotFoundException, UnauthorizedException {
+    throws IOException, NotFoundException, UnauthenticatedException {
     return getProgramRuns(program, ProgramRunStatus.ALL.name(), startTime, endTime, limit);
   }
 
@@ -572,10 +572,10 @@ public class ProgramClient {
    * @return the logs of the program
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application or program could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public String getProgramLogs(Id.Program program, long start, long stop)
-    throws IOException, NotFoundException, UnauthorizedException {
+    throws IOException, NotFoundException, UnauthenticatedException {
 
     String path = String.format("apps/%s/%s/%s/logs?start=%d&stop=%d",
                                 program.getApplicationId(), program.getType().getCategoryName(),
@@ -596,10 +596,10 @@ public class ProgramClient {
    * @return runtime args of the program
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the application or program could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public Map<String, String> getRuntimeArgs(Id.Program program)
-    throws IOException, UnauthorizedException, ProgramNotFoundException {
+    throws IOException, UnauthenticatedException, ProgramNotFoundException {
 
     String path = String.format("apps/%s/%s/%s/runtimeargs",
                                 program.getApplicationId(), program.getType().getCategoryName(), program.getId());
@@ -619,10 +619,10 @@ public class ProgramClient {
    * @param runtimeArgs args of the program
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the application or program could not be found
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void setRuntimeArgs(Id.Program program, Map<String, String> runtimeArgs)
-    throws IOException, UnauthorizedException, ProgramNotFoundException {
+    throws IOException, UnauthenticatedException, ProgramNotFoundException {
 
     String path = String.format("apps/%s/%s/%s/runtimeargs",
                                 program.getApplicationId(), program.getType().getCategoryName(), program.getId());

--- a/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
@@ -22,9 +22,8 @@ import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.ProgramStatus;
 import co.cask.cdap.proto.ScheduledRuntime;
 import co.cask.cdap.proto.codec.ScheduleSpecificationCodec;
 import co.cask.common.http.HttpMethod;
@@ -69,7 +68,7 @@ public class ScheduleClient {
   }
 
   public List<ScheduleSpecification> list(Id.Workflow workflow)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     String path = String.format("apps/%s/workflows/%s/schedules", workflow.getApplicationId(), workflow.getId());
     URL url = config.resolveNamespacedURLV3(workflow.getNamespace(), path);
@@ -94,7 +93,7 @@ public class ScheduleClient {
    * @return list of Scheduled runtimes for the Workflow. Empty list if there are no schedules.
    */
   public List<ScheduledRuntime> nextRuntimes(Id.Workflow workflow)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     String path = String.format("apps/%s/workflows/%s/nextruntime", workflow.getApplicationId(), workflow.getId());
     URL url = config.resolveNamespacedURLV3(workflow.getNamespace(), path);
@@ -109,7 +108,7 @@ public class ScheduleClient {
     return objectResponse.getResponseObject();
   }
 
-  public void suspend(Id.Schedule schedule) throws IOException, UnauthorizedException, NotFoundException {
+  public void suspend(Id.Schedule schedule) throws IOException, UnauthenticatedException, NotFoundException {
     String path = String.format("apps/%s/schedules/%s/suspend", schedule.getApplication().getId(), schedule.getId());
     URL url = config.resolveNamespacedURLV3(schedule.getNamespace(), path);
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
@@ -119,7 +118,7 @@ public class ScheduleClient {
     }
   }
 
-  public void resume(Id.Schedule schedule) throws IOException, UnauthorizedException, NotFoundException {
+  public void resume(Id.Schedule schedule) throws IOException, UnauthenticatedException, NotFoundException {
     String path = String.format("apps/%s/schedules/%s/resume", schedule.getApplication().getId(), schedule.getId());
     URL url = config.resolveNamespacedURLV3(schedule.getNamespace(), path);
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
@@ -129,7 +128,7 @@ public class ScheduleClient {
     }
   }
 
-  public String getStatus(Id.Schedule schedule) throws IOException, UnauthorizedException, NotFoundException {
+  public String getStatus(Id.Schedule schedule) throws IOException, UnauthenticatedException, NotFoundException {
     String path = String.format("apps/%s/schedules/%s/status", schedule.getApplication().getId(), schedule.getId());
     URL url = config.resolveNamespacedURLV3(schedule.getNamespace(), path);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),

--- a/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
@@ -24,7 +24,7 @@ import co.cask.cdap.api.service.http.ServiceHttpEndpoint;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpResponse;
@@ -62,11 +62,11 @@ public class ServiceClient {
    * @param service ID of the service
    * @return {@link ServiceSpecification} representing the service
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the app or service could not be found
    */
   public ServiceSpecification get(Id.Service service)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     URL url = config.resolveNamespacedURLV3(service.getNamespace(),
                                             String.format("apps/%s/services/%s",
@@ -86,11 +86,11 @@ public class ServiceClient {
    * @param service ID of the service
    * @return A list of {@link ServiceHttpEndpoint}
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the app or service could not be found
    */
   public List<ServiceHttpEndpoint> getEndpoints(Id.Service service)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
 
     ServiceSpecification specification = get(service);
     ImmutableList.Builder<ServiceHttpEndpoint> builder = new ImmutableList.Builder<>();
@@ -101,7 +101,7 @@ public class ServiceClient {
   }
 
   public URL getServiceURL(Id.Service service)
-    throws NotFoundException, IOException, UnauthorizedException {
+    throws NotFoundException, IOException, UnauthenticatedException {
     // Make sure the service actually exists
     get(service);
     return config.resolveNamespacedURLV3(service.getNamespace(),

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
@@ -23,7 +23,7 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.StreamNotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.stream.StreamEventTypeAdapter;
 import co.cask.cdap.common.utils.TimeMathParser;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
@@ -92,7 +92,7 @@ public class StreamClient {
    * @throws StreamNotFoundException if the stream was not found
    */
   public StreamProperties getConfig(Id.Stream stream)
-    throws IOException, StreamNotFoundException, UnauthorizedException {
+    throws IOException, StreamNotFoundException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(stream.getNamespace(), String.format("streams/%s", stream.getId()));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
@@ -109,12 +109,12 @@ public class StreamClient {
    * @param stream ID of the stream
    * @param properties properties to set
    * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the client is unauthorized
+   * @throws UnauthenticatedException if the client is unauthorized
    * @throws BadRequestException if the request is bad
    * @throws StreamNotFoundException if the stream was not found
    */
   public void setStreamProperties(Id.Stream stream, StreamProperties properties)
-    throws IOException, UnauthorizedException, BadRequestException, StreamNotFoundException {
+    throws IOException, UnauthenticatedException, BadRequestException, StreamNotFoundException {
 
     URL url = config.resolveNamespacedURLV3(stream.getNamespace(),
                                             String.format("streams/%s/properties", stream.getId()));
@@ -139,7 +139,7 @@ public class StreamClient {
    * @throws BadRequestException if the provided stream ID was invalid
    */
   public void create(Id.Stream newStreamId)
-    throws IOException, BadRequestException, UnauthorizedException {
+    throws IOException, BadRequestException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(newStreamId.getNamespace(),
                                             String.format("streams/%s", newStreamId.getId()));
@@ -159,7 +159,7 @@ public class StreamClient {
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void sendEvent(Id.Stream stream, String event) throws IOException,
-                                                              StreamNotFoundException, UnauthorizedException {
+                                                              StreamNotFoundException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(stream.getNamespace(), String.format("streams/%s", stream.getId()));
     writeEvent(url, stream, event);
   }
@@ -174,7 +174,7 @@ public class StreamClient {
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void asyncSendEvent(Id.Stream stream, String event) throws IOException,
-                                                                   StreamNotFoundException, UnauthorizedException {
+                                                                   StreamNotFoundException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(stream.getNamespace(), String.format("streams/%s/async", stream.getId()));
     writeEvent(url, stream, event);
   }
@@ -189,7 +189,7 @@ public class StreamClient {
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void sendFile(Id.Stream stream, String contentType,
-                       File file) throws IOException, StreamNotFoundException, UnauthorizedException {
+                       File file) throws IOException, StreamNotFoundException, UnauthenticatedException {
     sendBatch(stream, contentType, Files.newInputStreamSupplier(file));
   }
 
@@ -204,7 +204,7 @@ public class StreamClient {
    */
   public void sendBatch(Id.Stream stream, String contentType,
                         InputSupplier<? extends InputStream> inputSupplier)
-    throws IOException, StreamNotFoundException, UnauthorizedException {
+    throws IOException, StreamNotFoundException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(stream.getNamespace(), String.format("streams/%s/batch", stream.getId()));
     Map<String, String> headers = ImmutableMap.of("Content-type", contentType);
@@ -223,7 +223,7 @@ public class StreamClient {
    * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified name was not found
    */
-  public void truncate(Id.Stream stream) throws IOException, StreamNotFoundException, UnauthorizedException {
+  public void truncate(Id.Stream stream) throws IOException, StreamNotFoundException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(stream.getNamespace(),
                                             String.format("streams/%s/truncate", stream.getId()));
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
@@ -240,7 +240,7 @@ public class StreamClient {
    * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified name was not found
    */
-  public void delete(Id.Stream stream) throws IOException, StreamNotFoundException, UnauthorizedException {
+  public void delete(Id.Stream stream) throws IOException, StreamNotFoundException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(stream.getNamespace(), String.format("streams/%s", stream.getId()));
     HttpResponse response = restClient.execute(HttpMethod.DELETE, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -258,7 +258,7 @@ public class StreamClient {
    * @throws StreamNotFoundException if the stream with the specified name was not found
    */
   public void setTTL(Id.Stream stream, long ttlInSeconds)
-    throws IOException, StreamNotFoundException, UnauthorizedException {
+    throws IOException, StreamNotFoundException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(stream.getNamespace(),
                                             String.format("streams/%s/properties", stream.getId()));
@@ -276,7 +276,7 @@ public class StreamClient {
    * @return list of {@link StreamRecord}s
    * @throws IOException if a network error occurred
    */
-  public List<StreamDetail> list(Id.Namespace namespace) throws IOException, UnauthorizedException {
+  public List<StreamDetail> list(Id.Namespace namespace) throws IOException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(namespace, "streams");
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, new TypeToken<List<StreamDetail>>() {
@@ -297,7 +297,7 @@ public class StreamClient {
    */
   public <T extends Collection<? super StreamEvent>> T getEvents(Id.Stream streamId, String startTime,
                                                                  String endTime, int limit, final T results)
-    throws IOException, StreamNotFoundException, UnauthorizedException {
+    throws IOException, StreamNotFoundException, UnauthenticatedException {
     getEvents(streamId, startTime, endTime, limit, new Function<StreamEvent, Boolean>() {
       @Override
       public Boolean apply(StreamEvent input) {
@@ -323,7 +323,7 @@ public class StreamClient {
    */
   public <T extends Collection<? super StreamEvent>> T getEvents(Id.Stream streamId, long startTime,
                                                                  long endTime, int limit, final T results)
-    throws IOException, StreamNotFoundException, UnauthorizedException {
+    throws IOException, StreamNotFoundException, UnauthenticatedException {
     return getEvents(streamId, String.valueOf(startTime), String.valueOf(endTime), limit, results);
   }
 
@@ -341,7 +341,7 @@ public class StreamClient {
    */
   public void getEvents(Id.Stream streamId, long startTime, long endTime, int limit,
                         Function<? super StreamEvent, Boolean> callback)
-    throws IOException, StreamNotFoundException, UnauthorizedException {
+    throws IOException, StreamNotFoundException, UnauthenticatedException {
 
     getEvents(streamId, String.valueOf(startTime), String.valueOf(endTime), limit, callback);
   }
@@ -360,7 +360,7 @@ public class StreamClient {
    */
   public void getEvents(Id.Stream streamId, String start, String end, int limit,
                         Function<? super StreamEvent, Boolean> callback)
-    throws IOException, StreamNotFoundException, UnauthorizedException {
+    throws IOException, StreamNotFoundException, UnauthenticatedException {
 
     long startTime = TimeMathParser.parseTime(start, TimeUnit.MILLISECONDS);
     long endTime = TimeMathParser.parseTime(end, TimeUnit.MILLISECONDS);
@@ -384,7 +384,7 @@ public class StreamClient {
 
     try {
       if (urlConn.getResponseCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
-        throw new UnauthorizedException("Unauthorized status code received from the server.");
+        throw new UnauthenticatedException("Unauthorized status code received from the server.");
       }
       if (urlConn.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
         throw new StreamNotFoundException(streamId);
@@ -414,7 +414,7 @@ public class StreamClient {
    * Writes stream event using the given URL. The write maybe sync or async, depending on the URL.
    */
   private void writeEvent(URL url, Id.Stream stream, String event)
-    throws IOException, StreamNotFoundException, UnauthorizedException {
+    throws IOException, StreamNotFoundException, UnauthenticatedException {
 
     HttpRequest request = HttpRequest.post(url).withBody(event).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamViewClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamViewClient.java
@@ -21,7 +21,7 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ViewDetail;
@@ -70,7 +70,7 @@ public class StreamViewClient {
    * @return true if a view was created, false if updated
    */
   public boolean createOrUpdate(Id.Stream.View id, ViewSpecification viewSpecification)
-    throws NotFoundException, IOException, UnauthorizedException {
+    throws NotFoundException, IOException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(
       id.getNamespace(), String.format("streams/%s/views/%s", id.getStreamId(), id.getId()));
@@ -85,7 +85,7 @@ public class StreamViewClient {
    * @param id the view
    * @throws NotFoundException if the view was not found
    */
-  public void delete(Id.Stream.View id) throws IOException, UnauthorizedException, NotFoundException {
+  public void delete(Id.Stream.View id) throws IOException, UnauthenticatedException, NotFoundException {
     URL url = config.resolveNamespacedURLV3(
       id.getNamespace(), String.format("streams/%s/views/%s", id.getStreamId(), id.getId()));
     HttpResponse response = restClient.execute(HttpMethod.DELETE, url, config.getAccessToken(),
@@ -100,7 +100,7 @@ public class StreamViewClient {
    *
    * @return the list of views associated with a stream
    */
-  public List<String> list(Id.Stream stream) throws IOException, UnauthorizedException {
+  public List<String> list(Id.Stream stream) throws IOException, UnauthenticatedException {
     URL url = config.resolveNamespacedURLV3(stream.getNamespace(), String.format("streams/%s/views", stream.getId()));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, new TypeToken<List<String>>() { }).getResponseObject();
@@ -114,7 +114,7 @@ public class StreamViewClient {
    * @throws NotFoundException if the view was not found
    */
   public ViewDetail get(Id.Stream.View id)
-    throws NotFoundException, IOException, UnauthorizedException {
+    throws NotFoundException, IOException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(
       id.getNamespace(), String.format("streams/%s/views/%s", id.getStreamId(), id.getId()));

--- a/cdap-client/src/main/java/co/cask/cdap/client/WorkflowClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/WorkflowClient.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.WorkflowTokenDetail;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
@@ -68,7 +68,7 @@ public class WorkflowClient {
    * @return {@link WorkflowTokenDetail} for the specified workflow run
    */
   public WorkflowTokenDetail getWorkflowToken(Id.Run workflowRunId)
-    throws UnauthorizedException, IOException, NotFoundException {
+    throws UnauthenticatedException, IOException, NotFoundException {
     return getWorkflowToken(workflowRunId, null, null);
   }
 
@@ -81,7 +81,7 @@ public class WorkflowClient {
    * for the specified workflow run
    */
   public WorkflowTokenDetail getWorkflowToken(Id.Run workflowRunId, WorkflowToken.Scope scope)
-    throws UnauthorizedException, IOException, NotFoundException {
+    throws UnauthenticatedException, IOException, NotFoundException {
     return getWorkflowToken(workflowRunId, scope, null);
   }
 
@@ -93,7 +93,7 @@ public class WorkflowClient {
    * @return {@link WorkflowTokenDetail} containing all the values for the specified key
    */
   public WorkflowTokenDetail getWorkflowToken(Id.Run workflowRunId, String key)
-    throws UnauthorizedException, IOException, NotFoundException {
+    throws UnauthenticatedException, IOException, NotFoundException {
     return getWorkflowToken(workflowRunId, null, key);
   }
 
@@ -109,7 +109,7 @@ public class WorkflowClient {
    */
   public WorkflowTokenDetail getWorkflowToken(Id.Run workflowRunId, @Nullable WorkflowToken.Scope scope,
                                               @Nullable String key)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
     String path = String.format("apps/%s/workflows/%s/runs/%s/token",
                                 workflowRunId.getProgram().getApplicationId(), workflowRunId.getProgram().getId(),
                                 workflowRunId.getId());
@@ -135,7 +135,7 @@ public class WorkflowClient {
    * specified workflow run's {@link WorkflowToken}
    */
   public WorkflowTokenNodeDetail getWorkflowTokenAtNode(Id.Run workflowRunId, String nodeName)
-    throws UnauthorizedException, IOException, NotFoundException {
+    throws UnauthenticatedException, IOException, NotFoundException {
     return getWorkflowTokenAtNode(workflowRunId, nodeName, null, null);
   }
 
@@ -151,7 +151,7 @@ public class WorkflowClient {
    */
   public WorkflowTokenNodeDetail getWorkflowTokenAtNode(Id.Run workflowRunId, String nodeName,
                                                         WorkflowToken.Scope scope)
-    throws UnauthorizedException, IOException, NotFoundException {
+    throws UnauthenticatedException, IOException, NotFoundException {
     return getWorkflowTokenAtNode(workflowRunId, nodeName, scope, null);
   }
 
@@ -165,7 +165,7 @@ public class WorkflowClient {
    * specified {@link WorkflowToken.Scope}in the specified workflow run's {@link WorkflowToken}
    */
   public WorkflowTokenNodeDetail getWorkflowTokenAtNode(Id.Run workflowRunId, String nodeName, String key)
-    throws UnauthorizedException, IOException, NotFoundException {
+    throws UnauthenticatedException, IOException, NotFoundException {
     return getWorkflowTokenAtNode(workflowRunId, nodeName, null, key);
   }
 
@@ -181,7 +181,7 @@ public class WorkflowClient {
    */
   public WorkflowTokenNodeDetail getWorkflowTokenAtNode(Id.Run workflowRunId, String nodeName,
                                                         @Nullable WorkflowToken.Scope scope, @Nullable String key)
-    throws IOException, UnauthorizedException, NotFoundException {
+    throws IOException, UnauthenticatedException, NotFoundException {
     String path = String.format("apps/%s/workflows/%s/runs/%s/nodes/%s/token",
                                 workflowRunId.getProgram().getApplicationId(), workflowRunId.getProgram().getId(),
                                 workflowRunId.getId(), nodeName);

--- a/cdap-client/src/main/java/co/cask/cdap/client/util/RESTClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/util/RESTClient.java
@@ -18,7 +18,7 @@ package co.cask.cdap.client.util;
 
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.exception.DisconnectedException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.security.authentication.client.AccessToken;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
@@ -64,12 +64,12 @@ public class RESTClient {
   }
 
   public HttpResponse execute(HttpRequest request, AccessToken accessToken, int... allowedErrorCodes)
-    throws IOException, UnauthorizedException, DisconnectedException {
+    throws IOException, UnauthenticatedException, DisconnectedException {
     return execute(HttpRequest.builder(request).addHeaders(getAuthHeaders(accessToken)).build(), allowedErrorCodes);
   }
 
   public HttpResponse execute(HttpMethod httpMethod, URL url, AccessToken accessToken, int... allowedErrorCodes)
-    throws IOException, UnauthorizedException, DisconnectedException {
+    throws IOException, UnauthenticatedException, DisconnectedException {
     return execute(HttpRequest.builder(httpMethod, url)
                      .addHeaders(getAuthHeaders(accessToken))
                      .build(), allowedErrorCodes);
@@ -77,7 +77,7 @@ public class RESTClient {
 
   public HttpResponse execute(HttpMethod httpMethod, URL url, Map<String, String> headers, AccessToken accessToken,
                               int... allowedErrorCodes)
-    throws IOException, UnauthorizedException, DisconnectedException {
+    throws IOException, UnauthenticatedException, DisconnectedException {
     return execute(HttpRequest.builder(httpMethod, url)
                      .addHeaders(headers)
                      .addHeaders(getAuthHeaders(accessToken))
@@ -86,7 +86,7 @@ public class RESTClient {
 
   public HttpResponse execute(HttpMethod httpMethod, URL url, String body, Map<String, String> headers,
                               AccessToken accessToken, int... allowedErrorCodes)
-    throws IOException, UnauthorizedException, DisconnectedException {
+    throws IOException, UnauthenticatedException, DisconnectedException {
     return execute(HttpRequest.builder(httpMethod, url)
                      .addHeaders(headers)
                      .addHeaders(getAuthHeaders(accessToken))
@@ -94,7 +94,7 @@ public class RESTClient {
   }
 
   private HttpResponse execute(HttpRequest request, int... allowedErrorCodes)
-    throws IOException, UnauthorizedException, DisconnectedException {
+    throws IOException, UnauthenticatedException, DisconnectedException {
 
     int currentTry = 0;
     HttpResponse response;
@@ -119,7 +119,7 @@ public class RESTClient {
 
     int responseCode = response.getResponseCode();
     if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
-      throw new UnauthorizedException("Unauthorized status code received from the server.");
+      throw new UnauthenticatedException("Unauthorized status code received from the server.");
     }
     if (!isSuccessful(responseCode) && !ArrayUtils.contains(allowedErrorCodes, responseCode)) {
       throw new IOException(responseCode + ": " + response.getResponseBodyAsString());
@@ -140,7 +140,7 @@ public class RESTClient {
   }
 
   public HttpResponse upload(HttpRequest request, AccessToken accessToken, int... allowedErrorCodes)
-    throws IOException, UnauthorizedException, DisconnectedException {
+    throws IOException, UnauthenticatedException, DisconnectedException {
 
     HttpResponse response = HttpRequests.execute(
       HttpRequest.builder(request).addHeaders(getAuthHeaders(accessToken)).build(),
@@ -148,7 +148,7 @@ public class RESTClient {
     int responseCode = response.getResponseCode();
     if (!isSuccessful(responseCode) && !ArrayUtils.contains(allowedErrorCodes, responseCode)) {
       if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
-        throw new UnauthorizedException("Unauthorized status code received from the server.");
+        throw new UnauthenticatedException("Unauthorized status code received from the server.");
       }
       throw new IOException(response.getResponseBodyAsString());
     }

--- a/cdap-common/src/main/java/co/cask/cdap/common/HttpExceptionHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/HttpExceptionHandler.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.common;
 
 import co.cask.cdap.common.http.SecurityRequestContext;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.http.ExceptionHandler;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Throwables;
@@ -52,10 +53,10 @@ public class HttpExceptionHandler extends ExceptionHandler {
     } else if (t instanceof MethodNotAllowedException) {
       logWithTrace(request, t);
       responder.sendStatus(HttpResponseStatus.METHOD_NOT_ALLOWED);
-    } else if (t instanceof UnauthorizedException) {
+    } else if (t instanceof UnauthenticatedException) {
       logWithTrace(request, t);
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } else if (t instanceof co.cask.cdap.security.spi.authorization.UnauthorizedException) {
+    } else if (t instanceof UnauthorizedException) {
       logWithTrace(request, t);
       responder.sendStatus(HttpResponseStatus.FORBIDDEN);
     } else if (t instanceof FeatureDisabledException) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/UnauthenticatedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/UnauthenticatedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,20 +17,20 @@
 package co.cask.cdap.common;
 
 /**
- * Exception thrown when a user is not authenticated to perform an operation.
- * @deprecated since 3.4.0. Please use {@link UnauthenticatedException} instead.
+ * Thrown when a user is not authenticated.
+ * Note: This extends {@link UnauthorizedException} for backwards compatibility.
  */
-@Deprecated
-public class UnauthorizedException extends Exception {
-  public UnauthorizedException() {
+public class UnauthenticatedException extends UnauthorizedException {
+
+  public UnauthenticatedException() {
     super();
   }
 
-  public UnauthorizedException(String msg, Throwable throwable) {
+  public UnauthenticatedException(String msg, Throwable throwable) {
     super(msg, throwable);
   }
 
-  public UnauthorizedException(String message) {
+  public UnauthenticatedException(String message) {
     super(message);
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceClient.java
@@ -20,7 +20,7 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NamespaceAlreadyExistsException;
 import co.cask.cdap.common.NamespaceCannotBeDeletedException;
 import co.cask.cdap.common.NamespaceNotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.common.http.HttpRequest;
@@ -43,7 +43,7 @@ public abstract class AbstractNamespaceClient implements NamespaceAdmin {
   /**
    * Executes an HTTP request.
    */
-  protected abstract HttpResponse execute(HttpRequest request) throws IOException, UnauthorizedException;
+  protected abstract HttpResponse execute(HttpRequest request) throws IOException, UnauthenticatedException;
 
   /**
    * Resolves the specified URL.

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/InMemoryNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/InMemoryNamespaceClient.java
@@ -18,7 +18,7 @@ package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.common.http.HttpRequest;
@@ -100,7 +100,7 @@ public class InMemoryNamespaceClient extends AbstractNamespaceClient {
   }
 
   @Override
-  protected HttpResponse execute(HttpRequest request) throws IOException, UnauthorizedException {
+  protected HttpResponse execute(HttpRequest request) throws IOException, UnauthenticatedException {
     // not needed since we do not use HTTP here
     return null;
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/LocalNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/LocalNamespaceClient.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.common.namespace;
 
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.common.http.HttpRequest;
@@ -61,7 +61,7 @@ public class LocalNamespaceClient extends AbstractNamespaceClient {
 
   // This class overrides all public API methods to use in-memory namespaceAdmin, and so the following two are not used.
   @Override
-  protected HttpResponse execute(HttpRequest request) throws IOException, UnauthorizedException {
+  protected HttpResponse execute(HttpRequest request) throws IOException, UnauthenticatedException {
     return null;
   }
 

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -29,7 +29,7 @@ import co.cask.cdap.client.StreamClient;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.config.ConnectionConfig;
 import co.cask.cdap.client.util.RESTClient;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
@@ -117,7 +117,7 @@ public abstract class IntegrationTestBase {
       checkServicesWithRetry(cdapAvailable, errorMessage);
     } catch (Throwable e) {
       Throwable rootCause = Throwables.getRootCause(e);
-      if (rootCause instanceof UnauthorizedException) {
+      if (rootCause instanceof UnauthenticatedException) {
         // security is enabled, we need to get access token before checking system services
         try {
           accessToken = fetchAccessToken();
@@ -173,7 +173,7 @@ public abstract class IntegrationTestBase {
         // Also suppress and retry if the root cause is IOException
         Throwable rootCause = Throwables.getRootCause(e);
         if (!(rootCause instanceof IOException)) {
-          // Throw if root cause is any other exception e.g. UnauthorizedException
+          // Throw if root cause is any other exception e.g. UnauthenticatedException
           throw Throwables.propagate(rootCause);
         }
       }
@@ -184,7 +184,7 @@ public abstract class IntegrationTestBase {
     throw new TimeoutException(exceptionMessage);
   }
 
-  private void assertUnrecoverableResetEnabled() throws IOException, UnauthorizedException {
+  private void assertUnrecoverableResetEnabled() throws IOException, UnauthenticatedException {
     ConfigEntry configEntry = getMetaClient().getCDAPConfig().get(Constants.Dangerous.UNRECOVERABLE_RESET);
     Preconditions.checkNotNull(configEntry,
                                "Missing key from CDAP Configuration: {}", Constants.Dangerous.UNRECOVERABLE_RESET);

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/RemoteDatasetAdmin.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/RemoteDatasetAdmin.java
@@ -21,7 +21,7 @@ import co.cask.cdap.client.DatasetClient;
 import co.cask.cdap.common.DatasetAlreadyExistsException;
 import co.cask.cdap.common.DatasetNotFoundException;
 import co.cask.cdap.common.DatasetTypeNotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.Id;
 import com.google.common.base.Throwables;
@@ -53,7 +53,7 @@ public final class RemoteDatasetAdmin implements DatasetAdmin {
   public boolean exists() throws IOException {
     try {
       return datasetClient.exists(datasetInstance);
-    } catch (UnauthorizedException e) {
+    } catch (UnauthenticatedException e) {
       throw Throwables.propagate(e);
     }
   }
@@ -62,7 +62,7 @@ public final class RemoteDatasetAdmin implements DatasetAdmin {
   public void create() throws IOException {
     try {
       datasetClient.create(datasetInstance, dsConfiguration);
-    } catch (DatasetTypeNotFoundException | DatasetAlreadyExistsException | UnauthorizedException e) {
+    } catch (DatasetTypeNotFoundException | DatasetAlreadyExistsException | UnauthenticatedException e) {
       throw Throwables.propagate(e);
     }
   }
@@ -71,7 +71,7 @@ public final class RemoteDatasetAdmin implements DatasetAdmin {
   public void drop() throws IOException {
     try {
       datasetClient.delete(datasetInstance);
-    } catch (DatasetNotFoundException | UnauthorizedException e) {
+    } catch (DatasetNotFoundException | UnauthenticatedException e) {
       throw Throwables.propagate(e);
     }
   }
@@ -80,7 +80,7 @@ public final class RemoteDatasetAdmin implements DatasetAdmin {
   public void truncate() throws IOException {
     try {
       datasetClient.truncate(datasetInstance);
-    } catch (UnauthorizedException e) {
+    } catch (UnauthenticatedException e) {
       throw Throwables.propagate(e);
     }
   }

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkflowManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkflowManager.java
@@ -24,7 +24,7 @@ import co.cask.cdap.client.WorkflowClient;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.WorkflowTokenDetail;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
@@ -70,7 +70,7 @@ public class RemoteWorkflowManager extends AbstractProgramManager<WorkflowManage
                                       @Nullable String key) throws NotFoundException {
     try {
       return workflowClient.getWorkflowToken(new Id.Run(workflowId, runId), scope, key);
-    } catch (IOException | UnauthorizedException e) {
+    } catch (IOException | UnauthenticatedException e) {
       throw Throwables.propagate(e);
     }
   }
@@ -80,7 +80,7 @@ public class RemoteWorkflowManager extends AbstractProgramManager<WorkflowManage
                                                 @Nullable String key) throws NotFoundException {
     try {
       return workflowClient.getWorkflowTokenAtNode(new Id.Run(workflowId, runId), nodeName, scope, key);
-    } catch (IOException | UnauthorizedException e) {
+    } catch (IOException | UnauthenticatedException e) {
       throw Throwables.propagate(e);
     }
   }

--- a/cdap-integration-test/src/test/java/co/cask/cdap/test/TestSQL.java
+++ b/cdap-integration-test/src/test/java/co/cask/cdap/test/TestSQL.java
@@ -18,7 +18,7 @@ package co.cask.cdap.test;
 
 import co.cask.cdap.StandaloneTester;
 import co.cask.cdap.api.dataset.DatasetAdmin;
-import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.common.http.HttpMethod;
 import com.google.common.collect.ImmutableMap;
@@ -79,7 +79,8 @@ public class TestSQL extends IntegrationTestBase {
     Assert.assertFalse(dsAdmin.exists());
   }
 
-  private void put(ServiceManager serviceManager, String key, String value) throws IOException, UnauthorizedException {
+  private void put(ServiceManager serviceManager, String key,
+                   String value) throws IOException, UnauthenticatedException {
     URL url = new URL(serviceManager.getServiceURL(), key);
     getRestClient().execute(HttpMethod.PUT, url, value,
                             ImmutableMap.<String, String>of(), getClientConfig().getAccessToken());


### PR DESCRIPTION
…f UnauthenticatedException, since it was being thrown when access tokens weren't found, etc. UnauthenticatedException currently extends the deprecated UnauthorizedException so cdap-clients still remain backward-compatible. However, this relationship can be removed when UnauthorizedException is removed two releases down the line.

Jira: [CDAP-5212](https://issues.cask.co/browse/CDAP-5212)
Build: http://builds.cask.co/browse/CDAP-DUT3681
