### PR TITLE
Removes devDependencies from shrinkwrap to install production dependencies alone

### DIFF
--- a/cdap-ui/npm-shrinkwrap.json
+++ b/cdap-ui/npm-shrinkwrap.json
@@ -1,4528 +1,114 @@
 {
   "name": "cdap-ui",
   "version": "3.4.0-SNAPSHOT",
-  "npm-shrinkwrap-version": "5.4.1",
-  "node-version": "v0.12.0",
   "dependencies": {
-    "autoprefixer": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.2.tgz",
-      "dependencies": {
-        "browserslist": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.1.3.tgz"
-        },
-        "caniuse-db": {
-          "version": "1.0.30000430",
-          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000430.tgz"
-        },
-        "normalize-range": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
-        },
-        "num2fraction": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-        },
-        "postcss": {
-          "version": "5.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
-          "dependencies": {
-            "js-base64": {
-              "version": "2.1.9",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            },
-            "supports-color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "postcss-value-parser": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-        }
-      }
-    },
-    "babel-preset-es2015": {
-      "version": "6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.3.13.tgz",
-      "dependencies": {
-        "babel-plugin-check-es2015-constants": {
-          "version": "6.7.2",
-          "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.7.2.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-arrow-functions": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.5.2.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-block-scoped-functions": {
-          "version": "6.6.5",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.6.5.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.7.1.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            },
-            "babel-template": {
-              "version": "6.7.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.7.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                }
-              }
-            },
-            "babel-traverse": {
-              "version": "6.7.3",
-              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-              "dependencies": {
-                "babel-code-frame": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                          "dependencies": {
-                            "color-convert": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                    },
-                    "line-numbers": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                      "dependencies": {
-                        "left-pad": {
-                          "version": "0.0.3",
-                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                },
-                "babylon": {
-                  "version": "6.7.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "8.18.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "repeating": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                }
-              }
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-classes": {
-          "version": "6.6.5",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.6.5.tgz",
-          "dependencies": {
-            "babel-helper-define-map": {
-              "version": "6.6.5",
-              "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.6.5.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                }
-              }
-            },
-            "babel-helper-function-name": {
-              "version": "6.6.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.6.0.tgz",
-              "dependencies": {
-                "babel-helper-get-function-arity": {
-                  "version": "6.6.5",
-                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz"
-                }
-              }
-            },
-            "babel-helper-optimise-call-expression": {
-              "version": "6.6.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.6.0.tgz"
-            },
-            "babel-helper-replace-supers": {
-              "version": "6.7.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.7.0.tgz"
-            },
-            "babel-messages": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            },
-            "babel-template": {
-              "version": "6.7.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.7.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                }
-              }
-            },
-            "babel-traverse": {
-              "version": "6.7.3",
-              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-              "dependencies": {
-                "babel-code-frame": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                          "dependencies": {
-                            "color-convert": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                    },
-                    "line-numbers": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                      "dependencies": {
-                        "left-pad": {
-                          "version": "0.0.3",
-                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babylon": {
-                  "version": "6.7.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "8.18.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "repeating": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-computed-properties": {
-          "version": "6.6.5",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.6.5.tgz",
-          "dependencies": {
-            "babel-helper-define-map": {
-              "version": "6.6.5",
-              "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.6.5.tgz",
-              "dependencies": {
-                "babel-helper-function-name": {
-                  "version": "6.6.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.6.0.tgz",
-                  "dependencies": {
-                    "babel-helper-get-function-arity": {
-                      "version": "6.6.5",
-                      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz"
-                    },
-                    "babel-traverse": {
-                      "version": "6.7.3",
-                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-                      "dependencies": {
-                        "babel-code-frame": {
-                          "version": "6.7.2",
-                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                                  "dependencies": {
-                                    "color-convert": {
-                                      "version": "1.0.0",
-                                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "esutils": {
-                              "version": "2.0.2",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            },
-                            "line-numbers": {
-                              "version": "0.2.0",
-                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                              "dependencies": {
-                                "left-pad": {
-                                  "version": "0.0.3",
-                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babel-messages": {
-                          "version": "6.7.2",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                        },
-                        "babylon": {
-                          "version": "6.7.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                        },
-                        "debug": {
-                          "version": "2.2.0",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                          "dependencies": {
-                            "ms": {
-                              "version": "0.7.1",
-                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                            }
-                          }
-                        },
-                        "globals": {
-                          "version": "8.18.0",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.1",
-                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                          "dependencies": {
-                            "loose-envify": {
-                              "version": "1.1.0",
-                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                              "dependencies": {
-                                "js-tokens": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "repeating": {
-                          "version": "1.1.3",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-                  "dependencies": {
-                    "babel-traverse": {
-                      "version": "6.7.3",
-                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-                      "dependencies": {
-                        "babel-code-frame": {
-                          "version": "6.7.2",
-                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                                  "dependencies": {
-                                    "color-convert": {
-                                      "version": "1.0.0",
-                                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            },
-                            "line-numbers": {
-                              "version": "0.2.0",
-                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                              "dependencies": {
-                                "left-pad": {
-                                  "version": "0.0.3",
-                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babel-messages": {
-                          "version": "6.7.2",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                        },
-                        "babylon": {
-                          "version": "6.7.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                        },
-                        "debug": {
-                          "version": "2.2.0",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                          "dependencies": {
-                            "ms": {
-                              "version": "0.7.1",
-                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                            }
-                          }
-                        },
-                        "globals": {
-                          "version": "8.18.0",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.1",
-                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                          "dependencies": {
-                            "loose-envify": {
-                              "version": "1.1.0",
-                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                              "dependencies": {
-                                "js-tokens": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "repeating": {
-                          "version": "1.1.3",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            },
-            "babel-template": {
-              "version": "6.7.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
-              "dependencies": {
-                "babel-traverse": {
-                  "version": "6.7.3",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                              "dependencies": {
-                                "color-convert": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        },
-                        "line-numbers": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                          "dependencies": {
-                            "left-pad": {
-                              "version": "0.0.3",
-                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "8.18.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                    }
-                  }
-                },
-                "babylon": {
-                  "version": "6.7.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-          "version": "6.6.5",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.6.5.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-for-of": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.6.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-function-name": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.5.0.tgz",
-          "dependencies": {
-            "babel-helper-function-name": {
-              "version": "6.6.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.6.0.tgz",
-              "dependencies": {
-                "babel-helper-get-function-arity": {
-                  "version": "6.6.5",
-                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz"
-                },
-                "babel-template": {
-                  "version": "6.7.0",
-                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
-                  "dependencies": {
-                    "babylon": {
-                      "version": "6.7.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                    },
-                    "lodash": {
-                      "version": "3.10.1",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                    }
-                  }
-                },
-                "babel-traverse": {
-                  "version": "6.7.3",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                              "dependencies": {
-                                "color-convert": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        },
-                        "line-numbers": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                          "dependencies": {
-                            "left-pad": {
-                              "version": "0.0.3",
-                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                    },
-                    "babylon": {
-                      "version": "6.7.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "8.18.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "lodash": {
-                      "version": "3.10.1",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-              "dependencies": {
-                "babel-traverse": {
-                  "version": "6.7.3",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                              "dependencies": {
-                                "color-convert": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        },
-                        "line-numbers": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                          "dependencies": {
-                            "left-pad": {
-                              "version": "0.0.3",
-                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                    },
-                    "babylon": {
-                      "version": "6.7.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "8.18.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-literals": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.5.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.7.0.tgz",
-          "dependencies": {
-            "babel-plugin-transform-strict-mode": {
-              "version": "6.6.5",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.6.5.tgz"
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            },
-            "babel-template": {
-              "version": "6.7.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
-              "dependencies": {
-                "babel-traverse": {
-                  "version": "6.7.3",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                              "dependencies": {
-                                "color-convert": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        },
-                        "line-numbers": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                          "dependencies": {
-                            "left-pad": {
-                              "version": "0.0.3",
-                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "8.18.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babylon": {
-                  "version": "6.7.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-              "dependencies": {
-                "babel-traverse": {
-                  "version": "6.7.3",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                              "dependencies": {
-                                "color-convert": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        },
-                        "line-numbers": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                          "dependencies": {
-                            "left-pad": {
-                              "version": "0.0.3",
-                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                    },
-                    "babylon": {
-                      "version": "6.7.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "8.18.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-object-super": {
-          "version": "6.6.5",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.6.5.tgz",
-          "dependencies": {
-            "babel-helper-replace-supers": {
-              "version": "6.7.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.7.0.tgz",
-              "dependencies": {
-                "babel-helper-optimise-call-expression": {
-                  "version": "6.6.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.6.0.tgz"
-                },
-                "babel-messages": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                },
-                "babel-template": {
-                  "version": "6.7.0",
-                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
-                  "dependencies": {
-                    "babylon": {
-                      "version": "6.7.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                    },
-                    "lodash": {
-                      "version": "3.10.1",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                    }
-                  }
-                },
-                "babel-traverse": {
-                  "version": "6.7.3",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                              "dependencies": {
-                                "color-convert": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        },
-                        "line-numbers": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                          "dependencies": {
-                            "left-pad": {
-                              "version": "0.0.3",
-                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babylon": {
-                      "version": "6.7.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "8.18.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "lodash": {
-                      "version": "3.10.1",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "lodash": {
-                      "version": "3.10.1",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-parameters": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.7.0.tgz",
-          "dependencies": {
-            "babel-helper-call-delegate": {
-              "version": "6.6.5",
-              "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.6.5.tgz",
-              "dependencies": {
-                "babel-helper-hoist-variables": {
-                  "version": "6.6.5",
-                  "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.6.5.tgz"
-                }
-              }
-            },
-            "babel-helper-get-function-arity": {
-              "version": "6.6.5",
-              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz"
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            },
-            "babel-template": {
-              "version": "6.7.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.7.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                }
-              }
-            },
-            "babel-traverse": {
-              "version": "6.7.3",
-              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-              "dependencies": {
-                "babel-code-frame": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                          "dependencies": {
-                            "color-convert": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                    },
-                    "line-numbers": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                      "dependencies": {
-                        "left-pad": {
-                          "version": "0.0.3",
-                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                },
-                "babylon": {
-                  "version": "6.7.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "8.18.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "repeating": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.5.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-              "dependencies": {
-                "babel-traverse": {
-                  "version": "6.7.3",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                              "dependencies": {
-                                "color-convert": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        },
-                        "line-numbers": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                          "dependencies": {
-                            "left-pad": {
-                              "version": "0.0.3",
-                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                    },
-                    "babylon": {
-                      "version": "6.7.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "8.18.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-spread": {
-          "version": "6.6.5",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.6.5.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-sticky-regex": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.5.0.tgz",
-          "dependencies": {
-            "babel-helper-regex": {
-              "version": "6.6.5",
-              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.6.5.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-              "dependencies": {
-                "babel-traverse": {
-                  "version": "6.7.3",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                              "dependencies": {
-                                "color-convert": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        },
-                        "line-numbers": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                          "dependencies": {
-                            "left-pad": {
-                              "version": "0.0.3",
-                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.7.2",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                    },
-                    "babylon": {
-                      "version": "6.7.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "8.18.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-template-literals": {
-          "version": "6.6.5",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.6.5.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.6.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-unicode-regex": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.5.0.tgz",
-          "dependencies": {
-            "babel-helper-regex": {
-              "version": "6.6.5",
-              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.6.5.tgz",
-              "dependencies": {
-                "babel-types": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-                  "dependencies": {
-                    "babel-traverse": {
-                      "version": "6.7.3",
-                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-                      "dependencies": {
-                        "babel-code-frame": {
-                          "version": "6.7.2",
-                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                                  "dependencies": {
-                                    "color-convert": {
-                                      "version": "1.0.0",
-                                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            },
-                            "line-numbers": {
-                              "version": "0.2.0",
-                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                              "dependencies": {
-                                "left-pad": {
-                                  "version": "0.0.3",
-                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babel-messages": {
-                          "version": "6.7.2",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                        },
-                        "babylon": {
-                          "version": "6.7.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-                        },
-                        "debug": {
-                          "version": "2.2.0",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                          "dependencies": {
-                            "ms": {
-                              "version": "0.7.1",
-                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                            }
-                          }
-                        },
-                        "globals": {
-                          "version": "8.18.0",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.1",
-                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                          "dependencies": {
-                            "loose-envify": {
-                              "version": "1.1.0",
-                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                              "dependencies": {
-                                "js-tokens": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "repeating": {
-                          "version": "1.1.3",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            },
-            "regexpu-core": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-              "dependencies": {
-                "regenerate": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
-                },
-                "regjsgen": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-                },
-                "regjsparser": {
-                  "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                  "dependencies": {
-                    "jsesc": {
-                      "version": "0.5.0",
-                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-regenerator": {
-          "version": "6.6.5",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.6.5.tgz",
-          "dependencies": {
-            "babel-core": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.7.2.tgz",
-              "dependencies": {
-                "babel-code-frame": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                          "dependencies": {
-                            "color-convert": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                    },
-                    "line-numbers": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                      "dependencies": {
-                        "left-pad": {
-                          "version": "0.0.3",
-                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                        }
-                      }
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-generator": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.7.2.tgz",
-                  "dependencies": {
-                    "detect-indent": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-                      "dependencies": {
-                        "get-stdin": {
-                          "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                        },
-                        "minimist": {
-                          "version": "1.2.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        }
-                      }
-                    },
-                    "is-integer": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "trim-right": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-                    }
-                  }
-                },
-                "babel-helpers": {
-                  "version": "6.6.0",
-                  "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.6.0.tgz"
-                },
-                "babel-messages": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                },
-                "babel-register": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.7.2.tgz",
-                  "dependencies": {
-                    "core-js": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.2.0.tgz"
-                    },
-                    "home-or-tmp": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-                      "dependencies": {
-                        "os-tmpdir": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                        },
-                        "user-home": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-                        }
-                      }
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
-                    },
-                    "source-map-support": {
-                      "version": "0.2.10",
-                      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-                      "dependencies": {
-                        "source-map": {
-                          "version": "0.1.32",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                          "dependencies": {
-                            "amdefine": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-template": {
-                  "version": "6.7.0",
-                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz"
-                },
-                "convert-source-map": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    }
-                  }
-                },
-                "json5": {
-                  "version": "0.4.0",
-                  "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "path-exists": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                },
-                "shebang-regex": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
-                },
-                "slash": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
-                },
-                "source-map": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                }
-              }
-            },
-            "babel-plugin-syntax-async-functions": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.5.0.tgz"
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            },
-            "babel-traverse": {
-              "version": "6.7.3",
-              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-              "dependencies": {
-                "babel-code-frame": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                          "dependencies": {
-                            "color-convert": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                    },
-                    "line-numbers": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                      "dependencies": {
-                        "left-pad": {
-                          "version": "0.0.3",
-                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.7.2",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "8.18.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "repeating": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                }
-              }
-            },
-            "babylon": {
-              "version": "6.7.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-            },
-            "private": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-            }
-          }
-        }
-      }
-    },
     "body-parser": {
       "version": "1.14.2",
+      "from": "body-parser@1.14.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.2.0",
+          "from": "bytes@2.2.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
         },
         "content-type": {
           "version": "1.0.1",
+          "from": "content-type@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
         },
         "debug": {
           "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "http-errors": {
           "version": "1.3.1",
+          "from": "http-errors@>=1.3.1 <1.4.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "statuses": {
               "version": "1.2.1",
+              "from": "statuses@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
             }
           }
         },
         "iconv-lite": {
           "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
+          "from": "on-finished@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
+              "from": "ee-first@1.1.1",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "qs": {
           "version": "5.2.0",
+          "from": "qs@5.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
         },
         "raw-body": {
-          "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz",
+          "version": "2.1.6",
+          "from": "raw-body@>=2.1.5 <2.2.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
           "dependencies": {
+            "bytes": {
+              "version": "2.3.0",
+              "from": "bytes@2.3.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
+            },
             "unpipe": {
               "version": "1.0.0",
+              "from": "unpipe@1.0.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "type-is": {
-          "version": "1.6.11",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
+          "version": "1.6.12",
+          "from": "type-is@>=1.6.10 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
+              "from": "media-typer@0.3.0",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.9",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
+              "version": "2.1.10",
+              "from": "mime-types@>=2.1.10 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "bower": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.7.2.tgz",
-      "dependencies": {
-        "abbrev": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-        },
-        "archy": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
-        },
-        "bower-config": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.3.0.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                },
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                }
-              }
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                }
-              }
-            },
-            "untildify": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "bower-endpoint-parser": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
-        },
-        "bower-json": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
-          "dependencies": {
-            "deep-extend": {
-              "version": "0.2.11",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-            },
-            "graceful-fs": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-            },
-            "intersect": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
-            }
-          }
-        },
-        "bower-logger": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
-        },
-        "bower-registry-client": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-1.0.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.2.10",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-            },
-            "graceful-fs": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "mkdirp": {
-              "version": "0.3.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
-            },
-            "request-replay": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
-            }
-          }
-        },
-        "cardinal": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
-          "dependencies": {
-            "ansicolors": {
-              "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
-            },
-            "redeyed": {
-              "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
-              "dependencies": {
-                "esprima": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                }
-              }
-            }
-          }
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "chmodr": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz"
-        },
-        "configstore": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
-          "dependencies": {
-            "js-yaml": {
-              "version": "3.4.6",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-                  "dependencies": {
-                    "lodash": {
-                      "version": "3.10.1",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                    },
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.7.1",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
-                },
-                "inherit": {
-                  "version": "2.2.2",
-                  "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                }
-              }
-            },
-            "uuid": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-            },
-            "xdg-basedir": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
-            }
-          }
-        },
-        "decompress-zip": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
-          "dependencies": {
-            "binary": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-              "dependencies": {
-                "buffers": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
-                },
-                "chainsaw": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-                  "dependencies": {
-                    "traverse": {
-                      "version": "0.3.9",
-                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "mkpath": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            },
-            "touch": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "1.0.10",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
-                }
-              }
-            }
-          }
-        },
-        "destroy": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
-        },
-        "fs-write-stream-atomic": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.5.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-            }
-          }
-        },
-        "fstream": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "github": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
-          "dependencies": {
-            "mime": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-            }
-          }
-        },
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        },
-        "handlebars": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
-          "dependencies": {
-            "optimist": {
-              "version": "0.3.7",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                }
-              }
-            },
-            "uglify-js": {
-              "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                },
-                "source-map": {
-                  "version": "0.1.43",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "inquirer": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.10.0.tgz",
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz"
-            },
-            "ansi-regex": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "dependencies": {
-                "restore-cursor": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "dependencies": {
-                    "exit-hook": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
-                    },
-                    "onetime": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "cli-width": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
-            },
-            "figures": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
-            "readline2": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                },
-                "mute-stream": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-                }
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "dependencies": {
-                "once": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-            },
-            "through": {
-              "version": "2.3.8",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            }
-          }
-        },
-        "insight": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/insight/-/insight-0.7.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-            },
-            "configstore": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                },
-                "uuid": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-                },
-                "write-file-atomic": {
-                  "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-                    },
-                    "slide": {
-                      "version": "1.1.6",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-                    }
-                  }
-                },
-                "xdg-basedir": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash.debounce": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-            },
-            "os-name": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
-              "dependencies": {
-                "osx-release": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                    }
-                  }
-                },
-                "win-release": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-                  "dependencies": {
-                    "semver": {
-                      "version": "5.1.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            }
-          }
-        },
-        "is-root": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
-        },
-        "junk": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz"
-        },
-        "lockfile": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-        },
-        "md5-hex": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.0.tgz",
-          "dependencies": {
-            "md5-o-matic": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "mout": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz"
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
-        },
-        "opn": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
-        },
-        "p-throttler": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
-          "dependencies": {
-            "q": {
-              "version": "0.9.7",
-              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
-            }
-          }
-        },
-        "promptly": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
-          "dependencies": {
-            "read": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "q": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-        },
-        "request": {
-          "version": "2.53.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-            },
-            "bl": {
-              "version": "0.9.4",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.9.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
-            },
-            "combined-stream": {
-              "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                }
-              }
-            },
-            "forever-agent": {
-              "version": "0.5.2",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-            },
-            "form-data": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.9.2",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-                }
-              }
-            },
-            "hawk": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "dependencies": {
-                "boom": {
-                  "version": "2.10.1",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "dependencies": {
-                "asn1": {
-                  "version": "0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.0.14",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.12.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-            },
-            "oauth-sign": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
-            },
-            "qs": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-            }
-          }
-        },
-        "request-progress": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-          "dependencies": {
-            "throttleit": {
-              "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
-            }
-          }
-        },
-        "retry": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
-        },
-        "rimraf": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "6.0.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "semver": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
-        },
-        "semver-utils": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz"
-        },
-        "shell-quote": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
-          "dependencies": {
-            "array-filter": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
-            },
-            "array-map": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
-            },
-            "array-reduce": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-            }
-          }
-        },
-        "stringify-object": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
-        },
-        "tar-fs": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.9.0.tgz",
-          "dependencies": {
-            "pump": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
-              "dependencies": {
-                "end-of-stream": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "tar-stream": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.3.1.tgz",
-              "dependencies": {
-                "bl": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
-                },
-                "end-of-stream": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "tmp": {
-          "version": "0.0.24",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
-        },
-        "update-notifier": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.6.0.tgz",
-          "dependencies": {
-            "configstore": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
-                "object-assign": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                },
-                "uuid": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-                },
-                "write-file-atomic": {
-                  "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-                    },
-                    "slide": {
-                      "version": "1.1.6",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-                    }
-                  }
-                },
-                "xdg-basedir": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
-            },
-            "latest-version": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
-              "dependencies": {
-                "package-json": {
-                  "version": "2.3.0",
-                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.3.0.tgz",
-                  "dependencies": {
-                    "got": {
-                      "version": "5.3.0",
-                      "resolved": "https://registry.npmjs.org/got/-/got-5.3.0.tgz",
-                      "dependencies": {
-                        "create-error-class": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-2.0.1.tgz",
-                          "dependencies": {
-                            "capture-stack-trace": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.4.2",
-                          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
-                          "dependencies": {
-                            "end-of-stream": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                              "dependencies": {
-                                "once": {
-                                  "version": "1.3.3",
-                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                                  "dependencies": {
-                                    "wrappy": {
-                                      "version": "1.0.1",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "readable-stream": {
-                              "version": "2.0.5",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "is-plain-obj": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
-                        },
-                        "is-redirect": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
-                        },
-                        "is-stream": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
-                        },
-                        "lowercase-keys": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
-                        },
-                        "node-status-codes": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
-                        },
-                        "object-assign": {
-                          "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                        },
-                        "parse-json": {
-                          "version": "2.2.0",
-                          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                          "dependencies": {
-                            "error-ex": {
-                              "version": "1.3.0",
-                              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                              "dependencies": {
-                                "is-arrayish": {
-                                  "version": "0.2.1",
-                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.1",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                            }
-                          }
-                        },
-                        "read-all-stream": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
-                          "dependencies": {
-                            "pinkie-promise": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "readable-stream": {
-                              "version": "2.0.5",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "timed-out": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
-                        },
-                        "unzip-response": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
-                        },
-                        "url-parse-lax": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-                          "dependencies": {
-                            "prepend-http": {
-                              "version": "1.0.3",
-                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "rc": {
-                      "version": "1.1.6",
-                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-                      "dependencies": {
-                        "deep-extend": {
-                          "version": "0.4.0",
-                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
-                        },
-                        "ini": {
-                          "version": "1.3.4",
-                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                        },
-                        "minimist": {
-                          "version": "1.2.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        },
-                        "strip-json-comments": {
-                          "version": "1.0.4",
-                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "3.0.3",
-                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz"
-                    },
-                    "semver": {
-                      "version": "5.1.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "repeating": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-              "dependencies": {
-                "semver": {
-                  "version": "5.1.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                }
-              }
-            },
-            "string-length": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "user-home": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-        },
-        "which": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.1.tgz",
-          "dependencies": {
-            "is-absolute": {
-              "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-              "dependencies": {
-                "is-relative": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                  "version": "1.22.0",
+                  "from": "mime-db@>=1.22.0 <1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
             }
@@ -4532,427 +118,299 @@
     },
     "compression": {
       "version": "1.6.1",
+      "from": "compression@1.6.1",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.1.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.1.tgz",
+          "version": "1.3.2",
+          "from": "accepts@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.2.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.1.9",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
+              "version": "2.1.10",
+              "from": "mime-types@>=2.1.10 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                  "version": "1.22.0",
+                  "from": "mime-db@>=1.22.0 <1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.6.0",
+              "from": "negotiator@0.6.0",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
             }
           }
         },
         "bytes": {
           "version": "2.2.0",
+          "from": "bytes@2.2.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
         },
         "compressible": {
           "version": "2.0.7",
+          "from": "compressible@>=2.0.7 <2.1.0",
           "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.21.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+              "version": "1.22.0",
+              "from": "mime-db@>=1.21.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
             }
           }
         },
         "debug": {
           "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "on-headers": {
           "version": "1.0.1",
+          "from": "on-headers@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
         },
         "vary": {
           "version": "1.1.0",
+          "from": "vary@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
         }
       }
     },
     "cookie-parser": {
       "version": "1.4.1",
+      "from": "cookie-parser@1.4.1",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.1.tgz",
       "dependencies": {
         "cookie": {
           "version": "0.2.3",
+          "from": "cookie@0.2.3",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.2.3.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
+          "from": "cookie-signature@1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         }
       }
     },
-    "del": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
-      "dependencies": {
-        "globby": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
-          "dependencies": {
-            "array-union": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                }
-              }
-            },
-            "arrify": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-            },
-            "glob": {
-              "version": "6.0.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "is-path-cwd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
-        },
-        "is-path-in-cwd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-          "dependencies": {
-            "is-path-inside": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-              "dependencies": {
-                "path-is-inside": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-        },
-        "pinkie-promise": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-          "dependencies": {
-            "pinkie": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-            }
-          }
-        },
-        "rimraf": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "es6-promise": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
-    },
     "express": {
       "version": "4.13.4",
+      "from": "express@4.13.4",
       "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.2.13",
+          "from": "accepts@>=1.2.12 <1.3.0",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.1.9",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
+              "version": "2.1.10",
+              "from": "mime-types@>=2.1.10 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                  "version": "1.22.0",
+                  "from": "mime-db@>=1.22.0 <1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.5.3",
+              "from": "negotiator@0.5.3",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
             }
           }
         },
         "array-flatten": {
           "version": "1.1.1",
+          "from": "array-flatten@1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
         },
         "content-disposition": {
           "version": "0.5.1",
+          "from": "content-disposition@0.5.1",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
         },
         "content-type": {
           "version": "1.0.1",
+          "from": "content-type@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
         },
         "cookie": {
           "version": "0.1.5",
+          "from": "cookie@0.1.5",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
+          "from": "cookie-signature@1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "debug": {
           "version": "2.2.0",
+          "from": "debug@>=2.1.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "escape-html": {
           "version": "1.0.3",
+          "from": "escape-html@>=1.0.3 <1.1.0",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
         },
         "etag": {
           "version": "1.7.0",
+          "from": "etag@>=1.7.0 <1.8.0",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
         },
         "fresh": {
           "version": "0.3.0",
+          "from": "fresh@0.3.0",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
         },
         "merge-descriptors": {
           "version": "1.0.1",
+          "from": "merge-descriptors@1.0.1",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
         },
         "methods": {
           "version": "1.1.2",
+          "from": "methods@>=1.1.2 <1.2.0",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
+          "from": "on-finished@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
+              "from": "ee-first@1.1.1",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.1",
+          "from": "parseurl@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
         },
         "path-to-regexp": {
           "version": "0.1.7",
+          "from": "path-to-regexp@0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
         },
         "proxy-addr": {
           "version": "1.0.10",
+          "from": "proxy-addr@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
+              "from": "forwarded@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
               "version": "1.0.5",
+              "from": "ipaddr.js@1.0.5",
               "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
             }
           }
         },
         "qs": {
           "version": "4.0.0",
+          "from": "qs@4.0.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
         },
         "range-parser": {
           "version": "1.0.3",
+          "from": "range-parser@>=1.0.3 <1.1.0",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
         },
         "send": {
           "version": "0.13.1",
+          "from": "send@0.13.1",
           "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.4",
+              "from": "destroy@>=1.0.4 <1.1.0",
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
             },
             "http-errors": {
               "version": "1.3.1",
+              "from": "http-errors@>=1.3.1 <1.4.0",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.3.4",
+              "from": "mime@1.3.4",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
               "version": "0.7.1",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             },
             "statuses": {
               "version": "1.2.1",
+              "from": "statuses@>=1.2.1 <1.3.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
             }
           }
         },
         "serve-static": {
           "version": "1.10.2",
+          "from": "serve-static@>=1.10.2 <1.11.0",
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
         },
         "type-is": {
-          "version": "1.6.11",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
+          "version": "1.6.12",
+          "from": "type-is@>=1.6.6 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
+              "from": "media-typer@0.3.0",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.9",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
+              "version": "2.1.10",
+              "from": "mime-types@>=2.1.10 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                  "version": "1.22.0",
+                  "from": "mime-db@>=1.22.0 <1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
             }
@@ -4960,3906 +418,90 @@
         },
         "utils-merge": {
           "version": "1.0.0",
+          "from": "utils-merge@1.0.0",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         },
         "vary": {
           "version": "1.0.1",
+          "from": "vary@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
         }
       }
     },
     "finalhandler": {
       "version": "0.4.1",
+      "from": "finalhandler@0.4.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "escape-html": {
           "version": "1.0.3",
+          "from": "escape-html@>=1.0.3 <1.1.0",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
+          "from": "on-finished@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
+              "from": "ee-first@1.1.1",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "unpipe": {
           "version": "1.0.0",
+          "from": "unpipe@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-        }
-      }
-    },
-    "gulp": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.0.tgz",
-      "dependencies": {
-        "archy": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-              "dependencies": {
-                "color-convert": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                }
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "deprecated": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
-        },
-        "interpret": {
-          "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
-        },
-        "liftoff": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
-          "dependencies": {
-            "extend": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
-            },
-            "findup-sync": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "5.0.15",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "flagged-respawn": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
-            },
-            "resolve": {
-              "version": "1.1.7",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-        },
-        "orchestrator": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
-          "dependencies": {
-            "end-of-stream": {
-              "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-              "dependencies": {
-                "once": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "sequencify": {
-              "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
-            },
-            "stream-consume": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
-            }
-          }
-        },
-        "pretty-hrtime": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz"
-        },
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-        },
-        "tildify": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-            }
-          }
-        },
-        "v8flags": {
-          "version": "2.0.11",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
-          "dependencies": {
-            "user-home": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-            }
-          }
-        },
-        "vinyl-fs": {
-          "version": "0.3.14",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-          "dependencies": {
-            "defaults": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-                }
-              }
-            },
-            "glob-stream": {
-              "version": "3.1.18",
-              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "4.5.3",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "glob2base": {
-                  "version": "0.0.12",
-                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-                  "dependencies": {
-                    "find-index": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "ordered-read-streams": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-                },
-                "unique-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "glob-watcher": {
-              "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-              "dependencies": {
-                "gaze": {
-                  "version": "0.5.2",
-                  "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-                  "dependencies": {
-                    "globule": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                      "dependencies": {
-                        "glob": {
-                          "version": "3.1.21",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "1.2.3",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                            },
-                            "inherits": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "lodash": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                        },
-                        "minimatch": {
-                          "version": "0.2.14",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "2.7.3",
-                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                            },
-                            "sigmund": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "3.0.8",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "strip-bom": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-              "dependencies": {
-                "first-chunk-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
-                },
-                "is-utf8": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                }
-              }
-            },
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            },
-            "vinyl": {
-              "version": "0.4.6",
-              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-angular-templatecache": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/gulp-angular-templatecache/-/gulp-angular-templatecache-1.8.0.tgz",
-      "dependencies": {
-        "event-stream": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
-          "dependencies": {
-            "duplexer": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-            },
-            "from": {
-              "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
-            },
-            "map-stream": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
-            },
-            "pause-stream": {
-              "version": "0.0.11",
-              "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
-            },
-            "split": {
-              "version": "0.3.3",
-              "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
-            },
-            "stream-combiner": {
-              "version": "0.0.4",
-              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
-            },
-            "through": {
-              "version": "2.3.8",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            }
-          }
-        },
-        "gulp-footer": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/gulp-footer/-/gulp-footer-1.0.5.tgz",
-          "dependencies": {
-            "lodash.assign": {
-              "version": "4.0.6",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.6.tgz",
-              "dependencies": {
-                "lodash.keys": {
-                  "version": "4.0.5",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.5.tgz"
-                },
-                "lodash.rest": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "gulp-header": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.7.1.tgz",
-          "dependencies": {
-            "concat-with-sourcemaps": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
-              "dependencies": {
-                "source-map": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-            },
-            "through2": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "js-string-escape": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz"
-        },
-        "path": {
-          "version": "0.12.7",
-          "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-          "dependencies": {
-            "process": {
-              "version": "0.11.2",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
-            },
-            "util": {
-              "version": "0.10.3",
-              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-babel": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-6.1.1.tgz",
-      "dependencies": {
-        "babel-core": {
-          "version": "6.7.2",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.7.2.tgz",
-          "dependencies": {
-            "babel-code-frame": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.2.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                      "dependencies": {
-                        "color-convert": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    }
-                  }
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "js-tokens": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                },
-                "line-numbers": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                  "dependencies": {
-                    "left-pad": {
-                      "version": "0.0.3",
-                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                    }
-                  }
-                },
-                "repeating": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-generator": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.7.2.tgz",
-              "dependencies": {
-                "detect-indent": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-                  "dependencies": {
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                    },
-                    "minimist": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                    }
-                  }
-                },
-                "is-integer": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "repeating": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "trim-right": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-                }
-              }
-            },
-            "babel-helpers": {
-              "version": "6.6.0",
-              "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.6.0.tgz"
-            },
-            "babel-messages": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
-            },
-            "babel-register": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.7.2.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.2.0.tgz"
-                },
-                "home-or-tmp": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-                  "dependencies": {
-                    "os-tmpdir": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                    },
-                    "user-home": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
-                "source-map-support": {
-                  "version": "0.2.10",
-                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-                  "dependencies": {
-                    "source-map": {
-                      "version": "0.1.32",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                }
-              }
-            },
-            "babel-template": {
-              "version": "6.7.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz"
-            },
-            "babel-traverse": {
-              "version": "6.7.3",
-              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.3.tgz",
-              "dependencies": {
-                "globals": {
-                  "version": "8.18.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "repeating": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.7.2",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.2.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                }
-              }
-            },
-            "babylon": {
-              "version": "6.7.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
-            },
-            "convert-source-map": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
-            },
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                }
-              }
-            },
-            "json5": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "path-exists": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-            },
-            "private": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-            },
-            "shebang-regex": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
-            },
-            "slash": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        },
-        "replace-ext": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-concat": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
-      "dependencies": {
-        "concat-with-sourcemaps": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-cssnano": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.0.tgz",
-      "dependencies": {
-        "cssnano": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.5.2.tgz",
-          "dependencies": {
-            "decamelize": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-            },
-            "defined": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-            },
-            "indexes-of": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
-            },
-            "postcss": {
-              "version": "5.0.19",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
-              "dependencies": {
-                "js-base64": {
-                  "version": "2.1.9",
-                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-                },
-                "source-map": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                },
-                "supports-color": {
-                  "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-calc": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
-              "dependencies": {
-                "postcss-message-helpers": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
-                },
-                "reduce-css-calc": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.1.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
-                    },
-                    "reduce-function-call": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-colormin": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.0.tgz",
-              "dependencies": {
-                "colormin": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.0.tgz",
-                  "dependencies": {
-                    "color": {
-                      "version": "0.11.1",
-                      "resolved": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
-                      "dependencies": {
-                        "color-convert": {
-                          "version": "0.5.3",
-                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
-                        },
-                        "color-string": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-                          "dependencies": {
-                            "color-name": {
-                              "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "css-color-names": {
-                      "version": "0.0.3",
-                      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-convert-values": {
-              "version": "2.3.4",
-              "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz"
-            },
-            "postcss-discard-comments": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz"
-            },
-            "postcss-discard-duplicates": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.1.tgz"
-            },
-            "postcss-discard-empty": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.1.tgz"
-            },
-            "postcss-discard-unused": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.1.tgz",
-              "dependencies": {
-                "flatten": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
-                },
-                "uniqs": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-filter-plugins": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
-              "dependencies": {
-                "uniqid": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
-                }
-              }
-            },
-            "postcss-merge-idents": {
-              "version": "2.1.5",
-              "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.5.tgz",
-              "dependencies": {
-                "has-own": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz"
-                }
-              }
-            },
-            "postcss-merge-longhand": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz"
-            },
-            "postcss-merge-rules": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.6.tgz"
-            },
-            "postcss-minify-font-values": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.3.tgz",
-              "dependencies": {
-                "uniqs": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-minify-gradients": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz"
-            },
-            "postcss-minify-params": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "uniqs": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-minify-selectors": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.4.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "postcss-selector-parser": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
-                  "dependencies": {
-                    "flatten": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
-                    },
-                    "uniq": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-normalize-charset": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz"
-            },
-            "postcss-normalize-url": {
-              "version": "3.0.7",
-              "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.7.tgz",
-              "dependencies": {
-                "is-absolute-url": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
-                },
-                "normalize-url": {
-                  "version": "1.4.1",
-                  "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.1.tgz",
-                  "dependencies": {
-                    "prepend-http": {
-                      "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
-                    },
-                    "query-string": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.1.tgz",
-                      "dependencies": {
-                        "strict-uri-encode": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
-                        }
-                      }
-                    },
-                    "sort-keys": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
-                      "dependencies": {
-                        "is-plain-obj": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-ordered-values": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.1.0.tgz"
-            },
-            "postcss-reduce-idents": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.3.0.tgz"
-            },
-            "postcss-reduce-transforms": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz"
-            },
-            "postcss-svgo": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.2.tgz",
-              "dependencies": {
-                "is-svg": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz"
-                },
-                "svgo": {
-                  "version": "0.6.2",
-                  "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.2.tgz",
-                  "dependencies": {
-                    "coa": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz"
-                    },
-                    "colors": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
-                    },
-                    "csso": {
-                      "version": "1.6.4",
-                      "resolved": "https://registry.npmjs.org/csso/-/csso-1.6.4.tgz",
-                      "dependencies": {
-                        "clap": {
-                          "version": "1.0.10",
-                          "resolved": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                                  "dependencies": {
-                                    "color-convert": {
-                                      "version": "1.0.0",
-                                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "source-map": {
-                          "version": "0.5.3",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                        }
-                      }
-                    },
-                    "js-yaml": {
-                      "version": "3.5.4",
-                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.4.tgz",
-                      "dependencies": {
-                        "argparse": {
-                          "version": "1.0.6",
-                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz",
-                          "dependencies": {
-                            "sprintf-js": {
-                              "version": "1.0.3",
-                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "esprima": {
-                          "version": "2.7.2",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-                        }
-                      }
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
-                    },
-                    "sax": {
-                      "version": "1.1.6",
-                      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz"
-                    },
-                    "whet.extend": {
-                      "version": "0.9.9",
-                      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-unique-selectors": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "uniqs": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-value-parser": {
-              "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-            },
-            "postcss-zindex": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
-              "dependencies": {
-                "uniqs": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-htmlmin": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/gulp-htmlmin/-/gulp-htmlmin-1.3.0.tgz",
-      "dependencies": {
-        "bufferstreams": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.0.tgz"
-        },
-        "html-minifier": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.3.0.tgz",
-          "dependencies": {
-            "change-case": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
-              "dependencies": {
-                "camel-case": {
-                  "version": "1.2.2",
-                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
-                },
-                "constant-case": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
-                },
-                "dot-case": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
-                },
-                "is-lower-case": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
-                },
-                "is-upper-case": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
-                },
-                "lower-case": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
-                },
-                "lower-case-first": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
-                },
-                "param-case": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
-                },
-                "pascal-case": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
-                },
-                "path-case": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
-                },
-                "sentence-case": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
-                },
-                "snake-case": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
-                },
-                "swap-case": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
-                },
-                "title-case": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
-                },
-                "upper-case": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
-                },
-                "upper-case-first": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
-                }
-              }
-            },
-            "clean-css": {
-              "version": "3.4.10",
-              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.10.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.8.1",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.4.4",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "cli": {
-              "version": "0.11.2",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.11.2.tgz",
-              "dependencies": {
-                "exit": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-                },
-                "glob": {
-                  "version": "5.0.15",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "concat-stream": {
-              "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                }
-              }
-            },
-            "ncname": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
-              "dependencies": {
-                "xml-char-classes": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
-                }
-              }
-            },
-            "relateurl": {
-              "version": "0.2.6",
-              "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
-            },
-            "uglify-js": {
-              "version": "2.6.2",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                },
-                "source-map": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-                },
-                "yargs": {
-                  "version": "3.10.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                      "dependencies": {
-                        "center-align": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.0.2",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.3",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-                                }
-                              }
-                            },
-                            "lazy-cache": {
-                              "version": "1.0.3",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "right-align": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.0.2",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.3",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                    },
-                    "window-size": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
-            "process-nextick-args": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-            }
-          }
-        },
-        "tryit": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
-        }
-      }
-    },
-    "gulp-if": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.0.tgz",
-      "dependencies": {
-        "gulp-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.0.tgz",
-          "dependencies": {
-            "minimatch": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "ternary-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-          "dependencies": {
-            "duplexify": {
-              "version": "3.4.3",
-              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
-              "dependencies": {
-                "end-of-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "fork-stream": {
-              "version": "0.0.4",
-              "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-jshint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-2.0.0.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "rcloader": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
-          "dependencies": {
-            "lodash": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
-            },
-            "rcfinder": {
-              "version": "0.1.8",
-              "resolved": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.8.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-less": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.0.5.tgz",
-      "dependencies": {
-        "accord": {
-          "version": "0.20.5",
-          "resolved": "https://registry.npmjs.org/accord/-/accord-0.20.5.tgz",
-          "dependencies": {
-            "convert-source-map": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
-            },
-            "fobject": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/fobject/-/fobject-0.0.3.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "3.0.8",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-                }
-              }
-            },
-            "glob": {
-              "version": "5.0.15",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            },
-            "indx": {
-              "version": "0.2.3",
-              "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz"
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
-            "resolve": {
-              "version": "1.1.7",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-            },
-            "semver": {
-              "version": "4.3.6",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-            },
-            "uglify-js": {
-              "version": "2.6.2",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                },
-                "source-map": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-                },
-                "yargs": {
-                  "version": "3.10.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                      "dependencies": {
-                        "center-align": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.0.2",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.3",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-                                }
-                              }
-                            },
-                            "lazy-cache": {
-                              "version": "1.0.3",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "right-align": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.0.2",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.3",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                    },
-                    "window-size": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "when": {
-              "version": "3.7.7",
-              "resolved": "https://registry.npmjs.org/when/-/when-3.7.7.tgz"
-            }
-          }
-        },
-        "less": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/less/-/less-2.6.1.tgz",
-          "dependencies": {
-            "errno": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-              "dependencies": {
-                "prr": {
-                  "version": "0.0.0",
-                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.3",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-            },
-            "image-size": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.4.0.tgz"
-            },
-            "mime": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "promise": {
-              "version": "7.1.1",
-              "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-livereload": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-3.8.1.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-            }
-          }
-        },
-        "event-stream": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
-          "dependencies": {
-            "duplexer": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-            },
-            "from": {
-              "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
-            },
-            "map-stream": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
-            },
-            "pause-stream": {
-              "version": "0.0.11",
-              "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
-            },
-            "split": {
-              "version": "0.3.3",
-              "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
-            },
-            "stream-combiner": {
-              "version": "0.0.4",
-              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
-            },
-            "through": {
-              "version": "2.3.8",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            }
-          }
-        },
-        "lodash.assign": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-          "dependencies": {
-            "lodash._baseassign": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                }
-              }
-            },
-            "lodash._createassigner": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-              "dependencies": {
-                "lodash._bindcallback": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9",
-                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1",
-                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-                }
-              }
-            },
-            "lodash.keys": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.8",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                }
-              }
-            }
-          }
-        },
-        "mini-lr": {
-          "version": "0.1.9",
-          "resolved": "https://registry.npmjs.org/mini-lr/-/mini-lr-0.1.9.tgz",
-          "dependencies": {
-            "faye-websocket": {
-              "version": "0.7.3",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
-              "dependencies": {
-                "websocket-driver": {
-                  "version": "0.6.4",
-                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
-                  "dependencies": {
-                    "websocket-extensions": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "livereload-js": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz"
-            },
-            "parseurl": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
-            },
-            "qs": {
-              "version": "2.2.5",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.5.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-load-plugins": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-1.2.0.tgz",
-      "dependencies": {
-        "findup-sync": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "4.3.5",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "multimatch": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-            },
-            "array-union": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-        }
-      }
-    },
-    "gulp-ng-annotate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-ng-annotate/-/gulp-ng-annotate-1.1.0.tgz",
-      "dependencies": {
-        "bufferstreams": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-0.0.2.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.1.13",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            }
-          }
-        },
-        "merge": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
-        },
-        "ng-annotate": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/ng-annotate/-/ng-annotate-1.2.1.tgz",
-          "dependencies": {
-            "acorn": {
-              "version": "2.6.4",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz"
-            },
-            "alter": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz"
-            },
-            "convert-source-map": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                },
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                }
-              }
-            },
-            "ordered-ast-traverse": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/ordered-ast-traverse/-/ordered-ast-traverse-1.1.1.tgz",
-              "dependencies": {
-                "ordered-esprima-props": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/ordered-esprima-props/-/ordered-esprima-props-1.1.0.tgz"
-                }
-              }
-            },
-            "simple-fmt": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
-            },
-            "simple-is": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            },
-            "stable": {
-              "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
-            },
-            "stringmap": {
-              "version": "0.2.2",
-              "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
-            },
-            "stringset": {
-              "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
-            },
-            "tryor": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-              "dependencies": {
-                "object-keys": {
-                  "version": "0.4.0",
-                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.43",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-plumber": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.0.1.tgz",
-      "dependencies": {
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-postcss": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-6.1.0.tgz",
-      "dependencies": {
-        "postcss": {
-          "version": "5.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
-          "dependencies": {
-            "js-base64": {
-              "version": "2.1.9",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            },
-            "supports-color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-replace": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-0.5.4.tgz",
-      "dependencies": {
-        "istextorbinary": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
-          "dependencies": {
-            "binaryextensions": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.0.tgz"
-            },
-            "textextensions": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz"
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
-            "process-nextick-args": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-            }
-          }
-        },
-        "replacestream": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.0.tgz",
-          "dependencies": {
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "object-assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-rev": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-7.0.0.tgz",
-      "dependencies": {
-        "modify-filename": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz"
-        },
-        "object-assign": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        },
-        "rev-hash": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/rev-hash/-/rev-hash-1.0.0.tgz"
-        },
-        "rev-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/rev-path/-/rev-path-1.0.0.tgz"
-        },
-        "sort-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
-          "dependencies": {
-            "is-plain-obj": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "vinyl-file": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.3.0.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.3",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "dependencies": {
-                "is-utf8": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-bom-stream": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-              "dependencies": {
-                "first-chunk-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "vinyl": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                },
-                "replace-ext": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-uglify": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.5.1.tgz",
-      "dependencies": {
-        "deap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz"
-        },
-        "fancy-log": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                  "dependencies": {
-                    "color-convert": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                    }
-                  }
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "time-stamp": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz"
-            }
-          }
-        },
-        "isobject": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "uglify-js": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.2.10",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-            },
-            "yargs": {
-              "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                },
-                "cliui": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "dependencies": {
-                    "center-align": {
-                      "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.4",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "3.0.2",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.3",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.4",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-                            }
-                          }
-                        },
-                        "lazy-cache": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
-                        }
-                      }
-                    },
-                    "right-align": {
-                      "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.4",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "3.0.2",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.3",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.4",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                },
-                "window-size": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "uglify-save-license": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz"
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-util": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-      "dependencies": {
-        "array-differ": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-        },
-        "array-uniq": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-        },
-        "beeper": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-              "dependencies": {
-                "color-convert": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                }
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "dateformat": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "dependencies": {
-            "get-stdin": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-            },
-            "meow": {
-              "version": "3.7.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "2.1.1",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                },
-                "loud-rejection": {
-                  "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
-                  "dependencies": {
-                    "array-find-index": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
-                    },
-                    "signal-exit": {
-                      "version": "2.1.2",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
-                    }
-                  }
-                },
-                "map-obj": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                },
-                "normalize-package-data": {
-                  "version": "2.3.5",
-                  "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                  "dependencies": {
-                    "hosted-git-info": {
-                      "version": "2.1.4",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-                    },
-                    "is-builtin-module": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                      "dependencies": {
-                        "builtin-modules": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-                        }
-                      }
-                    },
-                    "semver": {
-                      "version": "5.1.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    },
-                    "validate-npm-package-license": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                      "dependencies": {
-                        "spdx-correct": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-license-ids": {
-                              "version": "1.2.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
-                            }
-                          }
-                        },
-                        "spdx-expression-parse": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-exceptions": {
-                              "version": "1.0.4",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
-                            },
-                            "spdx-license-ids": {
-                              "version": "1.2.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                      "dependencies": {
-                        "path-exists": {
-                          "version": "2.1.0",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.3",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-                            },
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.0",
-                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1",
-                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                }
-                              }
-                            },
-                            "strip-bom": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "dependencies": {
-                                "is-utf8": {
-                                  "version": "0.2.1",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.3",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "redent": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                  "dependencies": {
-                    "indent-string": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-indent": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-                    }
-                  }
-                },
-                "trim-newlines": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "fancy-log": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-          "dependencies": {
-            "time-stamp": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz"
-            }
-          }
-        },
-        "gulplog": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-          "dependencies": {
-            "glogg": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-              "dependencies": {
-                "sparkles": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "has-gulplog": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-          "dependencies": {
-            "sparkles": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
-            }
-          }
-        },
-        "lodash._reescape": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
-        },
-        "lodash._reevaluate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
-        },
-        "lodash._reinterpolate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-        },
-        "lodash.template": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-          "dependencies": {
-            "lodash._basecopy": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-            },
-            "lodash._basetostring": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-            },
-            "lodash._basevalues": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
-            },
-            "lodash._isiterateecall": {
-              "version": "3.0.9",
-              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-            },
-            "lodash.escape": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-              "dependencies": {
-                "lodash._root": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-                }
-              }
-            },
-            "lodash.keys": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.8",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-            },
-            "lodash.templatesettings": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-        },
-        "multipipe": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-          "dependencies": {
-            "duplexer2": {
-              "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-        },
-        "replace-ext": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "vinyl": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-          "dependencies": {
-            "clone": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-wrapper": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-wrapper/-/gulp-wrapper-1.0.0.tgz",
-      "dependencies": {
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
         }
       }
     },
     "jshint": {
       "version": "2.9.1",
+      "from": "jshint@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.1.tgz",
       "dependencies": {
         "cli": {
           "version": "0.6.6",
+          "from": "cli@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
+              "from": "glob@>=3.2.1 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -8870,96 +512,112 @@
         },
         "console-browserify": {
           "version": "1.1.0",
+          "from": "console-browserify@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
+          "from": "exit@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
           "version": "3.8.3",
+          "from": "htmlparser2@>=3.8.0 <3.9.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "dependencies": {
-            "domelementtype": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-            },
             "domhandler": {
               "version": "2.3.0",
+              "from": "domhandler@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
+              "from": "domutils@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
+                  "from": "dom-serializer@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
+                      "from": "domelementtype@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     },
                     "entities": {
                       "version": "1.1.1",
+                      "from": "entities@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                     }
                   }
                 }
               }
             },
-            "entities": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            "domelementtype": {
+              "version": "1.3.0",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             }
           }
         },
