### PR TITLE
CDAP-5186 add data pipeline application

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSparkProgram.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSparkProgram.java
@@ -28,7 +28,6 @@ import co.cask.cdap.etl.batch.BatchPhaseSpec;
 import co.cask.cdap.etl.batch.PipelinePluginInstantiator;
 import co.cask.cdap.etl.batch.TransformExecutorFactory;
 import co.cask.cdap.etl.common.Constants;
-import co.cask.cdap.etl.common.PipelinePhase;
 import co.cask.cdap.etl.common.TransformExecutor;
 import co.cask.cdap.etl.common.TransformResponse;
 import com.google.common.collect.ImmutableSet;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlan.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlan.java
@@ -42,6 +42,10 @@ public class PipelinePlan {
     return phases;
   }
 
+  public PipelinePhase getPhase(String name) {
+    return phases.get(name);
+  }
+
   public Set<Connection> getPhaseConnections() {
     return phaseConnections;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -242,9 +242,6 @@ public class PipelineSpecGenerator {
       }
       stages.put(stageName, new StageConnections(stage, stageInputs, stageOutputs));
     }
-    if (dag.getSources().size() > 1) {
-      throw new IllegalArgumentException("Multiple sources are not allowed at this time.");
-    }
 
     List<StageConnections> traversalOrder = new ArrayList<>(stages.size());
     for (String stageName : dag.getTopologicalOrder()) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2016 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap-etl</artifactId>
