### PR TITLE
CDAP-5146 refactoring and cleanup to prepare for new plugin types

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/CompositeFinisher.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/CompositeFinisher.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+import co.cask.cdap.etl.api.batch.BatchConfigurable;
+import co.cask.cdap.etl.api.batch.BatchContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A finisher of one or more {@link BatchConfigurable BatchConfigurables}.
+ * If any of them throws an exception, the exception will be logged before moving on to finish the other objects.
+ */
+public class CompositeFinisher implements Finisher {
+  private static final Logger LOG = LoggerFactory.getLogger(CompositeFinisher.class);
+  private final List<Finisher> finishers;
+
+  private CompositeFinisher(List<Finisher> finishers) {
+    this.finishers = finishers;
+  }
+
+  /**
+   * Run logic on program finish.
+   *
+   * @param succeeded whether the program run succeeded or not
+   */
+  public void onFinish(boolean succeeded) {
+    for (Finisher finisher : finishers) {
+      finisher.onFinish(succeeded);
+    }
+  }
+
+  /**
+   * @return builder for creating a composite finisher.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder to create a composite finisher
+   */
+  public static class Builder {
+    private final List<Finisher> finishers;
+
+    public Builder() {
+      this.finishers = new ArrayList<>();
+    }
+
+    public <T extends BatchContext> Builder add(final BatchConfigurable<T> configurable, final T context) {
+      finishers.add(new Finisher() {
+        @Override
+        public void onFinish(boolean succeeded) {
+          try {
+            configurable.onRunFinish(succeeded, context);
+          } catch (Throwable t) {
+            LOG.warn("Error calling onRunFinish on stage {}.", context.getStageName(), t);
+          }
+        }
+      });
+      return this;
+    }
+
+    public CompositeFinisher build() {
+      return new CompositeFinisher(finishers);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/Finisher.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/Finisher.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+/**
+ * Runs some logic on program finish.
+ */
+public interface Finisher {
+
+  /**
+   * Run logic on program finish.
+   *
+   * @param succeeded whether the program run succeeded or not
+   */
+  void onFinish(boolean succeeded);
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/TransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/TransformExecutorFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.common.DefaultStageMetrics;
+import co.cask.cdap.etl.common.LoggedTransform;
+import co.cask.cdap.etl.common.PipelinePhase;
+import co.cask.cdap.etl.common.TransformDetail;
+import co.cask.cdap.etl.common.TransformExecutor;
+import co.cask.cdap.etl.planner.StageInfo;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Helps create {@link TransformExecutor TransformExecutors}.
+ *
+ * @param <T> the type of input for the created transform executors
+ */
+public abstract class TransformExecutorFactory<T> {
+  protected final PluginContext pluginContext;
+  protected final Metrics metrics;
+  protected final long logicalStartTime;
+
+  public TransformExecutorFactory(PluginContext pluginContext, Metrics metrics, long logicalStartTime) {
+    this.pluginContext = pluginContext;
+    this.metrics = metrics;
+    this.logicalStartTime = logicalStartTime;
+  }
+
+  protected abstract BatchRuntimeContext createRuntimeContext(String stageName);
+
+  /**
+   * Create a transform executor for the specified pipeline. Will instantiate and initialize all sources,
+   * transforms, and sinks in the pipeline.
+   *
+   * @param pipeline the pipeline to create a transform executor for
+   * @return executor for the pipeline
+   * @throws InstantiationException if there was an error instantiating a plugin
+   * @throws Exception if there was an error initializing a plugin
+   */
+  public TransformExecutor<T> create(PipelinePhase pipeline) throws Exception {
+    Map<String, Set<String>> connections = pipeline.getConnections();
+    String sourceName = pipeline.getSource().getName();
+    BatchSource<?, ?, ?> source = pluginContext.newPluginInstance(sourceName);
+    source = new LoggedBatchSource<>(sourceName, source);
+    BatchRuntimeContext runtimeContext = createRuntimeContext(sourceName);
+    source.initialize(runtimeContext);
+
+    Map<String, TransformDetail> transformations = new HashMap<>();
+    transformations.put(sourceName, new TransformDetail(
+      source, new DefaultStageMetrics(metrics, sourceName), connections.get(sourceName)));
+    addTransforms(transformations, pipeline.getTransforms(), connections);
+
+    for (StageInfo sinkInfo : pipeline.getSinks()) {
+      String sinkName = sinkInfo.getName();
+      BatchSink<?, ?, ?> batchSink = pluginContext.newPluginInstance(sinkName);
+      batchSink = new LoggedBatchSink<>(sinkName, batchSink);
+      BatchRuntimeContext sinkContext = createRuntimeContext(sinkName);
+      batchSink.initialize(sinkContext);
+      transformations.put(sinkInfo.getName(), new TransformDetail(
+        batchSink, new DefaultStageMetrics(metrics, sinkInfo.getName()), new ArrayList<String>()));
+    }
+
+    return new TransformExecutor<>(transformations, ImmutableList.of(sourceName));
+  }
+
+  private void addTransforms(Map<String, TransformDetail> transformations,
+                             Set<StageInfo> transformInfos,
+                             Map<String, Set<String>> connections) throws Exception {
+    for (StageInfo transformInfo : transformInfos) {
+      String transformName = transformInfo.getName();
+      Transform<?, ?> transform = pluginContext.newPluginInstance(transformName);
+      transform = new LoggedTransform<>(transformName, transform);
+      BatchRuntimeContext transformContext = createRuntimeContext(transformName);
+      transform.initialize(transformContext);
+      transformations.put(transformName, new TransformDetail(
+        transform, new DefaultStageMetrics(metrics, transformName), connections.get(transformName)));
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.mapreduce;
+
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.batch.TransformExecutorFactory;
+import co.cask.cdap.etl.common.DatasetContextLookupProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Creates transform executors for mapreduce programs.
+ *
+ * @param <T> the type of input for the created transform executors
+ */
+public class MapReduceTransformExecutorFactory<T> extends TransformExecutorFactory<T> {
+  private final Map<String, Map<String, String>> pluginRuntimeArgs;
+  private final MapReduceTaskContext taskContext;
+
+  public MapReduceTransformExecutorFactory(MapReduceTaskContext taskContext, Metrics metrics, long logicalStartTime,
+                                           Map<String, Map<String, String>> pluginRuntimeArgs) {
+    super(taskContext, metrics, logicalStartTime);
+    this.taskContext = taskContext;
+    this.pluginRuntimeArgs = pluginRuntimeArgs;
+  }
+
+  @Override
+  protected BatchRuntimeContext createRuntimeContext(String stageName) {
+    Map<String, String> stageRuntimeArgs = pluginRuntimeArgs.get(stageName);
+    if (stageRuntimeArgs == null) {
+      stageRuntimeArgs = new HashMap<>();
+    }
+    return new MapReduceRuntimeContext(taskContext, metrics, new DatasetContextLookupProvider(taskContext),
+                                       stageName, stageRuntimeArgs);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/SinkOutput.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/SinkOutput.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.mapreduce;
+
+import java.util.Set;
+
+/**
+ * Holds information about a sink and what outputs it writes to.
+ */
+class SinkOutput {
+  private Set<String> sinkOutputs;
+  private String errorDatasetName;
+
+  SinkOutput(Set<String> sinkOutputs, String errorDatasetName) {
+    this.sinkOutputs = sinkOutputs;
+    this.errorDatasetName = errorDatasetName;
+  }
+
+  public Set<String> getSinkOutputs() {
+    return sinkOutputs;
+  }
+
+  public String getErrorDatasetName() {
+    return errorDatasetName;
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSparkProgram.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSparkProgram.java
@@ -21,18 +21,12 @@ import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.spark.JavaSparkProgram;
 import co.cask.cdap.api.spark.SparkContext;
-import co.cask.cdap.etl.api.Transform;
-import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
-import co.cask.cdap.etl.api.batch.BatchSink;
-import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.batch.TransformExecutorFactory;
 import co.cask.cdap.etl.common.Constants;
-import co.cask.cdap.etl.common.DefaultStageMetrics;
 import co.cask.cdap.etl.common.PipelinePhase;
-import co.cask.cdap.etl.common.TransformDetail;
 import co.cask.cdap.etl.common.TransformExecutor;
 import co.cask.cdap.etl.common.TransformResponse;
 import co.cask.cdap.etl.planner.StageInfo;
-import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.function.Function;
@@ -45,10 +39,8 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Spark program to run an ETL pipeline.
@@ -142,47 +134,10 @@ public class ETLSparkProgram implements JavaSparkProgram {
     }
 
     private TransformExecutor<KeyValue<Object, Object>> initialize() throws Exception {
+      TransformExecutorFactory<KeyValue<Object, Object>> transformExecutorFactory =
+        new SparkTransformExecutorFactory<>(pluginContext, metrics, logicalStartTime, runtimeArgs);
       PipelinePhase pipeline = GSON.fromJson(pipelineStr, PipelinePhase.class);
-      Map<String, Set<String>> connections = pipeline.getConnections();
-      // get source, transform, sink ids from program properties
-      String sourcePluginId = pipeline.getSource().getName();
-      BatchSource source = pluginContext.newPluginInstance(sourcePluginId);
-      BatchRuntimeContext runtimeContext = new SparkBatchRuntimeContext(pluginContext, metrics, logicalStartTime,
-                                                                        runtimeArgs, sourcePluginId);
-      source.initialize(runtimeContext);
-
-      Map<String, TransformDetail> transformations = new HashMap<>();
-      transformations.put(sourcePluginId, new TransformDetail(
-        source, new DefaultStageMetrics(metrics, sourcePluginId), connections.get(sourcePluginId)));
-      addTransforms(transformations, pipeline.getTransforms(), connections);
-
-      Set<StageInfo> sinkInfos = pipeline.getSinks();
-      for (StageInfo sinkInfo : sinkInfos) {
-        String sinkId = sinkInfo.getName();
-        BatchSink<Object, Object, Object> batchSink = pluginContext.newPluginInstance(sinkId);
-        BatchRuntimeContext sinkContext = new SparkBatchRuntimeContext(pluginContext, metrics, logicalStartTime,
-                                                                       runtimeArgs, sinkId);
-        batchSink.initialize(sinkContext);
-        transformations.put(sinkInfo.getName(), new TransformDetail(
-          batchSink, new DefaultStageMetrics(metrics, sinkInfo.getName()), new ArrayList<String>()));
-      }
-
-      return new TransformExecutor<>(transformations, ImmutableList.of(sourcePluginId));
-    }
-
-    private void addTransforms(Map<String, TransformDetail> transformations,
-                               Set<StageInfo> transformInfos,
-                               Map<String, Set<String>> connections) throws Exception {
-      for (StageInfo transformInfo : transformInfos) {
-        String transformId = transformInfo.getName();
-        Transform transform = pluginContext.newPluginInstance(transformId);
-        BatchRuntimeContext transformContext = new SparkBatchRuntimeContext(pluginContext, metrics,
-                                                                            logicalStartTime, runtimeArgs, transformId);
-        LOG.debug("Transform Class : {}", transform.getClass().getName());
-        transform.initialize(transformContext);
-        transformations.put(transformId, new TransformDetail(
-          transform, new DefaultStageMetrics(metrics, transformId), connections.get(transformId)));
-      }
+      return transformExecutorFactory.create(pipeline);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkTransformExecutorFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.spark;
+
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.batch.TransformExecutorFactory;
+
+import java.util.Map;
+
+/**
+ * Creates transform executors for spark programs.
+ *
+ * @param <T> the type of input for the created transform executors
+ */
+public class SparkTransformExecutorFactory<T> extends TransformExecutorFactory<T> {
+  private final Map<String, String> runtimeArgs;
+
+  public SparkTransformExecutorFactory(PluginContext pluginContext, Metrics metrics, long logicalStartTime,
+                                       Map<String, String> runtimeArgs) {
+    super(pluginContext, metrics, logicalStartTime);
+    this.runtimeArgs = runtimeArgs;
+  }
+
+  @Override
+  protected BatchRuntimeContext createRuntimeContext(String stageName) {
+    return new SparkBatchRuntimeContext(pluginContext, metrics, logicalStartTime, runtimeArgs, stageName);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Constants.java
@@ -22,12 +22,6 @@ import co.cask.cdap.api.data.schema.Schema;
  * Constants used in ETL Applications.
  */
 public final class Constants {
-  public static final String BATCH_SOURCE_TYPE = "batchsource";
-  public static final String BATCH_SINK_TYPE = "batchsink";
-  public static final String REALTIME_SOURCE_TYPE = "realtimesource";
-  public static final String REALTIME_SINK_TYPE = "realtimesink";
-  public static final String TRANSFORM_TYPE = "transform";
-
   public static final String ID_SEPARATOR = ":";
   public static final String PIPELINEID = "pipeline";
   public static final String STAGE_LOGGING_ENABLED = "stage.logging.enabled";
@@ -41,50 +35,6 @@ public final class Constants {
 
   private Constants() {
     throw new AssertionError("Suppress default constructor for noninstantiability");
-  }
-
-  /**
-   * Constants related to Source.
-   */
-  public static final class Source {
-    public static final String PLUGINTYPE = "source";
-
-    private Source() {
-      throw new AssertionError("Suppress default constructor for noninstantiability");
-    }
-  }
-
-  /**
-   * Constants related to Sink.
-   */
-  public static final class Sink {
-    public static final String PLUGINTYPE = "sink";
-
-    private Sink() {
-      throw new AssertionError("Suppress default constructor for noninstantiability");
-    }
-  }
-
-  /**
-   * Constants related to Transform.
-   */
-  public static final class Transform {
-    public static final String PLUGINTYPE = "transform";
-
-    private Transform() {
-      throw new AssertionError("Suppress default constructor for noninstantiability");
-    }
-  }
-
-  /**
-   * Constants related to Realtime ETL Applications.
-   */
-  public static final class Realtime {
-    public static final String UNIQUE_ID = "uniqueid";
-
-    private Realtime() {
-      throw new AssertionError("Suppress default constructor for noninstantiability");
-    }
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelineRegisterer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelineRegisterer.java
@@ -102,7 +102,7 @@ public class PipelineRegisterer {
                                                          .getPluginSelector(sourcePluginType, pluginName));
     if (source == null) {
       throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found.",
-                                                       Constants.Source.PLUGINTYPE,
+                                                       sourcePluginType,
                                                        sourceConfig.getPlugin().getName()));
     }
     // configure source, allowing it to add datasets, streams, etc
@@ -117,14 +117,14 @@ public class PipelineRegisterer {
 
       PluginProperties transformProperties = getPluginProperties(transformConfig);
       pluginName = transformConfig.getPlugin().getName();
-      Transform transformObj = configurer.usePlugin(Constants.Transform.PLUGINTYPE,
+      Transform transformObj = configurer.usePlugin(Transform.PLUGIN_TYPE,
                                                     pluginName,
                                                     transformId, transformProperties,
                                                     transformConfig.getPlugin()
-                                                      .getPluginSelector(Constants.Transform.PLUGINTYPE, pluginName));
+                                                      .getPluginSelector(Transform.PLUGIN_TYPE, pluginName));
       if (transformObj == null) {
         throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found",
-                                                         Constants.Transform.PLUGINTYPE,
+                                                         Transform.PLUGIN_TYPE,
                                                          transformConfig.getPlugin().getName()));
       }
       // if the transformation is configured to write filtered records to error dataset, we create that dataset.
@@ -163,7 +163,7 @@ public class PipelineRegisterer {
             "No Plugin of type '%s' named '%s' was found" +
               "Please check that an artifact containing the plugin exists, " +
               "and that it extends the etl application.",
-            Constants.Sink.PLUGINTYPE, sinkConfig.getPlugin().getName()));
+            sinkPluginType, sinkConfig.getPlugin().getName()));
       }
       // run configure pipeline on sink to let it add datasets, etc.
       PipelineConfigurer sinkConfigurer = new DefaultPipelineConfigurer(configurer, sinkPluginId);

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/ETLWorker.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/ETLWorker.java
@@ -86,6 +86,7 @@ public class ETLWorker extends AbstractWorker {
     Schema.Field.of(Constants.ErrorDataset.ERRMSG, Schema.unionOf(Schema.of(Schema.Type.STRING),
                                                                   Schema.of(Schema.Type.NULL))),
     Schema.Field.of(Constants.ErrorDataset.INVALIDENTRY, Schema.of(Schema.Type.STRING)));
+  private static final String UNIQUE_ID = "uniqueid";
 
   // only visible at configure time
   private final ETLRealtimeConfig config;
@@ -130,7 +131,7 @@ public class ETLWorker extends AbstractWorker {
     Map<String, String> properties = new HashMap<>();
     properties.put(Constants.PIPELINEID, GSON.toJson(pipeline));
     // Generate unique id for this app creation.
-    properties.put(Constants.Realtime.UNIQUE_ID, String.valueOf(System.currentTimeMillis()));
+    properties.put(UNIQUE_ID, String.valueOf(System.currentTimeMillis()));
     properties.put(Constants.STAGE_LOGGING_ENABLED, String.valueOf(config.isStageLoggingEnabled()));
     setProperties(properties);
   }
@@ -145,9 +146,9 @@ public class ETLWorker extends AbstractWorker {
     Map<String, String> properties = context.getSpecification().getProperties();
     appName = context.getApplicationSpecification().getName();
     Preconditions.checkArgument(properties.containsKey(Constants.PIPELINEID));
-    Preconditions.checkArgument(properties.containsKey(Constants.Realtime.UNIQUE_ID));
+    Preconditions.checkArgument(properties.containsKey(UNIQUE_ID));
 
-    String uniqueId = properties.get(Constants.Realtime.UNIQUE_ID);
+    String uniqueId = properties.get(UNIQUE_ID);
 
     // Each worker instance should have its own unique state.
     final String appName = context.getApplicationSpecification().getName();


### PR DESCRIPTION
ETLMapReduce is in dire need of cleanup so that we can more easily
modify it in the future. This takes a pass
at removing unneccessary logic, consolidating common logic,
removing warnings, and other general cleanup.

Consolidated onRunFinish logic that was happening in both spark
and mapreduce, which now both use the CompositeFinisher to avoid
special logic for sources and special logic for sinks and for
maintaining state about source, sinks, and their contexts.

Consolidated logic for creating a TransformExecutor into the
TransformExecutorFactory class, which should also help a good
deal when we need to create an executor in both the mapper and the
reducer.