### PR TITLE
[CDAP-5182] return original properties when listing datasets

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/ConversionHelpers.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/ConversionHelpers.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.datafabric.dataset.service;
 
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
@@ -101,7 +102,9 @@ class ConversionHelpers {
       if (QueueConstants.STATE_STORE_NAME.equals(spec.getName())) {
         continue;
       }
-      datasetSummaries.add(new DatasetSpecificationSummary(spec.getName(), spec.getType(), spec.getProperties()));
+      spec = DatasetsUtil.fixOriginalProperties(spec);
+      datasetSummaries.add(new DatasetSpecificationSummary(spec.getName(), spec.getType(),
+                                                           spec.getOriginalProperties()));
     }
     return datasetSummaries;
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerTest.java
@@ -114,7 +114,7 @@ public class DatasetInstanceHandlerTest extends DatasetServiceTestBase {
       instances = getInstances().getResponseObject();
       Assert.assertEquals(1, instances.size());
       // verifying spec is same as expected
-      DatasetSpecification dataset1Spec = createSpec("dataset1", "datasetType2", props);
+      DatasetSpecification dataset1Spec = createType2Spec("dataset1", "datasetType2", props);
       Assert.assertEquals(spec2Summary(dataset1Spec), instances.get(0));
 
       // verify created instance info can be retrieved
@@ -144,7 +144,6 @@ public class DatasetInstanceHandlerTest extends DatasetServiceTestBase {
       // verify creation of dataset instance with null properties
       Assert.assertEquals(HttpStatus.SC_OK, createInstance("nullPropertiesTable", "datasetType2").getResponseCode());
 
-    } finally {
       // delete dataset instance
       Assert.assertEquals(HttpStatus.SC_OK, deleteInstance("dataset1").getResponseCode());
       Assert.assertEquals(HttpStatus.SC_OK, deleteInstance("nullPropertiesTable").getResponseCode());
@@ -153,6 +152,12 @@ public class DatasetInstanceHandlerTest extends DatasetServiceTestBase {
       // delete dataset modules
       Assert.assertEquals(HttpStatus.SC_OK, deleteModule("module2").getResponseCode());
       Assert.assertEquals(HttpStatus.SC_OK, deleteModule("module1").getResponseCode());
+
+    } finally {
+      deleteInstance("dataset1");
+      deleteInstance("nullPropertiesTable");
+      deleteModule("module2");
+      deleteModule("module1");
     }
   }
 
@@ -409,14 +414,14 @@ public class DatasetInstanceHandlerTest extends DatasetServiceTestBase {
     }
   }
 
-  private static DatasetSpecification createSpec(String instanceName, String typeName,
-                                                 DatasetProperties properties) {
-    return DatasetSpecification.builder(instanceName, typeName).properties(properties.getProperties()).build()
+  private static DatasetSpecification createType2Spec(String instanceName, String typeName,
+                                                      DatasetProperties properties) {
+    return new TestModule2().createDefinition(typeName).configure(instanceName, properties)
       .setOriginalProperties(properties);
   }
 
   private DatasetSpecificationSummary spec2Summary(DatasetSpecification spec) {
-    return new DatasetSpecificationSummary(spec.getName(), spec.getType(), spec.getProperties());
+    return new DatasetSpecificationSummary(spec.getName(), spec.getType(), spec.getOriginalProperties());
   }
 
   @Test

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/TestModule1.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/TestModule1.java
@@ -43,7 +43,10 @@ public class TestModule1 implements DatasetModule {
     return new AbstractDatasetDefinition(name) {
       @Override
       public DatasetSpecification configure(String instanceName, DatasetProperties properties) {
-        return createSpec(instanceName, getName(), properties);
+        return DatasetSpecification
+          .builder(instanceName, getName())
+          .properties(properties.getProperties())
+          .build();
       }
 
       @Override
@@ -58,10 +61,6 @@ public class TestModule1 implements DatasetModule {
         return null;
       }
     };
-  }
-  private DatasetSpecification createSpec(String instanceName, String typeName,
-                                          DatasetProperties properties) {
-    return DatasetSpecification.builder(instanceName, typeName).properties(properties.getProperties()).build();
   }
 }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/TestModule2.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/TestModule2.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.dataset.lib.AbstractDatasetDefinition;
 import co.cask.cdap.api.dataset.lib.CompositeDatasetAdmin;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -41,11 +42,20 @@ public class TestModule2 implements DatasetModule {
     registry.add(createDefinition("datasetType2"));
   }
 
-  private DatasetDefinition createDefinition(String name) {
+  public DatasetDefinition createDefinition(String name) {
     return new AbstractDatasetDefinition(name) {
       @Override
       public DatasetSpecification configure(String instanceName, DatasetProperties properties) {
-        return createSpec(instanceName, getName(), properties);
+        return DatasetSpecification
+          .builder(instanceName, getName())
+          // This is to test that the dataset summary returned by list() contains the original properties.
+          // Original properties are different from the spec.getProperties() if the configure() method
+          // modifies the original properties. That is what we mimic here.
+          .properties(ImmutableMap.<String, String>builder()
+                        .putAll(properties.getProperties())
+                        .put("extra", "value")
+                        .build())
+          .build();
       }
 
       @Override
@@ -60,9 +70,5 @@ public class TestModule2 implements DatasetModule {
         return null;
       }
     };
-  }
-  private DatasetSpecification createSpec(String instanceName, String typeName,
-                                          DatasetProperties properties) {
-    return DatasetSpecification.builder(instanceName, typeName).properties(properties.getProperties()).build();
   }
 }


### PR DESCRIPTION
Listing dataset instances should return the properties that the dataset was created with. See the comment in CDAP-5182 (https://issues.cask.co/browse/CDAP-5182?focusedCommentId=21209&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-21209).

Build: http://builds.cask.co/browse/CDAP-DUT3702
