### PR TITLE
CDAP-4783 Documentation of Explore enable/disable endpoints

### DIFF
--- a/cdap-docs/developers-manual/source/data-exploration/index.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/index.rst
@@ -26,6 +26,18 @@ Queries can be run over streams and certain types of datasets.
 Note that if you are running a secure cluster, additional :ref:`configuration for a secure
 cluster <packages-configuration-enabling-kerberos>` is required.
 
+Exploration of data in CDAP is governed by a combination of enabling the CDAP Explore
+Service and then creating datasets and streams that are explorable. The CDAP Explore
+Service is enabled by a :ref:`setting in the CDAP configuration file
+<appendix-cdap-default-explore-service>` (``cdap-site.xml`` file).
+
+Datasets and streams (that were created before the Explore Service was enabled) can be
+enabled for exploration by using the :ref:`Query RESTful API <http-restful-api-query-enable-disable>`. 
+
+You can use the same Query RESTful API to disable exploration of a specific dataset or
+stream. The dataset or stream will still be accessible programmatically; it just won't
+respond to queries through the RESTful API or be available for exploration using the CDAP UI.
+
 
 .. |stream-exploration| replace:: **Stream Exploration:**
 .. _stream-exploration: streams.html

--- a/cdap-docs/reference-manual/source/http-restful-api/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/query.rst
@@ -468,14 +468,14 @@ For datasets::
   POST <base-url>/namespaces/<namespace>/data/explore/datasets/<dataset-name>/enable
   POST <base-url>/namespaces/<namespace>/data/explore/datasets/<dataset-name>/disable
 
-For stream views::
+For streams::
 
   POST <base-url>/namespaces/<namespace>/data/explore/streams/<stream-name>/tables/<table-name>/enable
   POST <base-url>/namespaces/<namespace>/data/explore/streams/<stream-name>/tables/<table-name>/disable
 
 Each of these endpoints returns a query handle that can be used |---| in the case of
 ``enable`` |---| to :ref:`submit queries <http-restful-api-query-submitting>` and explore
-the dataset/stream view or |---| in the case of ``disable`` |---| to retrieve the
+the dataset/stream or |---| in the case of ``disable`` |---| to retrieve the
 :ref:`status of the query <http-restful-api-query-status>`.
 
 .. list-table::

--- a/cdap-docs/reference-manual/source/http-restful-api/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/query.rst
@@ -19,6 +19,9 @@ processed asynchronously; to obtain query results, perform these steps:
 - once finished, retrieve the **result schema** and the **results**;
 - finally, **close the query** to free the resources that it holds.
 
+
+.. _http-restful-api-query-submitting:
+
 Submitting a Query
 ------------------
 To submit a SQL query, post the query string to the ``queries`` URL::
@@ -78,6 +81,8 @@ used to identify the query in subsequent requests::
        dataset, *mydataset* in the namespace *default*
 
 
+.. _http-restful-api-query-status:
+
 Status of a Query
 -----------------
 The status of a query is obtained using a HTTP GET request to the query's URL::
@@ -133,6 +138,8 @@ Status can be one of the following: ``INITIALIZED``, ``RUNNING``, ``FINISHED``, 
      - Retrieve the status of the query in the namespace *default* which has the handle
        ``57cf1b01-8dba-423a-a8b4-66cd29dd75e2``
 
+
+.. _http-restful-api-query-obtaining-results:
 
 Obtaining the Result Schema
 ---------------------------
