### PR TITLE
Add background formatting to literals, but not when they are in a table.

### DIFF
--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -376,8 +376,7 @@ ul.simple {
 /* -- Literals ---------------------------------------------------------- */
 
 .docutils.literal {
-  background: #f5f5f5;
-  border: 1px solid #ccc;
+  background: #F3F3F3;
   border-radius: 3px;
   padding: 1px 3px;
 }
@@ -386,7 +385,7 @@ td .docutils.literal {
   background: #ffffff;
   border: 0px;
   border-radius: 0px;
-  padding: 0px 0px;
+  padding: 0px;
 }
 
 /* -- Table styles used in Introduction page -------------------------------------- */

--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -373,6 +373,22 @@ ul.simple {
   margin-bottom: 1em;
 }
 
+/* -- Literals ---------------------------------------------------------- */
+
+.docutils.literal {
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 1px 3px;
+}
+
+td .docutils.literal {
+  background: #ffffff;
+  border: 0px;
+  border-radius: 0px;
+  padding: 0px 0px;
+}
+
 /* -- Table styles used in Introduction page -------------------------------------- */
 
 div.table-block.container {

--- a/cdap-docs/examples-manual/source/examples/hello-world.rst
+++ b/cdap-docs/examples-manual/source/examples/hello-world.rst
@@ -20,16 +20,16 @@ This application uses one stream, one dataset, one flow, and one service to impl
 - A flow with a single flowlet that reads the stream and stores in a dataset each name in a ``KeyValueTable``; and
 - A service that reads the name from the ``KeyValueTable`` and responds with ``"Hello [Name]!"``
 
-The ``HelloWorld`` Application
-------------------------------
+The *HelloWorld* Application
+----------------------------
 .. literalinclude:: /../../../cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java
    :language: java
    :lines: 47-57
    
 The application uses a stream called *who* to ingest data through a flow *WhoFlow* to a dataset *whom*.
 
-The ``WhoFlow``
----------------
+The *WhoFlow*
+-------------
 This is a trivial flow with a single flowlet named *saver* of type ``NameSaver``:
 
 .. literalinclude:: /../../../cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java
@@ -51,8 +51,8 @@ the counter ``names.longnames`` is incremented by one, and the metric ``names.by
 by the length of the name. We will see below how to retrieve these metrics using the 
 :ref:`http-restful-api-metrics`.
 
-The ``Greeting`` Service
-------------------------
+The *Greeting* Service
+----------------------
 This service has a single endpoint called ``greet`` that does not accept arguments. When invoked, it
 reads the name stored by the ``NameSaver`` from the key-value table. It return a simple greeting with that name:
 

--- a/cdap-docs/examples-manual/source/examples/log-analysis.rst
+++ b/cdap-docs/examples-manual/source/examples/log-analysis.rst
@@ -49,8 +49,8 @@ number of requests made by them.
 
 Let's look at some of these components, and then run the application and see the results.
 
-The LogAnalysis Application
----------------------------
+The *LogAnalysis* Application
+-----------------------------
 As in the other `examples <index.html>`__, the components
 of the application are tied together by the class ``LogAnalysisApp``:
 
@@ -58,15 +58,15 @@ of the application are tied together by the class ``LogAnalysisApp``:
    :language: java
    :lines: 60-94
 
-The *hitCount* and *responseCount* ``KeyValueTable``\ s and *reqCount* ``TimePartitionedFileSet``
--------------------------------------------------------------------------------------------------
+The *hitCount* and *responseCount* KeyValueTables and *reqCount* TimePartitionedFileSet
+---------------------------------------------------------------------------------------
 The calculated hit count for every unique URL is stored in a ``KeyValueTable`` dataset,
 *hitCount* and the total number of responses for a response code is stored in another
 ``KeyValueTable`` dataset, *responseCount*. The total number of requests made by every
 unique IP address is written to a ``TimePartitionedFileSet``, *ipCount*.
 
-The ``HitCounterService``, ``ResponseCounterService``, and ``RequestCounterService``
-------------------------------------------------------------------------------------
+The *HitCounterService*, *ResponseCounterService*, and *RequestCounterService*
+------------------------------------------------------------------------------
 These services provide convenient endpoints:
 
 - ``HitCounterService:`` ``hitcount`` endpoint to obtain the total number of hits for a given URL;

--- a/cdap-docs/examples-manual/source/examples/purchase.rst
+++ b/cdap-docs/examples-manual/source/examples/purchase.rst
@@ -53,8 +53,8 @@ you should not start it manually until after entering the first customers' purch
 
 Let's look at some of these components, and then run the application and see the results.
 
-The Purchase Application
-------------------------
+The *Purchase* Application
+--------------------------
 As in the other `examples <index.html>`__, the components
 of the application are tied together by the class ``PurchaseApp``:
 
@@ -62,8 +62,8 @@ of the application are tied together by the class ``PurchaseApp``:
     :language: java
     :lines: 31-
 
-Storing Purchases with the ``Purchase`` ObjectStore Data Storage
-----------------------------------------------------------------
+Storing Purchases with the *Purchase* ObjectStore Data Storage
+--------------------------------------------------------------
 The raw purchase data is stored in an ``ObjectMappedTable`` dataset, *purchases*,
 with this method defined in ``PurchaseStore.java``:
 
@@ -90,8 +90,8 @@ The memory requirements of the flowlet *PurchaseStore* are set in its ``configur
    :end-before:   /**
    :dedent: 2
 
-``PurchaseHistoryBuilder`` MapReduce
-------------------------------------
+*PurchaseHistoryBuilder* MapReduce
+----------------------------------
 This MapReduce program demonstrates the setting of the YARN container resources, both as
 default values used in configuration and as runtime arguments:
 
@@ -99,8 +99,8 @@ default values used in configuration and as runtime arguments:
    :language: java
    :lines: 47-78
 
-``PurchaseHistoryService`` Service
-----------------------------------
+*PurchaseHistoryService* Service
+--------------------------------
 This service has a ``history/{customer}`` endpoint to obtain the purchase history of a given customer. It also demonstrates
 the use of ``Resources`` to configure the memory requirements of the service:
 
@@ -109,8 +109,8 @@ the use of ``Resources`` to configure the memory requirements of the service:
     :lines: 39-46
     :dedent: 2
 
-``UserProfileService`` Service
-------------------------------
+*UserProfileService* Service
+----------------------------
 .. highlight:: console
 
 This service has two endpoints:

--- a/cdap-docs/examples-manual/source/examples/spark-k-means.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-k-means.rst
@@ -28,8 +28,8 @@ of the *CentersService*. It will respond with the center's coordinates based on 
 
 Let's look at some of these components, and then run the application and see the results.
 
-The SparkKMeans Application
----------------------------
+The *SparkKMeans* Application
+-----------------------------
 As in the other `examples <index.html>`__, the components
 of the application are tied together by the class ``SparkKMeansApp``:
 
@@ -37,13 +37,13 @@ of the application are tied together by the class ``SparkKMeansApp``:
    :language: java
    :lines: 51-82
 
-The ``points`` and ``centers`` ObjectStore Data Storage
--------------------------------------------------------
+The *points* and *centers* ObjectStore Data Storage
+---------------------------------------------------
 The raw points data is stored in an ObjectStore dataset, *points*.
 The calculated centers data is stored in a second ObjectStore dataset, *centers*.
 
-The ``CentersService`` Service
-------------------------------
+The *CentersService* Service
+----------------------------
 This service has a ``centers/{index}`` endpoint to obtain the center's coordinates of a given index.
 
 

--- a/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
@@ -34,8 +34,8 @@ It will send back a string result with page rank based on the ``url`` query para
 
 Let's look at some of these components, and then run the application and see the results.
 
-The SparkPageRank Application
------------------------------
+The *SparkPageRank* Application
+-------------------------------
 
 As in the other `examples <index.html>`__, the components
 of the application are tied together by the class ``SparkPageRankApp``:
@@ -44,14 +44,14 @@ of the application are tied together by the class ``SparkPageRankApp``:
    :language: java
    :lines: 50-97
 
-The ``ranks`` and ``rankscount`` ObjectStore Data Storage
----------------------------------------------------------
+The *ranks* and *rankscount* ObjectStore Data Storage
+-----------------------------------------------------
 
 The calculated page rank data is stored in an ObjectStore dataset, *ranks*,
 with the total number of pages for a page rank stored in an additional ObjectStore dataset, *rankscount*.
 
-The SparkPageRankService Service
---------------------------------------------------------
+The *SparkPageRankService* Service
+----------------------------------
 
 This ``SparkPageRankService`` service has a ``rank`` endpoint to obtain the page rank of a given URL.
 It also has a ``total`` endpoint to obtain the total number of pages with a given page rank.

--- a/cdap-docs/examples-manual/source/examples/user-profiles.rst
+++ b/cdap-docs/examples-manual/source/examples/user-profiles.rst
@@ -159,8 +159,8 @@ Then re-deploy the application.
 
 .. include:: _includes/_starting-service.txt
 
-Populate the ``profiles`` Table
--------------------------------
+Populate the *profiles* Table
+-----------------------------
 Populate the ``profiles`` table with users using a script. From the Standalone CDAP SDK directory, use::
 
   $ ./examples/UserProfiles/bin/add-users.sh

--- a/cdap-docs/faqs/source/cdap.rst
+++ b/cdap-docs/faqs/source/cdap.rst
@@ -231,11 +231,11 @@ Router on port 11015. Another solution is to simply run the CDAP Router on a dif
 host than HiveServer2.
 
 
-CDAP services on distributed CDAP aren't starting up due to ``java.lang.ClassNotFoundException``. What should I do?
--------------------------------------------------------------------------------------------------------------------
-If the CDAP services on a distributed CDAP environment wouldn't start up, you will see errors
-in the logs. You will find in the logs for ``cdap-master`` under ``/var/log/cdap/master*.log``
-errors such as these::
+CDAP services on distributed CDAP aren't starting up due to an exception. What should I do?
+-------------------------------------------------------------------------------------------
+If the CDAP services on a distributed CDAP environment wouldn't start up due to a
+``java.lang.ClassNotFoundException``, you will see errors in the logs. You will find in
+the logs for ``cdap-master`` under ``/var/log/cdap/master*.log`` errors such as these::
 
  "Exception in thread "main" java.lang.NoClassDefFoundError:
    co.cask.cdap.data.runtime.main.MasterServiceMain


### PR DESCRIPTION
This is a simple CSS change that adds a ``background box with a border`` to the documentation's literals, similar to ``this text`` in GitHub. The style is a little stronger, as it has a border in addition to the background coloring.

It does not do it when the text is in a table, as that doesn't work very well.

Some editing might be required, as text such ``"sample"`` no longer requires the quotes to distinguish it, and can instead just be ``sample``. As can be seen in the [Hello World example](http://builds.cask.co/artifact/CDAP-DOB152/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/examples-manual/examples/hello-world.html), some of the titles have literals in them; the literals can either be removed or suppressed.

Passes [Quick Build 2](http://builds.cask.co/browse/CDAP-DOB152-2)
*Build 2 implements @poornachandra's suggestion: no border, slightly darker background.*

Sample Pages:
- [Quick Start](http://builds.cask.co/artifact/CDAP-DOB152/shared/build-2/Docs-HTML/3.4.0-SNAPSHOT/en/developers-manual/getting-started/quick-start.html)
- [Lifecycle RESTful API](http://builds.cask.co/artifact/CDAP-DOB152/shared/build-2/Docs-HTML/3.4.0-SNAPSHOT/en/reference-manual/http-restful-api/lifecycle.html)
- [Hello World example](http://builds.cask.co/artifact/CDAP-DOB152/shared/build-2/Docs-HTML/3.4.0-SNAPSHOT/en/examples-manual/examples/hello-world.html)