### PR TITLE
(CDAP-5255) Added lifecycle management for authorization extensions.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/Transactional.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Transactional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,8 +28,7 @@ public interface Transactional {
 
   /**
    * Executes a set of operations via a {@link TxRunnable} that are committed as a single transaction.
-   * The {@link TxRunnable} can gain access to {@link Dataset} through the {@link DatasetContext} provided
-   * to it.
+   * The {@link TxRunnable} can gain access to {@link Dataset} through the provided {@link DatasetContext}.
    *
    * @param runnable the runnable to be executed in the transaction
    * @throws TransactionFailureException if failed to execute the given {@link TxRunnable} in a transaction

--- a/cdap-api/src/main/java/co/cask/cdap/api/TxRunnable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/TxRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +26,7 @@ import co.cask.cdap.api.dataset.Dataset;
 public interface TxRunnable {
 
   /**
-   * Provides a {@link co.cask.cdap.api.data.DatasetContext} to get instances of {@link Dataset}s.
+   * Provides a {@link DatasetContext} to get instances of {@link Dataset}s.
    *
    * <p>
    *   Operations executed on a dataset within the execution of this method are committed as a single transaction.
@@ -34,8 +34,8 @@ public interface TxRunnable {
    *   Exceptions thrown while committing the transaction or thrown by user-code result in a rollback of the
    *   transaction.
    * </p>
-   * @param context to get datasets from.
-   * @throws Exception
+   *
+   * @param context to get datasets from
    */
   void run(DatasetContext context) throws Exception;
 }

--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -79,6 +79,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-security</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>co.cask.tephra</groupId>
       <artifactId>tephra-api</artifactId>
     </dependency>

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -84,7 +84,6 @@ import co.cask.cdap.logging.run.LogSaverStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsProcessorStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsServiceManager;
 import co.cask.cdap.pipeline.PipelineFactory;
-import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
 import co.cask.http.HttpHandler;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
@@ -309,8 +308,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       for (Class<? extends HttpHandler> handlerClass : handlerClasses) {
         handlerBinder.addBinding().to(handlerClass);
       }