@@ -192,6 +199,8 @@ The type of each column is a data type as defined in the `Hive language manual
      - Retrieve the schema of the result of the query in the namespace *default* which has
        the handle 57cf1b01-8dba-423a-a8b4-66cd29dd75e2
 
+
+.. _http-restful-api-query-retrieving-results:
 
 Retrieving Query Results
 ------------------------
@@ -264,6 +273,9 @@ been retrieved, then the returned list is empty.
    * - Description
      - Retrieve the results of the query which has the handle 57cf1b01-8dba-423a-a8b4-66cd29dd75e2
 
+
+.. _http-restful-api-query-closing:
+
 Closing a Query
 ---------------
 The query can be closed by issuing an HTTP DELETE against its URL::
@@ -306,6 +318,9 @@ This frees all resources that are held by this query.
      - ``DELETE <base-url>/namespaces/default/data/explore/queries/57cf1b01-8dba-423a-a8b4-66cd29dd75e2``
    * - Description
      - Close the query in the namespace *default* which has the handle ``57cf1b01-8dba-423a-a8b4-66cd29dd75e2``
+
+
+.. _http-restful-api-query-listing:
 
 List of Queries
 ---------------
@@ -365,6 +380,9 @@ The results are returned as a JSON array, with each element containing informati
    * - Description
      - Retrieves all queries
 
+
+.. _http-restful-api-query-counting:
+
 Count of Active Queries
 -----------------------
 To return the count of active queries, use::
@@ -383,6 +401,9 @@ To return the count of active queries, use::
 The results are returned in the body as a JSON string::
 
   { "count":6 }
+
+
+.. _http-restful-api-query-downloading:
 
 Download Query Results
 ----------------------
@@ -421,3 +442,87 @@ if results for the ``query-handle`` are attempted to be downloaded again.
      - The query handle does not match any current query
    * - ``409 Conflict``
      - The query results were already downloaded
+
+
+.. _http-restful-api-query-enable-disable:
+
+Enabling and Disabling Querying
+-------------------------------
+Querying (or exploring) of datasets and stream views can be enabled and disabled using these endpoints.
+
+Exploration of data in CDAP is governed by a combination of enabling the CDAP Explore
+Service and then creating datasets and streams that are explorable. The CDAP Explore
+Service is enabled by a :ref:`setting in the CDAP configuration file
+<appendix-cdap-default-explore-service>` (``explore.enabled`` in ``cdap-site.xml`` file).
+
+Datasets and streams |---| that were created while the Explore Service was not enabled
+|---| can, once the service is enabled and CDAP restarted, be enabled for exploration by
+using these endpoints.
+
+You can also use these endpoints to disable exploration of a specific dataset or
+stream. The dataset or stream will still be accessible programmatically; it just won't
+respond to queries or be available for exploration using the CDAP UI.
+
+For datasets::
+
+  POST <base-url>/namespaces/<namespace>/data/explore/datasets/<dataset-name>/enable
+  POST <base-url>/namespaces/<namespace>/data/explore/datasets/<dataset-name>/disable
+
+For stream views::
+
+  POST <base-url>/namespaces/<namespace>/data/explore/streams/<stream-name>/tables/<table-name>/enable
+  POST <base-url>/namespaces/<namespace>/data/explore/streams/<stream-name>/tables/<table-name>/disable
+
+Each of these endpoints returns a query handle that can be used |---| in the case of
+``enable`` |---| to :ref:`submit queries <http-restful-api-query-submitting>` and explore
+the dataset/stream view or |---| in the case of ``disable`` |---| to retrieve the
+:ref:`status of the query <http-restful-api-query-status>`.
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``<namespace>``
+     - Namespace ID
+   * - ``<dataset-name>``
+     - Name of the dataset
+   * - ``<stream-name>``
+     - Name of the stream
+   * - ``<table-name>``
+     - Name of the table
+     
+.. rubric:: HTTP Responses
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Status Codes
+     - Description
+   * - ``200 OK``
+     - The query execution was successfully initiated, and the body will contain the query-handle
+       used to identify the query in subsequent requests
+   * - ``404 Not Found``
+     - The query is not well-formed or contains an error such as a nonexistent table name
+
+.. rubric:: Comments
+
+If the query execution was successful, the body will contain a query handle that can be used to
+identify the query in subsequent requests, such as a :ref:`status request
+<http-restful-api-query-status>`::
+
+  { "handle":"<query-handle>" }
+
+.. rubric:: Example
+.. list-table::
+   :widths: 20 80
+   :stub-columns: 1
+
+   * - HTTP Request
+     - ``POST <base-url>/namespaces/default/data/explore/datasets/logEventStream_converted/disable``
+   * - HTTP Response
+     - ``{"handle":"57cf1b01-8dba-423a-a8b4-66cd29dd75e2"}``
+   * - Description
+     - Submits a query in the namespace *default* to disable the
+       dataset *logEventStream_converted* from being explored. The handle can be used to check the status.

--- a/cdap-docs/reference-manual/source/http-restful-api/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/query.rst
@@ -448,7 +448,7 @@ if results for the ``query-handle`` are attempted to be downloaded again.
 
 Enabling and Disabling Querying
 -------------------------------
-Querying (or exploring) of datasets and stream views can be enabled and disabled using these endpoints.
+Querying (or exploring) of datasets and streams can be enabled and disabled using these endpoints.
 
 Exploration of data in CDAP is governed by a combination of enabling the CDAP Explore
 Service and then creating datasets and streams that are explorable. The CDAP Explore

--- a/cdap-docs/reference-manual/source/http-restful-api/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/query.rst
@@ -473,10 +473,8 @@ For streams::
   POST <base-url>/namespaces/<namespace>/data/explore/streams/<stream-name>/tables/<table-name>/enable
   POST <base-url>/namespaces/<namespace>/data/explore/streams/<stream-name>/tables/<table-name>/disable
 
-Each of these endpoints returns a query handle that can be used |---| in the case of
-``enable`` |---| to :ref:`submit queries <http-restful-api-query-submitting>` and explore
-the dataset/stream or |---| in the case of ``disable`` |---| to retrieve the
-:ref:`status of the query <http-restful-api-query-status>`.
+Each of these endpoints returns a query handle that can be used to submit requests
+tracking the :ref:`status of the query <http-restful-api-query-status>`.
 
 .. list-table::
    :widths: 20 80
@@ -508,7 +506,7 @@ the dataset/stream or |---| in the case of ``disable`` |---| to retrieve the
 
 .. rubric:: Comments
 
-If the query execution was successful, the body will contain a query handle that can be used to
+If the request was successful, the body will contain a query handle that can be used to
 identify the query in subsequent requests, such as a :ref:`status request
 <http-restful-api-query-status>`::
 
@@ -524,5 +522,6 @@ identify the query in subsequent requests, such as a :ref:`status request
    * - HTTP Response
      - ``{"handle":"57cf1b01-8dba-423a-a8b4-66cd29dd75e2"}``
    * - Description
