### PR TITLE
Make UnauthenticatedException once again extend UnauthorizedException

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/UnauthenticatedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/UnauthenticatedException.java
@@ -23,7 +23,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
  * Thrown when a user is not authenticated.
  * Note: This extends {@link UnauthorizedException} for backwards compatibility.
  */
-public class UnauthenticatedException extends Exception implements HttpErrorStatusProvider {
+public class UnauthenticatedException extends UnauthorizedException implements HttpErrorStatusProvider {
 
   public UnauthenticatedException() {
     super();


### PR DESCRIPTION
External repositories will have compile error with the existing implementation of UnauthenticatedException (see below for an example).
In order to make it backwards compatible, this change is needed (it was undone in https://github.com/caskdata/cdap/pull/5312).

![image](https://cloud.githubusercontent.com/assets/2440977/13852234/67256288-ec1e-11e5-8ba9-a94509e9415c.png)

http://builds.cask.co/browse/CDAP-DUT3705-5