-
-      bind(AuthorizerInstantiatorService.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AuthorizationModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AuthorizationModule.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.guice;
+
+import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
+import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.internal.app.runtime.DefaultAdmin;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.authorization.AuthorizationContextFactory;
+import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
+import co.cask.cdap.security.authorization.DefaultAuthorizationContext;
+import co.cask.cdap.security.spi.authorization.AuthorizationContext;
+import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.tephra.TransactionContext;
+import co.cask.tephra.TransactionFailureException;
+import co.cask.tephra.TransactionSystemClient;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.PrivateModule;
+import com.google.inject.Provider;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * {@link PrivateModule} for authorization classes. This module is necessary and must be in app-fabric because classes
+ * like {@link DatasetFramework}, {@link DynamicDatasetCache}, {@link DefaultAdmin} are not available in cdap-security.
+ *
+ * This module is part of the injector created in StandaloneMain and MasterServiceMain, which makes it available to
+ * services. The requirements for this module are:
+ * 1. This module is used for creating and exposing {@link AuthorizerInstantiatorService}.
+ * 2. The {@link AuthorizerInstantiatorService} needs a {@link DefaultAuthorizationContext}.
+ * 3. The {@link DefaultAuthorizationContext} needs a {@link DatasetContext}, a {@link Admin} and a
+ * {@link Transactional}.
+ *
+ * These requirements are fulfilled by:
+ * 1. Constructing a {@link Singleton} {@link MultiThreadDatasetCache} by injecting a {@link DatasetFramework}, a
+ * {@link TransactionSystemClient} and a {@link MetricsCollectionService}. This {@link MultiThreadDatasetCache} is
+ * created for datasets in the {@link NamespaceId#SYSTEM}, since the datasets that {@link Authorizer} extensions need
+ * are created in the system namespace.
+ * 2. Binding the {@link DatasetContext} to the {@link MultiThreadDatasetCache} created above.
+ * 3. Using the {@link MultiThreadDatasetCache} to create a {@link TransactionContext} for providing the
+ * {@link Transactional}.
+ * 4. Binding a {@link DefaultAdmin} by injecting {@link DatasetFramework}. This {@link DefaultAdmin} is also created
+ * for the {@link NamespaceId#SYSTEM}.
+ * 5. Using the bound {@link DatasetContext}, {@link Admin} and {@link Transactional} to provide the injections for
+ * {@link DefaultAuthorizationContext}, which is provided using a {@link Guice} {@link FactoryModuleBuilder} to
+ * construct a {@link AuthorizationContextFactory}.
+ * 6. Only exposing a {@link Singleton} binding to {@link AuthorizerInstantiatorService} from this module. The
+ * {@link AuthorizerInstantiatorService} can just {@link Inject} the {@link AuthorizationContextFactory} and call
+ * {@link AuthorizationContextFactory#create(Properties)} using an {@link Assisted} {@link Properties} object.
+ */
+public class AuthorizationModule extends PrivateModule {
+  @Override
+  protected void configure() {
+    bind(DynamicDatasetCache.class).toProvider(DynamicDatasetCacheProvider.class);
+    bind(DatasetContext.class).to(DynamicDatasetCache.class).in(Scopes.SINGLETON);
+    bind(Admin.class).toProvider(AdminProvider.class);
+    bind(Transactional.class).toProvider(TransactionalProvider.class);
+
+    install(
+      new FactoryModuleBuilder()
+        .implement(AuthorizationContext.class, DefaultAuthorizationContext.class)
+        .build(AuthorizationContextFactory.class)
+    );
+
+    bind(AuthorizerInstantiatorService.class).in(Scopes.SINGLETON);
+    expose(AuthorizerInstantiatorService.class);
+  }
+
+  @Singleton
+  private static final class DynamicDatasetCacheProvider implements Provider<DynamicDatasetCache> {
+
+    private final DatasetFramework dsFramework;
+    private final TransactionSystemClient txClient;
+    private final MetricsCollectionService metricsCollectionService;
+
+    @Inject
+    private DynamicDatasetCacheProvider(DatasetFramework dsFramework, TransactionSystemClient txClient,
+                                        MetricsCollectionService metricsCollectionService) {
+      this.dsFramework = dsFramework;
+      this.txClient = txClient;
+      this.metricsCollectionService = metricsCollectionService;
+    }
+
+    @Override
+    public DynamicDatasetCache get() {
+      SystemDatasetInstantiator dsInstantiator = new SystemDatasetInstantiator(dsFramework, null, null);
+      return new MultiThreadDatasetCache(
+        dsInstantiator, txClient, NamespaceId.SYSTEM, ImmutableMap.<String, String>of(),
+        metricsCollectionService.getContext(ImmutableMap.<String, String>of()),
+        ImmutableMap.<String, Map<String, String>>of()
+      );
+    }
+  }
+
+  @Singleton
+  private static final class AdminProvider implements Provider<Admin> {
+    private final DatasetFramework dsFramework;
+
+    @Inject
+    private AdminProvider(DatasetFramework dsFramework) {
+      this.dsFramework = dsFramework;
+    }
+
+    @Override
+    public Admin get() {
+      return new DefaultAdmin(dsFramework, NamespaceId.SYSTEM);
+    }
+  }
+
+  @Singleton
+  private static final class TransactionalProvider implements Provider<Transactional> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TransactionalProvider.class);
+
+    private final DynamicDatasetCache datasetCache;
+
+    @Inject
+    private TransactionalProvider(DynamicDatasetCache datasetCache) {
+      this.datasetCache = datasetCache;
+    }
+
+    @Override
+    public Transactional get() {
+      return new Transactional() {
+        @Override
+        public void execute(TxRunnable runnable) throws TransactionFailureException {
+          TransactionContext transactionContext = datasetCache.newTransactionContext();
+          transactionContext.start();
+          try {
+            runnable.run(datasetCache);
+            transactionContext.finish();
+          } catch (TransactionFailureException e) {
+            LOG.error("Exception while executing runnable inside a transaction. Aborting transaction.", e);
+            transactionContext.abort(e);
+          } catch (Throwable t) {
+            LOG.error("Exception while executing runnable inside a transaction. Aborting transaction.", t);
+            transactionContext.abort(new TransactionFailureException("Exception raised from TxRunnable.run()", t));
+          }
+        }
+      };
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/InMemoryAuthorizer.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/InMemoryAuthorizer.java
@@ -21,6 +21,7 @@ import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.Role;
+import co.cask.cdap.security.spi.authorization.AbstractAuthorizer;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
 import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
@@ -40,14 +41,10 @@ import javax.annotation.concurrent.NotThreadSafe;
  * In-memory implementation of {@link Authorizer}.
  */
 @NotThreadSafe
-public class InMemoryAuthorizer implements Authorizer {
+public class InMemoryAuthorizer extends AbstractAuthorizer {
 
   private final Table<EntityId, Principal, Set<Action>> table = HashBasedTable.create();
   private final Map<Role, Set<Principal>> roleToPrincipals = new HashMap<>();
-
-  public InMemoryAuthorizer(@SuppressWarnings("unused") Properties properties) {
-
-  }
 
   @Override
   public void enforce(EntityId entity, Principal principal, Action action) throws UnauthorizedException {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.guice;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.schedule.Schedule;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
+import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -111,6 +112,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new NamespaceClientRuntimeModule().getStandaloneModules());
     install(new NamespaceStoreModule().getStandaloneModules());
     install(new MetadataServiceModule());
+    install(new AuthorizationModule());
   }
 
   private Scheduler createNoopScheduler() {

--- a/cdap-authorization-dataset-plugin/pom.xml
+++ b/cdap-authorization-dataset-plugin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014-2016 Cask Data, Inc.
+  Copyright © 2015-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -28,21 +28,32 @@
   <artifactId>cdap-authorization-dataset-plugin</artifactId>
   <name>CDAP Authorization Dataset Plugin</name>
 
+  <properties>
+    <security.authorizer.class>co.cask.cdap.security.authorization.DatasetBasedAuthorizer</security.authorizer.class>
+    <slf4j.version>1.7.5</slf4j.version>
+  </properties>
+
   <dependencies>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-data-fabric</artifactId>
-      <version>${project.version}</version>
-    </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-security-spi</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
@@ -53,15 +64,65 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-security</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-fabric</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-data-fabric</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-app-fabric</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>${security.authorizer.class}</mainClass>
+            </manifest>
+          </archive>
+          <instructions>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/cdap-authorization-dataset-plugin/src/main/java/co/cask/cdap/security/authorization/ACLDatasetKey.java
+++ b/cdap-authorization-dataset-plugin/src/main/java/co/cask/cdap/security/authorization/ACLDatasetKey.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.common.Bytes;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+
+/**
+ * Class to generate and manage keys for {@link ACLDataset}.
+ */
+final class ACLDatasetKey {
+  private final byte[] key;
+
+  /**
+   * @param key bytearray as constructed by {@link Builder}
+   */
+  public ACLDatasetKey(byte[] key) {
+    this.key = key;
+  }
+
+  /**
+   * @return the underlying key
+   */
+  public byte[] getKey() {
+    return key;
+  }
+
+  /**
+   * Splits the keys into a {@link Splitter} which exposes the parts that comprise the key.
+   */
+  public Splitter split() {
+    return new Splitter(key);
+  }
+
+  /**
+   * Decodes the keys parts, as specified (int, long, byte[], String)
+   */
+  public static final class Splitter {
+    private final ByteBuffer byteBuffer;
+    private Splitter(byte[] bytes) {
+      byteBuffer = ByteBuffer.wrap(bytes);
+    }
+
+    /**
+     * Returns the next {@link String} part in the {@link Splitter}.
+     *
+     * @throws BufferUnderflowException if there is no String as expected
+     * @return the next String part in the splitter
+     */
+    public String getString() {
+      return Bytes.toString(getBytes());
+    }
+
+    /**
+     * Skips the next {@link String} part in the splitter.
+     *
+     * @throws BufferUnderflowException if there is no String as expected
+     */
+    public void skipString() {
+      skipBytes();
+    }
+
+    /**
+     * Returns the next byte[] part in the {@link Splitter}.
+     *
+     * @throws BufferUnderflowException if there is no byte[] as expected
+     * @return the next byte[] part in the {@link Splitter}
+     */
+    private byte[] getBytes() {
+      int len = byteBuffer.getInt();
+      if (byteBuffer.remaining() < len) {
+        throw new BufferUnderflowException();
+      }
+      byte[] bytes = new byte[len];
+      byteBuffer.get(bytes, 0, len);
+      return bytes;
+    }
+
+    /**
+     * Skips the next byte[] part in the {@link Splitter}.
+     *
+     * @throws BufferUnderflowException if there is no byte[] as expected
+     */
+    private void skipBytes() {
+      int len = byteBuffer.getInt();
+      int position = byteBuffer.position();
+      byteBuffer.position(position + len);
+    }
+  }
+
+  /**
+   * Builds an {@link ACLDatasetKey}.
+   */
+  public static final class Builder {
+    private byte[] key;
+
+    public Builder() {
+      key = new byte[0];
+    }
+
+    public Builder add(String part) {
+      add(Bytes.toBytes(part));
+      return this;
+    }
+
+    public ACLDatasetKey build() {
+      return new ACLDatasetKey(key);
+    }
+
+    // Encodes parts of the key with segments of <length> <value>
+    private Builder add(byte[] part) {
+      key = Bytes.add(key, Bytes.toBytes(part.length), part);
+      return this;
+    }
+  }
+}

--- a/cdap-authorization-dataset-plugin/src/main/java/co/cask/cdap/security/authorization/DatasetBasedAuthorizer.java
+++ b/cdap-authorization-dataset-plugin/src/main/java/co/cask/cdap/security/authorization/DatasetBasedAuthorizer.java
@@ -16,147 +16,131 @@
 
 package co.cask.cdap.security.authorization;
 
-import co.cask.cdap.api.data.DatasetInstantiationException;
-import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.InstanceConflictException;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
-import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
-import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
 import co.cask.cdap.proto.id.EntityId;
-import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.Role;
+import co.cask.cdap.security.spi.authorization.AbstractAuthorizer;
+import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
 import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
-import co.cask.tephra.TransactionAware;
-import co.cask.tephra.TransactionExecutor;
-import co.cask.tephra.TransactionExecutorFactory;
-import co.cask.tephra.TransactionSystemClient;
+import co.cask.tephra.TransactionFailureException;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
-import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * {@link Authorizer} that uses a dataset to manage ACLs.
  */
-public class DatasetBasedAuthorizer implements Authorizer {
+public class DatasetBasedAuthorizer extends AbstractAuthorizer {
+  private static final Logger LOG = LoggerFactory.getLogger(DatasetBasedAuthorizer.class);
+  private AuthorizationContext context;
+  private Supplier<ACLDataset> dsSupplier;
 
-  private final Supplier<ACLDataset> acls;
-  private final Supplier<TransactionExecutor> aclsTx;
-
-  @Inject
-  DatasetBasedAuthorizer(final DatasetFramework dsFramework,
-                         final TransactionExecutorFactory txExecutorFactory,
-                         TransactionSystemClient txClient) {
-    final MultiThreadDatasetCache dsCache = new MultiThreadDatasetCache(
-      new SystemDatasetInstantiator(dsFramework, null, null), txClient,
-      new NamespaceId(ACLDataset.ID.getNamespace().getId()), null, null, null);
-    this.acls =
-      new Supplier<ACLDataset>() {
-        @Override
-        public ACLDataset get() {
-          Table table;
-          try {
-            table = dsCache.getDataset(ACLDataset.ID.getId());
-          } catch (DatasetInstantiationException e) {
-            try {
-              table = DatasetsUtil.getOrCreateDataset(
-                dsFramework, ACLDataset.ID, "table",
-                DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null);
-            } catch (DatasetManagementException | IOException e1) {
-              throw Throwables.propagate(e1);
-            }
-          }
-          return new ACLDataset(table);
-        }
-      };
-    this.aclsTx = new Supplier<TransactionExecutor>() {
+  @Override
+  public void initialize(final AuthorizationContext context) throws Exception {
+    this.context = context;
+    this.dsSupplier = new Supplier<ACLDataset>() {
       @Override
-      public TransactionExecutor get() {
-        return txExecutorFactory.createExecutor(ImmutableList.of((TransactionAware) acls.get()));
+      public ACLDataset get() {
+        try {
+          context.createDataset(ACLDataset.TABLE_NAME, "table", DatasetProperties.EMPTY);
+        } catch (InstanceConflictException e) {
+          LOG.info("Dataset {} already exists. Not creating again.", ACLDataset.TABLE_NAME);
+        } catch (DatasetManagementException e) {
+          throw Throwables.propagate(e);
+        }
+        Table table = context.getDataset(ACLDataset.TABLE_NAME);
+        return new ACLDataset(table);
       }
     };
   }
 
   @Override
   public void enforce(final EntityId entity, final Principal principal,
-                      final Action action) throws UnauthorizedException {
-    boolean allowed = aclsTx.get().executeUnchecked(new TransactionExecutor.Function<ACLDataset, Boolean>() {
+                      final Action action) throws UnauthorizedException, TransactionFailureException {
+    final AtomicReference<Boolean> result = new AtomicReference<>(false);
+    context.execute(new TxRunnable() {
       @Override
-      public Boolean apply(ACLDataset acls) throws Exception {
-        Set<Action> unfulfilledActions = Sets.newHashSet(action);
+      public void run(DatasetContext context) throws Exception {
+        ACLDataset dataset = dsSupplier.get();
         for (EntityId current : entity.getHierarchy()) {
-          Set<Action> allowedActions = acls.search(current, principal);
-          if (allowedActions.contains(Action.ALL)) {
-            return true;
-          }
-          unfulfilledActions.removeAll(allowedActions);
-          if (unfulfilledActions.isEmpty()) {
-            return true;
+          Set<Action> allowedActions = dataset.search(current, principal);
+          if (allowedActions.contains(Action.ALL) || allowedActions.contains(action)) {
+            result.set(true);
+            return;
           }
         }
-        return unfulfilledActions.isEmpty();
       }
-    }, acls.get());
-    if (!allowed) {
+    });
+    if (!result.get()) {
       throw new UnauthorizedException(principal, action, entity);
     }
   }
 
   @Override
-  public void grant(final EntityId entity, final Principal principal, final Set<Action> actions) {
-    aclsTx.get().executeUnchecked(new TransactionExecutor.Procedure<ACLDataset>() {
+  public void grant(final EntityId entity, final Principal principal,
+                    final Set<Action> actions) throws TransactionFailureException {
+    context.execute(new TxRunnable() {
       @Override
-      public void apply(ACLDataset acls) throws Exception {
+      public void run(DatasetContext context) throws Exception {
+        ACLDataset dataset = dsSupplier.get();
         for (Action action : actions) {
-          acls.add(entity, principal, action);
+          dataset.add(entity, principal, action);
         }
       }
-    }, acls.get());
+    });
   }
 
   @Override
-  public void revoke(final EntityId entity, final Principal principal, final Set<Action> actions) {
-    aclsTx.get().executeUnchecked(new TransactionExecutor.Procedure<ACLDataset>() {
+  public void revoke(final EntityId entity, final Principal principal,
+                     final Set<Action> actions) throws TransactionFailureException {
+    context.execute(new TxRunnable() {
       @Override
-      public void apply(ACLDataset acls) throws Exception {
+      public void run(DatasetContext context) throws Exception {
+        ACLDataset dataset = dsSupplier.get();
         for (Action action : actions) {
-          acls.remove(entity, principal, action);
+          dataset.remove(entity, principal, action);
         }
       }
-    }, acls.get());
+    });
   }
 
   @Override
-  public Set<Privilege> listPrivileges(final Principal principal) {
-    return aclsTx.get().executeUnchecked(new TransactionExecutor.Function<ACLDataset, Set<Privilege>>() {
+  public void revoke(final EntityId entity) throws TransactionFailureException {
+    context.execute(new TxRunnable() {
       @Override
-      public Set<Privilege> apply(ACLDataset acls) throws Exception {
-        return acls.listPrivileges(principal);
+      public void run(DatasetContext context) throws Exception {
+        ACLDataset dataset = dsSupplier.get();
+        dataset.remove(entity);
       }
-    }, acls.get());
+    });
   }
 
   @Override
-  public void revoke(final EntityId entity) {
-    aclsTx.get().executeUnchecked(new TransactionExecutor.Procedure<ACLDataset>() {
+  public Set<Privilege> listPrivileges(final Principal principal) throws TransactionFailureException {
+    final AtomicReference<Set<Privilege>> result = new AtomicReference<>();
+    context.execute(new TxRunnable() {
       @Override
-      public void apply(ACLDataset acls) throws Exception {
-        acls.remove(entity);
+      public void run(DatasetContext context) throws Exception {
+        ACLDataset dataset = dsSupplier.get();
+        result.set(dataset.listPrivileges(principal));
       }
-    }, acls.get());
+    });
+    return result.get();
   }
 
   @Override

--- a/cdap-authorization-dataset-plugin/src/test/java/co/cask/cdap/security/authorization/ACLDatasetTest.java
+++ b/cdap-authorization-dataset-plugin/src/test/java/co/cask/cdap/security/authorization/ACLDatasetTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.security.authorization;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
@@ -42,19 +42,18 @@ public class ACLDatasetTest {
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
-  private static final Id.DatasetInstance tabInstance =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "tab");
+  private static final DatasetId tabInstance = new DatasetId("myspace", "tab");
   private static ACLDataset table;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    dsFrameworkUtil.createInstance("table", tabInstance, DatasetProperties.EMPTY);
-    table = new ACLDataset((Table) dsFrameworkUtil.getInstance(tabInstance));
+    dsFrameworkUtil.createInstance("table", tabInstance.toId(), DatasetProperties.EMPTY);
+    table = new ACLDataset((Table) dsFrameworkUtil.getInstance(tabInstance.toId()));
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
-    dsFrameworkUtil.deleteInstance(tabInstance);
+    dsFrameworkUtil.deleteInstance(tabInstance.toId());
   }
 
   @Test

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data.runtime.main;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
+import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.app.store.ServiceStore;
@@ -378,7 +379,8 @@ public class MasterServiceMain extends DaemonMain {
       new StreamAdminModules().getDistributedModules(),
       new NamespaceClientRuntimeModule().getDistributedModules(),
       new NamespaceStoreModule().getDistributedModules(),
-      new AuditModule().getDistributedModules()
+      new AuditModule().getDistributedModules(),
+      new AuthorizationModule()
     );
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.flow.FlowletConnection;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
+import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.app.queue.QueueSpecification;
@@ -479,6 +480,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
       new MetricsClientRuntimeModule().getDistributedModules(),
       new KafkaClientModule(),
       new NamespaceStoreModule().getDistributedModules(),
+      new AuthorizationModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
+import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -212,6 +213,7 @@ public class UpgradeTool {
       new NotificationServiceRuntimeModule().getInMemoryModules(),
       new KafkaClientModule(),
       new NamespaceStoreModule().getDistributedModules(),
+      new AuthorizationModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
+import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.app.queue.QueueSpecification;
@@ -346,6 +347,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
       new MetricsClientRuntimeModule().getDistributedModules(),
       new KafkaClientModule(),
       new NamespaceStoreModule().getDistributedModules(),
+      new AuthorizationModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-security-spi/pom.xml
+++ b/cdap-security-spi/pom.xml
@@ -26,6 +26,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>cdap-security-spi</artifactId>
+  <name>CDAP Security SPI</name>
+  <packaging>jar</packaging>
 
   <dependencies>
     <dependency>

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AbstractAuthorizer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AbstractAuthorizer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.spi.authorization;
+
+/**
+ * Abstract class that implements {@link Authorizer} and provides default no-op implementations of
+ * {@link Authorizer#initialize(AuthorizationContext)} and {@link Authorizer#destroy()} so classes extending it do not
+ * have to implement these methods unless necessary.
+ */
+public abstract class AbstractAuthorizer implements Authorizer {
+
+  /**
+   * Default no-op implementation of {@link Authorizer#initialize(AuthorizationContext)}.
+   */
+  public void initialize(AuthorizationContext context) throws Exception {
+    // default no-op implementation
+  }
+
+  /**
+   * Default no-op implementation of {@link Authorizer#destroy()}.
+   */
+  public void destroy() throws Exception {
+    // default no-op implementation
+  }
+}

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationContext.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.spi.authorization;
+
+import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.data.DatasetContext;
+
+import java.util.Properties;
+
+/**
+ * A context for {@link Authorizer} extensions to interact with CDAP. This context is available to {@link Authorizer}
+ * extensions in the {@link Authorizer#initialize(AuthorizationContext)} method.
+ *
+ * Extensions can use this class to:
+ * <ol>
+ *   <li>Perform admin operations such as create/update/truncate/drop/exists on a dataset.</li>
+ *   <li>Instantiate datasets and obtain objects for them.</li>
+ *   <li>Execute operations on datasets inside transactions.</li>
+ * </ol>
+ */
+public interface AuthorizationContext extends DatasetContext, Admin, Transactional {
+  /**
+   * Returns the properties for the authorization extension. These properties are composed of all the properties
+   * defined in {@code cdap-site.xml} with the prefix {@code security.authorization.extension.config.}.
+   *
+   * @return the {@link Properties} for the authorization extension
+   */
+  Properties getExtensionProperties();
+}

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NoOpAuthorizer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NoOpAuthorizer.java
@@ -22,12 +22,14 @@ import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.Role;
 
+import java.util.Properties;
 import java.util.Set;
 
 /**
  * A no-op authorizer to use when authorization is disabled.
  */
-public class NoOpAuthorizer implements Authorizer {
+public class NoOpAuthorizer extends AbstractAuthorizer {
+
   @Override
   public void enforce(EntityId entity, Principal principal, Action action) throws UnauthorizedException {
     // no-op

--- a/cdap-security-spi/src/test/java/co/cask/cdap/security/spi/authorization/AuthorizerTest.java
+++ b/cdap-security-spi/src/test/java/co/cask/cdap/security/spi/authorization/AuthorizerTest.java
@@ -60,7 +60,7 @@ public abstract class AuthorizerTest {
   }
 
   @Test
-  public void testWildcard() throws UnauthorizedException {
+  public void testWildcard() throws Exception {
     Authorizer authorizer = get();
 
     verifyAuthFailure(namespace, user, Action.READ);
@@ -76,7 +76,7 @@ public abstract class AuthorizerTest {
   }
 
   @Test
-  public void testAll() throws UnauthorizedException {
+  public void testAll() throws Exception {
     Authorizer authorizer = get();
 
     verifyAuthFailure(namespace, user, Action.READ);
@@ -99,7 +99,7 @@ public abstract class AuthorizerTest {
   }
 
   @Test
-  public void testHierarchy() throws UnauthorizedException {
+  public void testHierarchy() throws Exception {
     Authorizer authorizer = get();
 
     DatasetId dataset = namespace.dataset("bar");
@@ -211,7 +211,7 @@ public abstract class AuthorizerTest {
     }
   }
 
-  private void verifyAuthFailure(EntityId entity, Principal principal, Action action) {
+  private void verifyAuthFailure(EntityId entity, Principal principal, Action action) throws Exception {
     try {
       get().enforce(entity, principal, action);
       Assert.fail(String.format("Expected authorization failure, but it succeeded for entity %s, principal %s," +

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationContextFactory.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationContextFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.security.spi.authorization.AuthorizationContext;
+import com.google.inject.assistedinject.Assisted;
+
+import java.util.Properties;
+
+/**
+ * Guice factory for creating {@link AuthorizationContext} instances
+ */
+public interface AuthorizationContextFactory {
+  /**
+   * Creates an {@link AuthorizationContext}.
+   *
+   * @param extensionProperties the properties to supply to the authorization extension
+   * @return the {@link AuthorizationContext} for the extension
+   */
+  AuthorizationContext create(@Assisted("extension-properties") Properties extensionProperties);
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerClassLoader.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerClassLoader.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorService.java
@@ -19,11 +19,16 @@ package co.cask.cdap.security.authorization;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.lang.InstantiatorFactory;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.NoOpAuthorizer;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.base.Supplier;
+import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
@@ -33,8 +38,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Properties;
 import java.util.jar.Attributes;
@@ -43,11 +46,14 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipException;
 
 /**
- * Class to instantiate {@link Authorizer} extensions. {@link Authorizer} extensions are instantiated using a
- * separate {@link ClassLoader} that is built using a bundled jar for the {@link Authorizer} implementation that
+ * Class to instantiate {@link Authorizer} extensions. Authorization extensions are instantiated using a
+ * separate {@link ClassLoader} that is built using a bundled jar for the {@link Authorizer} extension that
  * contains all its required dependencies. The {@link ClassLoader} is created with the parent as the classloader with
  * which the {@link Authorizer} interface is instantiated. This parent only has classes required by the
  * {@code cdap-security-spi} module.
+ *
+ * It is implemented as a {@link AbstractIdleService} so it can manage initialization and destruction of the
+ * {@link AuthorizerClassLoader} in a reliable manner.
  *
  * The {@link AuthorizerInstantiatorService} has the following expectations from the extension:
  * <ul>
@@ -56,30 +62,37 @@ import java.util.zip.ZipException;
  *   <li>The path to the extension jar bundled with all its dependencies is read from the setting
  *   {@link Constants.Security.Authorization#EXTENSION_JAR_PATH} in cdap-site.xml</li>
  *   <li>The instantiator reads a fully qualified class name specified as the {@link Attributes.Name#MAIN_CLASS}
- *   attribute in the extension jar's manifest file. This class must implement {@link Authorizer} and have a public
- *   constructor that accepts a single {@link Properties} object as parameter. This constructor is invoked with a
+ *   attribute in the extension jar's manifest file. This class must implement {@link Authorizer} and have a default
+ *   constructor.</li>
+ *   <li>During {@link AbstractIdleService#startUp()}, the service creates an instance of of the {@link Authorizer}
+ *   class and also calls its {@link Authorizer#initialize(AuthorizationContext)} method with an
+ *   {@link AuthorizationContext} created using a {@link AuthorizationContextFactory} by providing it a
  *   {@link Properties} object that is populated with all configuration settings from {@code cdap-site.xml} that have
  *   keys with the prefix {@link Constants.Security.Authorization#EXTENSION_CONFIG_PREFIX}.</li>
+ *   <li>During {@link AbstractIdleService#shutDown()}, the {@link Authorizer#destroy()} method is invoked, and the
+ *   {@link AuthorizerClassLoader} is closed.</li>
  * </ul>
- *
- * Implemented as a {@link AbstractIdleService} so it can manage initialization and destruction of the
- * {@link AuthorizerClassLoader} in a reliable manner.
  */
-public class AuthorizerInstantiatorService extends AbstractIdleService {
+public class AuthorizerInstantiatorService extends AbstractIdleService implements Supplier<Authorizer> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AuthorizerInstantiatorService.class);
 
   private final CConfiguration cConf;
   private final boolean authorizationEnabled;
+  private final InstantiatorFactory instantiatorFactory;
+  private final AuthorizationContextFactory authorizationContextFactory;
 
   private File tmpDir;
   private AuthorizerClassLoader authorizerClassLoader;
   private Authorizer authorizer;
 
   @Inject
-  public AuthorizerInstantiatorService(CConfiguration cConf) {
+  @VisibleForTesting
+  public AuthorizerInstantiatorService(CConfiguration cConf, AuthorizationContextFactory authorizationContextFactory) {
     this.cConf = cConf;
     this.authorizationEnabled = cConf.getBoolean(Constants.Security.Authorization.ENABLED);
+    this.instantiatorFactory = new InstantiatorFactory(false);
+    this.authorizationContextFactory = authorizationContextFactory;
   }
 
   @Override
@@ -102,11 +115,12 @@ public class AuthorizerInstantiatorService extends AbstractIdleService {
                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
     this.tmpDir = DirUtils.createTempDir(tmpDir);
     this.authorizerClassLoader = createAuthorizerClassLoader(authorizerExtensionJar);
-    this.authorizer = createAuthorizerInstance(authorizerExtensionJar);
+    this.authorizer = createAndInitializeAuthorizerInstance(authorizerExtensionJar);
   }
 
   @Override
   protected void shutDown() throws Exception {
+    authorizer.destroy();
     if (!authorizationEnabled) {
       // nothing to close, since we would not have created a class loader
       return;
@@ -125,19 +139,21 @@ public class AuthorizerInstantiatorService extends AbstractIdleService {
   }
 
   /**
-   * @return an instance of the configured {@link Authorizer} extension, or of {@link NoOpAuthorizer}, if authorization
-   * is disabled
+   * Returns an instance of the configured {@link Authorizer} extension, or of {@link NoOpAuthorizer}, if
+   * authorization is disabled.
    */
-  public Authorizer get() throws IOException, InvalidAuthorizerException {
+  @Override
+  public Authorizer get() {
     return authorizer;
   }
 
   /**
-   * Creates a new instance of the configured {@link Authorizer} extension, based on the provided extension jar file.
+   * Creates a new instance of the configured {@link Authorizer} extension, based on the provided extension jar
+   * file.
    *
    * @return a new instance of the configured {@link Authorizer} extension
    */
-  private Authorizer createAuthorizerInstance(File authorizerExtensionJar)
+  private Authorizer createAndInitializeAuthorizerInstance(File authorizerExtensionJar)
     throws IOException, InvalidAuthorizerException {
     Class<? extends Authorizer> authorizerClass = loadAuthorizerClass(authorizerExtensionJar);
     // Set the context class loader to the AuthorizerClassLoader before creating a new instance of the extension,
@@ -146,23 +162,22 @@ public class AuthorizerInstantiatorService extends AbstractIdleService {
     Thread.currentThread().setContextClassLoader(authorizerClassLoader);
     LOG.debug("Setting context classloader to {}. Old classloader was {}.", authorizerClassLoader, oldClassLoader);
     try {
-      Constructor<? extends Authorizer> constructor;
+      Authorizer authorizer;
       try {
-        constructor = authorizerClass.getDeclaredConstructor(Properties.class);
-      } catch (NoSuchMethodException e) {
-        throw new InvalidAuthorizerException(
-          String.format("No suitable constructor for Authorizer extension %s. Please make sure that the extension is " +
-                          "a public class with a public constructor that accepts a single parameter of type %s.",
-                        authorizerClass.getName(), Properties.class.getName()), e);
-      }
-      try {
-        return constructor.newInstance(createExtensionProperties());
-      } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+        authorizer = instantiatorFactory.get(TypeToken.of(authorizerClass)).create();
+      } catch (Exception e) {
         throw new InvalidAuthorizerException(
           String.format("Error while instantiating for authorizer extension %s. Please make sure that the extension " +
-                          "is a public class with a public constructor that accepts a single parameter of type %s.",
-                        authorizerClass.getName(), Properties.class.getName()), e);
+                          "is a public class with a default constructor.", authorizerClass.getName()), e);
       }
+      AuthorizationContext context = authorizationContextFactory.create(createExtensionProperties());
+      try {
+        authorizer.initialize(context);
+      } catch (Exception e) {
+        throw new InvalidAuthorizerException(
+          String.format("Error while initializing authorizer extension %s.", authorizerClass.getName()), e);
+      }
+      return authorizer;
     } finally {
       // After the process of creation of a new instance has completed (success or failure), reset the context
       // classloader back to the original class loader.

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.security.spi.authorization.AuthorizationContext;
+import co.cask.tephra.TransactionFailureException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * An {@link AuthorizationContext} that delegates to the provided {@link DatasetContext}, {@link Admin} and
+ * {@link Transactional}.
+ */
+public class DefaultAuthorizationContext implements AuthorizationContext {
+  private final Properties extensionProperties;
+  private final DatasetContext delegateDatasetContext;
+  private final Admin delegateAdmin;
+  private final Transactional delegateTxnl;
+
+  @Inject
+  @VisibleForTesting
+  public DefaultAuthorizationContext(@Assisted("extension-properties") Properties extensionProperties,
+                                     DatasetContext delegateDatasetContext, Admin delegateAdmin,
+                                     Transactional delegateTxnl) {
+    this.extensionProperties = extensionProperties;
+    this.delegateDatasetContext = delegateDatasetContext;
+    this.delegateAdmin = delegateAdmin;
+    this.delegateTxnl = delegateTxnl;
+  }
+
+  @Override
+  public boolean datasetExists(String name) throws DatasetManagementException {
+    return delegateAdmin.datasetExists(name);
+  }
+
+  @Override
+  public String getDatasetType(String name) throws DatasetManagementException {
+    return delegateAdmin.getDatasetType(name);
+  }
+
+  @Override
+  public DatasetProperties getDatasetProperties(String name) throws DatasetManagementException {
+    return delegateAdmin.getDatasetProperties(name);
+  }
+
+  @Override
+  public void createDataset(String name, String type, DatasetProperties properties) throws DatasetManagementException {
+    delegateAdmin.createDataset(name, type, properties);
+  }
+
+  @Override
+  public void updateDataset(String name, DatasetProperties properties) throws DatasetManagementException {
+    delegateAdmin.updateDataset(name, properties);
+  }
+
+  @Override
+  public void dropDataset(String name) throws DatasetManagementException {
+    delegateAdmin.dropDataset(name);
+  }
+
+  @Override
+  public void truncateDataset(String name) throws DatasetManagementException {
+    delegateAdmin.truncateDataset(name);
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
+    return delegateDatasetContext.getDataset(name);
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
+    throws DatasetInstantiationException {
+    return delegateDatasetContext.getDataset(name, arguments);
+  }
+
+  @Override
+  public void releaseDataset(Dataset dataset) {
+    delegateDatasetContext.releaseDataset(dataset);
+  }
+
+  @Override
+  public void discardDataset(Dataset dataset) {
+    delegateDatasetContext.discardDataset(dataset);
+  }
+
+  @Override
+  public void execute(TxRunnable runnable) throws TransactionFailureException {
+    delegateTxnl.execute(runnable);
+  }
+
+  @Override
+  public Properties getExtensionProperties() {
+    return extensionProperties;
+  }
+}

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpAdmin.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpAdmin.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.InstanceNotFoundException;
+
+/**
+ * A no-op implementation of {@link Admin} for use in tests
+ */
+public class NoOpAdmin implements Admin {
+  @Override
+  public boolean datasetExists(String name) throws DatasetManagementException {
+    return false;
+  }
+
+  @Override
+  public String getDatasetType(String name) throws DatasetManagementException {
+    throw new InstanceNotFoundException(name);
+  }
+
+  @Override
+  public DatasetProperties getDatasetProperties(String name) throws DatasetManagementException {
+    throw new InstanceNotFoundException(name);
+  }
+
+  @Override
+  public void createDataset(String name, String type, DatasetProperties properties) throws DatasetManagementException {
+    //no-op
+  }
+
+  @Override
+  public void updateDataset(String name, DatasetProperties properties) throws DatasetManagementException {
+    //no-op
+  }
+
+  @Override
+  public void dropDataset(String name) throws DatasetManagementException {
+    //no-op
+  }
+
+  @Override
+  public void truncateDataset(String name) throws DatasetManagementException {
+    //no-op
+  }
+}

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpDatasetContext.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpDatasetContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.dataset.Dataset;
+
+import java.util.Map;
+
+/**
+ * A no-op implementation of {@link DatasetContext} for use in unit tests.
+ */
+public class NoOpDatasetContext implements DatasetContext {
+  @Override
+  public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
+    throw new DatasetInstantiationException("NoOpDatasetContext cannot instantiate datasets");
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
+    throws DatasetInstantiationException {
+    throw new DatasetInstantiationException("NoOpDatasetContext cannot instantiate datasets");
+  }
+
+  @Override
+  public void releaseDataset(Dataset dataset) {
+
+  }
+
+  @Override
+  public void discardDataset(Dataset dataset) {
+
+  }
+}

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -18,6 +18,7 @@ package co.cask.cdap;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
+import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.app.store.ServiceStore;
@@ -386,7 +387,8 @@ public class StandaloneMain {
       new NamespaceClientRuntimeModule().getStandaloneModules(),
       new NamespaceStoreModule().getStandaloneModules(),
       new MetadataServiceModule(),
-      new AuditModule().getStandaloneModules()
+      new AuditModule().getStandaloneModules(),
+      new AuthorizationModule()
     );
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
+import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.InMemoryProgramRunnerModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -216,6 +217,7 @@ public class TestBase {
       new NotificationServiceRuntimeModule().getInMemoryModules(),
       new NamespaceClientRuntimeModule().getStandaloneModules(),
       new NamespaceStoreModule().getStandaloneModules(),
+      new AuthorizationModule(),
       new AbstractModule() {
         @Override
         @SuppressWarnings("deprecation")


### PR DESCRIPTION
- Added an ``AuthorizationContext`` which currently allows extensions to perform ``DatasetContext``, ``Admin`` and ``Transactional`` operations. In addition, it also exposes a ``getExtensionProperties`` method that returns a ``Properties`` object.
- Added ``initialize(AuthorizationContext)`` and ``destroy()`` methods in ``Authorizer`` to allow extensions to manage lifecycle. ``initialize`` is called during ``AuthorizationInstantiatorService`` startup and destroy is called during its shutdown. Also added default no-op implementations of these methods in ``AbstractAuthorizer`` so they need not be overriden unless necessary.
- Authorization extensions are now instantiated with the default constructor, immediately after which the ``initialize(AuthorizationContext)`` method is invoked.
- Converted the existing ``DatasetBasedAuthorizer`` into an extension that does not have access to internal CDAP classes like ``DatasetFramework``, ``SystemDatsetInstantiator``, etc.
- Fixed ``DatasetBasedAuthorizerTest`` currently using internal CDAP classes that are only available to test code.

Jira: [CDAP-5255](https://issues.cask.co/browse/CDAP-5255)
Build: http://builds.cask.co/browse/CDAP-DUT3719