### PR TITLE
Refactored the WorkflowDriver code to move execution of the Custom actions in separate class.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowAction.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowAction.java
@@ -50,7 +50,7 @@ public interface WorkflowAction extends Runnable {
   void initialize(WorkflowContext context) throws Exception;
 
   /**
-   * This method is called after the {@link #run} method completes and it can be used for resource cleanup. 
+   * This method is called after the {@link #run} method completes and it can be used for resource cleanup.
    * Any exception thrown only gets logged but does not affect execution of the {@link Workflow}.
    */
   void destroy();

--- a/cdap-api/src/main/java/co/cask/cdap/internal/workflow/ProgramWorkflowAction.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/workflow/ProgramWorkflowAction.java
@@ -37,7 +37,6 @@ public final class ProgramWorkflowAction extends AbstractWorkflowAction {
   public static final String PROGRAM_TYPE = "ProgramType";
 
   private String programName;
-  private Runnable programRunner;
   private SchedulableProgramType programType;
 
   public ProgramWorkflowAction(String programName, SchedulableProgramType programType) {
@@ -57,23 +56,10 @@ public final class ProgramWorkflowAction extends AbstractWorkflowAction {
   }
 
   @Override
-  public void initialize(WorkflowContext context) throws Exception {
-    programName = context.getSpecification().getProperties().get(PROGRAM_NAME);
-    if (programName == null) {
-      throw new IllegalArgumentException("No Program name provided.");
-    }
-
-    programRunner = context.getProgramRunner(programName);
-    programType = context.getSpecification().getProperties().containsKey(PROGRAM_TYPE) ?
-      SchedulableProgramType.valueOf(context.getSpecification().getProperties().get(PROGRAM_TYPE)) : null;
-
-    LOG.info("Initialized for {} Program {} in workflow action",
-             programType != null ? programType.name() : null, programName);
-  }
-
-  @Override
   public void run() {
     try {
+      String programName = getContext().getSpecification().getProperties().get(PROGRAM_NAME);
+      Runnable programRunner = getContext().getProgramRunner(programName);
       LOG.info("Starting Program for workflow action: {}", programName);
       programRunner.run();
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/CustomActionExecutor.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/CustomActionExecutor.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.workflow;
+
+import co.cask.cdap.api.workflow.WorkflowAction;
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.common.lang.CombineClassLoader;
+import co.cask.cdap.common.lang.InstantiatorFactory;
+import co.cask.cdap.common.lang.PropertyFieldSetter;
+import co.cask.cdap.internal.app.runtime.DataSetFieldSetter;
+import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
+import co.cask.cdap.internal.lang.Reflections;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.tephra.TransactionContext;
+import co.cask.tephra.TransactionFailureException;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Execute the custom action in the Workflow.
+ */
+public class CustomActionExecutor {
+  private static final Logger LOG = LoggerFactory.getLogger(CustomActionExecutor.class);
+  private final ProgramRunId workflowRunId;
+  private final BasicWorkflowContext workflowContext;
+  private final WorkflowAction action;
+
+  /**
+   * Creates instance which will be used to initialize, run, and destroy the custom action.
+   * @param workflowRunId the Workflow run which started the execution of this custom action.
+   * @param workflowContext an instance of context
+   * @param instantiator to instantiates the custom action class
+   * @param classLoader used to load the custom action class
+   * @throws Exception when failed to instantiate the custom action
+   */
+  public CustomActionExecutor(ProgramRunId workflowRunId, BasicWorkflowContext workflowContext,
+                              InstantiatorFactory instantiator, ClassLoader classLoader) throws Exception {
+    this.workflowRunId = workflowRunId;
+    this.workflowContext = workflowContext;
+    this.action = createAction(workflowContext, instantiator, classLoader);
+  }
+
+  @SuppressWarnings("unchecked")
+  private WorkflowAction createAction(BasicWorkflowContext context, InstantiatorFactory instantiator,
+                                      ClassLoader classLoader) throws Exception {
+    Class<?> clz = Class.forName(context.getSpecification().getClassName(), true, classLoader);
+    Preconditions.checkArgument(WorkflowAction.class.isAssignableFrom(clz), "%s is not a WorkflowAction.", clz);
+    WorkflowAction action = instantiator.get(TypeToken.of((Class<? extends WorkflowAction>) clz)).create();
+    Reflections.visit(action, action.getClass(),
+                      new PropertyFieldSetter(context.getSpecification().getProperties()),
+                      new DataSetFieldSetter(context),
+                      new MetricsFieldSetter(context.getMetrics()));
+    return action;
+  }
+
+  void execute() throws Exception {
+    ClassLoader oldClassLoader = setContextCombinedClassLoader(action);
+    try {
+      initializeInTransaction();
+      runInTransaction();
+    } finally {
+      destroyInTransaction();
+      ClassLoaders.setContextClassLoader(oldClassLoader);
+    }
+  }
+
+  private void initializeInTransaction() throws Exception {
+    TransactionContext txContext = workflowContext.getDatasetCache().newTransactionContext();
+    txContext.start();
+    try {
+      action.initialize(workflowContext);
+      txContext.finish();
+    } catch (TransactionFailureException e) {
+      txContext.abort(e);
+    } catch (Throwable t) {
+      txContext.abort(new TransactionFailureException("Transaction function failure for transaction. ", t));
+    }
+  }
+
+  private void runInTransaction() throws Exception {
+    TransactionContext txContext = workflowContext.getDatasetCache().newTransactionContext();
+    txContext.start();
+    try {
+      action.run();
+      txContext.finish();
+    } catch (TransactionFailureException e) {
+      txContext.abort(e);
+    } catch (Throwable t) {
+      txContext.abort(new TransactionFailureException("Transaction function failure for transaction. ", t));
+    }
+  }
+
+  private void destroyInTransaction() {
+    TransactionContext txContext = workflowContext.getDatasetCache().newTransactionContext();
+    try {
+      txContext.start();
+      try {
+        action.destroy();
+        txContext.finish();
+      } catch (TransactionFailureException e) {
+        txContext.abort(e);
+      } catch (Throwable t) {
+        txContext.abort(new TransactionFailureException("Transaction function failure for transaction. ", t));
+      }
+    } catch (Throwable t) {
+      LOG.error("Failed to execute the destroy method on action {} for Workflow run {}",
+                workflowContext.getSpecification().getName(), workflowRunId, t);
+    }
+  }
+
+  private ClassLoader setContextCombinedClassLoader(WorkflowAction action) {
+    return ClassLoaders.setContextClassLoader(
+      new CombineClassLoader(null, ImmutableList.of(action.getClass().getClassLoader(), getClass().getClassLoader())));
+  }
+}


### PR DESCRIPTION
Moved execution of the custom action to separate class.
This is done because custom action lifecycle methods - `initialize`, `run`, and `destroy` runs in transaction and they are executed on the Workflow driver side. While program lifecycle methods are handled by respective program runners such as `MapReduceProgramRunner` and `SparkProgramRunner`. We wrap the program under `ProgramWorkflowAction`, however `run` method of it does not really need to be executed in transaction. 
