### PR TITLE
CDAP-5186 add connector implementations

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/BatchPhaseSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/BatchPhaseSpec.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.etl.common.PipelinePhase;
+
+import java.util.Map;
+
+/**
+ * Information required by one phase of a batch pipeline.
+ */
+public class BatchPhaseSpec {
+  private final String phaseName;
+  private final PipelinePhase phase;
+  private final Resources resources;
+  private final boolean isStageLoggingEnabled;
+  private final Map<String, String> connectorDatasets;
+
+  public BatchPhaseSpec(String phaseName, PipelinePhase phase, Resources resources, boolean
+    isStageLoggingEnabled, Map<String, String> connectorDatasets) {
+    this.phaseName = phaseName;
+    this.phase = phase;
+    this.resources = resources;
+    this.isStageLoggingEnabled = isStageLoggingEnabled;
+    this.connectorDatasets = connectorDatasets;
+  }
+
+  public String getPhaseName() {
+    return phaseName;
+  }
+
+  public PipelinePhase getPhase() {
+    return phase;
+  }
+
+  public Resources getResources() {
+    return resources;
+  }
+
+  public boolean isStageLoggingEnabled() {
+    return isStageLoggingEnabled;
+  }
+
+  public Map<String, String> getConnectorDatasets() {
+    return connectorDatasets;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/PipelinePluginInstantiator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/PipelinePluginInstantiator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.etl.batch.connector.ConnectorSink;
+import co.cask.cdap.etl.batch.connector.ConnectorSource;
+import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.planner.StageInfo;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Layer between the ETL programs and CDAP PluginContext to instantiate plugins for a stage in a pipeline.
+ * This is required because {@link ConnectorSource} and {@link ConnectorSink} are not plugins because we want to
+ * them to be internal only.
+ */
+public class PipelinePluginInstantiator {
+  private final PluginContext pluginContext;
+  private final BatchPhaseSpec phaseSpec;
+  private final Set<String> connectorSources;
+  private final Set<String> connectorSinks;
+
+  public PipelinePluginInstantiator(PluginContext pluginContext, BatchPhaseSpec phaseSpec) {
+    this.pluginContext = pluginContext;
+    this.phaseSpec = phaseSpec;
+    this.connectorSources = new HashSet<>();
+    this.connectorSinks = new HashSet<>();
+    for (StageInfo connectorStage : phaseSpec.getPhase().getStagesOfType(Constants.CONNECTOR_TYPE)) {
+      String connectorName = connectorStage.getName();
+      if (phaseSpec.getPhase().getSources().contains(connectorName)) {
+        connectorSources.add(connectorName);
+      }
+      if (phaseSpec.getPhase().getSinks().contains(connectorName)) {
+        connectorSinks.add(connectorName);
+      }
+    }
+  }
+
+  public <T> T newPluginInstance(String stageName) throws InstantiationException {
+    if (connectorSources.contains(stageName)) {
+      String datasetName = phaseSpec.getConnectorDatasets().get(stageName);
+      return (T) new ConnectorSource(datasetName, null);
+    } else if (connectorSinks.contains(stageName)) {
+      String datasetName = phaseSpec.getConnectorDatasets().get(stageName);
+      return (T) new ConnectorSink(datasetName, phaseSpec.getPhaseName(), true);
+    }
+
+    return pluginContext.newPluginInstance(stageName);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/connector/ConnectorSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/connector/ConnectorSink.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.connector;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.format.StructuredRecordStringConverter;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Internal batch sink used as a connector between pipeline phases.
+ * Though this extends BatchSink, this will not be instantiated through the plugin framework, but will
+ * be created explicitly through the application.
+ *
+ * The batch connector is just a PartitionedFileSet, where a partition is the name of a phase that wrote to it.
+ * This way, multiple phases can have the same local PartitionedFileSet as a sink, and the source will read data
+ * from all partitions.
+ *
+ * This is because we don't want this to show up as a plugin that users can select and use, and also because
+ * it uses features not exposed in the etl api (local workflow datasets).
+ *
+ * TODO: improve storage format. It is currently a json of the record but that is obviously not ideal
+ */
+public class ConnectorSink extends BatchSink<StructuredRecord, NullWritable, Text> {
+  private final String datasetName;
+  private final String phaseName;
+  private final boolean writeSchema;
+
+  public ConnectorSink(String datasetName, String phaseName, boolean writeSchema) {
+    this.datasetName = datasetName;
+    this.phaseName = phaseName;
+    this.writeSchema = writeSchema;
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) throws Exception {
+    Map<String, String> arguments = new HashMap<>();
+    PartitionKey outputPartition = PartitionKey.builder().addStringField("phase", phaseName).build();
+    PartitionedFileSetArguments.setOutputPartitionKey(arguments, outputPartition);
+    context.addOutput(datasetName, arguments);
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<KeyValue<NullWritable, Text>> emitter) throws Exception {
+    if (writeSchema) {
+      input = modifyRecord(input);
+    }
+    emitter.emit(new KeyValue<>(NullWritable.get(), new Text(StructuredRecordStringConverter.toJsonString(input))));
+  }
+
+  private StructuredRecord modifyRecord(StructuredRecord input) throws IOException {
+    Schema inputSchema = input.getSchema();
+    return StructuredRecord.builder(ConnectorSource.RECORD_WITH_SCHEMA)
+      .set("schema", inputSchema.toString())
+      .set("record", StructuredRecordStringConverter.toJsonString(input))
+      .build();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/connector/ConnectorSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/connector/ConnectorSource.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.connector;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
+import co.cask.cdap.api.dataset.lib.PartitionFilter;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import co.cask.cdap.api.workflow.WorkflowConfigurer;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.format.StructuredRecordStringConverter;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Internal batch source used as a connector between pipeline phases.
+ * Though this extends BatchSource, this will not be instantiated through the plugin framework, but will
+ * be created explicitly through the application.
+ *
+ * The batch connector is just a PartitionedFileSet, where a partition is the name of a phase that wrote to it.
+ * This way, multiple phases can have the same local PartitionedFileSet as a sink, and the source will read data
+ * from all partitions.
+ *
+ * This is because we don't want this to show up as a plugin that users can select and use, and also because
+ * it uses features not exposed in the etl api (local workflow datasets).
+ *
+ * TODO: improve storage format. It is currently a json of the record but that is obviously not ideal
+ */
+public class ConnectorSource extends BatchSource<LongWritable, Text, StructuredRecord> {
+  static final Schema RECORD_WITH_SCHEMA = Schema.recordOf(
+    "record",
+    Schema.Field.of("schema", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("record", Schema.of(Schema.Type.STRING)));
+  private final String datasetName;
+  @Nullable
+  private final Schema schema;
+
+  public ConnectorSource(String datasetName, @Nullable Schema schema) {
+    this.datasetName = datasetName;
+    this.schema = schema;
+  }
+
+  // not the standard configurePipeline method. Need a workflowConfigurer to create a local dataset
+  // we may want to expose local datasets in cdap-etl-api, but that is a separate track.
+  public void configure(WorkflowConfigurer workflowConfigurer) {
+    Partitioning partitioning = Partitioning.builder()
+      .addField("phase", Partitioning.FieldType.STRING)
+      .build();
+    workflowConfigurer.createLocalDataset(datasetName, PartitionedFileSet.class,
+                                          PartitionedFileSetProperties.builder()
+                                            .setPartitioning(partitioning)
+                                            .setInputFormat(TextInputFormat.class)
+                                            .setOutputFormat(TextOutputFormat.class)
+                                            .build());
+  }
+
+  @Override
+  public void prepareRun(BatchSourceContext context) throws Exception {
+    Map<String, String> arguments = new HashMap<>();
+    PartitionedFileSet inputFileset = context.getDataset(datasetName);
+    for (PartitionDetail partitionDetail : inputFileset.getPartitions(PartitionFilter.ALWAYS_MATCH)) {
+      PartitionedFileSetArguments.addInputPartition(arguments, partitionDetail);
+    }
+    context.setInput(datasetName, arguments);
+  }
+
+  @Override
+  public void transform(KeyValue<LongWritable, Text> input,
+                        Emitter<StructuredRecord> emitter) throws Exception {
+    StructuredRecord output;
+    String inputStr = input.getValue().toString();
+    if (schema == null) {
+      StructuredRecord recordWithSchema =
+        StructuredRecordStringConverter.fromJsonString(inputStr, RECORD_WITH_SCHEMA);
+      Schema outputSchema = Schema.parseJson((String) recordWithSchema.get("schema"));
+      output = StructuredRecordStringConverter.fromJsonString((String) recordWithSchema.get("record"), outputSchema);
+    } else {
+      output = StructuredRecordStringConverter.fromJsonString(inputStr, schema);
+    }
+    emitter.emit(output);
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
@@ -19,6 +19,7 @@ package co.cask.cdap.etl.batch.mapreduce;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.batch.PipelinePluginInstantiator;
 import co.cask.cdap.etl.batch.TransformExecutorFactory;
 import co.cask.cdap.etl.common.DatasetContextLookupProvider;
 
@@ -34,9 +35,11 @@ public class MapReduceTransformExecutorFactory<T> extends TransformExecutorFacto
   private final Map<String, Map<String, String>> pluginRuntimeArgs;
   private final MapReduceTaskContext taskContext;
 
-  public MapReduceTransformExecutorFactory(MapReduceTaskContext taskContext, Metrics metrics, long logicalStartTime,
+  public MapReduceTransformExecutorFactory(MapReduceTaskContext taskContext,
+                                           PipelinePluginInstantiator pluginInstantiator,
+                                           Metrics metrics,
                                            Map<String, Map<String, String>> pluginRuntimeArgs) {
-    super(taskContext, metrics, logicalStartTime);
+    super(pluginInstantiator, metrics);
     this.taskContext = taskContext;
     this.pluginRuntimeArgs = pluginRuntimeArgs;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkTransformExecutorFactory.java
@@ -19,6 +19,7 @@ package co.cask.cdap.etl.batch.spark;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.batch.PipelinePluginInstantiator;
 import co.cask.cdap.etl.batch.TransformExecutorFactory;
 
 import java.util.Map;
@@ -29,11 +30,17 @@ import java.util.Map;
  * @param <T> the type of input for the created transform executors
  */
 public class SparkTransformExecutorFactory<T> extends TransformExecutorFactory<T> {
+  private final PluginContext pluginContext;
+  private final long logicalStartTime;
   private final Map<String, String> runtimeArgs;
 
-  public SparkTransformExecutorFactory(PluginContext pluginContext, Metrics metrics, long logicalStartTime,
+  public SparkTransformExecutorFactory(PluginContext pluginContext,
+                                       PipelinePluginInstantiator pluginInstantiator,
+                                       Metrics metrics, long logicalStartTime,
                                        Map<String, String> runtimeArgs) {
-    super(pluginContext, metrics, logicalStartTime);
+    super(pluginInstantiator, metrics);
+    this.pluginContext = pluginContext;
+    this.logicalStartTime = logicalStartTime;
     this.runtimeArgs = runtimeArgs;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Constants.java
@@ -25,6 +25,7 @@ public final class Constants {
   public static final String ID_SEPARATOR = ":";
   public static final String PIPELINEID = "pipeline";
   public static final String STAGE_LOGGING_ENABLED = "stage.logging.enabled";
+  public static final String CONNECTOR_TYPE = "connector";
   public static final Schema ERROR_SCHEMA = Schema.recordOf(
     "error",
     Schema.Field.of(ErrorDataset.ERRCODE, Schema.of(Schema.Type.INT)),

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelinePhase.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelinePhase.java
@@ -17,9 +17,15 @@
 package co.cask.cdap.etl.common;
 
 import co.cask.cdap.etl.planner.StageInfo;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -28,39 +34,49 @@ import java.util.Set;
  * Keeps track of the plugin ids for the source, transforms, and sink of a pipeline phase.
  */
 public class PipelinePhase {
-  private final StageInfo source;
-  private final StageInfo aggregator;
-  private final Set<StageInfo> sinks;
-  private final Set<StageInfo> transforms;
+  // plugin type -> stage info
+  private final Map<String, Set<StageInfo>> stages;
   private final Map<String, Set<String>> connections;
+  private final Set<String> sources;
+  private final Set<String> sinks;
 
-  public PipelinePhase(StageInfo source, StageInfo aggregator, Set<StageInfo> sinks, Set<StageInfo> transforms,
-                       Map<String, Set<String>> connections) {
-    this.source = source;
-    this.aggregator = aggregator;
-    this.sinks = ImmutableSet.copyOf(sinks);
-    this.transforms = ImmutableSet.copyOf(transforms);
+  private PipelinePhase(Map<String, Set<StageInfo>> stages, Map<String, Set<String>> connections) {
+    this.stages = ImmutableMap.copyOf(stages);
     this.connections = ImmutableMap.copyOf(connections);
+    Set<String> stagesWithOutput = new HashSet<>();
+    for (Set<String> outputStages : connections.values()) {
+      stagesWithOutput.addAll(outputStages);
+    }
+    this.sources = Sets.difference(connections.keySet(), stagesWithOutput);
+    this.sinks = Sets.difference(stagesWithOutput, connections.keySet());
   }
 
-  public StageInfo getSource() {
-    return source;
-  }
-
-  public StageInfo getAggregator() {
-    return aggregator;
-  }
-
-  public Set<StageInfo> getSinks() {
-    return sinks;
-  }
-
-  public Set<StageInfo> getTransforms() {
-    return transforms;
+  /**
+   * Get an unmodifiable set of stages that use the specified plugin type.
+   *
+   * @param pluginType the plugin type
+   * @return unmodifiable set of stages that use the specified plugin type
+   */
+  public Set<StageInfo> getStagesOfType(String pluginType) {
+    Set<StageInfo> stageInfos = stages.get(pluginType);
+    return Collections.unmodifiableSet(stageInfos == null ? new HashSet<StageInfo>() : stageInfos);
   }
 
   public Map<String, Set<String>> getConnections() {
     return connections;
+  }
+
+  public Set<String> getStageOutputs(String stage) {
+    Set<String> outputs = connections.get(stage);
+    return Collections.unmodifiableSet(outputs == null ? new HashSet<String>() : outputs);
+  }
+
+  public Set<String> getSources() {
+    return sources;
+  }
+
+  public Set<String> getSinks() {
+    return sinks;
   }
 
   @Override
@@ -74,26 +90,91 @@ public class PipelinePhase {
 
     PipelinePhase that = (PipelinePhase) o;
 
-    return Objects.equals(source, that.source) &&
-      Objects.equals(aggregator, that.aggregator) &&
-      Objects.equals(sinks, that.sinks) &&
-      Objects.equals(transforms, that.transforms) &&
-      Objects.equals(connections, that.connections);
+    return Objects.equals(stages, that.stages) &&
+      Objects.equals(connections, that.connections) &&
+      Objects.equals(sources, that.sources) &&
+      Objects.equals(sinks, that.sinks);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(source, aggregator, sinks, transforms, connections);
+    return Objects.hash(stages, connections, sources, sinks);
   }
 
   @Override
   public String toString() {
     return "PipelinePhase{" +
-      "source=" + source +
-      ", aggregator=" + aggregator +
-      ", sinks=" + sinks +
-      ", transforms=" + transforms +
+      "stages=" + stages +
       ", connections=" + connections +
+      ", sources=" + sources +
+      ", sinks=" + sinks +
       '}';
+  }
+
+  /**
+   * Get a builder used to create a pipeline phase.
+   *
+   * @param supportedPluginTypes types of plugins supported in the phase
+   * @return builder used to create a pipeline phase
+   */
+  public static Builder builder(Set<String> supportedPluginTypes) {
+    return new Builder(supportedPluginTypes);
+  }
+
+  /**
+   * Builder to create a {@link PipelinePhase}.
+   */
+  public static class Builder {
+    private final Set<String> supportedPluginTypes;
+    private final Map<String, Set<StageInfo>> stages;
+    private final Map<String, Set<String>> connections;
+
+    public Builder(Set<String> supportedPluginTypes) {
+      this.supportedPluginTypes = supportedPluginTypes;
+      this.stages = new HashMap<>();
+      this.connections = new HashMap<>();
+    }
+
+    public Builder addStage(String pluginType, StageInfo stageInfo) {
+      return addStages(pluginType, ImmutableSet.of(stageInfo));
+    }
+
+    public Builder addStages(String pluginType, Collection<StageInfo> stages) {
+      if (!supportedPluginTypes.contains(pluginType)) {
+        throw new IllegalArgumentException(
+          String.format("%s is an unsupported plugin type. Plugin type must be one of %s.",
+                        pluginType, Joiner.on(',').join(supportedPluginTypes)));
+      }
+      Set<StageInfo> existingStages = this.stages.get(pluginType);
+      if (existingStages == null) {
+        existingStages = new HashSet<>();
+        this.stages.put(pluginType, existingStages);
+      }
+      existingStages.addAll(stages);
+      return this;
+    }
+
+    public Builder addConnection(String from, String to) {
+      return addConnections(from, ImmutableSet.of(to));
+    }
+
+    public Builder addConnections(String from, Collection<String> to) {
+      Set<String> existingOutputs = connections.get(from);
+      if (existingOutputs == null) {
+        existingOutputs = new HashSet<>();
+        connections.put(from, existingOutputs);
+      }
+      existingOutputs.addAll(to);
+      return this;
+    }
+
+    public Builder addConnections(Map<String, Set<String>> connections) {
+      this.connections.putAll(connections);
+      return this;
+    }
+
+    public PipelinePhase build() {
+      return new PipelinePhase(stages, connections);
+    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformExecutor.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformExecutor.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -36,10 +37,10 @@ import java.util.Map;
  */
 public class TransformExecutor<IN> implements Destroyable {
 
-  private final List<String> startingPoints;
+  private final Set<String> startingPoints;
   private final Map<String, TransformDetail> transformDetailMap;
 
-  public TransformExecutor(Map<String, TransformDetail> transformDetailMap, List<String> startingPoints) {
+  public TransformExecutor(Map<String, TransformDetail> transformDetailMap, Set<String> startingPoints) {
     this.transformDetailMap = transformDetailMap;
     this.startingPoints = startingPoints;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/StageInfo.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/StageInfo.java
@@ -25,12 +25,14 @@ import javax.annotation.Nullable;
 public class StageInfo {
   private final String name;
   private final String errorDatasetName;
-  private final boolean isConnector;
 
-  public StageInfo(String name, @Nullable String errorDatasetName, boolean isConnector) {
+  public StageInfo(String name) {
+    this(name, null);
+  }
+
+  public StageInfo(String name, @Nullable String errorDatasetName) {
     this.name = name;
     this.errorDatasetName = errorDatasetName;
-    this.isConnector = isConnector;
   }
 
   public String getName() {
@@ -40,10 +42,6 @@ public class StageInfo {
   @Nullable
   public String getErrorDatasetName() {
     return errorDatasetName;
-  }
-
-  public boolean isConnector() {
-    return isConnector;
   }
 
   @Override
@@ -58,13 +56,12 @@ public class StageInfo {
     StageInfo that = (StageInfo) o;
 
     return Objects.equals(name, that.name) &&
-      Objects.equals(errorDatasetName, that.errorDatasetName) &&
-      isConnector == that.isConnector;
+      Objects.equals(errorDatasetName, that.errorDatasetName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, errorDatasetName, isConnector);
+    return Objects.hash(name, errorDatasetName);
   }
 
   @Override
@@ -72,7 +69,6 @@ public class StageInfo {
     return "StageInfo{" +
       "name='" + name + '\'' +
       ", errorDatasetName='" + errorDatasetName + '\'' +
-      ", isConnector=" + isConnector +
       '}';
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpec.java
@@ -59,7 +59,7 @@ public class PipelineSpec {
     return resources;
   }
 
-  public boolean getStageLoggingEnabled() {
+  public boolean isStageLoggingEnabled() {
     return stageLoggingEnabled;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/TransformExecutorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/TransformExecutorTest.java
@@ -21,6 +21,7 @@ import co.cask.cdap.etl.api.InvalidEntry;
 import co.cask.cdap.etl.api.Transform;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -42,7 +43,7 @@ public class TransformExecutorTest {
                                                       new ArrayList<String>()));
 
     TransformExecutor executor =
-      new TransformExecutor(transformationMap, ImmutableList.of("sink"));
+      new TransformExecutor(transformationMap, ImmutableSet.of("sink"));
     TransformResponse transformResponse = executor.runOneIteration(1d);
     Map<String, Collection<Object>> sinkResult = transformResponse.getSinksResults();
     Assert.assertTrue(sinkResult.containsKey("sink"));
@@ -75,7 +76,7 @@ public class TransformExecutorTest {
                                                        new DefaultStageMetrics(mockMetrics, "sink2"),
                                                        ImmutableList.<String>of()));
 
-    TransformExecutor<Integer> executor = new TransformExecutor<>(transformationMap, ImmutableList.of("transform1"));
+    TransformExecutor<Integer> executor = new TransformExecutor<>(transformationMap, ImmutableSet.of("transform1"));
 
     TransformResponse transformResponse = executor.runOneIteration(1);
 
@@ -166,7 +167,7 @@ public class TransformExecutorTest {
 
 
     TransformExecutor<Integer> executor = new TransformExecutor<>(transformationMap,
-                                                                  ImmutableList.of("conversion"));
+                                                                  ImmutableSet.of("conversion"));
 
     TransformResponse transformResponse = executor.runOneIteration(200);
     assertResults(transformResponse.getSinksResults(), ImmutableMap.of("sink1", 3, "sink2", 2, "sink3", 3));
@@ -219,7 +220,7 @@ public class TransformExecutorTest {
 
 
     TransformExecutor<Double> executor = new TransformExecutor<>(transformationMap,
-                                                                 ImmutableList.of("filter1", "filter2"));
+                                                                 ImmutableSet.of("filter1", "filter2"));
 
     executor.runOneIteration(200d);
     executor.runOneIteration(2000d);


### PR DESCRIPTION
Adds a source and sink for connector nodes. Also introduces a
PipelinePluginInstantiator that will instantiate these sources
and sinks directly instead of the through the plugin context, and
will instantiate all other plugins through the plugin context.
This is because we dont want to expose these classes as actual
sources and sinks that people can use.

As part of this work, refactoring PipelinePhase so that it tracks
plugin types instead of having specific knowledge about what a
source or transform or aggregator is.