### PR TITLE
Refactor context logic for logical start time

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -79,7 +79,6 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
 
   private final MapReduceSpecification spec;
   private final LoggingContext loggingContext;
-  private final long logicalStartTime;
   private final WorkflowProgramInfo workflowProgramInfo;
   private final Metrics userMetrics;
   private final Map<String, Plugin> plugins;
@@ -100,7 +99,6 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
                                    RunId runId, String taskId,
                                    Arguments runtimeArguments,
                                    MapReduceSpecification spec,
-                                   long logicalStartTime,
                                    @Nullable WorkflowProgramInfo workflowProgramInfo,
                                    DiscoveryServiceClient discoveryServiceClient,
                                    MetricsCollectionService metricsCollectionService,
@@ -112,7 +110,6 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
     super(program, runId, runtimeArguments, ImmutableSet.<String>of(),
           getMetricCollector(program, runId.getId(), taskId, metricsCollectionService, type),
           dsFramework, txClient, discoveryServiceClient, false, pluginInstantiator);
-    this.logicalStartTime = logicalStartTime;
     this.workflowProgramInfo = workflowProgramInfo;
     this.transaction = transaction;
 
@@ -187,11 +184,6 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
   @Override
   public MapReduceSpecification getSpecification() {
     return spec;
-  }
-
-  @Override
-  public long getLogicalStartTime() {
-    return logicalStartTime;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -57,7 +57,6 @@ public final class MapReduceContextConfig {
   private static final Gson GSON = new Gson();
 
   private static final String HCONF_ATTR_RUN_ID = "hconf.program.run.id";
-  private static final String HCONF_ATTR_LOGICAL_START_TIME = "hconf.program.logical.start.time";
   private static final String HCONF_ATTR_WORKFLOW_INFO = "hconf.program.workflow.info";
   private static final String HCONF_ATTR_PLUGINS = "hconf.program.plugins.map";
   private static final String HCONF_ATTR_ARGS = "hconf.program.args";
@@ -88,7 +87,6 @@ public final class MapReduceContextConfig {
   public void set(BasicMapReduceContext context, CConfiguration conf, Transaction tx, URI programJarURI,
                   Map<String, String> localizedUserResources) {
     setRunId(context.getRunId().getId());
-    setLogicalStartTime(context.getLogicalStartTime());
     setWorkflowProgramInfo(context.getWorkflowProgramInfo());
     setPlugins(context.getPlugins());
     setArguments(context.getRuntimeArguments());
@@ -120,20 +118,6 @@ public final class MapReduceContextConfig {
    */
   public RunId getRunId() {
     return RunIds.fromString(hConf.get(HCONF_ATTR_RUN_ID));
-  }
-
-  private void setLogicalStartTime(long startTime) {
-    hConf.setLong(HCONF_ATTR_LOGICAL_START_TIME, startTime);
-  }
-
-  /**
-   * Returns the logical start time for the MapReduce program.
-   */
-  public long getLogicalStartTime() {
-    long startTime = hConf.getLong(HCONF_ATTR_LOGICAL_START_TIME, -1L);
-    // It shouldn't happen
-    Preconditions.checkArgument(startTime >= 0, "Logical start time is not present.");
-    return startTime;
   }
 
   private void setWorkflowProgramInfo(@Nullable WorkflowProgramInfo info) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -192,7 +192,7 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
 
         return new BasicMapReduceTaskContext(
           program, taskType, contextConfig.getRunId(), key.getTaskAttemptID().getTaskID().toString(),
-          contextConfig.getArguments(), spec, contextConfig.getLogicalStartTime(),
+          contextConfig.getArguments(), spec,
           workflowInfo, discoveryServiceClient, metricsCollectionService, txClient,
           contextConfig.getTx(), programDatasetFramework, classLoader.getPluginInstantiator(),
           contextConfig.getLocalizedResources()

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextConfig.java
@@ -18,10 +18,8 @@ package co.cask.cdap.internal.app.runtime.spark;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.spark.SparkSpecification;
-import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
-import co.cask.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.proto.Id;
@@ -53,7 +51,6 @@ public class SparkContextConfig {
   private static final String HCONF_ATTR_PROGRAM_SPEC = "cdap.spark.program.spec";
   private static final String HCONF_ATTR_PROGRAM_ID = "cdap.spark.program.id";
   private static final String HCONF_ATTR_RUN_ID = "cdap.spark.run.id";
-  private static final String HCONF_ATTR_LOGICAL_START_TIME = "hconf.program.logical.start.time";
   private static final String HCONF_ATTR_ARGS = "hconf.program.args";
   private static final String HCONF_ATTR_NEW_TX = "hconf.program.newtx.tx";
   private static final String HCONF_ATTR_WORKFLOW_INFO = "hconf.program.workflow.info";
@@ -95,7 +92,6 @@ public class SparkContextConfig {
     setSpecification(context.getSpecification());
     setProgramId(context.getProgramId());
     setRunId(context.getRunId().getId());
-    setLogicalStartTime(context.getLogicalStartTime());
     setArguments(context.getRuntimeArguments());
     setTransaction(context.getTransaction());
     setWorkflowProgramInfo(context.getWorkflowProgramInfo());
@@ -133,13 +129,6 @@ public class SparkContextConfig {
    */
   public Map<String, String> getArguments() {
     return GSON.fromJson(hConf.get(HCONF_ATTR_ARGS), ARGS_TYPE);
-  }
-
-  /**
-   * @return the logical start time stored in the configuration.
-   */
-  public long getLogicalStartTime() {
-    return hConf.getLong(HCONF_ATTR_LOGICAL_START_TIME, System.currentTimeMillis());
   }
 
   /**
@@ -181,10 +170,6 @@ public class SparkContextConfig {
 
   private void setArguments(Map<String, String> runtimeArgs) {
     hConf.set(HCONF_ATTR_ARGS, GSON.toJson(runtimeArgs, ARGS_TYPE));
-  }
-
-  private void setLogicalStartTime(long startTime) {
-    hConf.setLong(HCONF_ATTR_LOGICAL_START_TIME, startTime);
   }
 
   private void setTransaction(Transaction tx) {


### PR DESCRIPTION
- Unify logic for getting logical start time 
- Remove unnecessary configs for MR and Spark for logical start time.