-        "lodash": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
-        },
         "minimatch": {
           "version": "2.0.10",
+          "from": "minimatch@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+              "version": "1.1.3",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.3.0",
+                  "from": "balanced-match@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -8968,652 +626,152 @@
         },
         "shelljs": {
           "version": "0.3.0",
+          "from": "shelljs@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.4",
+          "from": "strip-json-comments@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+        },
+        "lodash": {
+          "version": "3.7.0",
+          "from": "lodash@>=3.7.0 <3.8.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
         }
       }
     },
     "lodash": {
       "version": "4.0.1",
+      "from": "lodash@4.0.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.0.1.tgz"
     },
     "log4js": {
       "version": "0.6.30",
+      "from": "log4js@0.6.30",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.30.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
+          "from": "readable-stream@>=1.0.2 <1.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
+              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "semver": {
           "version": "4.3.6",
+          "from": "semver@>=4.3.3 <4.4.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-        }
-      }
-    },
-    "main-bower-files": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/main-bower-files/-/main-bower-files-2.11.1.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-              "dependencies": {
-                "color-convert": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                }
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "extend": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
-        },
-        "globby": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
-          "dependencies": {
-            "array-union": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                }
-              }
-            },
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-            },
-            "glob": {
-              "version": "5.0.15",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-            }
-          }
-        },
-        "multimatch": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-            },
-            "array-union": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                }
-              }
-            },
-            "arrify": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-        },
-        "vinyl-fs": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
-          "dependencies": {
-            "duplexify": {
-              "version": "3.4.3",
-              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
-              "dependencies": {
-                "end-of-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "glob-stream": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "4.5.3",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "glob2base": {
-                  "version": "0.0.12",
-                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-                  "dependencies": {
-                    "find-index": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "ordered-read-streams": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-                },
-                "unique-stream": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-                  "dependencies": {
-                    "json-stable-stringify": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                      "dependencies": {
-                        "jsonify": {
-                          "version": "0.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-                        }
-                      }
-                    },
-                    "through2-filter": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-                      "dependencies": {
-                        "through2": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-                          "dependencies": {
-                            "readable-stream": {
-                              "version": "2.0.6",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "isarray": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "xtend": {
-                          "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "glob-watcher": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
-              "dependencies": {
-                "gaze": {
-                  "version": "0.5.2",
-                  "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-                  "dependencies": {
-                    "globule": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                      "dependencies": {
-                        "glob": {
-                          "version": "3.1.21",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "1.2.3",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                            },
-                            "inherits": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "lodash": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                        },
-                        "minimatch": {
-                          "version": "0.2.14",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "2.7.3",
-                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                            },
-                            "sigmund": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "3.0.8",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-            },
-            "merge-stream": {
-              "version": "0.1.8",
-              "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-            },
-            "strip-bom": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-              "dependencies": {
-                "first-chunk-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
-                },
-                "is-utf8": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                }
-              }
-            },
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            },
-            "vinyl": {
-              "version": "0.4.6",
-              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "merge-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
-            "process-nextick-args": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-            }
-          }
         }
       }
     },
     "node-uuid": {
       "version": "1.4.7",
+      "from": "node-uuid@1.4.7",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "object-hash": {
       "version": "1.1.0",
+      "from": "object-hash@1.1.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.1.0.tgz"
     },
     "q": {
       "version": "1.4.1",
+      "from": "q@1.4.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
     },
     "request": {
       "version": "2.69.0",
+      "from": "request@2.69.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
       "dependencies": {
         "aws-sign2": {
           "version": "0.6.0",
+          "from": "aws-sign2@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
+          "version": "1.3.2",
+          "from": "aws4@>=1.2.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.7.3",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+              "version": "4.0.0",
+              "from": "lru-cache@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
+              "dependencies": {
+                "pseudomap": {
+                  "version": "1.0.2",
+                  "from": "pseudomap@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                },
+                "yallist": {
+                  "version": "2.0.0",
+                  "from": "yallist@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+                }
+              }
             }
           }
         },
         "bl": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz",
+          "version": "1.0.3",
+          "from": "bl@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
           "dependencies": {
             "readable-stream": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "version": "2.0.6",
+              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -9622,122 +780,155 @@
         },
         "caseless": {
           "version": "0.11.0",
+          "from": "caseless@>=0.11.0 <0.12.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
+          "from": "combined-stream@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
+              "from": "delayed-stream@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
         "extend": {
           "version": "3.0.0",
+          "from": "extend@>=3.0.0 <3.1.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
+          "from": "forever-agent@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
-          "version": "1.0.0-rc3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+          "version": "1.0.0-rc4",
+          "from": "form-data@>=1.0.0-rc3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
           "dependencies": {
             "async": {
               "version": "1.5.2",
+              "from": "async@>=1.5.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             }
           }
         },
         "har-validator": {
           "version": "2.0.6",
+          "from": "har-validator@>=2.0.6 <2.1.0",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
+              "from": "chalk@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                  "version": "2.2.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+                  "dependencies": {
+                    "color-convert": {
+                      "version": "1.0.0",
+                      "from": "color-convert@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                    }
+                  }
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.9.0",
+              "from": "commander@>=2.9.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "is-my-json-valid": {
-              "version": "2.12.4",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
+              "version": "2.13.1",
+              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
+                      "from": "is-property@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "2.0.0",
+                  "from": "jsonpointer@2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "pinkie-promise": {
               "version": "2.0.0",
+              "from": "pinkie-promise@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
+                  "from": "pinkie@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 }
               }
@@ -9746,79 +937,104 @@
         },
         "hawk": {
           "version": "3.1.3",
+          "from": "hawk@>=3.1.0 <3.2.0",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
+            "hoek": {
+              "version": "2.16.3",
+              "from": "hoek@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+            },
             "boom": {
               "version": "2.10.1",
+              "from": "boom@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
+              "from": "cryptiles@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "sntp": {
               "version": "1.0.9",
+              "from": "sntp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "http-signature": {
           "version": "1.1.1",
+          "from": "http-signature@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.2.0",
+              "from": "assert-plus@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
               "version": "1.2.2",
+              "from": "jsprim@>=1.2.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.0.2",
+                  "from": "extsprintf@1.0.2",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
                 "json-schema": {
                   "version": "0.2.2",
+                  "from": "json-schema@0.2.2",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
+                  "from": "verror@1.3.6",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                 }
               }
             },
             "sshpk": {
-              "version": "1.7.3",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz",
+              "version": "1.7.4",
+              "from": "sshpk@>=1.7.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
+                  "from": "asn1@>=0.2.3 <0.3.0",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                 },
                 "dashdash": {
-                  "version": "1.12.2",
-                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
-                },
-                "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                },
-                "jodid25519": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                  "version": "1.13.0",
+                  "from": "dashdash@>=1.10.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    }
+                  }
                 },
                 "jsbn": {
                   "version": "0.1.0",
+                  "from": "jsbn@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
                 "tweetnacl": {
-                  "version": "0.13.3",
-                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                  "version": "0.14.1",
+                  "from": "tweetnacl@>=0.13.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.1.tgz"
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 }
               }
             }
@@ -9826,84 +1042,103 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
+          "from": "is-typedarray@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
         },
         "isstream": {
           "version": "0.1.2",
+          "from": "isstream@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.1",
+          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
-          "version": "2.1.9",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
+          "version": "2.1.10",
+          "from": "mime-types@>=2.1.7 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.21.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+              "version": "1.22.0",
+              "from": "mime-db@>=1.22.0 <1.23.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.8.1",
+          "from": "oauth-sign@>=0.8.0 <0.9.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
         },
         "qs": {
           "version": "6.0.2",
+          "from": "qs@>=6.0.2 <6.1.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
+          "from": "stringstream@>=0.0.4 <0.1.0",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+          "version": "2.2.2",
+          "from": "tough-cookie@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.2",
+          "from": "tunnel-agent@>=0.4.1 <0.5.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
         }
       }
     },
     "serve-favicon": {
       "version": "2.3.0",
+      "from": "serve-favicon@2.3.0",
       "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz",
       "dependencies": {
         "etag": {
           "version": "1.7.0",
+          "from": "etag@>=1.7.0 <1.8.0",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
         },
         "fresh": {
           "version": "0.3.0",
+          "from": "fresh@0.3.0",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
         },
         "ms": {
           "version": "0.7.1",
+          "from": "ms@0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "parseurl": {
           "version": "1.3.1",
+          "from": "parseurl@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
         }
       }
     },
     "sockjs": {
       "version": "0.3.15",
+      "from": "sockjs@0.3.15",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.15.tgz",
       "dependencies": {
         "faye-websocket": {
           "version": "0.9.4",
+          "from": "faye-websocket@>=0.9.3 <0.10.0",
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
           "dependencies": {
             "websocket-driver": {
               "version": "0.6.4",
+              "from": "websocket-driver@>=0.5.1",
               "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
               "dependencies": {
                 "websocket-extensions": {
                   "version": "0.1.1",
+                  "from": "websocket-extensions@>=0.1.1",
                   "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
                 }
               }


### PR DESCRIPTION
This is reverted as shrinkwrap maintains everything as "dependencies" instead of differentiating between dev & production dependencies. So ```npm install --production``` causes dev dependencies to be installed in production environment. 

This [npm#10073 - PR](https://github.com/npm/npm/pull/10073) seems to fix this issue. However if we need to take this release we need to upgrade node & npm versions which we are not right now doing. Hence resorting to this change.

Checkstyle build - http://builds.cask.co/browse/CDAP-DRC3492-1