### PR TITLE
CDAP-4075 Added lifecycle methods for the Workflow.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
@@ -44,6 +44,7 @@ import java.util.Map;
 public abstract class AbstractWorkflow implements Workflow {
 
   private WorkflowConfigurer configurer;
+  private WorkflowContext context;
 
   @Override
   public final void configure(WorkflowConfigurer configurer) {
@@ -188,5 +189,22 @@ public abstract class AbstractWorkflow implements Workflow {
    */
   protected final void createLocalDataset(String datasetName, Class<? extends Dataset> datasetClass) {
     createLocalDataset(datasetName, datasetClass, DatasetProperties.EMPTY);
+  }
+
+  @Override
+  public void initialize(WorkflowContext context) throws Exception {
+    this.context = context;
+  }
+
+  @Override
+  public void destroy() {
+    // Do nothing
+  }
+
+  /**
+   * Return an instance of the {@link WorkflowContext}.
+   */
+  protected final WorkflowContext getContext() {
+    return context;
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/Workflow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/Workflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,13 +15,15 @@
  */
 package co.cask.cdap.api.workflow;
 
+import co.cask.cdap.api.ProgramLifecycle;
+
 /**
  * Defines an interface for the Workflow.
  */
-public interface Workflow {
+public interface Workflow extends ProgramLifecycle<WorkflowContext> {
 
   /**
-   * Configures a {@link Workflow} using the given {@link WorkflowConfigurer}
+   * Configures a {@link Workflow} using the given {@link WorkflowConfigurer}.
    */
   void configure(WorkflowConfigurer configurer);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -31,6 +31,7 @@ import co.cask.cdap.internal.app.store.WorkflowDataset;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.WorkflowStatistics;
+import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import org.apache.twill.api.RunId;
@@ -356,11 +357,10 @@ public interface Store {
   /**
    * Updates the {@link WorkflowToken} for a specified run of a workflow.
    *
-   * @param workflowId {@link Id.Workflow} of the workflow whose {@link WorkflowToken} is to be updated
-   * @param workflowRunId Run Id of the workflow for which the {@link WorkflowToken} is to be updated
+   * @param workflowRunId workflow run for which the {@link WorkflowToken} is to be updated
    * @param token the {@link WorkflowToken} to update
    */
-  void updateWorkflowToken(Id.Workflow workflowId, String workflowRunId, WorkflowToken token);
+  void updateWorkflowToken(ProgramRunId workflowRunId, WorkflowToken token);
 
   /**
    * Retrieves the {@link WorkflowToken} for a specified run of a workflow.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.workflow.ScheduleProgramInfo;
+import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowAction;
 import co.cask.cdap.api.workflow.WorkflowActionNode;
 import co.cask.cdap.api.workflow.WorkflowActionSpecification;
@@ -48,8 +49,6 @@ import co.cask.cdap.common.lang.PropertyFieldSetter;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.data2.registry.UsageRegistry;
-import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.DataSetFieldSetter;
 import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
@@ -59,7 +58,9 @@ import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.internal.workflow.ProgramWorkflowAction;
 import co.cask.cdap.logging.context.WorkflowLoggingContext;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.http.NettyHttpService;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionFailureException;
@@ -74,7 +75,6 @@ import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,13 +120,15 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   private boolean suspended;
   private Lock lock;
   private Condition condition;
-  private final RunId runId;
   private final MetricsCollectionService metricsCollectionService;
   private final NameMappedDatasetFramework datasetFramework;
   private final DiscoveryServiceClient discoveryServiceClient;
   private final TransactionSystemClient txClient;
   private final Store store;
-  private final Id.Workflow workflowId;
+  private final ProgramRunId workflowRunId;
+  private Workflow workflow;
+  private final BasicWorkflowContext basicWorkflowContext;
+
   private final CConfiguration cConf;
 
   WorkflowDriver(Program program, ProgramOptions options, InetAddress hostname,
@@ -140,21 +142,27 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     this.workflowSpec = workflowSpec;
     this.lock = new ReentrantLock();
     this.condition = lock.newCondition();
-    this.runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
+    String runId = options.getArguments().getOption(ProgramOptionConstants.RUN_ID);
+    this.workflowRunId = new ProgramRunId(program.getNamespaceId(), program.getApplicationId(), ProgramType.WORKFLOW,
+                                          program.getName(), runId);
     this.loggingContext = new WorkflowLoggingContext(program.getNamespaceId(), program.getApplicationId(),
-                                                     program.getName(), runId.getId());
+                                                     program.getName(), workflowRunId.getRun());
 
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = new NameMappedDatasetFramework(datasetFramework,
                                                            workflowSpec.getLocalDatasetSpecs().keySet(),
-                                                           runId.getId());
+                                                           workflowRunId.getRun());
     this.discoveryServiceClient = discoveryServiceClient;
     this.txClient = txClient;
     this.store = store;
-    this.workflowId = Id.Workflow.from(program.getId().getApplication(), workflowSpec.getName());
     this.cConf = cConf;
     this.workflowProgramRunnerFactory = new ProgramWorkflowRunnerFactory(workflowSpec, programRunnerFactory,
                                                                          program, options);
+
+    this.basicWorkflowContext = new BasicWorkflowContext(workflowSpec, null, null, new BasicArguments(runtimeArgs),
+                                                         null, program, RunIds.fromString(runId),
+                                                         metricsCollectionService, datasetFramework, txClient,
+                                                         discoveryServiceClient);
   }
 
   @Override
@@ -173,6 +181,30 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     httpService.startAndWait();
     runningThread = Thread.currentThread();
     createLocalDatasets();
+    workflow = initializeWorkflow();
+  }
+
+  private Workflow initializeWorkflow() throws Exception {
+    Class<?> clz = Class.forName(workflowSpec.getClassName(), true, program.getClassLoader());
+    if (!Workflow.class.isAssignableFrom(clz)) {
+      throw new IllegalStateException(String.format("%s is not Workflow.", clz));
+    }
+
+    @SuppressWarnings("unchecked")
+    Class<? extends Workflow> workflowClass = (Class<? extends Workflow>) clz;
+    Workflow workflow = new InstantiatorFactory(false).get(TypeToken.of(workflowClass)).create();
+
+    TransactionContext transactionContext = basicWorkflowContext.getDatasetCache().newTransactionContext();
+    transactionContext.start();
+
+    try {
+      workflow.initialize(basicWorkflowContext);
+    } catch (Throwable t) {
+      LOG.error(String.format("Failed to initialize the Workflow %s", workflowRunId), t);
+      transactionContext.abort(new TransactionFailureException("Transaction function failure for transaction. ", t));
+    }
+    transactionContext.finish();
+    return workflow;
   }
 
   private void blockIfSuspended() {
@@ -222,6 +254,23 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   protected void shutDown() throws Exception {
     httpService.stopAndWait();
     deleteLocalDatasets();
+    destroyWorkflow();
+  }
+
+  private void destroyWorkflow() {
+    TransactionContext transactionContext = basicWorkflowContext.getDatasetCache().newTransactionContext();
+    try {
+      transactionContext.start();
+      workflow.destroy();
+      transactionContext.finish();
+    } catch (Throwable t) {
+      LOG.error(String.format("Failed to destroy the Workflow %s", workflowRunId), t);
+      try {
+        transactionContext.abort();
+      } catch (Throwable e) {
+        LOG.error("Failed to abort the transaction.", e);
+      }
+    }
   }
 
   private void executeAction(WorkflowActionNode node,
@@ -267,7 +316,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       executorTerminateLatch.await();
       status.remove(node.getNodeId());
     }
-    store.updateWorkflowToken(workflowId, runId.getId(), token);
+    store.updateWorkflowToken(workflowRunId, token);
   }
 
   private WorkflowActionSpecification getActionSpecification(WorkflowActionNode node,
@@ -380,7 +429,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       }
     } finally {
       // Update the WorkflowToken after the execution of the FORK node completes.
-      store.updateWorkflowToken(workflowId, runId.getId(), token);
+      store.updateWorkflowToken(workflowRunId, token);
       executorService.shutdownNow();
       // Wait for the executor termination
       executorTerminateLatch.await();
@@ -416,8 +465,9 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
 
     WorkflowContext context = new BasicWorkflowContext(workflowSpec, null, null,
                                                        new BasicArguments(runtimeArgs), token,
-                                                       program, runId, metricsCollectionService,
-                                                       datasetFramework, txClient, discoveryServiceClient);
+                                                       program, RunIds.fromString(workflowRunId.getRun()),
+                                                       metricsCollectionService, datasetFramework, txClient,
+                                                       discoveryServiceClient);
     Iterator<WorkflowNode> iterator;
     if (predicate.apply(context)) {
       // execute the if branch
@@ -429,17 +479,17 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     // If a workflow updates its token at a condition node, it will be persisted after the execution of the next node.
     // However, the call below ensures that even if the workflow fails/crashes after a condition node, updates from the
     // condition node are also persisted.
-    store.updateWorkflowToken(workflowId, runId.getId(), token);
+    store.updateWorkflowToken(workflowRunId, token);
     executeAll(iterator, appSpec, instantiator, classLoader, token);
   }
 
   private void createLocalDatasets() throws IOException, DatasetManagementException {
     for (Map.Entry<String, String> entry : datasetFramework.getDatasetNameMapping().entrySet()) {
       String localInstanceName = entry.getValue();
-      Id.DatasetInstance instanceId = Id.DatasetInstance.from(program.getNamespaceId(), localInstanceName);
+      DatasetId instanceId = new DatasetId(workflowRunId.getNamespace(), localInstanceName);
       DatasetCreationSpec instanceSpec = workflowSpec.getLocalDatasetSpecs().get(entry.getKey());
       LOG.debug("Adding Workflow local dataset instance: {}", localInstanceName);
-      datasetFramework.addInstance(instanceSpec.getTypeName(), instanceId, instanceSpec.getProperties());
+      datasetFramework.addInstance(instanceSpec.getTypeName(), instanceId.toId(), instanceSpec.getProperties());
     }
   }
 
@@ -451,10 +501,10 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       }
 
       String localInstanceName = entry.getValue();
-      Id.DatasetInstance instanceId = Id.DatasetInstance.from(program.getNamespaceId(), localInstanceName);
+      DatasetId instanceId = new DatasetId(workflowRunId.getNamespace(), localInstanceName);
       LOG.debug("Deleting Workflow local dataset instance: {}", localInstanceName);
       try {
-        datasetFramework.deleteInstance(instanceId);
+        datasetFramework.deleteInstance(instanceId.toId());
       } catch (Throwable t) {
         LOG.warn("Failed to delete the Workflow local dataset instance {}", localInstanceName, t);
       }
@@ -510,7 +560,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                                                      WorkflowToken token, String nodeId) {
     return new BasicWorkflowContext(workflowSpec, actionSpec,
                                     workflowProgramRunnerFactory.getProgramWorkflowRunner(actionSpec, token, nodeId),
-                                    new BasicArguments(runtimeArgs), token, program, runId, metricsCollectionService,
+                                    new BasicArguments(runtimeArgs), token, program,
+                                    RunIds.fromString(workflowRunId.getRun()), metricsCollectionService,
                                     datasetFramework, txClient, discoveryServiceClient);
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -56,6 +56,7 @@ import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.WorkflowStatistics;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
@@ -889,12 +890,12 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void updateWorkflowToken(final Id.Workflow workflowId, final String workflowRunId, final WorkflowToken token) {
+  public void updateWorkflowToken(final ProgramRunId workflowRunId, final WorkflowToken token) {
     appsTx.get().executeUnchecked(
       new TransactionExecutor.Function<AppMetadataStore, Void>() {
         @Override
         public Void apply(AppMetadataStore mds) throws Exception {
-          mds.updateWorkflowToken(workflowId, workflowRunId, token);
+          mds.updateWorkflowToken(workflowRunId, token);
           return null;
         }
       }, apps.get());

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeWorkflow.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeWorkflow.java
@@ -40,6 +40,16 @@ public class FakeWorkflow implements Workflow {
     configurer.addAction(new FakeAction(FakeAction.ANOTHER_FAKE_NAME));
   }
 
+  @Override
+  public void initialize(WorkflowContext context) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public void destroy() {
+    // no-op
+  }
+
   /**
    * DummyAction
    */

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -446,20 +446,33 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     // Execute Workflow without keeping the local datasets after run
     Map<String, String> additionalParams = new HashMap<>();
     String runId = executeWorkflow(applicationManager, additionalParams);
-    verifyWorkflowRun(runId, false, false);
-
+    verifyWorkflowRun(runId, false, false, "COMPLETED");
 
     additionalParams.put("dataset.wordcount.keep.local", "true");
     runId = executeWorkflow(applicationManager, additionalParams);
-    verifyWorkflowRun(runId, true, false);
+    verifyWorkflowRun(runId, true, false, "COMPLETED");
 
     additionalParams.clear();
     additionalParams.put("dataset.*.keep.local", "true");
     runId = executeWorkflow(applicationManager, additionalParams);
-    verifyWorkflowRun(runId, true, true);
+    verifyWorkflowRun(runId, true, true, "COMPLETED");
+
+    additionalParams.clear();
+    additionalParams.put("dataset.*.keep.local", "true");
+    additionalParams.put("destroy.throw.exception", "true");
+    runId = executeWorkflow(applicationManager, additionalParams);
+    verifyWorkflowRun(runId, true, true, "STARTED");
+
+    WorkflowManager wfManager = applicationManager.getWorkflowManager(WorkflowAppWithLocalDatasets.WORKFLOW_NAME);
+    List<RunRecord> history = wfManager.getHistory();
+    Assert.assertEquals(4, history.size());
+    for (RunRecord record : history) {
+      Assert.assertEquals(ProgramRunStatus.COMPLETED, record.getStatus());
+    }
   }
 
-  private void verifyWorkflowRun(String runId, boolean shouldKeepWordCountDataset, boolean shouldKeepCSVFilesetDataset)
+  private void verifyWorkflowRun(String runId, boolean shouldKeepWordCountDataset, boolean shouldKeepCSVFilesetDataset,
+                                 String expectedRunStatus)
     throws Exception {
 
     // Once the Workflow run is complete local datasets should not be available
@@ -490,6 +503,11 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     // There should not be any local copy of the non local dataset
     nonLocalKeyValueDataset = getDataset(testSpace, WorkflowAppWithLocalDatasets.RESULT_DATASET + "." + runId);
     Assert.assertNull(nonLocalKeyValueDataset.get());
+
+    DataSetManager<KeyValueTable> workflowRuns
+      = getDataset(testSpace, WorkflowAppWithLocalDatasets.WORKFLOW_RUNS_DATASET);
+
+    Assert.assertEquals(expectedRunStatus, Bytes.toString(workflowRuns.get().read(runId)));
   }
 
   private String executeWorkflow(ApplicationManager applicationManager, Map<String, String> additionalParams)


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-4075

This PR adds `initialize` and `destroy` methods to the Workflow. 
Next PR will contain following changes - 
1. Ability to get the map of node ids to the `WorkflowNodeState` from `WorkflowContext`. The dependent PR is already opened here #5326 
2. Ability to get the status of the Workflow through `WorkflowContext`.