+    <version>3.4.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cdap-etl-data-pipeline</artifactId>
+  <name>CDAP Data Pipeline Application</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <app.main.class>co.cask.cdap.etl.datapipeline.DataPipelineApp</app.main.class>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-batch</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>2.3.7</version>
+          <extensions>true</extensions>
+          <configuration>
+            <archive>
+              <manifest>
+                <mainClass>${app.main.class}</mainClass>
+              </manifest>
+            </archive>
+            <instructions>
+              <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+              <Embed-Transitive>true</Embed-Transitive>
+              <Embed-Directory>lib</Embed-Directory>
+              <_exportcontents>co.cask.cdap.etl.api.*;org.apache.avro.*</_exportcontents>
+            </instructions>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>bundle</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/BranchProgramAdder.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/BranchProgramAdder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.datapipeline;
+
+import co.cask.cdap.api.workflow.WorkflowForkConfigurer;
+
+/**
+ * Adds programs on a workflow branch.
+ */
+public class BranchProgramAdder implements WorkflowProgramAdder {
+  private final WorkflowForkConfigurer forkConfigurer;
+
+  public BranchProgramAdder(WorkflowForkConfigurer forkConfigurer) {
+    this.forkConfigurer = forkConfigurer;
+  }
+
+  @Override
+  public void addMapReduce(String name) {
+    forkConfigurer.addMapReduce(name);
+  }
+
+  @Override
+  public void addSpark(String name) {
+    forkConfigurer.addSpark(name);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/DataPipelineApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/DataPipelineApp.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.datapipeline;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.api.schedule.Schedules;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.batch.BatchAggregator;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.planner.PipelinePlan;
+import co.cask.cdap.etl.planner.PipelinePlanner;
+import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
+import co.cask.cdap.etl.spec.PipelineSpec;
+import co.cask.cdap.etl.spec.PipelineSpecGenerator;
+import com.google.common.collect.ImmutableSet;
+import org.apache.avro.mapreduce.AvroKeyInputFormat;
+import org.apache.avro.mapreduce.AvroKeyOutputFormat;
+
+import java.util.Set;
+
+/**
+ * ETL Data Pipeline Application.
+ */
+public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
+  public static final String SCHEDULE_NAME = "dataPipelineSchedule";
+  public static final String DEFAULT_DESCRIPTION = "Data Pipeline Application";
+  private static final Set<String> supportedPluginTypes = ImmutableSet.of(
+    BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE, Transform.PLUGIN_TYPE,
+    Constants.CONNECTOR_TYPE, BatchAggregator.PLUGIN_TYPE);
+
+  @Override
+  public void configure() {
+    ETLBatchConfig config = getConfig();
+    setDescription(DEFAULT_DESCRIPTION);
+
+    PipelineSpecGenerator specGenerator =
+      new PipelineSpecGenerator(getConfigurer(), BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE,
+                                TimePartitionedFileSet.class,
+                                FileSetProperties.builder()
+                                  .setInputFormat(AvroKeyInputFormat.class)
+                                  .setOutputFormat(AvroKeyOutputFormat.class)
+                                  .setEnableExploreOnCreate(true)
+                                  .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
+                                  .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
+                                  .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
+                                  .setTableProperty("avro.schema.literal", Constants.ERROR_SCHEMA.toString())
+                                  .build());
+    PipelineSpec spec = specGenerator.generateSpec(config);
+
+    PipelinePlanner planner = new PipelinePlanner(supportedPluginTypes, ImmutableSet.of("aggregator"));
+    PipelinePlan plan = planner.plan(spec);
+
+    addWorkflow(new SmartWorkflow(spec, plan, getConfigurer()));
+    scheduleWorkflow(Schedules.builder(SCHEDULE_NAME)
+                       .setDescription("Data pipeline schedule")
+                       .createTimeSchedule(config.getSchedule()),
+                     SmartWorkflow.NAME);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/SmartWorkflow.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.datapipeline;
+
+import co.cask.cdap.api.app.ApplicationConfigurer;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+import co.cask.cdap.api.workflow.WorkflowConfigurer;
+import co.cask.cdap.api.workflow.WorkflowForkConfigurer;
+import co.cask.cdap.etl.batch.BatchPhaseSpec;
+import co.cask.cdap.etl.batch.connector.ConnectorSource;
+import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
+import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.PipelinePhase;
+import co.cask.cdap.etl.planner.ControlDag;
+import co.cask.cdap.etl.planner.PipelinePlan;
+import co.cask.cdap.etl.planner.StageInfo;
+import co.cask.cdap.etl.spec.PipelineSpec;
+import co.cask.cdap.internal.io.SchemaTypeAdapter;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Data Pipeline Smart Workflow.
+ */
+public class SmartWorkflow extends AbstractWorkflow {
+  public static final String NAME = "DataPipelineWorkflow";
+  public static final String DESCRIPTION = "Data Pipeline Workflow";
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter()).create();
+
+  private final PipelineSpec spec;
+  private final ControlDag dag;
+  private final PipelinePlan plan;
+  private final ApplicationConfigurer applicationConfigurer;
+  // connector stage -> local dataset name
+  private final Map<String, String> connectorDatasets;
+  private int phaseNum;
+
+  public SmartWorkflow(PipelineSpec spec, PipelinePlan plan, ApplicationConfigurer applicationConfigurer) {
+    this.spec = spec;
+    this.plan = plan;
+    this.applicationConfigurer = applicationConfigurer;
+    this.phaseNum = 1;
+    this.dag = new ControlDag(plan.getPhaseConnections());
+    this.dag.flatten();
+    this.connectorDatasets = new HashMap<>();
+  }
+
+  @Override
+  protected void configure() {
+    setName(NAME);
+    setDescription(DESCRIPTION);
+
+    // set the pipeline spec as a property in case somebody like the UI wants to read it
+    Map<String, String> properties = new HashMap<>();
+    properties.put("pipeline.spec", GSON.toJson(spec));
+    setProperties(properties);
+
+    // after flattening, there is guaranteed to be just one source
+    String start = dag.getSources().iterator().next();
+    addPrograms(start, getConfigurer());
+  }
+
+  private void addPrograms(String node, WorkflowConfigurer configurer) {
+    addProgram(node, new TrunkProgramAdder(configurer));
+
+    Set<String> outputs = dag.getNodeOutputs(node);
+    if (outputs.isEmpty()) {
+      return;
+    }
+
+    // if this is a fork
+    if (outputs.size() > 1) {
+      WorkflowForkConfigurer<? extends WorkflowConfigurer> forkConfigurer = configurer.fork();
+      for (String output : outputs) {
+        // need to make sure we don't call also() if this is the final branch
+        if (!addBranchPrograms(output, forkConfigurer)) {
+          forkConfigurer = forkConfigurer.also();
+        }
+      }
+    } else {
+      addPrograms(outputs.iterator().next(), configurer);
+    }
+  }
+
+  // returns whether this is the final branch of the fork
+  private boolean addBranchPrograms(String node, WorkflowForkConfigurer<? extends WorkflowConfigurer> forkConfigurer) {
+    // if this is a join node
+    Set<String> inputs = dag.getNodeInputs(node);
+    if (dag.getNodeInputs(node).size() > 1) {
+      // if we've reached the join from the final branch of the fork
+      if (dag.visit(node) == inputs.size()) {
+        // join the fork and continue on
+        addPrograms(node, forkConfigurer.join());
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    // a flattened control dag guarantees that if this is not a join node, there is exactly one output
+    addProgram(node, new BranchProgramAdder(forkConfigurer));
+    return addBranchPrograms(dag.getNodeOutputs(node).iterator().next(), forkConfigurer);
+  }
+
+  private void addProgram(String phaseName, WorkflowProgramAdder programAdder) {
+    PipelinePhase phase = plan.getPhase(phaseName);
+    // if the origin plan didn't have this name, it means it is a join node
+    // artificially added by the control dag flattening process. So nothing to add, skip it
+    if (phase == null) {
+      return;
+    }
+
+    // can't use phase name as a program name because it might contain invalid characters
+    String programName = "phase-" + phaseNum;
+    phaseNum++;
+    // TODO: add support for other program types based on the plugin types in the phase
+
+    // if this phase uses connectors, add the local dataset for that connector if we haven't already
+    for (StageInfo connectorInfo : phase.getStagesOfType(Constants.CONNECTOR_TYPE)) {
+      String connectorName = connectorInfo.getName();
+      String datasetName = connectorDatasets.get(connectorName);
+      if (datasetName == null) {
+        datasetName = UUID.randomUUID().toString();
+        connectorDatasets.put(connectorName, datasetName);
+        // add the local dataset
+        ConnectorSource connectorSource = new ConnectorSource(datasetName, null);
+        connectorSource.configure(getConfigurer());
+      }
+    }
+
+    Map<String, String> phaseConnectorDatasets = new HashMap<>();
+    for (StageInfo connectorStage : phase.getStagesOfType(Constants.CONNECTOR_TYPE)) {
+      phaseConnectorDatasets.put(connectorStage.getName(), connectorDatasets.get(connectorStage.getName()));
+    }
+    BatchPhaseSpec batchPhaseSpec = new BatchPhaseSpec(programName, phase, spec.getResources(),
+                                                       spec.isStageLoggingEnabled(), phaseConnectorDatasets);
+    applicationConfigurer.addMapReduce(new ETLMapReduce(batchPhaseSpec));
+    programAdder.addMapReduce(programName);
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/TrunkProgramAdder.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/TrunkProgramAdder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.datapipeline;
+
+import co.cask.cdap.api.workflow.WorkflowConfigurer;
+
+/**
+ * Adds programs on the workflow trunk.
+ */
+public class TrunkProgramAdder implements WorkflowProgramAdder {
+  private final WorkflowConfigurer configurer;
+
+  public TrunkProgramAdder(WorkflowConfigurer configurer) {
+    this.configurer = configurer;
+  }
+
+  @Override
+  public void addMapReduce(String name) {
+    configurer.addMapReduce(name);
+  }
+
+  @Override
+  public void addSpark(String name) {
+    configurer.addSpark(name);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/WorkflowProgramAdder.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/WorkflowProgramAdder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.datapipeline;
+
+import co.cask.cdap.api.workflow.WorkflowConfigurer;
+import co.cask.cdap.api.workflow.WorkflowForkConfigurer;
+
+/**
+ * Adds workflow programs.
+ * This is required because {@link WorkflowForkConfigurer} doesn't extend {@link WorkflowConfigurer}.
+ */
+public interface WorkflowProgramAdder {
+
+  void addMapReduce(String name);
+
+  void addSpark(String name);
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/DataPipelineTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.datapipeline;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.etl.api.PipelineConfigurable;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.datapipeline.mock.IdentityTransform;
+import co.cask.cdap.etl.datapipeline.mock.MockSink;
+import co.cask.cdap.etl.datapipeline.mock.MockSource;
+import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
+import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
+import co.cask.cdap.test.WorkflowManager;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ */
+public class DataPipelineTest extends TestBase {
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
+  protected static final Id.Artifact APP_ARTIFACT_ID = Id.Artifact.from(Id.Namespace.DEFAULT, "datapipeline", "3.4.0");
+  protected static final ArtifactSummary ETLBATCH_ARTIFACT = new ArtifactSummary("datapipeline", "3.4.0");
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    // add the artifact for etl batch app
+    addAppArtifact(APP_ARTIFACT_ID, DataPipelineApp.class,
+                   BatchSource.class.getPackage().getName(),
+                   PipelineConfigurable.class.getPackage().getName());
+
+    // add some test plugins
+    addPluginArtifact(Id.Artifact.from(Id.Namespace.DEFAULT, "test-plugins", "1.0.0"), APP_ARTIFACT_ID,
+                      MockSource.class, MockSink.class, IdentityTransform.class);
+  }
+
+  @Test
+  public void testMultiSource() throws Exception {
+    /*
+     * source1 --|                 |--> sink1
+     *           |--> transform1 --|
+     * source2 --|                 |
+     *                             |--> transform2 --> sink2
+     * source3 --------------------|
+     */
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source1", MockSource.getPlugin("msInput1")))
+      .addStage(new ETLStage("source2", MockSource.getPlugin("msInput2")))
+      .addStage(new ETLStage("source3", MockSource.getPlugin("msInput3")))
+      .addStage(new ETLStage("transform1", IdentityTransform.getPlugin()))
+      .addStage(new ETLStage("transform2", IdentityTransform.getPlugin()))
+      .addStage(new ETLStage("sink1", MockSink.getPlugin("msOutput1")))
+      .addStage(new ETLStage("sink2", MockSink.getPlugin("msOutput2")))
+      .addConnection("source1", "transform1")
+      .addConnection("source2", "transform1")
+      .addConnection("transform1", "sink1")
+      .addConnection("transform1", "transform2")
+      .addConnection("transform2", "sink2")
+      .addConnection("source3", "transform2")
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "MultiSourceApp");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    Schema schema = Schema.recordOf(
+      "testRecord",
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING))
+    );
+
+    StructuredRecord recordSamuel = StructuredRecord.builder(schema).set("name", "samuel").build();
+    StructuredRecord recordBob = StructuredRecord.builder(schema).set("name", "bob").build();
+    StructuredRecord recordJane = StructuredRecord.builder(schema).set("name", "jane").build();
+
+    // write one record to each source
+    DataSetManager<Table> inputManager = getDataset(Id.Namespace.DEFAULT, "msInput1");
+    MockSource.writeInput(inputManager, ImmutableList.of(recordSamuel));
+    inputManager = getDataset(Id.Namespace.DEFAULT, "msInput2");
+    MockSource.writeInput(inputManager, ImmutableList.of(recordBob));
+    inputManager = getDataset(Id.Namespace.DEFAULT, "msInput3");
+    MockSource.writeInput(inputManager, ImmutableList.of(recordJane));
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    // sink1 should get records from source1 and source2
+    DataSetManager<Table> sinkManager = getDataset("msOutput1");
+    Set<StructuredRecord> expected = ImmutableSet.of(recordSamuel, recordBob);
+    Set<StructuredRecord> actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
+    Assert.assertEquals(expected, actual);
+
+    // sink2 should get all records
+    sinkManager = getDataset("msOutput2");
+    expected = ImmutableSet.of(recordSamuel, recordBob, recordJane);
+    actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/mock/IdentityTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/mock/IdentityTransform.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.datapipeline.mock;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
+import co.cask.cdap.etl.api.Transform;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Identity transform for testing.
+ */
+@Plugin(type = Transform.PLUGIN_TYPE)
+@Name("Identity")
+public class IdentityTransform extends Transform<StructuredRecord, StructuredRecord> {
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+    stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
+    emitter.emit(input);
+  }
+
+  public static co.cask.cdap.etl.proto.v2.ETLPlugin getPlugin() {
+    Map<String, String> properties = new HashMap<>();
+    return new co.cask.cdap.etl.proto.v2.ETLPlugin("Identity", Transform.PLUGIN_TYPE, properties, null);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/mock/MockSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/mock/MockSink.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.datapipeline.mock;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.format.StructuredRecordStringConverter;
+import co.cask.cdap.test.DataSetManager;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Mock sink that writes records to a Table and has a utility method for getting all records written.
+ */
+@Plugin(type = BatchSink.PLUGIN_TYPE)
+@Name("Mock")
+public class MockSink extends BatchSink<StructuredRecord, byte[], Put> {
+  private static final byte[] SCHEMA_COL = Bytes.toBytes("s");
+  private static final byte[] RECORD_COL = Bytes.toBytes("r");
+  private final Config config;
+
+  public MockSink(Config config) {
+    this.config = config;
+  }
+
+  public static class Config extends PluginConfig {
+    private String tableName;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.createDataset(config.tableName, Table.class);
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) throws Exception {
+    context.addOutput(config.tableName);
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<KeyValue<byte[], Put>> emitter) throws Exception {
+    byte[] rowkey = Bytes.toBytes(UUID.randomUUID());
+    Put put = new Put(rowkey);
+    put.add(SCHEMA_COL, input.getSchema().toString());
+    put.add(RECORD_COL, StructuredRecordStringConverter.toJsonString(input));
+    emitter.emit(new KeyValue<>(rowkey, put));
+  }
+
+  public static co.cask.cdap.etl.proto.v2.ETLPlugin getPlugin(String tableName) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("tableName", tableName);
+    return new co.cask.cdap.etl.proto.v2.ETLPlugin("Mock", BatchSink.PLUGIN_TYPE, properties, null);
+  }
+
+  /**
+   * Used to read the records written by this sink.
+   *
+   * @param tableManager dataset manager used to get the sink dataset to read from
+   */
+  public static List<StructuredRecord> readOutput(DataSetManager<Table> tableManager) throws Exception {
+    Table table = tableManager.get();
+
+    Scanner scanner = table.scan(null, null);
+    try {
+      List<StructuredRecord> records = new ArrayList<>();
+      Row row;
+      while ((row = scanner.next()) != null) {
+        Schema schema = Schema.parseJson(row.getString(SCHEMA_COL));
+        String recordStr = row.getString(RECORD_COL);
+        records.add(StructuredRecordStringConverter.fromJsonString(recordStr, schema));
+      }
+      return records;
+    } finally {
+      scanner.close();
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/mock/MockSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/mock/MockSource.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.datapipeline.mock;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.format.StructuredRecordStringConverter;
+import co.cask.cdap.test.DataSetManager;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Mock source that can be used to write a list of records in a Table and reads them out in a pipeline run.
+ */
+@Plugin(type = BatchSource.PLUGIN_TYPE)
+@Name("Mock")
+public class MockSource extends BatchSource<byte[], Row, StructuredRecord> {
+  private static final byte[] SCHEMA_COL = Bytes.toBytes("s");
+  private static final byte[] RECORD_COL = Bytes.toBytes("r");
+  private final Config config;
+
+  public MockSource(Config config) {
+    this.config = config;
+  }
+
+  public static class Config extends PluginConfig {
+    private String tableName;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.createDataset(config.tableName, Table.class);
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+  }
+
+  @Override
+  public void transform(KeyValue<byte[], Row> input, Emitter<StructuredRecord> emitter) throws Exception {
+    Schema schema = Schema.parseJson(input.getValue().getString(SCHEMA_COL));
+    String recordStr = input.getValue().getString(RECORD_COL);
+    emitter.emit(StructuredRecordStringConverter.fromJsonString(recordStr, schema));
+  }
+
+  @Override
+  public void prepareRun(BatchSourceContext context) throws Exception {
+    context.setInput(config.tableName);
+  }
+
+  public static co.cask.cdap.etl.proto.v2.ETLPlugin getPlugin(String tableName) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("tableName", tableName);
+    return new co.cask.cdap.etl.proto.v2.ETLPlugin("Mock", BatchSource.PLUGIN_TYPE, properties, null);
+  }
+
+  /**
+   * Used to write the input records for the pipeline run. Should be called after the pipeline has been created.
+   *
+   * @param tableManager dataset manager used to write to the source dataset
+   * @param records records that should be the input for the pipeline
+   */
+  public static void writeInput(DataSetManager<Table> tableManager, List<StructuredRecord> records) throws Exception {
+    tableManager.flush();
+    Table table = tableManager.get();
+    // write each record as a separate row, with the serialized record as one column and schema as another
+    // each rowkey will be a UUID.
+    for (StructuredRecord record : records) {
+      byte[] row = Bytes.toBytes(UUID.randomUUID());
+      table.put(row, SCHEMA_COL, Bytes.toBytes(record.getSchema().toString()));
+      table.put(row, RECORD_COL, Bytes.toBytes(StructuredRecordStringConverter.toJsonString(record)));
+    }
+    tableManager.flush();
+  }
+}

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -31,11 +31,12 @@
 
   <modules>
     <module>cdap-etl-api</module>
+    <module>cdap-etl-archetypes</module>
     <module>cdap-etl-batch</module>
     <module>cdap-etl-core</module>
-    <module>cdap-etl-realtime</module>
-    <module>cdap-etl-archetypes</module>
+    <module>cdap-etl-data-pipeline</module>
     <module>cdap-etl-proto</module>
+    <module>cdap-etl-realtime</module>
     <module>cdap-etl-tools</module>
   </modules>
 


### PR DESCRIPTION
Add the application for data pipeline. The app will use the
pipeline planner to break up a logical pipeline into physical
phases. Each phase is a program with its own source(s), transforms,
and sink(s). Phases are connected through local datasets.