-     - Submits a query in the namespace *default* to disable the
-       dataset *logEventStream_converted* from being explored. The handle can be used to check the status.
+     - Submits a request in the namespace *default* to disable the dataset
+       *logEventStream_converted* from being explored. The handle can be used to check the
+       status.

--- a/cdap-docs/tools/doc-cdap-default.py
+++ b/cdap-docs/tools/doc-cdap-default.py
@@ -59,6 +59,7 @@ OTHER_CDAP_XML_FILES = 'cdap-xml-files.txt'
 
 FIRST_TWO_SECTIONS = ['General Configuration', 'Global Configuration']
 
+RST_ANCHOR_TEMPLATE = ".. _appendix-cdap-default-%s:"
 
 RST_TABLE_HEADER = """
 .. list-table::
@@ -233,7 +234,8 @@ class Section:
         if name.endswith(CONFIG):
             name = name[0:-len(CONFIG)]
         underline = "-" * len(name)
-        rst = "\n%s\n%s\n%s\n" % (name, underline, RST_TABLE_HEADER)
+        anchor = RST_ANCHOR_TEMPLATE % name.lower().replace(' ','-')
+        rst = "\n%s\n\n%s\n%s\n%s\n" % (anchor, name, underline, RST_TABLE_HEADER)
         return rst
 
     def display(self):


### PR DESCRIPTION
Passes [Quick Build 3](http://builds.cask.co/browse/CDAP-DOB149-3).

Fix for https://issues.cask.co/browse/CDAP-4783.

Pages of interest:

- [Query RESTful API, "Enable and Disable Querying"](http://builds.cask.co/artifact/CDAP-DOB149/shared/build-3/Docs-HTML/3.4.0-SNAPSHOT/en/reference-manual/http-restful-api/query.html#enabling-and-disabling-querying)
- [Data Exploration](http://builds.cask.co/artifact/CDAP-DOB149/shared/build-3/Docs-HTML/3.4.0-SNAPSHOT/en/developers-manual/data-exploration/index.html)