### PR TITLE
CDAP-5232 Upgrade Instructions

### DIFF
--- a/cdap-docs/admin-manual/source/upgrading/ambari.rst
+++ b/cdap-docs/admin-manual/source/upgrading/ambari.rst
@@ -17,7 +17,7 @@ To upgrade CDAP installations that were installed and are managed with Apache Am
 follow our instructions for upgrading CDAP installations that were installed with
 packages, either RPM or Debian:
 
-  :ref:`Upgrading CDAP via Package Managers <admin-upgrading-packages-cdap>`
+  :ref:`Upgrading CDAP via Package Managers <admin-upgrading-packages-upgrading-cdap>`
 
 
 Upgrading Apache Ambari
@@ -26,4 +26,4 @@ When upgrading Apache Ambari and HDP (Hortonworks Data Platform), please follow 
 instructions for upgrading Hadoop installations that were installed with packages, either
 RPM or Debian:
 
-  :ref:`Upgrading Hadoop <admin-upgrading-packages-hadoop>`
+  :ref:`Upgrading Hadoop <admin-upgrading-packages-upgrading-hadoop>`

--- a/cdap-docs/admin-manual/source/upgrading/cloudera.rst
+++ b/cdap-docs/admin-manual/source/upgrading/cloudera.rst
@@ -9,10 +9,17 @@ Upgrading CDAP using Cloudera Manager
 =====================================
 
 
-.. _admin-upgrading-cloudera-cdap:
+.. _admin-upgrading-cloudera-upgrading-cdap:
 
 Upgrading CDAP
 ==============
+When upgrading an existing CDAP installation from a previous version, you will need
+to make sure the CDAP table definitions in HBase are up-to-date.
+
+**These steps will upgrade from CDAP** |bold-previous-short-version|\ **.x to**
+|bold-version|\ **.** If you are on an earlier version of CDAP, please follow the
+upgrade instructions for the earlier versions and upgrade first to
+|previous-short-version|\.x before proceeding.
 
 Upgrading CDAP Patch Release Versions
 -------------------------------------
@@ -21,24 +28,19 @@ version to a higher |short-version|\.x version.
 When a new compatible CDAP parcel is released, it will be available via the Parcels page
 in the Cloudera Manager UI.
 
-#. Stop all flows, services, and other programs in all your applications.
-
-#. Stop CDAP services.
-
-#. Use the Cloudera Manager UI to download, distribute, and activate the parcel on all
-   cluster hosts.
-
-#. Start CDAP services.
-
 Upgrading CDAP Major/Minor Release Versions
 -------------------------------------------
 Upgrading between major versions of CDAP (for example, from a |previous-short-version|\.x version 
-to |short-version|\.x) involves the additional steps of upgrading the
-CSD, and running the included CDAP Upgrade Tool. Upgrades between multiple Major/Minor
+to |short-version|\.x) involves the additional step of upgrading the
+CSD. Upgrades between multiple Major/Minor
 versions must be done consecutively, and a version cannot be skipped unless otherwise
 noted.
 
-The following is the generic procedure for Major/Minor version upgrades:
+The following is the generic procedure for all upgrades. These steps will stop CDAP,
+update the installation, run an upgrade tool for the table definitions, and then restart
+CDAP:
+
+.. highlight:: console
 
 #. Stop all flows, services, and other programs in all your applications.
 
@@ -86,8 +88,10 @@ goes wrong, see these troubleshooting instructions for :ref:`problems while upgr
 
 **Upgrade Steps**
 
+.. highlight:: console
+
 1. Upgrade CDAP to a version that will support the new CDH version, following the usual
-   :ref:`CDAP-Cloudera Manager upgrade procedure <admin-upgrading-cloudera-cdap>`. 
+   :ref:`CDAP-Cloudera Manager upgrade procedure <admin-upgrading-cloudera-upgrading-cdap>`. 
 
 #. After upgrading CDAP, start CDAP and check that it is working correctly.
 

--- a/cdap-docs/admin-manual/source/upgrading/mapr.rst
+++ b/cdap-docs/admin-manual/source/upgrading/mapr.rst
@@ -17,7 +17,7 @@ To upgrade CDAP installations that were installed and are managed with MapR, ple
 follow our instructions for upgrading CDAP installations that were installed with
 packages, either RPM or Debian:
 
-  :ref:`Upgrading CDAP via Package Managers <admin-upgrading-packages-cdap>`
+  :ref:`Upgrading CDAP via Package Managers <admin-upgrading-packages-upgrading-cdap>`
 
 
 Upgrading MapR
@@ -25,4 +25,4 @@ Upgrading MapR
 When upgrading MapR, please follow our instructions for upgrading Hadoop installations
 that were installed with packages, either RPM or Debian:
 
-  :ref:`Upgrading Hadoop <admin-upgrading-packages-hadoop>`
+  :ref:`Upgrading Hadoop <admin-upgrading-packages-upgrading-hadoop>`

--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -8,7 +8,7 @@
 Upgrading CDAP using Packages
 =============================
 
-.. _admin-upgrading-packages-cdap:
+.. _admin-upgrading-packages-upgrading-cdap:
 
 Upgrading CDAP
 ==============
@@ -19,7 +19,7 @@ These steps will stop CDAP, update the installation, run an upgrade tool for the
 and then restart CDAP.
 
 **These steps will upgrade from CDAP** |bold-previous-short-version|\ **.x to**
-|bold-short-version|\ **.x.** If you are on an earlier version of CDAP, please follow the
+|bold-version|\ **.** If you are on an earlier version of CDAP, please follow the
 upgrade instructions for the earlier versions and upgrade first to
 |previous-short-version|\.x before proceeding.
 
@@ -107,7 +107,7 @@ upgrade instructions for the earlier versions and upgrade first to
      $ for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i start ; done
 
 
-.. _admin-upgrading-packages-hadoop:
+.. _admin-upgrading-packages-upgrading-hadoop:
 
 Upgrading Hadoop
 ================
@@ -155,7 +155,7 @@ version. The steps below will, if required, update the coprocessors appropriatel
 get upgraded correctly and HBase regionservers may crash.**
 
 1. Upgrade CDAP to a version that will support the new Hadoop version, following the usual
-   :ref:`CDAP upgrade procedure for packages <admin-upgrading-packages-cdap>`. 
+   :ref:`CDAP upgrade procedure for packages <admin-upgrading-packages-upgrading-cdap>`. 
 
 #. After upgrading CDAP, start CDAP and check that it is working correctly.
 


### PR DESCRIPTION
- Adjusted text for upgrade to always run the upgrade tool with any update.
- Corrected links that were jumping when resolved.

Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DOB148-1)

Pages of interest:
- [Upgrading CDAP using Cloudera Manager]()
- [Upgrading CDAP using Packages]()

Fix for https://issues.cask.co/browse/CDAP-5232