### PR TITLE
Fix Javadocs

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -173,7 +173,8 @@ public interface MapReduceContext
   void addOutput(String datasetName, Map<String, String> arguments);
 
   /**
-   * Updates the output configuration of this MapReduce job to also allow writing using the given OutputFormatProvider.
+   * Updates the output configuration of this MapReduce job to also allow writing using the given 
+   * {@link OutputFormatProvider}.
    *
    * @param outputName the name of the output
    * @param outputFormatProvider the outputFormatProvider which specifies an OutputFormat and configuration to be used

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
@@ -40,7 +40,7 @@ public interface MapReduceTaskContext<KEYOUT, VALUEOUT> extends RuntimeContext, 
 
   /**
    * Write key and value to the named output Dataset. This method must only be used if the MapReduce writes to
-   * more than one output. If there is a single output, {@link #write(Object, Object)} must be used, or else
+   * more than one output. If there is a single output, {@link #write(Object, Object)} must be used, or the
    * data may not be written correctly.
    *
    * @param namedOutput the name of the output Dataset
@@ -50,8 +50,8 @@ public interface MapReduceTaskContext<KEYOUT, VALUEOUT> extends RuntimeContext, 
   <K, V> void write(String namedOutput, K key, V value) throws IOException, InterruptedException;
 
   /**
-   * Write key and value to the hadoop context. This method must only be used in the MapReduce writes to a single
-   * output. If there is more than one outputs, {@link #write(String, Object, Object)} must be used.
+   * Write key and value to the Hadoop context. This method must only be used if the MapReduce writes to a single
+   * output. If there is more than one output, {@link #write(String, Object, Object)} must be used instead.
    *
    * @param key         the key
    * @param value       the value
@@ -65,7 +65,7 @@ public interface MapReduceTaskContext<KEYOUT, VALUEOUT> extends RuntimeContext, 
 
   /**
    * Returns the logical start time of this MapReduce job. Logical start time is the time when this MapReduce
-   * job is supposed to start if this job is started by the scheduler. Otherwise it would be the current time when the
+   * job is supposed to start if this job is started by the scheduler. Otherwise, it is the current time when the
    * job runs.
    *
    * @return Time in milliseconds since epoch time (00:00:00 January 1, 1970 UTC).

--- a/cdap-spark-core/pom.xml
+++ b/cdap-spark-core/pom.xml
@@ -155,6 +155,15 @@
         <artifactId>scala-maven-plugin</artifactId>
         <version>3.2.2</version>
       </plugin>
+      <!-- TODO, remove --> 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Removes the cdap-spark-core from the Javadoc build and adds a TO-DO to fix when the Javadocs are complete for the new module.

Adds a missing link to the MapReduce Javadocs.
Corrects spelling and grammar in MapReduceTaskContext.

Passes a [Docs Develop Build](http://builds.cask.co/browse/CDAP-DDB34-1)

[New Javadocs](http://builds.cask.co/artifact/CDAP-DDB34/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/reference-manual/javadocs/index.html)