### PR TITLE
CDAP-5155: Role Management in Authorization

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AuthorizationHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AuthorizationHandler.java
@@ -22,39 +22,57 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.AuditLogEntry;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
+import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.AuthorizationRequest;
 import co.cask.cdap.proto.security.CheckAuthorizedRequest;
 import co.cask.cdap.proto.security.GrantRequest;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.RevokeRequest;
+import co.cask.cdap.proto.security.Role;
 import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Type;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
+import javax.annotation.Nullable;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 
 /**
  * Exposes {@link Authorizer} operations via HTTP.
  */
-@Path(Constants.Gateway.API_VERSION_3 + "/security")
+@Path(Constants.Gateway.API_VERSION_3 + "/security/authorization")
 public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
 
   private static final Logger AUDIT_LOG = LoggerFactory.getLogger("authorization-access");
   private final AuthorizerInstantiatorService authorizerInstantiatorService;
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter())
+    .create();
+  private static final Type PRIVILEGE_SET_TYPE = new TypeToken<Set<Privilege>>() { }.getType();
   private final boolean enabled;
 
   @Inject
@@ -63,14 +81,17 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
     this.enabled = conf.getBoolean(Constants.Security.Authorization.ENABLED);
   }
 
-  private void createLogEntry(HttpRequest httpRequest, AuthorizationRequest request,
+  private void createLogEntry(HttpRequest httpRequest, @Nullable AuthorizationRequest request,
                               HttpResponseStatus responseStatus) throws UnknownHostException {
-    String reqBody = String.format("[%s %s %s]", request.getPrincipal(), request.getEntity(), request.getActions());
+
     AuditLogEntry logEntry = new AuditLogEntry();
     logEntry.setUserName(Objects.firstNonNull(SecurityRequestContext.getUserId(), "-"));
     logEntry.setClientIP(InetAddress.getByName(Objects.firstNonNull(SecurityRequestContext.getUserIP(), "0.0.0.0")));
     logEntry.setRequestLine(httpRequest.getMethod(), httpRequest.getUri(), httpRequest.getProtocolVersion());
-    logEntry.setRequestBody(reqBody);
+    if (request != null) {
+      logEntry.setRequestBody(String.format("[%s %s %s]", request.getPrincipal(), request.getEntity(),
+                                            request.getActions()));
+    }
     logEntry.setResponseCode(responseStatus.getCode());
     AUDIT_LOG.trace(logEntry.toString());
   }
@@ -128,6 +149,90 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
 
     httpResponder.sendStatus(HttpResponseStatus.OK);
     createLogEntry(httpRequest, request, HttpResponseStatus.OK);
+  }
+
+  @Path("{principal-type}/{principal-name}/privileges")
+  @GET
+  public void listPrivileges(HttpRequest httpRequest, HttpResponder httpResponder,
+                             @PathParam("principal-type") String principalType,
+                             @PathParam("principal-name") String principalName) throws Exception {
+    ensureAuthorizationEnabled();
+    Principal principal = new Principal(principalName, Principal.PrincipalType.valueOf(principalType.toUpperCase()));
+    httpResponder.sendJson(HttpResponseStatus.OK, authorizerInstantiatorService.get().listPrivileges(principal),
+                           PRIVILEGE_SET_TYPE, GSON);
+    createLogEntry(httpRequest, null, HttpResponseStatus.OK);
+  }
+
+
+  /********************************************************************************************************************
+   * Role Management : For Role Based Access Control
+   ********************************************************************************************************************/
+
+  @Path("/roles/{role-name}")
+  @PUT
+  public void createRole(HttpRequest httpRequest, HttpResponder httpResponder,
+                         @PathParam("role-name") String roleName) throws Exception {
+    ensureAuthorizationEnabled();
+    authorizerInstantiatorService.get().createRole(new Role(roleName));
+    httpResponder.sendStatus(HttpResponseStatus.OK);
+    createLogEntry(httpRequest, null, HttpResponseStatus.OK);
+  }
+
+  @Path("/roles/{role-name}")
+  @DELETE
+  public void dropRole(HttpRequest httpRequest, HttpResponder httpResponder,
+                       @PathParam("role-name") String roleName) throws Exception {
+    ensureAuthorizationEnabled();
+    authorizerInstantiatorService.get().dropRole(new Role(roleName));
+    httpResponder.sendStatus(HttpResponseStatus.OK);
+    createLogEntry(httpRequest, null, HttpResponseStatus.OK);
+  }
+
+  @Path("/roles")
+  @GET
+  public void listAllRoles(HttpRequest httpRequest, HttpResponder httpResponder) throws Exception {
+    ensureAuthorizationEnabled();
+    httpResponder.sendJson(HttpResponseStatus.OK, authorizerInstantiatorService.get().listAllRoles());
+    createLogEntry(httpRequest, null, HttpResponseStatus.OK);
+  }
+
+  @Path("{principal-type}/{principal-name}/roles")
+  @GET
+  public void listRoles(HttpRequest httpRequest, HttpResponder httpResponder,
+                        @PathParam("principal-type") String principalType,
+                        @PathParam("principal-name") String principalName) throws Exception {
+    ensureAuthorizationEnabled();
+    Principal principal = new Principal(principalName, Principal.PrincipalType.valueOf(principalType.toUpperCase()));
+    httpResponder.sendJson(HttpResponseStatus.OK, authorizerInstantiatorService.get().listRoles(principal));
+    createLogEntry(httpRequest, null, HttpResponseStatus.OK);
+  }
+
+  @Path("/{principal-type}/{principal-name}/roles/{role-name}")
+  @PUT
+  public void addRoleToPrincipal(HttpRequest httpRequest, HttpResponder httpResponder,
+                                 @PathParam("principal-type") String principalType,
+                                 @PathParam("principal-name") String principalName,
+                                 @PathParam("role-name") String roleName) throws Exception {
+    ensureAuthorizationEnabled();
+    authorizerInstantiatorService.get().addRoleToPrincipal(new Role(roleName),
+                                  new Principal(principalName,
+                                                Principal.PrincipalType.valueOf(principalType.toUpperCase())));
+    httpResponder.sendStatus(HttpResponseStatus.OK);
+    createLogEntry(httpRequest, null, HttpResponseStatus.OK);
+  }
+
+  @Path("/{principal-type}/{principal-name}/roles/{role-name}")
+  @DELETE
+  public void removeRoleFromPrincipal(HttpRequest httpRequest, HttpResponder httpResponder,
+                                      @PathParam("principal-type") String principalType,
+                                      @PathParam("principal-name") String principalName,
+                                      @PathParam("role-name") String roleName) throws Exception {
+    ensureAuthorizationEnabled();
+    authorizerInstantiatorService.get().removeRoleFromPrincipal(new Role(roleName),
+                                       new Principal(principalName,
+                                                     Principal.PrincipalType.valueOf(principalType.toUpperCase())));
+    httpResponder.sendStatus(HttpResponseStatus.OK);
+    createLogEntry(httpRequest, null, HttpResponseStatus.OK);
   }
 
   private void ensureAuthorizationEnabled() throws FeatureDisabledException {

--- a/cdap-authorization-dataset-plugin/src/main/java/co/cask/cdap/security/authorization/DatasetBasedAuthorizer.java
+++ b/cdap-authorization-dataset-plugin/src/main/java/co/cask/cdap/security/authorization/DatasetBasedAuthorizer.java
@@ -29,7 +29,11 @@ import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.proto.security.Role;
 import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
+import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
@@ -136,6 +140,16 @@ public class DatasetBasedAuthorizer implements Authorizer {
   }
 
   @Override
+  public Set<Privilege> listPrivileges(final Principal principal) {
+    return aclsTx.get().executeUnchecked(new TransactionExecutor.Function<ACLDataset, Set<Privilege>>() {
+      @Override
+      public Set<Privilege> apply(ACLDataset acls) throws Exception {
+        return acls.listPrivileges(principal);
+      }
+    }, acls.get());
+  }
+
+  @Override
   public void revoke(final EntityId entity) {
     aclsTx.get().executeUnchecked(new TransactionExecutor.Procedure<ACLDataset>() {
       @Override
@@ -143,5 +157,35 @@ public class DatasetBasedAuthorizer implements Authorizer {
         acls.remove(entity);
       }
     }, acls.get());
+  }
+
+  @Override
+  public void createRole(Role role) throws RoleAlreadyExistsException {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
+  }
+
+  @Override
+  public void dropRole(Role role) throws RoleNotFoundException {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
+  }
+
+  @Override
+  public void addRoleToPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
+  }
+
+  @Override
+  public void removeRoleFromPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
+  }
+
+  @Override
+  public Set<Role> listRoles(Principal principal) {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
+  }
+
+  @Override
+  public Set<Role> listAllRoles() {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
   }
 }

