### PR TITLE
CDAP-5216 Improve determining dataset access type for MapReduce and Spark

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -37,6 +37,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
 import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
 import co.cask.cdap.data2.dataset2.SingleThreadDatasetCache;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.internal.app.program.ProgramTypeMetricTag;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.proto.Id;
@@ -170,7 +171,12 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   @Override
   public <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
     throws DatasetInstantiationException {
-    return datasetCache.getDataset(name, arguments);
+    return getDataset(name, arguments, AccessType.UNKNOWN);
+  }
+
+  protected <T extends Dataset> T getDataset(String name, Map<String, String> arguments, AccessType accessType)
+    throws DatasetInstantiationException {
+    return datasetCache.getDataset(name, arguments, accessType);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -37,6 +37,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data.stream.StreamInputFormatProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.batch.dataset.DatasetInputFormatProvider;
@@ -274,7 +275,8 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     // compatibility for the #setOutput(String, Dataset) method, so delaying the instantiation of this dataset will
     // bring about code complexity without much benefit. Once #setOutput(String, Dataset) is removed, we can postpone
     // this dataset instantiation
-    addOutput(datasetName, new DatasetOutputFormatProvider(datasetName, arguments, getDataset(datasetName, arguments),
+    addOutput(datasetName, new DatasetOutputFormatProvider(datasetName, arguments,
+                                                           getDataset(datasetName, arguments, AccessType.WRITE),
                                                            MapReduceBatchWritableOutputFormat.class));
   }
 
@@ -390,7 +392,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
       return (Input.InputFormatProviderInput) input.alias(originalAlias);
     }
     DatasetInputFormatProvider datasetInputFormatProvider =
-      new DatasetInputFormatProvider(datasetName, datasetArgs, getDataset(datasetName, datasetArgs),
+      new DatasetInputFormatProvider(datasetName, datasetArgs, getDataset(datasetName, datasetArgs, AccessType.READ),
                                      datasetInput.getSplits(), MapReduceBatchReadableInputFormat.class);
     return (Input.InputFormatProviderInput) Input.of(datasetName, datasetInputFormatProvider).alias(originalAlias);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -37,6 +37,7 @@ import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.DefaultTaskLocalizationContext;
 import co.cask.cdap.internal.app.runtime.batch.dataset.CloseableBatchWritable;
@@ -61,6 +62,7 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -248,7 +250,12 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
   @Override
   public <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
     throws DatasetInstantiationException {
-    T dataset = super.getDataset(name, arguments);
+    return getDataset(name, arguments, AccessType.UNKNOWN);
+  }
+
+  protected <T extends Dataset> T getDataset(String name, Map<String, String> arguments, AccessType accessType)
+    throws DatasetInstantiationException {
+    T dataset = super.getDataset(name, arguments, accessType);
     if (dataset instanceof TransactionAware) {
       TransactionAware txAware = (TransactionAware) dataset;
       if (txAwares.add(txAware)) {
@@ -291,7 +298,7 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
    * Returns a {@link BatchReadable} that reads data from the given dataset.
    */
   <K, V> BatchReadable<K, V> getBatchReadable(String datasetName, Map<String, String> datasetArgs) {
-    Dataset dataset = getDataset(datasetName, datasetArgs);
+    Dataset dataset = getDataset(datasetName, datasetArgs, AccessType.READ);
     // Must be BatchReadable.
     Preconditions.checkArgument(dataset instanceof BatchReadable, "Dataset '%s' is not a BatchReadable.", datasetName);
 
@@ -335,7 +342,7 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
    * Returns a {@link CloseableBatchWritable} that writes data to the given dataset.
    */
   <K, V> CloseableBatchWritable<K, V> getBatchWritable(String datasetName, Map<String, String> datasetArgs) {
-    Dataset dataset = getDataset(datasetName, datasetArgs);
+    Dataset dataset = getDataset(datasetName, datasetArgs, AccessType.WRITE);
     // Must be BatchWritable.
     Preconditions.checkArgument(dataset instanceof BatchWritable, "Dataset '%s' is not a BatchWritable.", datasetName);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/NameMappedDatasetFramework.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/NameMappedDatasetFramework.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
@@ -24,6 +25,7 @@ import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.ForwardingProgramContextAwareDatasetFramework;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.proto.Id;
 import com.google.common.base.Function;
 
@@ -151,7 +153,23 @@ public class NameMappedDatasetFramework extends ForwardingProgramContextAwareDat
                                           @Nullable Iterable<? extends Id> owners)
     throws DatasetManagementException, IOException {
     return super.getDataset(getMappedDatasetInstance(datasetInstanceId), arguments, classLoader,
-                               classLoaderProvider, owners);
+                            classLoaderProvider, owners);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader,
+                                          DatasetClassLoaderProvider classLoaderProvider,
+                                          @Nullable Iterable<? extends Id> owners, AccessType accessType)
+    throws DatasetManagementException, IOException {
+    return super.getDataset(getMappedDatasetInstance(datasetInstanceId),
+                            arguments, classLoader, classLoaderProvider, owners, accessType);
+  }
+
+  @Override
+  public void writeLineage(Id.DatasetInstance datasetInstanceId, AccessType accessType) {
+    super.writeLineage(getMappedDatasetInstance(datasetInstanceId), accessType);
   }
 
   private Id.DatasetInstance getMappedDatasetInstance(Id.DatasetInstance datasetInstanceId) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -789,7 +789,7 @@ public class DefaultStoreTest {
     specsToBeVerified.addAll(spec.getSpark().keySet());
 
     //Verify if there are 6 program specs in AllProgramsApp
-    Assert.assertEquals(6, specsToBeVerified.size());
+    Assert.assertEquals(7, specsToBeVerified.size());
 
     Id.Application appId = Id.Application.from(DefaultId.NAMESPACE, "App");
     // Check the diff with the same app - re-deployment scenario where programs are not removed.
@@ -801,7 +801,7 @@ public class DefaultStoreTest {
 
     //Get the deleted program specs by sending a spec with same name as AllProgramsApp but with no programs
     deletedSpecs = store.getDeletedProgramSpecifications(appId, spec);
-    Assert.assertEquals(6, deletedSpecs.size());
+    Assert.assertEquals(7, deletedSpecs.size());
 
     for (ProgramSpecification specification : deletedSpecs) {
       //Remove the spec that is verified, to check the count later.
@@ -830,7 +830,7 @@ public class DefaultStoreTest {
 
     //Get the deleted program specs by sending a spec with same name as AllProgramsApp but with no programs
     List<ProgramSpecification> deletedSpecs = store.getDeletedProgramSpecifications(appId, spec);
-    Assert.assertEquals(1, deletedSpecs.size());
+    Assert.assertEquals(2, deletedSpecs.size());
 
     for (ProgramSpecification specification : deletedSpecs) {
       //Remove the spec that is verified, to check the count later.

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
@@ -27,12 +27,14 @@ import co.cask.cdap.data2.metadata.lineage.Relation;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.tephra.TransactionExecutorFactory;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.twill.api.RunId;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -74,6 +76,11 @@ public class LineageAdminTest extends MetadataTestBase {
 
   private final Id.Program program5 = Id.Program.from("default", "app5", ProgramType.SERVICE, "service5");
   private final Id.Run run5 = new Id.Run(program5, RunIds.generate(700).getId());
+
+  @After
+  public void cleanup() throws Exception {
+    deleteNamespace(NamespaceId.DEFAULT.getNamespace());
+  }
 
   @Test
   public void testSimpleLineage() throws Exception {
@@ -165,6 +172,68 @@ public class LineageAdminTest extends MetadataTestBase {
   }
 
   @Test
+  public void testLineageSimplifying() throws Exception {
+    // tests that if there's a READ and a WRITE, it gets served as a READ_WRITE
+    // also tests that UNKNOWN is ignored when a READ_WRITE is served
+
+    // Lineage for D3 -> P2 -> D2 -> P1 -> D1
+    //             |     |
+    //             |     V
+    //             |<-----
+
+    LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
+                                                 Id.DatasetInstance.from("default", "testSimpleLineage"));
+    Store store = getInjector().getInstance(Store.class);
+    MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
+    LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityValidator());
+
+    // Add accesses for D3 -> P2 -> D2 -> P1 -> D1
+    // We need to use current time here as metadata store stores access time using current time
+    Id.Run run1 = new Id.Run(program1, RunIds.generate(System.currentTimeMillis()).getId());
+    Id.Run run2 = new Id.Run(program2, RunIds.generate(System.currentTimeMillis()).getId());
+    addRuns(store, run1, run2);
+    // It is okay to use current time here since access time is ignore during assertions
+    lineageStore.addAccess(run1, dataset1, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset2, AccessType.READ, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset2, AccessType.UNKNOWN, System.currentTimeMillis(), flowlet1);
+
+    lineageStore.addAccess(run2, dataset2, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
+    // a READ, WRITE, and UNKNOWN will be served as a READ_WRITE
+    lineageStore.addAccess(run2, dataset3, AccessType.READ, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset3, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset3, AccessType.UNKNOWN, System.currentTimeMillis(), flowlet2);
+
+    Lineage expectedLineage = new Lineage(
+      ImmutableSet.of(
+        new Relation(dataset1, program1, AccessType.WRITE, twillRunId(run1), toSet(flowlet1)),
+        new Relation(dataset2, program1, AccessType.READ, twillRunId(run1), toSet(flowlet1)),
+        new Relation(dataset2, program1, AccessType.UNKNOWN, twillRunId(run1), toSet(flowlet1)),
+        new Relation(dataset2, program2, AccessType.WRITE, twillRunId(run2), toSet(flowlet2)),
+        new Relation(dataset3, program2, AccessType.READ_WRITE, twillRunId(run2), toSet(flowlet2))
+      )
+    );
+
+    // Lineage for D1
+    Assert.assertEquals(expectedLineage,
+                        lineageAdmin.computeLineage(dataset1, 500, System.currentTimeMillis() + 10000, 100));
+
+    // Lineage for D2
+    Assert.assertEquals(expectedLineage,
+                        lineageAdmin.computeLineage(dataset2, 500, System.currentTimeMillis() + 10000, 100));
+
+    // Lineage for D1 for one level should be D2 -> P1 -> D1
+    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset1, 500, System.currentTimeMillis() + 10000, 1);
+
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new Relation(dataset1, program1, AccessType.WRITE, twillRunId(run1), toSet(flowlet1)),
+        new Relation(dataset2, program1, AccessType.READ, twillRunId(run1), toSet(flowlet1)),
+        new Relation(dataset2, program1, AccessType.UNKNOWN, twillRunId(run1), toSet(flowlet1))
+      ),
+      oneLevelLineage.getRelations());
+  }
+
+  @Test
   public void testSimpleLoopLineage() throws Exception {
     // Lineage for D1 -> P1 -> D2 -> P2 -> D3 -> P3 -> D4
     //             |                 |
@@ -247,10 +316,7 @@ public class LineageAdminTest extends MetadataTestBase {
     lineageStore.addAccess(run1, dataset1, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
 
     Lineage expectedLineage = new Lineage(
-      ImmutableSet.of(
-        new Relation(dataset1, program1, AccessType.READ, twillRunId(run1), toSet(flowlet1)),
-        new Relation(dataset1, program1, AccessType.WRITE, twillRunId(run1), toSet(flowlet1))
-      )
+      ImmutableSet.of(new Relation(dataset1, program1, AccessType.READ_WRITE, twillRunId(run1), toSet(flowlet1)))
     );
 
     Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1, 500, 20000, 100));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
@@ -196,11 +196,14 @@ public class LineageTest extends MetadataTestBase {
     Id.Application app = Id.Application.from(namespace, AllProgramsApp.NAME);
     Id.Flow flow = Id.Flow.from(app, AllProgramsApp.NoOpFlow.NAME);
     Id.Program mapreduce = Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR.NAME);
+    Id.Program mapreduce2 = Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR2.NAME);
     Id.Program spark = Id.Program.from(app, ProgramType.SPARK, AllProgramsApp.NoOpSpark.NAME);
     Id.Program service = Id.Program.from(app, ProgramType.SERVICE, AllProgramsApp.NoOpService.NAME);
     Id.Program worker = Id.Program.from(app, ProgramType.WORKER, AllProgramsApp.NoOpWorker.NAME);
     Id.Program workflow = Id.Program.from(app, ProgramType.WORKFLOW, AllProgramsApp.NoOpWorkflow.NAME);
     Id.DatasetInstance dataset = Id.DatasetInstance.from(namespace, AllProgramsApp.DATASET_NAME);
+    Id.DatasetInstance dataset2 = Id.DatasetInstance.from(namespace, AllProgramsApp.DATASET_NAME2);
+    Id.DatasetInstance dataset3 = Id.DatasetInstance.from(namespace, AllProgramsApp.DATASET_NAME3);
     Id.Stream stream = Id.Stream.from(namespace, AllProgramsApp.STREAM_NAME);
 
     Assert.assertEquals(200, status(createNamespace(namespace)));
@@ -224,6 +227,7 @@ public class LineageTest extends MetadataTestBase {
       // Start all programs
       RunId flowRunId = runAndWait(flow);
       RunId mrRunId = runAndWait(mapreduce);
+      RunId mrRunId2 = runAndWait(mapreduce2);
       RunId sparkRunId = runAndWait(spark);
       runAndWait(workflow);
       RunId workflowMrRunId = getRunId(mapreduce, mrRunId);
@@ -235,6 +239,7 @@ public class LineageTest extends MetadataTestBase {
       // Wait for programs to finish
       waitForStop(flow, true);
       waitForStop(mapreduce, false);
+      waitForStop(mapreduce2, false);
       waitForStop(spark, false);
       waitForStop(workflow, false);
       waitForStop(worker, false);
@@ -255,9 +260,13 @@ public class LineageTest extends MetadataTestBase {
             // Dataset access
             new Relation(dataset, flow, AccessType.UNKNOWN, flowRunId,
                          ImmutableSet.of(Id.Flow.Flowlet.from(flow, AllProgramsApp.A.NAME))),
-            new Relation(dataset, mapreduce, AccessType.UNKNOWN, mrRunId),
-            new Relation(dataset, spark, AccessType.UNKNOWN, sparkRunId),
-            new Relation(dataset, mapreduce, AccessType.UNKNOWN, workflowMrRunId),
+            new Relation(dataset, mapreduce, AccessType.WRITE, mrRunId),
+            new Relation(dataset, mapreduce2, AccessType.WRITE, mrRunId2),
+            new Relation(dataset2, mapreduce2, AccessType.READ, mrRunId2),
+            new Relation(dataset, spark, AccessType.READ, sparkRunId),
+            new Relation(dataset2, spark, AccessType.WRITE, sparkRunId),
+            new Relation(dataset3, spark, AccessType.READ_WRITE, sparkRunId),
+            new Relation(dataset, mapreduce, AccessType.WRITE, workflowMrRunId),
             new Relation(dataset, service, AccessType.UNKNOWN, serviceRunId),
             new Relation(dataset, worker, AccessType.UNKNOWN, workerRunId),
 
@@ -299,6 +308,8 @@ public class LineageTest extends MetadataTestBase {
       Assert.assertEquals(toSet(new MetadataRecord(app, MetadataScope.USER, emptyMap(), emptySet()),
                                 new MetadataRecord(programForSpark, MetadataScope.USER, emptyMap(), sparkTags),
                                 new MetadataRecord(dataset, MetadataScope.USER, datasetProperties, emptySet()),
+                                new MetadataRecord(dataset2, MetadataScope.USER, emptyMap(), emptySet()),
+                                new MetadataRecord(dataset3, MetadataScope.USER, emptyMap(), emptySet()),
                                 new MetadataRecord(stream, MetadataScope.USER, emptyMap(), emptySet())),
                           fetchRunMetadata(new Id.Run(spark, sparkRunId.getId())));
     } finally {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -675,6 +675,8 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
              AllProgramsApp.NoOpFlow.NAME)
         .put(ProgramType.MAPREDUCE.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + AllProgramsApp.NoOpMR.NAME,
              AllProgramsApp.NoOpMR.NAME)
+        .put(ProgramType.MAPREDUCE.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + AllProgramsApp.NoOpMR2.NAME,
+             AllProgramsApp.NoOpMR2.NAME)
         .put(ProgramType.SERVICE.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR +
                AllProgramsApp.NoOpService.NAME, AllProgramsApp.NoOpService.NAME)
         .put(ProgramType.SPARK.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + AllProgramsApp.NoOpSpark.NAME,
@@ -957,9 +959,12 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR.NAME)),
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR2.NAME)),
         new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.WORKFLOW, AllProgramsApp.NoOpWorkflow.NAME)),
         new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.SPARK, AllProgramsApp.NoOpSpark.NAME)),
         new MetadataSearchResultRecord(Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DATASET_NAME)),
+        new MetadataSearchResultRecord(Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DATASET_NAME2)),
+        new MetadataSearchResultRecord(Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DATASET_NAME3)),
         new MetadataSearchResultRecord(
           Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DS_WITH_SCHEMA_NAME)),
         new MetadataSearchResultRecord(myds)
