### PR TITLE
CDAP-5248 Application configuration for ETL example

### DIFF
--- a/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
@@ -180,7 +180,7 @@ For example, if you wrote the above JSON to a file named ``conversion.json``:
 .. container:: highlight
 
   .. parsed-literal::
-    cdap > create app trades_conversion cdap-etl-batch |version| system <path-to-conversion.json>
+    cdap > create app trades_conversion cdap-etl-batch |release| system <path-to-conversion.json>
 
 
 This will create and configure an application. The application's schedule (named, by default, to ``etlWorkflow``)

--- a/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
@@ -175,7 +175,7 @@ To do this, write the following JSON to a config file::
 the ``schema`` values) to be a conforming JSON file. 
 
 Then use your config file with the ``cdap-etl-batch`` artifact to create an application through the CLI.
-For example, if you wrote the above JSON to a file named ``conversion.json``::
+For example, if you wrote the above JSON to a file named ``conversion.json``:
 
   .. container:: highlight
 

--- a/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
@@ -177,10 +177,10 @@ the ``schema`` values) to be a conforming JSON file.
 Then use your config file with the ``cdap-etl-batch`` artifact to create an application through the CLI.
 For example, if you wrote the above JSON to a file named ``conversion.json``:
 
-  .. container:: highlight
+.. container:: highlight
 
-    .. parsed-literal::
-      cdap > create app trades_conversion cdap-etl-batch |version| system <path-to-conversion.json>
+  .. parsed-literal::
+    cdap > create app trades_conversion cdap-etl-batch |version| system <path-to-conversion.json>
 
 
 This will create and configure an application. The application's schedule (named, by default, to ``etlWorkflow``)

--- a/cdap-docs/introduction/source/index.rst
+++ b/cdap-docs/introduction/source/index.rst
@@ -211,13 +211,13 @@ Data Exploration
        
             |cdap >| execute 'describe stream_logEventStream'
 
-            +=========================================================================================================+
-            | col_name: STRING                 | data_type: STRING                | comment: STRING                   |
-            +=========================================================================================================+
-            | ts                               | bigint                           | from deserializer                 |
-            | headers                          | map<string,string>               | from deserializer                 |
-            | body                             | string                           | from deserializer                 |
-            +=========================================================================================================+
+            +===========================================================+
+            | col_name: STRING | data_type: STRING  | comment: STRING   |
+            +===========================================================+
+            | ts               | bigint             | from deserializer |
+            | headers          | map<string,string> | from deserializer |
+            | body             | string             | from deserializer |
+            +===========================================================+
             Fetched 3 rows
 
 .. container:: table-block
@@ -916,7 +916,7 @@ Transforming Your Data
      
           .. parsed-literal::
 
-            |cdap >| create app logEventStreamConverter cdap-etl-batch |version| system examples/resources/app-config.json
+            |cdap >| create app logEventStreamConverter cdap-etl-batch |release| system examples/resources/app-config.json
             Successfully created application
           
             |cdap >| resume schedule logEventStreamConverter.etlWorkflow
@@ -950,7 +950,7 @@ Transforming Your Data
             | id                      | descript | artifactName   | artifactVersion | artifactScope |
             |                         | ion      |                |                 |               |
             +=======================================================================================+
