### PR TITLE
removes nodeId / increases errorCount when node label is empty

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag.html
+++ b/cdap-ui/app/directives/dag/my-dag.html
@@ -112,7 +112,7 @@
                  ng-click="MyDAGController.onNodeDelete($event, node)"></div>
             <div class="icon fa {{node.icon}}"></div>
           </div>
-          <div class="plugin-name" ng-if="node.plugin.label" ng-bind="node.plugin.label | myEllipsis: 25"></div>
+          <div class="plugin-name" ng-bind="node.plugin.label | myEllipsis: 25"></div>
         </div>
 
         <div ng-repeat="comment in MyDAGController.comments"

--- a/cdap-ui/app/directives/dag/my-dag.html
+++ b/cdap-ui/app/directives/dag/my-dag.html
@@ -112,7 +112,7 @@
                  ng-click="MyDAGController.onNodeDelete($event, node)"></div>
             <div class="icon fa {{node.icon}}"></div>
           </div>
-          <div class="plugin-name" ng-bind="node.plugin.label || node.name | myEllipsis: 25"></div>
+          <div class="plugin-name" ng-if="node.plugin.label" ng-bind="node.plugin.label | myEllipsis: 25"></div>
         </div>
 
         <div ng-repeat="comment in MyDAGController.comments"

--- a/cdap-ui/app/features/hydrator/services/non-store-pipeline-error-factory.js
+++ b/cdap-ui/app/features/hydrator/services/non-store-pipeline-error-factory.js
@@ -46,6 +46,9 @@ let countUnFilledRequiredFields = (node) => {
       }
     });
   }
+  if (!node.plugin.label) {
+    requiredFieldCount++;
+  }
   return requiredFieldCount;
 };
 
@@ -71,6 +74,11 @@ let isUniqueNodeNames = (myHelpers, nodes, cb) => {
   }
   let nodesIdMap = {};
   angular.forEach(nodes, function (node) {
+    // Check for multiple nodes with empty labels
+    // Multiple empty labels shouldn't be considered duplicates
+    if (!node.plugin.label) {
+      return;
+    }
     if (!nodesIdMap[node.plugin.label]) {
       nodesIdMap[node.plugin.label] = [];
     }


### PR DESCRIPTION
*  Removes node ID from DAG display in scenarios when node label is empty
*  Increases error count if node label is left blank
*  Adds condition to check for multiple empty node labels (as they shouldn't be treated as duplicates)

![label](https://cloud.githubusercontent.com/assets/5335210/13755159/17e51cf2-e9d7-11e5-9f3e-5c8e9f180d87.gif)