@@ -1010,7 +1015,8 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
       searchMetadata(Id.Namespace.DEFAULT, ProgramType.FLOW.getPrettyName(), MetadataSearchTargetType.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
-        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR.NAME))),
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR.NAME)),
+        new MetadataSearchResultRecord(Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR2.NAME))),
       searchMetadata(Id.Namespace.DEFAULT, ProgramType.MAPREDUCE.getPrettyName(), MetadataSearchTargetType.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
@@ -1033,6 +1039,8 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
 
   private void assertDataEntitySearch() throws Exception {
     Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DATASET_NAME);
+    Id.DatasetInstance datasetInstance2 = Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DATASET_NAME2);
+    Id.DatasetInstance datasetInstance3 = Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DATASET_NAME3);
     Id.DatasetInstance dsWithSchema = Id.DatasetInstance.from(Id.Namespace.DEFAULT, AllProgramsApp.DS_WITH_SCHEMA_NAME);
     Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, AllProgramsApp.STREAM_NAME);
     Id.Stream.View view = Id.Stream.View.from(streamId, "view");
@@ -1087,7 +1095,8 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
 
     // search dataset
     ImmutableSet<MetadataSearchResultRecord> expectedKvTables = ImmutableSet.of(
-      new MetadataSearchResultRecord(datasetInstance), new MetadataSearchResultRecord(myds)
+      new MetadataSearchResultRecord(datasetInstance), new MetadataSearchResultRecord(datasetInstance2),
+      new MetadataSearchResultRecord(datasetInstance3), new MetadataSearchResultRecord(myds)
     );
     ImmutableSet<MetadataSearchResultRecord> expectedAllDatasets = ImmutableSet.<MetadataSearchResultRecord>builder()
       .addAll(expectedKvTables)

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiator.java
@@ -25,6 +25,7 @@ import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DirectoryClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.base.Objects;
@@ -77,18 +78,23 @@ public class SystemDatasetInstantiator implements Closeable {
     return getDataset(datasetId, DatasetDefinition.NO_ARGUMENTS);
   }
 
