### PR TITLE
User should be able to define partition metadata, when using DynamicPartitioner

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/AbstractVerifier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/AbstractVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,7 +25,7 @@ import com.google.common.base.CharMatcher;
  */
 public abstract class AbstractVerifier<T> implements Verifier<T> {
 
-  protected boolean isId(final String name) {
+  public static boolean isId(final String name) {
     return !name.isEmpty() && CharMatcher.inRange('A', 'Z')
              .or(CharMatcher.inRange('a', 'z'))
              .or(CharMatcher.is('-'))

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultipleInputs.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultipleInputs.java
@@ -23,13 +23,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
-import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.Mapper;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * This utility class supports MapReduce jobs that have multiple inputs with

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
@@ -29,6 +29,7 @@ import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.avro.generic.GenericRecord;
@@ -112,14 +113,19 @@ public class AppWithMapReduceUsingAvroDynamicPartitioner extends AbstractApplica
    * MapReduce job that dynamically partitions records based upon the 'zip' field in the record.
    */
   public static final class DynamicPartitioningMapReduce extends AbstractMapReduce {
+    public static final Map<String, String> METADATA = ImmutableMap.of("someKey1", "thisValue",
+                                                                       "someKey2", "otherValue",
+                                                                       "finalKey", "final.Value",
+                                                                       "post.-final", "actually.final.value");
 
     @Override
     public void beforeSubmit(MapReduceContext context) throws Exception {
       context.setInput(INPUT_DATASET);
 
-      Map<String, String> cleanRecordsArgs = new HashMap<>();
-      PartitionedFileSetArguments.setDynamicPartitioner(cleanRecordsArgs, TimeAndZipPartitioner.class);
-      context.addOutput(OUTPUT_DATASET, cleanRecordsArgs);
+      Map<String, String> outputDatasetArgs = new HashMap<>();
+      PartitionedFileSetArguments.setDynamicPartitioner(outputDatasetArgs, TimeAndZipPartitioner.class);
+      PartitionedFileSetArguments.setOutputPartitionMetadata(outputDatasetArgs, METADATA);
+      context.addOutput(OUTPUT_DATASET, outputDatasetArgs);
 
       Job job = context.getHadoopJob();
       job.setMapperClass(FileMapper.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/DynamicPartitionerWithAvroTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/DynamicPartitionerWithAvroTest.java
@@ -114,6 +114,9 @@ public class DynamicPartitionerWithAvroTest extends MapReduceRunnerTestBase {
           Map<PartitionKey, PartitionDetail> partitions = new HashMap<>();
           for (PartitionDetail partition : pfs.getPartitions(null)) {
             partitions.put(partition.getPartitionKey(), partition);
+            // check that the mapreduce wrote the output partition metadata to all the output partitions
+            Assert.assertEquals(AppWithMapReduceUsingAvroDynamicPartitioner.DynamicPartitioningMapReduce.METADATA,
+                                partition.getMetadata().asMap());
           }
           Assert.assertEquals(3, partitions.size());
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/MultipleOutputsTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/MultipleOutputsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset;
+
+
+import org.apache.hadoop.mapreduce.Job;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Tests for {@link MultipleOutputs}.
+ */
+public class MultipleOutputsTest {
+
+  @Test
+  public void testInvalidInputName() throws IOException {
+    Job job = Job.getInstance();
+    try {
+      // the other parameters don't matter, because it fails just checking the name
+      MultipleOutputs.addNamedOutput(job, "name.with.dots", null, null, null, null);
+      Assert.fail("Expected not to be able to add an output with a '.' in the name");
+    } catch (IllegalArgumentException expected) {
+      // just check the its not some other IllegalArgumentException that happened
+      Assert.assertTrue(expected.getMessage().contains("must consist only of ASCII letters, numbers,"));
+    }
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/ConfigurationUtilTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/ConfigurationUtilTest.java
@@ -35,15 +35,18 @@ public class ConfigurationUtilTest {
     Map<String, String> name1Config = ImmutableMap.of("key1", "value1",
                                                       "key2", "value2");
     Map<String, String> name2Config = ImmutableMap.of("name2key", "name2value");
+    Map<String, String> nameDotConfig = ImmutableMap.of("name3key", "name3value");
     Map<String, String> emptyConfig = ImmutableMap.of();
 
     ConfigurationUtil.setNamedConfigurations(conf, "name1", name1Config);
     ConfigurationUtil.setNamedConfigurations(conf, "name2", name2Config);
+    ConfigurationUtil.setNamedConfigurations(conf, "name.", nameDotConfig);
     ConfigurationUtil.setNamedConfigurations(conf, "emptyConfig", emptyConfig);
 
 
     Assert.assertEquals(name1Config, ConfigurationUtil.getNamedConfigurations(conf, "name1"));
     Assert.assertEquals(name2Config, ConfigurationUtil.getNamedConfigurations(conf, "name2"));
+    Assert.assertEquals(nameDotConfig, ConfigurationUtil.getNamedConfigurations(conf, "name."));
     Assert.assertEquals(emptyConfig, ConfigurationUtil.getNamedConfigurations(conf, "emptyConfig"));
   }
 

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -144,7 +144,7 @@ function download_includes() {
   test_an_include 9f963a17090976d2c15a4d092bd9e8de ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
   
   test_an_include 16fabc25230c648f6aa157121145734f ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
-  test_an_include 7f665f50faa05e0141dc7b82d50179f5 ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+  test_an_include 7babc1855b0e3c367d65bd6d939b348f ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
 
   test_an_include 8a7b4aacee88800cd82d96b07280cc64 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
   test_an_include 6943e3861b243c72ab212fe30bbaf5f0 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java

--- a/cdap-docs/examples-manual/source/examples/data-cleansing.rst
+++ b/cdap-docs/examples-manual/source/examples/data-cleansing.rst
@@ -109,7 +109,7 @@ Otherwise, this is the default schema that is matched against the records:
 
 .. literalinclude:: /../../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
     :language: java
-    :lines: 122-126
+    :lines: 127-131
     :dedent: 2
 
 Querying the Results

--- a/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+++ b/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,6 +28,7 @@ import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.api.metrics.Metrics;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonParser;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
@@ -68,13 +69,17 @@ public class DataCleansingMapReduce extends AbstractMapReduce {
     Long timeKey = Long.valueOf(context.getRuntimeArguments().get(OUTPUT_PARTITION_KEY));
     PartitionKey outputKey = PartitionKey.builder().addLongField("time", timeKey).build();
 
+    Map<String, String> metadataToAssign = ImmutableMap.of("source.program", "DataCleansingMapReduce");
+
     // set up two outputs - one for invalid records and one for valid records
     Map<String, String> invalidRecordsArgs = new HashMap<>();
     PartitionedFileSetArguments.setOutputPartitionKey(invalidRecordsArgs, outputKey);
+    PartitionedFileSetArguments.setOutputPartitionMetadata(invalidRecordsArgs, metadataToAssign);
     context.addOutput(DataCleansing.INVALID_RECORDS, invalidRecordsArgs);
 
     Map<String, String> cleanRecordsArgs = new HashMap<>();
     PartitionedFileSetArguments.setDynamicPartitioner(cleanRecordsArgs, TimeAndZipPartitioner.class);
+    PartitionedFileSetArguments.setOutputPartitionMetadata(cleanRecordsArgs, metadataToAssign);
     context.addOutput(DataCleansing.CLEAN_RECORDS, cleanRecordsArgs);
 
     Job job = context.getHadoopJob();

--- a/cdap-examples/DataCleansing/src/test/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduceTest.java
+++ b/cdap-examples/DataCleansing/src/test/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -194,6 +194,8 @@ public class DataCleansingMapReduceTest extends TestBase {
     Set<PartitionDetail> partitions = partitionedFileSet.getPartitions(filter);
     Set<String> cleanData = new HashSet<>();
     for (PartitionDetail partition : partitions) {
+      Assert.assertEquals(ImmutableMap.of("source.program", "DataCleansingMapReduce"),
+                          partition.getMetadata().asMap());
       Location partitionLocation = partition.getLocation();
       for (Location location : partitionLocation.list()) {
         if (location.getName().startsWith("part-")) {


### PR DESCRIPTION
User should be able to define partition metadata, when using DynamicPartitioner.

https://issues.cask.co/browse/CDAP-4071
http://builds.cask.co/browse/CDAP-DUT3701-3