### PR TITLE
Feature/auth extension

### DIFF
--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -68,6 +68,11 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-security</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-data-fabric</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -84,18 +84,14 @@ import co.cask.cdap.logging.run.LogSaverStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsProcessorStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsServiceManager;
 import co.cask.cdap.pipeline.PipelineFactory;
-import co.cask.cdap.security.spi.authorization.Authorizer;
-import co.cask.cdap.security.spi.authorization.NoOpAuthorizer;
+import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
 import co.cask.http.HttpHandler;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Binder;
-import com.google.inject.Inject;
-import com.google.inject.Injector;
 import com.google.inject.Module;
-import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
@@ -314,28 +310,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
         handlerBinder.addBinding().to(handlerClass);
       }
 
-      bind(Authorizer.class).toProvider(AuthorizerProvider.class);
-    }
-
-    private static final class AuthorizerProvider implements Provider<Authorizer> {
-      private final Injector injector;
-      private final CConfiguration cConf;
-
-      @Inject
-      private AuthorizerProvider(Injector injector, CConfiguration cConf) {
-        this.injector = injector;
-        this.cConf = cConf;
-      }
-
-      @Override
-      public Authorizer get() {
-        if (!cConf.getBoolean(Constants.Security.Authorization.ENABLED)) {
-          return injector.getInstance(NoOpAuthorizer.class);
-        }
-        Class<? extends Authorizer> authorizerClass =
-          cConf.getClass(Constants.Security.Authorization.HANDLER_CLASS, null, Authorizer.class);
-        return injector.getInstance(authorizerClass);
-      }
+      bind(AuthorizerInstantiatorService.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -204,7 +204,7 @@ public class PluginInstantiator implements Closeable {
 
   @Override
   public void close() throws IOException {
-    // Cleanup the ClassLoader cache and the temporary directoy for the expanded plugin jar.
+    // Cleanup the ClassLoader cache and the temporary directory for the expanded plugin jar.
     classLoaders.invalidateAll();
     if (parentClassLoader instanceof Closeable) {
       Closeables.closeQuietly((Closeable) parentClassLoader);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -31,6 +31,7 @@ import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
 import co.cask.http.HandlerHook;
 import co.cask.http.HttpHandler;
 import co.cask.http.NettyHttpService;
@@ -73,6 +74,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final ProgramLifecycleService programLifecycleService;
   private final DefaultNamespaceEnsurer defaultNamespaceEnsurer;
   private final SystemArtifactLoader systemArtifactLoader;
+  private final AuthorizerInstantiatorService authorizerInstantiatorService;
 
   private NettyHttpService httpService;
   private Set<HttpHandler> handlers;
@@ -95,7 +97,8 @@ public class AppFabricServer extends AbstractIdleService {
                          @Named("appfabric.services.names") Set<String> servicesNames,
                          @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
                          DefaultNamespaceEnsurer defaultNamespaceEnsurer,
-                         SystemArtifactLoader systemArtifactLoader) {
+                         SystemArtifactLoader systemArtifactLoader,
+                         AuthorizerInstantiatorService authorizerInstantiatorService) {
     this.hostname = hostname;
     this.discoveryService = discoveryService;
     this.schedulerService = schedulerService;
@@ -111,6 +114,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.programLifecycleService = programLifecycleService;
     this.defaultNamespaceEnsurer = defaultNamespaceEnsurer;
     this.systemArtifactLoader = systemArtifactLoader;
+    this.authorizerInstantiatorService = authorizerInstantiatorService;
   }
 
   /**
@@ -129,7 +133,8 @@ public class AppFabricServer extends AbstractIdleService {
         systemArtifactLoader.start(),
         programRuntimeService.start(),
         streamCoordinatorClient.start(),
-        programLifecycleService.start()
+        programLifecycleService.start(),
+        authorizerInstantiatorService.start()
       )
     ).get();
 
@@ -217,5 +222,6 @@ public class AppFabricServer extends AbstractIdleService {
     systemArtifactLoader.stopAndWait();
     notificationService.stopAndWait();
     programLifecycleService.stopAndWait();
+    authorizerInstantiatorService.stopAndWait();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,6 +27,7 @@ import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.notifications.service.NotificationService;
+import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
 import co.cask.http.HttpHandler;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -62,11 +63,12 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
                                    DefaultNamespaceEnsurer defaultNamespaceEnsurer,
                                    MetricStore metricStore,
-                                   SystemArtifactLoader systemArtifactLoader) {
+                                   SystemArtifactLoader systemArtifactLoader,
+                                   AuthorizerInstantiatorService authorizerInstantiatorService) {
     super(configuration, discoveryService, schedulerService, notificationService, hostname, handlers,
           metricsCollectionService, programRuntimeService, applicationLifecycleService,
           programLifecycleService, streamCoordinatorClient, servicesNames, handlerHookNames, defaultNamespaceEnsurer,
-          systemArtifactLoader);
+          systemArtifactLoader, authorizerInstantiatorService);
     this.metricStore = metricStore;
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -680,8 +680,11 @@ public final class Constants {
     public static final class Authorization {
       /** Enables authorization */
       public static final String ENABLED = "security.authorization.enabled";
-      /** AuthorizationPlugin class name */
-      public static final String HANDLER_CLASS = "security.authorization.pluginClassName";
+      /** Extension jar path */
+      public static final String EXTENSION_JAR_PATH = "security.authorization.extension.jar.path";
+      /** Prefix for extension properties */
+      public static final String EXTENSION_CONFIG_PREFIX =
+        "security.authorization.extension.config.";
     }
 
     /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassPathResources.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassPathResources.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.lang;
+
+import co.cask.cdap.common.internal.guava.ClassPath;
+import co.cask.cdap.common.internal.guava.ClassPath.ResourceInfo;
+import com.google.common.base.Function;
+import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import org.apache.twill.api.ClassAcceptor;
+import org.apache.twill.internal.utils.Dependencies;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Utility methods for {@link ClassPath} {@link ResourceInfo resources}.
+ */
+public final class ClassPathResources {
+
+  private static final Function<ClassPath.ClassInfo, String> CLASS_INFO_TO_CLASS_NAME =
+    new Function<ClassPath.ClassInfo, String>() {
+      @Override
+      public String apply(ClassPath.ClassInfo input) {
+        return input.getName();
+      }
+    };
+  public static final Function<ClassPath.ResourceInfo, String> RESOURCE_INFO_TO_RESOURCE_NAME =
+    new Function<ClassPath.ResourceInfo, String>() {
+      @Override
+      public String apply(ClassPath.ResourceInfo input) {
+        return input.getResourceName();
+      }
+    };
+
+  /**
+   * Returns the base set of resources needed to load the specified {@link Class} using the
+   * specified {@link ClassLoader}. Also traces and includes the dependencies for the specified class.
+   *
+   * @param classLoader the {@link ClassLoader} to use to generate the set of resources
+   * @param classz the {@link Class} to generate the set of resources for
+   * @return the set of resources needed to load the specified {@link Class} using the specified {@link ClassLoader}
+   * @throws IOException
+   */
+  public static Set<String> getResourcesWithDependencies(ClassLoader classLoader, Class<?> classz) throws IOException {
+    ClassPath classPath = getClassPath(classLoader, classz);
+
+    // Add everything in the classpath as visible resources
+    Set<String> result = Sets.newHashSet(Iterables.transform(classPath.getResources(),
+                                                             RESOURCE_INFO_TO_RESOURCE_NAME));
+    // Trace dependencies for all classes in the classpath
+    findClassDependencies(
+      classLoader, Iterables.transform(classPath.getAllClasses(), CLASS_INFO_TO_CLASS_NAME), result);
+
+    return result;
+  }
+
+  /**
+   * Returns a set of {@link ResourceInfo} required for the specified {@link Class} using the specified
+   * {@link ClassLoader}. Does not trace dependencies of the specified class.
+   *
+   * @param classLoader the {@link ClassLoader} to use to return the set of {@link ResourceInfo} for the specified
+   *                    {@link Class}
+   * @param cls the {@link Class} for which to return the set of {@link ResourceInfo}
+   * @return the set of {@link ResourceInfo} required for the specified {@link Class} using the specified
+   * {@link ClassLoader}
+   */
+  public static Set<ClassPath.ResourceInfo> getClassPathResources(ClassLoader classLoader,
+                                                                  Class<?> cls) throws IOException {
+    return getClassPath(classLoader, cls).getResources();
+  }
+
+  /**
+   * Returns a {@link ClassPath} instance that represents the classpath that the given class is loaded from the given
+   * ClassLoader.
+   */
+  private static ClassPath getClassPath(ClassLoader classLoader, Class<?> cls) throws IOException {
+    String resourceName = cls.getName().replace('.', '/') + ".class";
+    URL url = classLoader.getResource(resourceName);
+    if (url == null) {
+      throw new IOException("Resource not found for " + resourceName);
+    }
+
+    try {
+      URI classPathURI = getClassPathURL(resourceName, url).toURI();
+      return ClassPath.from(classPathURI, classLoader);
+    } catch (URISyntaxException e) {
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Finds all resource names that the given set of classes depends on.
+   *
+   * @param classLoader class loader for looking up .class resources
+   * @param classes set of class names that need to trace dependencies from
+   * @param result collection to store the resulting resource names
+   * @param <T> type of the result collection
+   * @throws IOException if fails to load class bytecode during tracing
+   */
+  private static <T extends Collection<String>> T findClassDependencies(final ClassLoader classLoader,
+                                                                        Iterable<String> classes,
+                                                                        final T result) throws IOException {
+    final Set<String> bootstrapClassPaths = getBootstrapClassPaths();
+    final Set<URL> classPathSeen = Sets.newHashSet();
+
+    Dependencies.findClassDependencies(classLoader, new ClassAcceptor() {
+      @Override
+      public boolean accept(String className, URL classUrl, URL classPathUrl) {
+        // Ignore bootstrap classes
+        if (bootstrapClassPaths.contains(classPathUrl.getFile())) {
+          return false;
+        }
+
+        // Should ignore classes from SLF4J implementation, otherwise it will includes logback lib, which shouldn't be
+        // visible through the program classloader.
+        if (className.startsWith("org.slf4j.impl.")) {
+          return false;
+        }
+
+        if (!classPathSeen.add(classPathUrl)) {
+          return true;
+        }
+
+        // Add all resources in the given class path
+        try {
+          ClassPath classPath = ClassPath.from(classPathUrl.toURI(), classLoader);
+          for (ClassPath.ResourceInfo resourceInfo : classPath.getResources()) {
+            result.add(resourceInfo.getResourceName());
+          }
+        } catch (Exception e) {
+          // If fail to get classes/resources from the classpath, ignore this classpath.
+        }
+        return true;
+      }
+    }, classes);
+
+    return result;
+  }
+
+  /**
+   * Returns a Set containing all bootstrap classpaths as defined in the {@code sun.boot.class.path} property.
+   */
+  private static Set<String> getBootstrapClassPaths() {
+    // Get the bootstrap classpath. This is for exclusion while tracing class dependencies.
+    Set<String> bootstrapPaths = Sets.newHashSet();
+    for (String classpath : Splitter.on(File.pathSeparatorChar).split(System.getProperty("sun.boot.class.path"))) {
+      File file = new File(classpath);
+      bootstrapPaths.add(file.getAbsolutePath());
+      try {
+        bootstrapPaths.add(file.getCanonicalPath());
+      } catch (IOException e) {
+        // Ignore the exception and proceed.
+      }
+    }
+    return bootstrapPaths;
+  }
+
+  /**
+   * Find the URL of the classpath that contains the given resource.
+   */
+  private static URL getClassPathURL(String resourceName, URL resourceURL) {
+    try {
+      if ("file".equals(resourceURL.getProtocol())) {
+        String path = resourceURL.getFile();
+        // Compute the directory container the class.
+        int endIdx = path.length() - resourceName.length();
+        if (endIdx > 1) {
+          // If it is not the root directory, return the end index to remove the trailing '/'.
+          endIdx--;
+        }
+        return new URL("file", "", -1, path.substring(0, endIdx));
+      }
+      if ("jar".equals(resourceURL.getProtocol())) {
+        String path = resourceURL.getFile();
+        return URI.create(path.substring(0, path.indexOf("!/"))).toURL();
+      }
+    } catch (MalformedURLException e) {
+      throw Throwables.propagate(e);
+    }
+    throw new IllegalStateException("Unsupported class URL: " + resourceURL);
+  }
+
+  private ClassPathResources() {
+  }
+}

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1471,7 +1471,18 @@
     <name>security.authorization.enabled</name>
     <value>false</value>
     <description>
-      Determines if authorization checks are enabled
+      When set to true, all operations in CDAP are authorized using the authorizer implementation found at the
+      property security.authorization.extension.jar.path.
+    </description>
+  </property>
+
+  <property>
+    <name>security.authorization.extension.jar.path</name>
+    <value></value>
+    <description>
+      If an external authorization system is used for authorizing operations on CDAP entities, this property sets
+      the path to the bundled JAR file containing the extension code. This jar is only used when
+      authorization is enabled by setting security.authorization.enabled to true.
     </description>
   </property>
 
@@ -1567,22 +1578,6 @@
     <value>false</value>
     <description>
       Determines if SSL is enabled
-    </description>
-  </property>
-
-  <property>
-    <name>security.authorization.enabled</name>
-    <value>false</value>
-    <description>
-      Determines if authorization is enabled
-    </description>
-  </property>
-
-  <property>
-    <name>security.authorization.pluginClassName</name>
-    <value>co.cask.cdap.security.authorization.DatasetBasedAuthorizer</value>
-    <description>
-      Class name of the AuthorizationPlugin implementation to use
     </description>
   </property>
 

--- a/cdap-common/src/test/java/co/cask/cdap/common/lang/FilterClassLoaderTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/lang/FilterClassLoaderTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 
 import java.io.IOException;
-import javax.script.ScriptEngineFactory;
 import javax.ws.rs.PUT;
 
 /**

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="9d9ce5b185a4085b09e7b0021938eb3e"
+DEFAULT_XML_MD5_HASH="bbc2499fa2329f34b090f99f8afadcd6"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/Authorizer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/Authorizer.java
@@ -20,11 +20,27 @@ import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 
+import java.util.Properties;
 import java.util.Set;
+import java.util.jar.Attributes;
 
 /**
  * Interface to grant/revoke {@link Principal principals} authorization for {@link Action actions} on
- * {@link EntityId CDAP entities}.
+ * {@link EntityId CDAP entities}. Authorization extensions must implement this interface to delegate authorization
+ * to appropriate authorization backends. The contract with Authorization extensions is as below:
+ *
+ * <ul>
+ *   <li>Authorization is enabled setting the parameter {@code security.authorization.enabled} to true in
+ *   {@code cdap-site.xml}.</li>
+ *   <li>The path to the extension jar bundled with all its dependencies must be specified by
+ *   {@code security.authorization.extension.jar.path} in cdap-site.xml</li>
+ *   <li>The extension jar must contain a class that implements {@link Authorizer}. This class must be specified as
+ *   the {@link Attributes.Name#MAIN_CLASS} in the extension jar's manifest file.</li>
+ *   <li>The contract with the class that implements {@link Authorizer} is that it must have a public constructor that
+ *   accepts a single {@link Properties} object as parameter. This constructor is invoked with a {@link Properties}
+ *   object that is populated with all configuration settings from {@code cdap-site.xml} that have keys with the prefix
+ *   {@code security.authorization.extension.config}.</li>
+ * </ul>
  */
 public interface Authorizer {
   /**

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerClassLoader.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerClassLoader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.common.lang.ClassPathResources;
+import co.cask.cdap.common.lang.DirectoryClassLoader;
+import co.cask.cdap.common.lang.FilterClassLoader;
+import co.cask.cdap.security.spi.authorization.Authorizer;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * {@link DirectoryClassLoader} for {@link Authorizer} extensions.
+ */
+public class AuthorizerClassLoader extends DirectoryClassLoader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuthorizerClassLoader.class);
+
+  @VisibleForTesting
+  static ClassLoader createParent() {
+    ClassLoader baseClassLoader = AuthorizerClassLoader.class.getClassLoader();
+    Set<String> authorizerResources;
+    try {
+      authorizerResources = ClassPathResources.getResourcesWithDependencies(baseClassLoader, Authorizer.class);
+    } catch (IOException e) {
+      LOG.error("Failed to determine resources for authorizer class loader.", e);
+      authorizerResources = ImmutableSet.of();
+    }
+
+    return FilterClassLoader.create(Predicates.in(authorizerResources),
+                                    Predicates.<String>alwaysTrue(),
+                                    baseClassLoader);
+  }
+
+  AuthorizerClassLoader(File unpackedJarDir) {
+    super(unpackedJarDir, createParent(), "lib");
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorService.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.lang.jar.BundleJarUtil;
+import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.cdap.security.spi.authorization.NoOpAuthorizer;
+import com.google.common.base.Strings;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.zip.ZipException;
+
+/**
+ * Class to instantiate {@link Authorizer} extensions. {@link Authorizer} extensions are instantiated using a
+ * separate {@link ClassLoader} that is built using a bundled jar for the {@link Authorizer} implementation that
+ * contains all its required dependencies. The {@link ClassLoader} is created with the parent as the classloader with
+ * which the {@link Authorizer} interface is instantiated. This parent only has classes required by the
+ * {@code cdap-security-spi} module.
+ *
+ * The {@link AuthorizerInstantiatorService} has the following expectations from the extension:
+ * <ul>
+ *   <li>Authorization is enabled setting the parameter {@link Constants.Security.Authorization#ENABLED} to true in
+ *   {@code cdap-site.xml}. When authorization is disabled, an instance of {@link NoOpAuthorizer} is returned.</li>
+ *   <li>The path to the extension jar bundled with all its dependencies is read from the setting
+ *   {@link Constants.Security.Authorization#EXTENSION_JAR_PATH} in cdap-site.xml</li>
+ *   <li>The instantiator reads a fully qualified class name specified as the {@link Attributes.Name#MAIN_CLASS}
+ *   attribute in the extension jar's manifest file. This class must implement {@link Authorizer} and have a public
+ *   constructor that accepts a single {@link Properties} object as parameter. This constructor is invoked with a
+ *   {@link Properties} object that is populated with all configuration settings from {@code cdap-site.xml} that have
+ *   keys with the prefix {@link Constants.Security.Authorization#EXTENSION_CONFIG_PREFIX}.</li>
+ * </ul>
+ *
+ * Implemented as a {@link AbstractIdleService} so it can manage initialization and destruction of the
+ * {@link AuthorizerClassLoader} in a reliable manner.
+ */
+public class AuthorizerInstantiatorService extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuthorizerInstantiatorService.class);
+
+  private final CConfiguration cConf;
+  private final boolean authorizationEnabled;
+
+  private File tmpDir;
+  private AuthorizerClassLoader authorizerClassLoader;
+  private Authorizer authorizer;
+
+  @Inject
+  public AuthorizerInstantiatorService(CConfiguration cConf) {
+    this.cConf = cConf;
+    this.authorizationEnabled = cConf.getBoolean(Constants.Security.Authorization.ENABLED);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    if (!authorizationEnabled) {
+      this.authorizer = new NoOpAuthorizer();
+      return;
+    }
+    // Authorization is enabled, so continue with startup now
+    String authorizerExtensionJarPath = cConf.get(Constants.Security.Authorization.EXTENSION_JAR_PATH);
+    if (Strings.isNullOrEmpty(authorizerExtensionJarPath)) {
+      throw new IllegalArgumentException(
+        String.format("Authorizer extension jar path not found in configuration. Please set %s in cdap-site.xml to " +
+                        "the fully qualified path of the jar file to use as the authorization backend.",
+                      Constants.Security.Authorization.EXTENSION_JAR_PATH));
+    }
+    File authorizerExtensionJar = new File(authorizerExtensionJarPath);
+    ensureValidAuthExtensionJar(authorizerExtensionJar);
+    File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
+                           cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+    this.tmpDir = DirUtils.createTempDir(tmpDir);
+    this.authorizerClassLoader = createAuthorizerClassLoader(authorizerExtensionJar);
+    this.authorizer = createAuthorizerInstance(authorizerExtensionJar);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    if (!authorizationEnabled) {
+      // nothing to close, since we would not have created a class loader
+      return;
+    }
+    try {
+      authorizerClassLoader.close();
+    } catch (IOException e) {
+      LOG.warn("Failed to close authorizer class loader", e);
+    }
+    try {
+      DirUtils.deleteDirectoryContents(tmpDir);
+    } catch (IOException e) {
+      // It's a cleanup step. Nothing much can be done if cleanup fails.
+      LOG.warn("Failed to delete directory {}", tmpDir, e);
+    }
+  }
+
+  /**
+   * @return an instance of the configured {@link Authorizer} extension, or of {@link NoOpAuthorizer}, if authorization
+   * is disabled
+   */
+  public Authorizer get() throws IOException, InvalidAuthorizerException {
+    return authorizer;
+  }
+
+  /**
+   * Creates a new instance of the configured {@link Authorizer} extension, based on the provided extension jar file.
+   *
+   * @return a new instance of the configured {@link Authorizer} extension
+   */
+  private Authorizer createAuthorizerInstance(File authorizerExtensionJar)
+    throws IOException, InvalidAuthorizerException {
+    Class<? extends Authorizer> authorizerClass = loadAuthorizerClass(authorizerExtensionJar);
+    // Set the context class loader to the AuthorizerClassLoader before creating a new instance of the extension,
+    // so all classes required in this process are created from the AuthorizerClassLoader.
+    ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(authorizerClassLoader);
+    LOG.debug("Setting context classloader to {}. Old classloader was {}.", authorizerClassLoader, oldClassLoader);
+    try {
+      Constructor<? extends Authorizer> constructor;
+      try {
+        constructor = authorizerClass.getDeclaredConstructor(Properties.class);
+      } catch (NoSuchMethodException e) {
+        throw new InvalidAuthorizerException(
+          String.format("No suitable constructor for Authorizer extension %s. Please make sure that the extension is " +
+                          "a public class with a public constructor that accepts a single parameter of type %s.",
+                        authorizerClass.getName(), Properties.class.getName()), e);
+      }
+      try {
+        return constructor.newInstance(createExtensionProperties());
+      } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+        throw new InvalidAuthorizerException(
+          String.format("Error while instantiating for authorizer extension %s. Please make sure that the extension " +
+                          "is a public class with a public constructor that accepts a single parameter of type %s.",
+                        authorizerClass.getName(), Properties.class.getName()), e);
+      }
+    } finally {
+      // After the process of creation of a new instance has completed (success or failure), reset the context
+      // classloader back to the original class loader.
+      Thread.currentThread().setContextClassLoader(oldClassLoader);
+      LOG.debug("Resetting context classloader to {} from {}.", oldClassLoader, authorizerClassLoader);
+    }
+  }
+
+  private Properties createExtensionProperties() {
+    Properties extensionProperties = new Properties();
+    for (Map.Entry<String, String> cConfEntry : cConf) {
+      if (cConfEntry.getKey().startsWith(Constants.Security.Authorization.EXTENSION_CONFIG_PREFIX)) {
+        extensionProperties.put(
+          cConfEntry.getKey().substring(Constants.Security.Authorization.EXTENSION_CONFIG_PREFIX.length()),
+          cConfEntry.getValue()
+        );
+      }
+    }
+    return extensionProperties;
+  }
+
+  private AuthorizerClassLoader createAuthorizerClassLoader(File authorizerExtensionJar)
+    throws IOException, InvalidAuthorizerException {
+    LOG.info("Creating authorization extension using jar {}.", authorizerExtensionJar);
+    try {
+      BundleJarUtil.unJar(Locations.toLocation(authorizerExtensionJar), tmpDir);
+      return new AuthorizerClassLoader(tmpDir);
+    } catch (ZipException e) {
+      throw new InvalidAuthorizerException(
+        String.format("Authorization extension jar %s specified as %s must be a jar file.", authorizerExtensionJar,
+                      Constants.Security.Authorization.EXTENSION_JAR_PATH), e
+      );
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private Class<? extends Authorizer> loadAuthorizerClass(File authorizerExtensionJar)
+    throws IOException, InvalidAuthorizerException {
+    String authorizerClassName = getAuthorizerClassName(authorizerExtensionJar);
+    Class<?> authorizerClass;
+    try {
+      authorizerClass = authorizerClassLoader.loadClass(authorizerClassName);
+    } catch (ClassNotFoundException e) {
+      throw new InvalidAuthorizerException(
+        String.format("Authorizer extension class %s not found. Please make sure that the right class is specified " +
+                        "in the extension jar's manifest located at %s.",
+                      authorizerClassName, authorizerExtensionJar), e);
+    }
+    if (!Authorizer.class.isAssignableFrom(authorizerClass)) {
+      throw new InvalidAuthorizerException(
+        String.format("Class %s defined as %s in the authorization extension's manifest at %s must implement %s",
+                      authorizerClass.getName(), Attributes.Name.MAIN_CLASS, authorizerExtensionJar,
+                      Authorizer.class.getName()));
+    }
+    return (Class<? extends Authorizer>) authorizerClass;
+  }
+
+  /**
+   * Inspect the given auth extension jar to find the {@link Authorizer} class contained in it.
+   *
+   * @param authorizerExtensionJar the bundled jar file for the authorizer extension
+   * @return name of the class defined as the {@link Attributes.Name#MAIN_CLASS} in the authorizer extension jar
+   * @throws IOException if there was an exception opening the jar file
+   */
+  private String getAuthorizerClassName(File authorizerExtensionJar) throws IOException, InvalidAuthorizerException {
+    File manifestFile = new File(tmpDir, JarFile.MANIFEST_NAME);
+    if (!manifestFile.isFile() && !manifestFile.exists()) {
+      throw new InvalidAuthorizerException(
+        String.format("No Manifest found in authorizer extension jar '%s'.", authorizerExtensionJar));
+    }
+    try (InputStream is = new FileInputStream(manifestFile)) {
+      Manifest manifest = new Manifest(is);
+      Attributes manifestAttributes = manifest.getMainAttributes();
+      if (manifestAttributes == null) {
+        throw new InvalidAuthorizerException(
+          String.format("No attributes found in authorizer extension jar '%s'.", authorizerExtensionJar));
+      }
+      if (!manifestAttributes.containsKey(Attributes.Name.MAIN_CLASS)) {
+        throw new InvalidAuthorizerException(
+          String.format("Authorizer class not set in the manifest of the authorizer extension jar located at %s. " +
+                          "Please set the attribute %s to the fully qualified class name of the class that " +
+                          "implements %s in the extension jar's manifest.",
+                        authorizerExtensionJar, Attributes.Name.MAIN_CLASS, Authorizer.class.getName()));
+      }
+      return manifestAttributes.getValue(Attributes.Name.MAIN_CLASS);
+    }
+  }
+
+  private void ensureValidAuthExtensionJar(File authorizerExtensionJar) throws InvalidAuthorizerException {
+    if (!authorizerExtensionJar.exists()) {
+      throw new InvalidAuthorizerException(
+        String.format("Authorization extension jar %s specified as %s does not exist.", authorizerExtensionJar,
+                      Constants.Security.Authorization.EXTENSION_JAR_PATH)
+      );
+    }
+    if (!authorizerExtensionJar.isFile()) {
+      throw new InvalidAuthorizerException(
+        String.format("Authorization extension jar %s specified as %s must be a file.", authorizerExtensionJar,
+                      Constants.Security.Authorization.EXTENSION_JAR_PATH)
+      );
+    }
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/InvalidAuthorizerException.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/InvalidAuthorizerException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+/**
+ * Thrown when an authorizer extension jar is found to be invalid during inspection.
+ */
+public class InvalidAuthorizerException extends Exception {
+
+  public InvalidAuthorizerException(String message) {
+    super(message);
+  }
+
+  public InvalidAuthorizerException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerClassLoaderTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerClassLoaderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.app.Application;
+import co.cask.cdap.common.lang.ClassPathResources;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Tests for {@link AuthorizerClassLoader}.
+ */
+public class AuthorizerClassLoaderTest {
+  private final ClassLoader parent = AuthorizerClassLoader.createParent();
+
+  @Test
+  public void testAuthorizerClassLoaderParentAvailableClasses() throws ClassNotFoundException {
+    // classes from java.* should be available
+    parent.loadClass(List.class.getName());
+    // classes from javax.* should be available
+    parent.loadClass(Nullable.class.getName());
+    // classes from gson should be available
+    parent.loadClass(Gson.class.getName());
+    // classes from cdap-api should be available
+    parent.loadClass(Application.class.getName());
+    // classes from cdap-proto should be available
+    parent.loadClass(Principal.class.getName());
+    // classes from cdap-security-spi should be available
+    parent.loadClass(Authorizer.class.getName());
+    parent.loadClass(UnauthorizedException.class.getName());
+  }
+
+  @Test
+  public void testAuthorizerClassLoaderParentUnavailableClasses() {
+    // classes from guava should not be available
+    assertClassUnavailable(ImmutableList.class);
+    // classes from hadoop should not be available
+    assertClassUnavailable(Configuration.class);
+    // classes from hbase should not be available
+    assertClassUnavailable(HTable.class);
+    // classes from spark should not be available
+    assertClassUnavailable("org.apache.spark.SparkConf");
+    // classes from twill should not be available
+    assertClassUnavailable(LocationFactory.class);
+    // classes from logback should not be available
+    assertClassUnavailable(Logger.class);
+    // classes from cdap-common should not be available
+    assertClassUnavailable(ClassPathResources.class);
+    // classes from cdap-security should not be available
+    assertClassUnavailable(AuthorizerClassLoader.class);
+    // classes from cdap-data-fabric should not be available
+    assertClassUnavailable("co.cask.cdap.data2.util.TableId");
+    // classes from cdap-app-fabric should not be available
+    assertClassUnavailable("co.cask.cdap.internal.app.namespace.DefaultNamespaceAdmin");
+  }
+
+  private void assertClassUnavailable(Class<?> aClass) {
+    assertClassUnavailable(aClass.getName());
+  }
+
+  private void assertClassUnavailable(String aClassName) {
+    try {
+      parent.loadClass(aClassName);
+      Assert.fail(String.format("Class %s should not be available from the parent class loader of the " +
+                                  "AuthorizerClassLoader, but it is.", aClassName));
+    } catch (ClassNotFoundException e) {
+      // expected
+    }
+  }
+}

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorServiceTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorServiceTest.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.twill.LocalLocationFactory;
+import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.cdap.security.spi.authorization.NoOpAuthorizer;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.gson.Gson;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Properties;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import javax.annotation.Nullable;
+
+/**
+ * Tests for {@link AuthorizerInstantiatorService}.
+ */
+public class AuthorizerInstantiatorServiceTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  private static final CConfiguration cConf = CConfiguration.create();
+  private static LocationFactory locationFactory;
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMPORARY_FOLDER.newFolder().getAbsolutePath());
+    cConf.setBoolean(Constants.Security.Authorization.ENABLED, true);
+    locationFactory = new LocalLocationFactory(TEMPORARY_FOLDER.newFolder());
+  }
+
+  @Test
+  public void testAuthorizationDisabled() throws InvalidAuthorizerException, IOException {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMPORARY_FOLDER.newFolder().getAbsolutePath());
+    AuthorizerInstantiatorService instantiator = new AuthorizerInstantiatorService(cConf);
+    try {
+      instantiator.startAndWait();
+      Authorizer authorizer = instantiator.get();
+      Assert.assertTrue("When authorization is disabled, a NoOpAuthorizer must be returned.",
+                        authorizer instanceof NoOpAuthorizer);
+    } finally {
+      instantiator.stopAndWait();
+    }
+  }
+
+  @Test(expected = InvalidAuthorizerException.class)
+  public void testNonExistingAuthorizerJarPath() throws Throwable {
+    cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, "/path/to/external-test-authorizer.jar");
+    AuthorizerInstantiatorService instantiator = new AuthorizerInstantiatorService(cConf);
+    try {
+      instantiator.startAndWait();
+    } catch (UncheckedExecutionException e) {
+      throw Throwables.getRootCause(e);
+    }
+    Assert.assertFalse("Authorizer Instantiator should not have started because extension jar does not exist",
+                       instantiator.isRunning());
+  }
+
+  @Test(expected = InvalidAuthorizerException.class)
+  public void testAuthorizerJarPathIsDirectory() throws Throwable {
+    cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, TEMPORARY_FOLDER.newFolder().getPath());
+    AuthorizerInstantiatorService instantiator = new AuthorizerInstantiatorService(cConf);
+    try {
+      instantiator.startAndWait();
+    } catch (UncheckedExecutionException e) {
+      throw Throwables.getRootCause(e);
+    }
+    Assert.assertFalse("Authorizer Instantiator should not have started because extension jar is a directory",
+                       instantiator.isRunning());
+  }
+
+  @Test(expected = InvalidAuthorizerException.class)
+  public void testAuthorizerJarPathIsNotJar() throws Throwable {
+    cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH,
+              TEMPORARY_FOLDER.newFile("abc.txt").getPath());
+    AuthorizerInstantiatorService instantiator = new AuthorizerInstantiatorService(cConf);
+    try {
+      instantiator.startAndWait();
+    } catch (UncheckedExecutionException e) {
+      throw Throwables.getRootCause(e);
+    }
+    Assert.assertFalse("Authorizer Instantiator should not have started because extension jar is not a jar file",
+                       instantiator.isRunning());
+  }
+
+  @Test(expected = InvalidAuthorizerException.class)
+  public void testMissingManifest() throws Throwable {
+    Location externalAuthJar = createInvalidExternalAuthJar(null);
+    cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, externalAuthJar.toString());
+    AuthorizerInstantiatorService instantiator = new AuthorizerInstantiatorService(cConf);
+    try {
+      instantiator.startAndWait();
+    } catch (UncheckedExecutionException e) {
+      throw Throwables.getRootCause(e);
+    }
+    Assert.assertFalse("Authorizer Instantiator should not have started because extension jar does not have a manifest",
+                       instantiator.isRunning());
+  }
+
+  @Test(expected = InvalidAuthorizerException.class)
+  public void testMissingAuthorizerClassName() throws Throwable {
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+    Location externalAuthJar = createInvalidExternalAuthJar(manifest);
+    cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, externalAuthJar.toString());
+    AuthorizerInstantiatorService instantiator = new AuthorizerInstantiatorService(cConf);
+    try {
+      instantiator.startAndWait();
+    } catch (UncheckedExecutionException e) {
+      throw Throwables.getRootCause(e);
+    }
+    Assert.assertFalse("Authorizer Instantiator should not have started because extension jar's manifest does not " +
+                         "define Authorizer class.", instantiator.isRunning());
+  }
+
+  @Test(expected = InvalidAuthorizerException.class)
+  public void testDoesNotImplementAuthorizer() throws Throwable {
+    Manifest manifest = new Manifest();
+    Attributes mainAttributes = manifest.getMainAttributes();
+    mainAttributes.put(Attributes.Name.MAIN_CLASS, DoesNotImplementAuthorizer.class.getName());
+    Location externalAuthJar = AppJarHelper.createDeploymentJar(locationFactory, DoesNotImplementAuthorizer.class,
+                                                                manifest);
+    cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, externalAuthJar.toString());
+    AuthorizerInstantiatorService instantiator = new AuthorizerInstantiatorService(cConf);
+    try {
+      instantiator.startAndWait();
+    } catch (UncheckedExecutionException e) {
+      throw Throwables.getRootCause(e);
+    }
+    Assert.assertFalse("Authorizer Instantiator should not have started because the Authorizer class defined in " +
+                         "the extension jar's manifest does not implement Authorizer.", instantiator.isRunning());
+  }
+
+  @Test(expected = InvalidAuthorizerException.class)
+  public void testInvalidConstructor() throws Throwable {
+    Manifest manifest = new Manifest();
+    Attributes mainAttributes = manifest.getMainAttributes();
+    mainAttributes.put(Attributes.Name.MAIN_CLASS, InvalidConstructor.class.getName());
+    Location externalAuthJar = AppJarHelper.createDeploymentJar(locationFactory, InvalidConstructor.class, manifest);
+    cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, externalAuthJar.toString());
+    AuthorizerInstantiatorService instantiator = new AuthorizerInstantiatorService(cConf);
+    try {
+      instantiator.startAndWait();
+    } catch (UncheckedExecutionException e) {
+      throw e.getCause();
+    }
+    Assert.assertFalse("Authorizer Instantiator should not have started because the Authorizer class defined in " +
+                         "the extension jar's manifest does not define a constructor that accepts a Properties object.",
+                       instantiator.isRunning());
+  }
+
+  @Test(expected = InvalidAuthorizerException.class)
+  public void testConstructorNotVisible() throws Throwable {
+    Manifest manifest = new Manifest();
+    Attributes mainAttributes = manifest.getMainAttributes();
+    mainAttributes.put(Attributes.Name.MAIN_CLASS, ConstructorNotVisible.class.getName());
+    Location externalAuthJar = AppJarHelper.createDeploymentJar(locationFactory, ConstructorNotVisible.class, manifest);
+    cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, externalAuthJar.toString());
+    AuthorizerInstantiatorService instantiator = new AuthorizerInstantiatorService(cConf);
+    try {
+      instantiator.startAndWait();
+    } catch (UncheckedExecutionException e) {
+      throw e.getCause();
+    }
+    Assert.assertFalse("Authorizer Instantiator should not have started because the Authorizer class defined in " +
+                         "the extension jar's manifest defines a constructor that accepts a Properties object, " +
+                         "but it is not visible.",
+                       instantiator.isRunning());
+  }
+
+  @Test
+  public void testAuthorizerExtension() throws IOException, ClassNotFoundException, InvalidAuthorizerException {
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MAIN_CLASS, ValidExternalAuthorizer.class.getName());
+    Location externalAuthJar = AppJarHelper.createDeploymentJar(locationFactory, ValidExternalAuthorizer.class,
+                                                                manifest);
+    CConfiguration cConfCopy = CConfiguration.copy(cConf);
+    cConfCopy.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, externalAuthJar.toString());
+    cConfCopy.set(Constants.Security.Authorization.EXTENSION_CONFIG_PREFIX + "config.path",
+                  "/path/config.ini");
+    cConfCopy.set(Constants.Security.Authorization.EXTENSION_CONFIG_PREFIX + "service.address",
+                  "http://foo.bar.co:5555");
+    cConfCopy.set("foo." + Constants.Security.Authorization.EXTENSION_CONFIG_PREFIX + "dont.include",
+                  "not.prefix.should.not.be.included");
+    AuthorizerInstantiatorService instantiator = new AuthorizerInstantiatorService(cConfCopy);
+    try {
+      instantiator.startAndWait();
+      Assert.assertTrue(instantiator.isRunning());
+      // should be able to load the ExternalAuthorizer class via the AuthorizerInstantiatorService
+      Authorizer externalAuthorizer1 = instantiator.get();
+      Assert.assertNotNull(externalAuthorizer1);
+      Authorizer externalAuthorizer2 = instantiator.get();
+      Assert.assertNotNull(externalAuthorizer2);
+      // verify that get returns the same  instance each time it is called.
+      Assert.assertEquals(externalAuthorizer1, externalAuthorizer2);
+
+      ClassLoader authorizerClassLoader = externalAuthorizer1.getClass().getClassLoader();
+      ClassLoader parent = authorizerClassLoader.getParent();
+      // should be able to load the Authorizer interface via the parent
+      parent.loadClass(Authorizer.class.getName());
+      // should not be able to load the ExternalAuthorizer class via the parent class loader
+      try {
+        parent.loadClass(ValidExternalAuthorizer.class.getName());
+        Assert.fail("Should not be able to load external authorizer classes via the parent classloader of the " +
+                      "Authorizer class loader.");
+      } catch (ClassNotFoundException expected) {
+        // expected
+      }
+      // should be able to load the ExternalAuthorizer class via the AuthorizerClassLoader
+      authorizerClassLoader.loadClass(ValidExternalAuthorizer.class.getName());
+
+      // have to do this because the external authorizer instance is created in a new classloader, so casting will
+      // not work.
+      Gson gson = new Gson();
+      ValidExternalAuthorizer validAuthorizer = gson.fromJson(gson.toJson(externalAuthorizer1),
+                                                              ValidExternalAuthorizer.class);
+      Properties expectedProps = new Properties();
+      expectedProps.put("config.path", "/path/config.ini");
+      expectedProps.put("service.address", "http://foo.bar.co:5555");
+      Properties actualProps = validAuthorizer.getProperties();
+      Assert.assertEquals(expectedProps, actualProps);
+    } finally {
+      instantiator.stopAndWait();
+    }
+  }
+
+  private Location createInvalidExternalAuthJar(@Nullable Manifest manifest) throws IOException {
+    String jarName = "external-authorizer";
+    Location externalAuthJar = locationFactory.create(jarName).getTempFile(".jar");
+    try (
+      OutputStream out = externalAuthJar.getOutputStream();
+      JarOutputStream jarOutput = manifest == null ? new JarOutputStream(out) : new JarOutputStream(out, manifest)
+    ) {
+      JarEntry entry = new JarEntry("dummy.class");
+      jarOutput.putNextEntry(entry);
+      jarOutput.closeEntry();
+    }
+    return externalAuthJar;
+  }
+
+  public static final class ValidExternalAuthorizer implements Authorizer {
+
+    private final Properties properties;
+
+    @SuppressWarnings("unused")
+    public ValidExternalAuthorizer(Properties properties) {
+      this.properties = properties;
+    }
+
+    @Override
+    public void grant(EntityId entity, Principal principal, Set<Action> actions) {
+      // no-op
+    }
+
+    @Override
+    public void revoke(EntityId entity, Principal principal, Set<Action> actions) {
+      // no-op
+    }
+
+    @Override
+    public void revoke(EntityId entity) {
+      // no-op
+    }
+
+    @Override
+    public void enforce(EntityId entity, Principal principal, Action action) throws UnauthorizedException {
+      // no-op
+    }
+
+    public Properties getProperties() {
+      return properties;
+    }
+  }
+
+  private static final class DoesNotImplementAuthorizer {
+  }
+
+  private static final class InvalidConstructor implements Authorizer {
+
+    @Override
+    public void enforce(EntityId entity, Principal principal, Action action) throws UnauthorizedException {
+      // no-op
+    }
+
+    @Override
+    public void grant(EntityId entity, Principal principal, Set<Action> actions) {
+      // no-op
+    }
+
+    @Override
+    public void revoke(EntityId entity, Principal principal, Set<Action> actions) {
+      // no-op
+    }
+
+    @Override
+    public void revoke(EntityId entity) {
+      // no-op
+    }
+  }
+
+  private static final class ConstructorNotVisible implements Authorizer {
+
+    @SuppressWarnings("unused")
+    private ConstructorNotVisible(Properties properties) {
+      // no-op
+    }
+
+    @Override
+    public void enforce(EntityId entity, Principal principal, Action action) throws UnauthorizedException {
+      // no-op
+    }
+
+    @Override
+    public void grant(EntityId entity, Principal principal, Set<Action> actions) {
+      // no-op
+    }
+
+    @Override
+    public void revoke(EntityId entity, Principal principal, Set<Action> actions) {
+      // no-op
+    }
+
+    @Override
+    public void revoke(EntityId entity) {
+      // no-op
+    }
+  }
+}


### PR DESCRIPTION
This PR contains:

- [x] ``AuthorizationInstantiatorService`` to create a separate classloader to load authorization extensions. This is implemented as an ``AbstractIdleService`` to manage the construction and destruction of authorizer classloaders reliably. 
- [x] Refactoring of some common code from ``ProgramResources`` into a ``ClassPathResources`` utility class
- [ ] Lifecycle management of Authorization extensions will be in a separate PR
- [ ] Adapting the existing ``DatasetBasedAuthorizer`` to be an extension will also be a separate PR 

Jira: [CDAP-5172](https://issues.cask.co/browse/CDAP-5172)
Build: http://builds.cask.co/browse/CDAP-DUT3647