### PR TITLE
Fix broken doc build, and updates the MD5 hashes.

### DIFF
--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -81,7 +81,7 @@ function download_includes() {
   download_readme_file_and_test ${includes_dir} ${ingest_url} 5fc88ec3a658062775403f5be30afbe9 cdap-stream-clients/ruby
 
   echo_red_bold "Check included example files for changes"
-  test_an_include b53dd493c4e9c2cb89b593baa4139087 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+  test_an_include 26e904a0a4524ab5dd97c4b3072d26fc ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
   test_an_include 80216a08a2b3d480e4a081722408222f ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
   test_an_include 7f83b852a8e7b4594094d4e88d80a0b4 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java

--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
@@ -338,7 +338,10 @@ are set:
 
 .. literalinclude:: /../../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
    :language: java
-   :lines: 44-54
+   :lines: 47-57
+   :append: ...
+
+..   :lines: 44-54
 
 The Resources API, if called with two arguments, sets both the memory used in megabytes
 and the number of virtual cores used.

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -148,15 +148,15 @@ function download_includes() {
 
   test_an_include 8a7b4aacee88800cd82d96b07280cc64 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
   test_an_include 6943e3861b243c72ab212fe30bbaf5f0 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
-  test_an_include 738f54aa72df27c8a7022bd25c92e27f ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
+  test_an_include d859373458f43c169866f0b00a7bdaa5 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
   
   test_an_include c2374d482454dc57c5944e557b544dba ../../cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java
 
   test_an_include a9a7fd53c199defff09e6e3c73e4e71f ../../cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
   
-  test_an_include 38245f25cef322b873b729a1e1286235 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
+  test_an_include ad0d0b46225a2e4e0564d8755fbb99b0 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
-  test_an_include b53dd493c4e9c2cb89b593baa4139087 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+  test_an_include 26e904a0a4524ab5dd97c4b3072d26fc ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
   test_an_include 80216a08a2b3d480e4a081722408222f ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
 
   test_an_include 950241d0199883f3bcb23d6f7da0551f ../../cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java

--- a/cdap-docs/examples-manual/source/examples/fileset-example.rst
+++ b/cdap-docs/examples-manual/source/examples/fileset-example.rst
@@ -81,7 +81,8 @@ MapReduce over Files
 
 .. literalinclude:: /../../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
     :language: java
-    :lines: 39-55
+    :lines: 40-57
+    :append: ...
 
 It is worth mentioning that nothing in ``WordCount`` is specifically programmed to use a FileSet. Instead of
 *lines* and *counts*, it could use any other dataset as long as the key and value types match.

--- a/cdap-docs/examples-manual/source/examples/purchase.rst
+++ b/cdap-docs/examples-manual/source/examples/purchase.rst
@@ -60,9 +60,7 @@ of the application are tied together by the class ``PurchaseApp``:
 
 .. literalinclude:: /../../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
     :language: java
-    :prepend: public class PurchaseApp extends AbstractApplication {
-    :start-after: public class PurchaseApp extends AbstractApplication {
-    :dedent: 2
+    :lines: 31-
 
 Storing Purchases with the ``Purchase`` ObjectStore Data Storage
 ----------------------------------------------------------------
@@ -99,7 +97,7 @@ default values used in configuration and as runtime arguments:
 
 .. literalinclude:: /../../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
    :language: java
-   :lines: 44-74
+   :lines: 47-78
 
 ``PurchaseHistoryService`` Service
 ----------------------------------


### PR DESCRIPTION
Passes [Quick Build 2](http://builds.cask.co/browse/CDAP-DOB150-2)

This fixes the MD5 hashes, and adjusts the documentation for changes in the included files.