--- a/cdap-authorization-dataset-plugin/src/test/java/co/cask/cdap/security/authorization/ACLDatasetTest.java
+++ b/cdap-authorization-dataset-plugin/src/test/java/co/cask/cdap/security/authorization/ACLDatasetTest.java
@@ -24,6 +24,7 @@ import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionFailureException;
 import com.google.common.collect.ImmutableSet;
@@ -75,6 +76,7 @@ public class ACLDatasetTest {
       public void apply() throws Exception {
         table.add(namespace, user, Action.READ);
         Assert.assertEquals(ImmutableSet.of(Action.READ), table.search(namespace, user));
+        Assert.assertEquals(ImmutableSet.of(new Privilege(namespace, Action.READ)), table.listPrivileges(user));
         table.remove(namespace, user, Action.READ);
         Assert.assertEquals(ImmutableSet.of(), table.search(namespace, user));
       }

--- a/cdap-authorization-dataset-plugin/src/test/java/co/cask/cdap/security/authorization/DatasetBasedAuthorizerTest.java
+++ b/cdap-authorization-dataset-plugin/src/test/java/co/cask/cdap/security/authorization/DatasetBasedAuthorizerTest.java
@@ -36,6 +36,7 @@ import com.google.inject.multibindings.MapBinder;
 import com.google.inject.name.Names;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Tests for {@link DatasetBasedAuthorizer}.
@@ -80,5 +81,12 @@ public class DatasetBasedAuthorizerTest extends AuthorizerTest {
   @Override
   protected Authorizer get() {
     return datasetAuthorizer;
+  }
+
+  @Override
+  @Test(expected = UnsupportedOperationException.class)
+  public void testRBAC() throws Exception {
+    // DatasetBasedAuthorizer currently does not support role based access control
+    super.testRBAC();
   }
 }

--- a/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
@@ -28,11 +28,17 @@ import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.CheckAuthorizedRequest;
 import co.cask.cdap.proto.security.GrantRequest;
 import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.RevokeRequest;
+import co.cask.cdap.proto.security.Role;
+import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
+import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
+import co.cask.common.http.ObjectResponse;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -40,6 +46,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 /**
@@ -51,6 +58,9 @@ public class AuthorizationClient {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter())
     .create();
+  public static final String AUTHORIZATION_BASE = "security/authorization/";
+  private static final TypeToken<Set<Privilege>> TYPE_OF_PRIVILEGE_SET = new TypeToken<Set<Privilege>>() { };
+  private static final TypeToken<Set<Role>> TYPE_OF_ROLE_SET = new TypeToken<Set<Role>>() { };
   private final RESTClient restClient;
   private final ClientConfig config;
 
@@ -69,9 +79,9 @@ public class AuthorizationClient {
 
     CheckAuthorizedRequest checkRequest = new CheckAuthorizedRequest(entity, principal, ImmutableSet.of(action));
 
-    URL url = config.resolveURLV3("security/authorized");
+    URL url = config.resolveURLV3(AUTHORIZATION_BASE + "authorized");
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(checkRequest)).build();
-    executeAuthorizationRequest(request, principal, action, entity);
+    executeRequest(request, HttpURLConnection.HTTP_FORBIDDEN, HttpURLConnection.HTTP_NOT_IMPLEMENTED);
   }
 
   public void grant(EntityId entity, Principal principal, Set<Action> actions) throws IOException,
@@ -79,9 +89,9 @@ public class AuthorizationClient {
 
     GrantRequest grantRequest = new GrantRequest(entity, principal, actions);
 
-    URL url = config.resolveURLV3("security/grant");
+    URL url = config.resolveURLV3(AUTHORIZATION_BASE + "grant");
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(grantRequest)).build();
-    executeAuthorizationRequest(request, principal, Action.ADMIN, entity);
+    executeRequest(request, HttpURLConnection.HTTP_FORBIDDEN, HttpURLConnection.HTTP_NOT_IMPLEMENTED);
   }
 
   public void revoke(EntityId entity, Principal principal, Set<Action> actions) throws IOException,
@@ -101,22 +111,105 @@ public class AuthorizationClient {
 
   public void revoke(RevokeRequest revokeRequest)
     throws IOException, UnauthenticatedException, FeatureDisabledException, UnauthorizedException {
-    URL url = config.resolveURLV3("security/revoke");
+    URL url = config.resolveURLV3(AUTHORIZATION_BASE + "revoke");
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(revokeRequest)).build();
-    executeAuthorizationRequest(request, revokeRequest.getPrincipal(), Action.ADMIN,
-                                revokeRequest.getEntity());
+    executeRequest(request, HttpURLConnection.HTTP_FORBIDDEN, HttpURLConnection.HTTP_NOT_IMPLEMENTED);
   }
 
-  private void executeAuthorizationRequest(HttpRequest request, Principal principal, Action action, EntityId entity)
+  public Set<Privilege> listPrivileges(Principal principal) throws IOException, FeatureDisabledException,
+    UnauthenticatedException, UnauthorizedException {
+    URL url = config.resolveURLV3(String.format(AUTHORIZATION_BASE + "%s/%s/privileges", principal.getType(),
+                                                principal.getName()));
+    HttpRequest request = HttpRequest.get(url).build();
+    HttpResponse response = executeRequest(request, HttpURLConnection.HTTP_FORBIDDEN,
+                                           HttpURLConnection.HTTP_NOT_IMPLEMENTED);
+    if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
+      return ObjectResponse.fromJsonBody(response, TYPE_OF_PRIVILEGE_SET, GSON).getResponseObject();
+    }
+    throw new IOException(String.format("Cannot list privileges. Reason: %s", response.getResponseBodyAsString()));
+  }
+
+  public void createRole(Role role) throws IOException, FeatureDisabledException, UnauthenticatedException,
+    UnauthorizedException, RoleAlreadyExistsException {
+    URL url = config.resolveURLV3(String.format(AUTHORIZATION_BASE + "roles/%s", role.getName()));
+    HttpRequest request = HttpRequest.put(url).build();
+    HttpResponse httpResponse = executeRequest(request, HttpURLConnection.HTTP_FORBIDDEN,
+                                               HttpURLConnection.HTTP_NOT_IMPLEMENTED, HttpURLConnection.HTTP_CONFLICT);
+    if (httpResponse.getResponseCode() == HttpURLConnection.HTTP_CONFLICT) {
+      throw new RoleAlreadyExistsException(role);
+    }
+  }
+
+  public void dropRole(Role role) throws IOException, FeatureDisabledException, UnauthenticatedException,
+    UnauthorizedException, RoleNotFoundException {
+    URL url = config.resolveURLV3(String.format(AUTHORIZATION_BASE + "roles/%s", role.getName()));
+    HttpRequest request = HttpRequest.delete(url).build();
+    executeRoleRequest(role, request);
+  }
+
+  public Set<Role> listAllRoles() throws FeatureDisabledException, UnauthenticatedException, UnauthorizedException,
+    IOException {
+    return listRolesHelper(null);
+  }
+
+  public Set<Role> listRoles(Principal principal) throws FeatureDisabledException, UnauthenticatedException,
+    UnauthorizedException,
+    IOException {
+    return listRolesHelper(principal);
+  }
+
+  public void addRoleToPrincipal(Role role, Principal principal) throws IOException, FeatureDisabledException,
+    UnauthenticatedException, UnauthorizedException, RoleNotFoundException {
+    URL url = config.resolveURLV3(String.format(AUTHORIZATION_BASE + "%s/%s/roles/%s", principal.getType(),
+                                                principal.getName(), role.getName()));
+    HttpRequest request = HttpRequest.put(url).build();
+    executeRoleRequest(role, request);
+  }
+
+  public void removeRoleFromPrincipal(Role role, Principal principal) throws IOException, FeatureDisabledException,
+    UnauthenticatedException, UnauthorizedException, RoleNotFoundException {
+    URL url = config.resolveURLV3(String.format(AUTHORIZATION_BASE + "%s/%s/roles/%s", principal.getType(),
+                                                principal.getName(), role.getName()));
+    HttpRequest request = HttpRequest.delete(url).build();
+    executeRoleRequest(role, request);
+  }
+
+  private Set<Role> listRolesHelper(@Nullable Principal principal) throws IOException, FeatureDisabledException,
+    UnauthenticatedException, UnauthorizedException {
+    URL url = principal == null ? config.resolveURLV3(AUTHORIZATION_BASE + "roles") :
+      config.resolveURLV3(String.format(AUTHORIZATION_BASE + "%s/%s/roles", principal.getType(), principal.getName()));
+    HttpRequest request = HttpRequest.get(url).build();
+    HttpResponse response = executeRequest(request, HttpURLConnection.HTTP_FORBIDDEN,
+                                           HttpURLConnection.HTTP_NOT_IMPLEMENTED);
+
+    if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
+      return ObjectResponse.fromJsonBody(response, TYPE_OF_ROLE_SET).getResponseObject();
+    }
+    throw new IOException(String.format("Cannot list roles. Reason: %s", response.getResponseBodyAsString()));
+  }
+
+  private void executeRoleRequest(Role role, HttpRequest request) throws IOException, UnauthenticatedException,
+    FeatureDisabledException, UnauthorizedException, RoleNotFoundException {
+    HttpResponse httpResponse = executeRequest(request, HttpURLConnection.HTTP_FORBIDDEN,
+                                               HttpURLConnection.HTTP_NOT_IMPLEMENTED,
+                                               HttpURLConnection.HTTP_NOT_FOUND);
+    if (httpResponse.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new RoleNotFoundException(role);
+    }
+  }
+
+  private HttpResponse executeRequest(HttpRequest request, int... allowedErrorCodes)
     throws IOException, UnauthenticatedException, FeatureDisabledException, UnauthorizedException {
-    HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_FORBIDDEN,
-                                               HttpURLConnection.HTTP_NOT_IMPLEMENTED);
+    HttpResponse response = restClient.execute(request, config.getAccessToken(), allowedErrorCodes);
     if (HttpURLConnection.HTTP_FORBIDDEN == response.getResponseCode()) {
-      throw new UnauthorizedException(principal, action, entity);
+      // TODO:(CDAP-5302) Include the logged in username here
+      throw new UnauthorizedException(String.format("Unauthorized to perform %s %s with body %s",
+                                                    request.getMethod(), request.getURL(), request.getBody()));
     }
     if (HttpURLConnection.HTTP_NOT_IMPLEMENTED == response.getResponseCode()) {
       throw new FeatureDisabledException("Authorization", "cdap-site.xml", Constants.Security.Authorization.ENABLED,
                                          "true");
     }
+    return response;
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/Principal.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/Principal.java
@@ -54,14 +54,14 @@ public class Principal {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    // check here for instance not the classes so that it can match Role class which extends Principal
+    if (!(o instanceof Principal)) {
       return false;
     }
 
     Principal principal = (Principal) o;
 
     return name.equals(principal.name) && type == principal.type;
-
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/Privilege.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/Privilege.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.security;
+
+import co.cask.cdap.proto.id.EntityId;
+
+import java.util.Objects;
+
+/**
+ * Represents a privilege granted to a {@link Principal user}, {@link Principal group} or a {@link Principal role}.
+ * It determines if the user or group can perform a given {@link Action} on an {@link EntityId}.
+ */
+public class Privilege {
+  private final EntityId entity;
+  private final Action action;
+
+  public Privilege(EntityId entity, Action action) {
+    this.entity = entity;
+    this.action = action;
+  }
+
+  public EntityId getEntity() {
+    return entity;
+  }
+
+  public Action getAction() {
+    return action;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Privilege)) {
+      return false;
+    }
+
+    Privilege privilege = (Privilege) o;
+    return Objects.equals(entity, privilege.entity) && Objects.equals(action, privilege.action);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(entity, action);
+  }
+
+  @Override
+  public String toString() {
+    return "Privilege{" +
+      "entity=" + entity +
+      ", action=" + action +
+      '}';
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/Role.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/Role.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.security;
+
+/**
+ * Represents a {@link Role} that can be added to a {@link Principal user} or {@link Principal group}.
+ * This is used in Role Based Access Control such as Apache Sentry.
+ */
+public class Role extends Principal {
+
+  public Role(String name) {
+    super(name, PrincipalType.ROLE);
+  }
+}

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/Authorizer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/Authorizer.java
@@ -19,6 +19,8 @@ package co.cask.cdap.security.spi.authorization;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.proto.security.Role;
 
 import java.util.Properties;
 import java.util.Set;
@@ -58,7 +60,7 @@ public interface Authorizer {
    * Grants a {@link Principal} authorization to perform a set of {@link Action actions} on an {@link EntityId}.
    *
    * @param entity the {@link EntityId} to whom {@link Action actions} are to be granted
-   * @param principal the {@link Principal} that performs the actions. This could be a user, group or a role
+   * @param principal the {@link Principal} that performs the actions. This could be a user, or role
    * @param actions the set of {@link Action actions} to grant.
    */
   void grant(EntityId entity, Principal principal, Set<Action> actions);
@@ -68,7 +70,7 @@ public interface Authorizer {
    * an {@link EntityId}.
    *
    * @param entity the {@link EntityId} whose {@link Action actions} are to be revoked
-   * @param principal the {@link Principal} that performs the actions. This could be a user, group or a role
+   * @param principal the {@link Principal} that performs the actions. This could be a user, group or role
    * @param actions the set of {@link Action actions} to revoke
    */
   void revoke(EntityId entity, Principal principal, Set<Action> actions);
@@ -80,4 +82,62 @@ public interface Authorizer {
    * @param entity the {@link EntityId} on which all {@link Action actions} are to be revoked
    */
   void revoke(EntityId entity);
+
+  /**
+   * Returns all the {@link Privilege} for the specified {@link Principal}.
+   *
+   * @param principal the {@link Principal} for which to return privileges
+   * @return a {@link Set} of {@link Privilege} for the specified principal
+   */
+  Set<Privilege> listPrivileges(Principal principal) throws Exception;
+
+  /********************************* Role Management: APIs for Role Based Access Control ******************************/
+  /**
+   * Create a role.
+   *
+   * @param role the {@link Role} to create
+   * @throws RoleAlreadyExistsException if the the role to be created already exists
+   */
+  void createRole(Role role) throws Exception;
+
+  /**
+   * Drop a role.
+   *
+   * @param role the {@link Role} to drop
+   * @throws RoleNotFoundException if the role to be dropped is not found
+   */
+  void dropRole(Role role) throws Exception;
+
+  /**
+   * Add a role to the specified {@link Principal}.
+   *
+   * @param role the {@link Role} to add to the specified group
+   * @param principal the {@link Principal} to add the role to
+   * @throws RoleNotFoundException if the role to be added to the principals is not found
+   */
+  void addRoleToPrincipal(Role role, Principal principal) throws Exception;
+
+  /**
+   * Delete a role from the specified {@link Principal}.
+   *
+   * @param role the {@link Role} to remove from the specified group
+   * @param principal the {@link Principal} to remove the role from
+   * @throws RoleNotFoundException if the role to be removed to the principals is not found
+   */
+  void removeRoleFromPrincipal(Role role, Principal principal) throws Exception;
+
+  /**
+   * Returns a set of all {@link Role roles} for the specified {@link Principal}.
+   *
+   * @param principal the {@link Principal} to look up roles for
+   * @return Set of {@link Role} for the specified {@link Principal}
+   */
+  Set<Role> listRoles(Principal principal) throws Exception;
+
+  /**
+   * Returns all available {@link Role}. Only a super user can perform this operation.
+   *
+   * @return a set of all available {@link Role} in the system.
+   */
+  Set<Role> listAllRoles() throws Exception;
 }

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NoOpAuthorizer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NoOpAuthorizer.java
@@ -19,6 +19,8 @@ package co.cask.cdap.security.spi.authorization;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.proto.security.Role;
 
 import java.util.Set;
 
@@ -44,5 +46,40 @@ public class NoOpAuthorizer implements Authorizer {
   @Override
   public void revoke(EntityId entity) {
     //no-op
+  }
+
+  @Override
+  public void createRole(Role role) {
+    //no-op
+  }
+
+  @Override
+  public void dropRole(Role role) {
+    //no-op
+  }
+
+  @Override
+  public void addRoleToPrincipal(Role role, Principal principal) {
+    //no-op
+  }
+
+  @Override
+  public void removeRoleFromPrincipal(Role role, Principal principal) {
+    //no-op
+  }
+
+  @Override
+  public Set<Role> listRoles(Principal principal) {
+    return null;
+  }
+
+  @Override
+  public Set<Role> listAllRoles() {
+    return null;
+  }
+
+  @Override
+  public Set<Privilege> listPrivileges(Principal principal) {
+    return null;
   }
 }

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/RoleAlreadyExistsException.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/RoleAlreadyExistsException.java
@@ -17,29 +17,20 @@
 package co.cask.cdap.security.spi.authorization;
 
 import co.cask.cdap.api.common.HttpErrorStatusProvider;
-import co.cask.cdap.proto.id.EntityId;
-import co.cask.cdap.proto.security.Action;
-import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Role;
 
 import java.net.HttpURLConnection;
 
 /**
- * Exception thrown when Authentication is successful, but a {@link Principal} is not authorized to perform an
- * {@link Action} on an {@link EntityId}.
+ * Exception thrown when an {@link Role} already exists
  */
-public class UnauthorizedException extends Exception implements HttpErrorStatusProvider {
-
-  public UnauthorizedException(Principal principal, Action action, EntityId entityId) {
-    super(String.format("Principal '%s' is not authorized to perform action '%s' on entity '%s'",
-                        principal, action, entityId));
-  }
-
-  public UnauthorizedException(String message) {
-    super(message);
+public class RoleAlreadyExistsException extends Exception implements HttpErrorStatusProvider {
+  public RoleAlreadyExistsException(Role role) {
+    super(String.format("%s already exists.", role));
   }
 
   @Override
   public int getStatusCode() {
-    return HttpURLConnection.HTTP_FORBIDDEN;
+    return HttpURLConnection.HTTP_CONFLICT;
   }
 }

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/RoleNotFoundException.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/RoleNotFoundException.java
@@ -17,29 +17,20 @@
 package co.cask.cdap.security.spi.authorization;
 
 import co.cask.cdap.api.common.HttpErrorStatusProvider;
-import co.cask.cdap.proto.id.EntityId;
-import co.cask.cdap.proto.security.Action;
-import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Role;
 
 import java.net.HttpURLConnection;
 
 /**
- * Exception thrown when Authentication is successful, but a {@link Principal} is not authorized to perform an
- * {@link Action} on an {@link EntityId}.
+ * Exception thrown when a {@link Role} is not found
  */
-public class UnauthorizedException extends Exception implements HttpErrorStatusProvider {
-
-  public UnauthorizedException(Principal principal, Action action, EntityId entityId) {
-    super(String.format("Principal '%s' is not authorized to perform action '%s' on entity '%s'",
-                        principal, action, entityId));
-  }
-
-  public UnauthorizedException(String message) {
-    super(message);
+public class RoleNotFoundException extends Exception implements HttpErrorStatusProvider {
+  public RoleNotFoundException(Role role) {
+    super(String.format("%s not found.", role));
   }
 
   @Override
   public int getStatusCode() {
-    return HttpURLConnection.HTTP_FORBIDDEN;
+    return HttpURLConnection.HTTP_NOT_FOUND;
   }
 }

--- a/cdap-security-spi/src/test/java/co/cask/cdap/security/spi/authorization/AuthorizerTest.java
+++ b/cdap-security-spi/src/test/java/co/cask/cdap/security/spi/authorization/AuthorizerTest.java
@@ -21,11 +21,16 @@ import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.proto.security.Role;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Tests for {@link Authorizer}.
@@ -38,13 +43,17 @@ public abstract class AuthorizerTest {
   protected abstract Authorizer get();
 
   @Test
-  public void testSimple() throws UnauthorizedException {
+  public void testSimple() throws Exception {
     Authorizer authorizer = get();
 
     verifyAuthFailure(namespace, user, Action.READ);
 
     authorizer.grant(namespace, user, Collections.singleton(Action.READ));
     authorizer.enforce(namespace, user, Action.READ);
+
+    Set<Privilege> expectedPrivileges = new HashSet<>();
+    expectedPrivileges.add(new Privilege(namespace, Action.READ));
+    Assert.assertEquals(expectedPrivileges, authorizer.listPrivileges(user));
 
     authorizer.revoke(namespace, user, Collections.singleton(Action.READ));
     verifyAuthFailure(namespace, user, Action.READ);
@@ -104,7 +113,102 @@ public abstract class AuthorizerTest {
     verifyAuthFailure(namespace, user, Action.WRITE);
 
     authorizer.revoke(namespace, user, Collections.singleton(Action.READ));
+    authorizer.revoke(dataset);
     verifyAuthFailure(namespace, user, Action.READ);
+  }
+
+  @Test
+  public void testRBAC() throws Exception {
+    Authorizer authorizer = get();
+
+    Role admins = new Role("admins");
+    Role engineers = new Role("engineers");
+    // create a role
+    authorizer.createRole(admins);
+    // add another role
+    authorizer.createRole(engineers);
+
+    // listing role should show the added role
+    Set<Role> roles = authorizer.listAllRoles();
+    Assert.assertEquals(Collections.singleton(Arrays.asList(admins, engineers)), roles);
+
+    // creating a role which already exists should throw an exception
+    try {
+      authorizer.createRole(admins);
+      Assert.fail(String.format("Created a role %s which already exists. Should have failed.", admins.getName()));
+    } catch (RoleAlreadyExistsException expected) {
+      // expected
+    }
+
+    // drop an existing role
+    authorizer.dropRole(admins);
+
+    // the list should not have the dropped role
+    roles = authorizer.listAllRoles();
+    Assert.assertEquals(Collections.singleton(engineers), roles);
+
+    // dropping a non-existing role should throw exception
+    try {
+      authorizer.dropRole(admins);
+      Assert.fail(String.format("Dropped a role %s which does not exists. Should have failed.", admins.getName()));
+    } catch (RoleNotFoundException expected) {
+      // expected
+    }
+
+    // add an user to an existing role
+    Principal spiderman = new Principal("spiderman", Principal.PrincipalType.USER);
+    authorizer.addRoleToPrincipal(engineers, spiderman);
+
+    // add an user to an non-existing role should throw an exception
+    try {
+      authorizer.addRoleToPrincipal(admins, spiderman);
+      Assert.fail(String.format("Added role %s to principal %s. Should have failed.", admins, spiderman));
+    } catch (RoleNotFoundException expected) {
+      // expectedRoles
+    }
+
+    // check listing roles for spiderman have engineers role
+    Assert.assertEquals(Collections.singleton(engineers), authorizer.listRoles(spiderman));
+
+    // authorization checks with roles
+    NamespaceId ns1 = Ids.namespace("ns1");
+
+    // check that spiderman who has engineers roles cannot read from ns1
+    verifyAuthFailure(ns1, spiderman, Action.READ);
+
+    // give a permission to engineers role
+    authorizer.grant(ns1, engineers, Collections.singleton(Action.READ));
+
+    // check that a spiderman who has engineers role has access
+    authorizer.enforce(ns1, spiderman, Action.READ);
+
+    // list privileges for spiderman should have read action on ns1
+    Assert.assertEquals((Collections.singleton(new Privilege(ns1, Action.READ))),
+                        authorizer.listPrivileges(spiderman));
+
+    // revoke action from the role
+    authorizer.revoke(ns1, engineers, (Collections.singleton(Action.READ)));
+
+    // now the privileges for spiderman should be empty
+    Assert.assertEquals(Collections.EMPTY_SET, authorizer.listPrivileges(spiderman));
+
+    // check that the user of this role is not authorized to do the revoked operation
+    verifyAuthFailure(ns1, spiderman, Action.READ);
+
+    // remove an user from a existing role
+    authorizer.removeRoleFromPrincipal(engineers, spiderman);
+
+    // check listing roles for spiderman should be empty
+    Assert.assertEquals(Collections.EMPTY_SET, authorizer.listRoles(spiderman));
+
+    // remove an user from a non-existing role should throw exception
+    try {
+      authorizer.removeRoleFromPrincipal(admins, spiderman);
+      Assert.fail(String.format("Removed non-existing role %s from principal %s. Should have failed.", admins,
+                                spiderman));
+    } catch (RoleNotFoundException expected) {
+      // expectedRoles
+    }
   }
 
   private void verifyAuthFailure(EntityId entity, Principal principal, Action action) {

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorServiceTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorServiceTest.java
@@ -23,8 +23,12 @@ import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.proto.security.Role;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.NoOpAuthorizer;
+import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
+import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.UncheckedExecutionException;
@@ -299,6 +303,41 @@ public class AuthorizerInstantiatorServiceTest {
     }
 
     @Override
+    public Set<Privilege> listPrivileges(Principal principal) {
+      return null;
+    }
+
+    @Override
+    public void createRole(Role role) throws RoleAlreadyExistsException {
+      // no-op
+    }
+
+    @Override
+    public void dropRole(Role role) throws RoleNotFoundException {
+      // no-op
+    }
+
+    @Override
+    public void addRoleToPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+      // no-op
+    }
+
+    @Override
+    public void removeRoleFromPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+      // no-op
+    }
+
+    @Override
+    public Set<Role> listRoles(Principal principal) {
+      return null;
+    }
+
+    @Override
+    public Set<Role> listAllRoles() {
+      return null;
+    }
+
+    @Override
     public void enforce(EntityId entity, Principal principal, Action action) throws UnauthorizedException {
       // no-op
     }
@@ -332,6 +371,41 @@ public class AuthorizerInstantiatorServiceTest {
     public void revoke(EntityId entity) {
       // no-op
     }
+
+    @Override
+    public Set<Privilege> listPrivileges(Principal principal) {
+      return null;
+    }
+
+    @Override
+    public void createRole(Role role) throws RoleAlreadyExistsException {
+      // no-op
+    }
+
+    @Override
+    public void dropRole(Role role) throws RoleNotFoundException {
+      // no-op
+    }
+
+    @Override
+    public void addRoleToPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+      // no-op
+    }
+
+    @Override
+    public void removeRoleFromPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+      // no-op
+    }
+
+    @Override
+    public Set<Role> listRoles(Principal principal) {
+      return null;
+    }
+
+    @Override
+    public Set<Role> listAllRoles() {
+      return null;
+    }
   }
 
   private static final class ConstructorNotVisible implements Authorizer {
@@ -359,6 +433,41 @@ public class AuthorizerInstantiatorServiceTest {
     @Override
     public void revoke(EntityId entity) {
       // no-op
+    }
+
+    @Override
+    public Set<Privilege> listPrivileges(Principal principal) {
+      return null;
+    }
+
+    @Override
+    public void createRole(Role role) throws RoleAlreadyExistsException {
+      // no-op
+    }
+
+    @Override
+    public void dropRole(Role role) throws RoleNotFoundException {
+      // no-op
+    }
+
+    @Override
+    public void addRoleToPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+      // no-op
+    }
+
+    @Override
+    public void removeRoleFromPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+      // no-op
+    }
+
+    @Override
+    public Set<Role> listRoles(Principal principal) {
+      return null;
+    }
+
+    @Override
+    public Set<Role> listAllRoles() {
+      return null;
     }
   }
 }


### PR DESCRIPTION
- This introduces the concepts of roles in CDAP Authorization: This is needed to support RBAC such as apache sentry.
- Added role based API to AuthorizerHandler as discussed here: https://wiki.cask.co/display/CE/Authorization+API
- Added support for RBAC in InMemoryAuthorizer
- Added unit tests to test RBAC

- Note: This PR does not include associated CLI commands. That will be in a separate PR.

- Issue: https://issues.cask.co/browse/CDAP-5155
- Build: http://builds.cask.co/browse/CDAP-DUT3716-1