-  @SuppressWarnings("unchecked")
   public <T extends Dataset> T getDataset(DatasetId datasetId, Map<String, String> arguments)
     throws DatasetInstantiationException {
     return getDataset((Id.DatasetInstance) datasetId.toId(), arguments);
   }
 
-  @SuppressWarnings("unchecked")
-    public <T extends Dataset> T getDataset(Id.DatasetInstance datasetId, Map<String, String> arguments)
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetId, Map<String, String> arguments)
     throws DatasetInstantiationException {
+    return getDataset(datasetId, arguments, AccessType.UNKNOWN);
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetId, Map<String, String> arguments,
+                                          AccessType accessType) throws DatasetInstantiationException {
 
     try {
-      T dataset = datasetFramework.getDataset(datasetId, arguments, parentClassLoader, classLoaderProvider, owners);
+      T dataset = datasetFramework.getDataset(datasetId, arguments, parentClassLoader, classLoaderProvider, owners,
+                                              accessType);
       if (dataset == null) {
         throw new DatasetInstantiationException("Trying to access dataset that does not exist: " + datasetId);
       }
@@ -96,6 +102,10 @@ public class SystemDatasetInstantiator implements Closeable {
     } catch (Exception e) {
       throw new DatasetInstantiationException("Failed to access dataset: " + datasetId, e);
     }
+  }
+
+  public void writeLineage(Id.DatasetInstance datasetId, AccessType accessType) {
+    datasetFramework.writeLineage(datasetId, accessType);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -32,6 +32,7 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.SingleTypeModule;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.DatasetTypeMeta;
@@ -251,6 +252,17 @@ public class RemoteDatasetFramework implements DatasetFramework {
     DatasetClassLoaderProvider classLoaderProvider,
     @Nullable Iterable<? extends Id> owners) throws DatasetManagementException, IOException {
 
+    return getDataset(datasetInstanceId, arguments, classLoader, classLoaderProvider, owners, AccessType.UNKNOWN);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader,
+                                          DatasetClassLoaderProvider classLoaderProvider,
+                                          @Nullable Iterable<? extends Id> owners, AccessType accessType)
+    throws DatasetManagementException, IOException {
+
     DatasetMeta instanceInfo = clientCache.getUnchecked(datasetInstanceId.getNamespace())
       .getInstance(datasetInstanceId.getId(), owners);
     if (instanceInfo == null) {
@@ -260,6 +272,11 @@ public class RemoteDatasetFramework implements DatasetFramework {
     return (T) instances.get(
       datasetInstanceId, instanceInfo.getType(), instanceInfo.getSpec(),
       classLoaderProvider, classLoader, arguments);
+  }
+
+  @Override
+  public void writeLineage(Id.DatasetInstance datasetInstanceId, AccessType accessType) {
+    // no-op. The RemoteDatasetFramework doesn't need to do anything. The lineage should be recorded before this point.
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,6 +26,7 @@ import co.cask.cdap.api.dataset.InstanceNotFoundException;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import com.google.common.annotations.VisibleForTesting;
@@ -313,6 +314,38 @@ public interface DatasetFramework {
                                    DatasetClassLoaderProvider classLoaderProvider,
                                    @Nullable Iterable<? extends Id> owners)
     throws DatasetManagementException, IOException;
+
+  /**
+   * Gets dataset to be used to perform data operations. This one is used when the classloader(s) for a dataset may
+   * create some resources that need to be cleaned up on close, and an access type is specified.
+   *
+   * @param <T> dataset type to be returned
+   * @param datasetInstanceId dataset instance id
+   * @param arguments runtime arguments for the dataset instance
+   * @param classLoader parent classLoader to be used to load classes or {@code null} to use system classLoader
+   * @param classLoaderProvider provider to get classloaders for different dataset modules
+   * @param owners owners of the dataset
+   * @param accessType accessType for this request
+   * @return instance of dataset or {@code null} if dataset instance of this name doesn't exist.
+   * @throws DatasetManagementException when there's trouble getting dataset meta info
+   * @throws IOException when there's trouble to instantiate {@link co.cask.cdap.api.dataset.Dataset}
+   * @throws ServiceUnavailableException when the dataset service is not running
+   */
+  @Nullable
+  <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                   @Nullable ClassLoader classLoader,
+                                   DatasetClassLoaderProvider classLoaderProvider,
+                                   @Nullable Iterable<? extends Id> owners,
+                                   AccessType accessType)
+    throws DatasetManagementException, IOException;
+
+  /**
+   * Write lineage for a particular dataset instance.
+   *
+   * @param datasetInstanceId dataset instance id
+   * @param accessType accessType to be recorded
+   */
+  void writeLineage(Id.DatasetInstance datasetInstanceId, AccessType accessType);
 
   /**
    * Creates a namespace in the Storage Providers - HBase/LevelDB, Hive and HDFS/Local File System.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingDatasetFramework.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.data2.dataset2;
 
 import co.cask.cdap.api.dataset.Dataset;
@@ -22,6 +23,7 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import org.apache.twill.filesystem.Location;
@@ -157,6 +159,21 @@ public class ForwardingDatasetFramework implements DatasetFramework {
                                           @Nullable Iterable<? extends Id> owners)
     throws DatasetManagementException, IOException {
     return delegate.getDataset(datasetInstanceId, arguments, classLoader, classLoaderProvider, owners);
+  }
+
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader,
+                                          DatasetClassLoaderProvider classLoaderProvider,
+                                          @Nullable Iterable<? extends Id> owners, AccessType accessType)
+    throws DatasetManagementException, IOException {
+    return delegate.getDataset(datasetInstanceId, arguments, classLoader, classLoaderProvider, owners, accessType);
+  }
+
+  @Override
+  public void writeLineage(Id.DatasetInstance datasetInstanceId, AccessType accessType) {
+    delegate.writeLineage(datasetInstanceId, accessType);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
@@ -167,11 +167,40 @@ public class LineageWriterDatasetFramework extends ForwardingDatasetFramework im
     return dataset;
   }
 
-  private <T extends Dataset> void writeLineage(Id.DatasetInstance datasetInstanceId, T dataset) {
-    if (dataset != null && programContext.getRun() != null) {
-      lineageWriter.addAccess(programContext.getRun(), datasetInstanceId, AccessType.UNKNOWN,
+  @Nullable
+  @Override
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+                                          @Nullable ClassLoader classLoader,
+                                          DatasetClassLoaderProvider classLoaderProvider,
+                                          @Nullable Iterable<? extends Id> owners, AccessType accessType)
+    throws DatasetManagementException, IOException {
+    T dataset = super.getDataset(datasetInstanceId, arguments, classLoader, classLoaderProvider, owners, accessType);
+    writeLineage(datasetInstanceId, dataset, accessType);
+    return dataset;
+  }
+
+  @Override
+  public void writeLineage(Id.DatasetInstance datasetInstanceId, AccessType accessType) {
+    super.writeLineage(datasetInstanceId, accessType);
+    doWriteLineage(datasetInstanceId, accessType);
+  }
+
+  private <T extends Dataset> void writeLineage(Id.DatasetInstance datasetInstanceId, @Nullable T dataset) {
+    writeLineage(datasetInstanceId, dataset, AccessType.UNKNOWN);
+  }
+
+  private <T extends Dataset> void writeLineage(Id.DatasetInstance datasetInstanceId, @Nullable T dataset,
+                                                AccessType accessType) {
+    if (dataset != null) {
+      doWriteLineage(datasetInstanceId, accessType);
+    }
+  }
+
+  private void doWriteLineage(Id.DatasetInstance datasetInstanceId, AccessType accessType) {
+    if (programContext.getRun() != null) {
+      lineageWriter.addAccess(programContext.getRun(), datasetInstanceId, accessType,
                               programContext.getComponentId());
-      AuditPublishers.publishAccess(auditPublisher, datasetInstanceId, AccessType.UNKNOWN, programContext.getRun());
+      AuditPublishers.publishAccess(auditPublisher, datasetInstanceId, accessType, programContext.getRun());
     }
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/DynamicDatasetCacheTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/DynamicDatasetCacheTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -117,8 +118,12 @@ public abstract class DynamicDatasetCacheTest {
     Assert.assertSame(a, a2);
 
     TestDataset b = cache.getDataset("b", B_ARGUMENTS);
-    TestDataset b1 = cache.getDataset("b", B_ARGUMENTS);
+    TestDataset b1 = cache.getDataset("b", B_ARGUMENTS, AccessType.READ);
+    TestDataset b2 = cache.getDataset("b", B_ARGUMENTS, AccessType.WRITE);
     Assert.assertSame(b, b1);
+
+    // assert that b1 and b2 are the same, even though their accessType is different
+    Assert.assertSame(b1, b2);
 
     // validate that arguments for a are the global runtime args of the cache
     Assert.assertEquals(2, a.getArguments().size());


### PR DESCRIPTION
For MapReduce and Spark, we know the dataset access types (when setting as input or output of the MR/Spark program), so we can specify that particular accessType, instead of `AccessType.Unknown`.

This updates DynamicDatasetCache, SystemDatasetInstantiator, and DatasetFramework to have a `getDataset` method that takes in an `AccessType`.
One thing to note is that `RemoteDatasetFramework` and `InMemoryDatasetFramework` have implementation of this method that totally ignore this parameter, because it is only needed up until the `lineageWriterDatasetFramework`.

https://issues.cask.co/browse/CDAP-5216
http://builds.cask.co/browse/CDAP-DUT3767-5