-            | logEventStreamConverter | Batch Ex | cdap-etl-batch | 3.2.0           | SYSTEM        |
+            | logEventStreamConverter | Batch Ex | cdap-etl-batch | |version|           | SYSTEM        |
             |                         | tract-Tr |                |                 |               |
             |                         | ansform- |                |                 |               |
             |                         | Load (ET |                |                 |               |
@@ -999,7 +999,7 @@ Transforming Your Data
             +=================================================================================================================+
             | application | program     | program type | name        | type        | description | properties  | runtime args |
             +=================================================================================================================+
-            | logEventStr | ETLWorkflow | WORKFLOW     | etlWorkflow | co.cask.cda | batch etl s | cron entry: | {}           |
+            | logEventStr | ETLWorkflow | WORKFLOW     | etlWorkflow | co.cask.cda | ETL Batch s | cron entry: | {}           |
             | eamConverte |             |              |             | p.internal. | chedule     |  \*/5 * * *  |              |
             | r           |             |              |             | schedule.Ti |             | *           |              |
             |             |             |              |             | meSchedule  |             |             |              |
@@ -1275,10 +1275,10 @@ Building Real World Applications
             +=====================================================================+
             | type      | id                    | description                     |
             +=====================================================================+
-            | Flow      | WiseFlow              | Wise flow                       |
+            | Flow      | WiseFlow              | Wise Flow                       |
             | MapReduce | BounceCountsMapReduce | Bounce Counts MapReduce Program |
             | Service   | WiseService           |                                 |
-            | workflow  | WiseWorkflow          | Wise workflow                   |
+            | workflow  | WiseWorkflow          | Wise Workflow                   |
             +=====================================================================+
 
 .. container:: table-block

--- a/cdap-docs/introduction/source/index.rst
+++ b/cdap-docs/introduction/source/index.rst
@@ -890,15 +890,15 @@ Transforming Your Data
                                   \"name\":\"logEvent\",
                                   \"fields\":[
                                       {\"name\":\"ts\",\"type\":\"long\"},
-                                      {\"name\":\"remotehost\",\"type\":[\"string\",\"null\"]},
-                                      {\"name\":\"remotelogname\",\"type\":[\"string\",\"null\"]},
-                                      {\"name\":\"authuser\",\"type\":[\"string\",\"null\"]},
+                                      {\"name\":\"remote_host\",\"type\":[\"string\",\"null\"]},
+                                      {\"name\":\"remote_login\",\"type\":[\"string\",\"null\"]},
+                                      {\"name\":\"auth_user\",\"type\":[\"string\",\"null\"]},
                                       {\"name\":\"date\",\"type\":[\"string\",\"null\"]},
                                       {\"name\":\"request\",\"type\":[\"string\",\"null\"]},
                                       {\"name\":\"status\",\"type\":[\"int\",\"null\"]},
-                                      {\"name\":\"contentlength\",\"type\":[\"int\",\"null\"]},
+                                      {\"name\":\"content_length\",\"type\":[\"int\",\"null\"]},
                                       {\"name\":\"referrer\",\"type\":[\"string\",\"null\"]},
-                                      {\"name\":\"useragent\",\"type\":[\"string\",\"null\"]}
+                                      {\"name\":\"user_agent\",\"type\":[\"string\",\"null\"]}
                                   ]
                               }",
                               "basePath": "logEventStream_converted"
@@ -1095,15 +1095,15 @@ Transforming Your Data
             | col_name: STRING        | data_type: STRING    | comment: STRING      |
             +=======================================================================+
             | ts                      | bigint               | from deserializer    |
-            | remotehost              | string               | from deserializer    |
-            | remotelogname           | string               | from deserializer    |
-            | authuser                | string               | from deserializer    |
+            | remote_host             | string               | from deserializer    |
+            | remote_login            | string               | from deserializer    |
+            | auth_user               | string               | from deserializer    |
             | date                    | string               | from deserializer    |
             | request                 | string               | from deserializer    |
             | status                  | int                  | from deserializer    |
-            | contentlength           | int                  | from deserializer    |
+            | content_length          | int                  | from deserializer    |
             | referrer                | string               | from deserializer    |
-            | useragent               | string               | from deserializer    |
+            | user_agent              | string               | from deserializer    |
             | year                    | int                  |                      |
             | month                   | int                  |                      |
             | day                     | int                  |                      |
@@ -1149,7 +1149,8 @@ Transforming Your Data
 
             |cdap >| start workflow logEventStreamConverter.ETLWorkflow
             
-            Successfully started workflow 'ETLWorkflow' of application 'logEventStreamConverter' with stored runtime arguments '{}'            
+            Successfully started workflow 'ETLWorkflow' of application 'logEventStreamConverter'
+            with stored runtime arguments '{}'            
             
             |cdap >| get workflow status logEventStreamConverter.ETLWorkflow
             
@@ -1307,7 +1308,8 @@ Building Real World Applications
 
             |cdap >| start flow Wise.WiseFlow
           
-            Successfully started flow 'WiseFlow' of application 'Wise' with stored runtime arguments '{}'
+            Successfully started flow 'WiseFlow' of application 'Wise'
+            with stored runtime arguments '{}'
 
 .. container:: table-block
 
@@ -1441,7 +1443,8 @@ Building Real World Applications
 
             |cdap >| start workflow Wise.WiseWorkflow
           
-            Successfully started workflow 'WiseWorkflow' of application 'Wise' with stored runtime arguments '{}'
+            Successfully started workflow 'WiseWorkflow' of application 'Wise' 
+            with stored runtime arguments '{}'
 
 .. container:: table-block
 
@@ -1497,7 +1500,8 @@ Building Real World Applications
 
             |cdap >| start service Wise.WiseService
           
-            Successfully started service 'WiseService' of application 'Wise' with stored runtime arguments '{}'
+            Successfully started service 'WiseService' of application 'Wise' 
+            with stored runtime arguments '{}'
 
 .. container:: table-block
 


### PR DESCRIPTION
Fixes errors in filenames in the Application configuration for an ETL example.
Fixes formatting and content error in an Impala example.

Fixes https://issues.cask.co/browse/CDAP-5248.

Passes [Quick Build 3](http://builds.cask.co/browse/CDAP-DOB147-3)

- [Revised ETL example](http://builds.cask.co/artifact/CDAP-DOB147/shared/build-3/Docs-HTML/3.4.0-SNAPSHOT/en/introduction/index.html#transforming-your-data)
- [Revised Impala example](http://builds.cask.co/artifact/CDAP-DOB147/shared/build-3/Docs-HTML/3.4.0-SNAPSHOT/en/integrations/partners/cloudera/ingesting.html#ingesting-and-exploring-data-with-impala)