### PR TITLE
CDAP-5333 Fixing issue with inclusion of javadoc and sources as additional artifacts

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -299,6 +299,8 @@
                         <include name="${additional.artifacts.jar.pattern}"/>
                         <include name="${additional.artifacts.config.pattern}"/>
                         <exclude name="${additional.artifacts.exclude.pattern}"/>
+                        <exclude name="*:sources"/>
+                        <exclude name="*:javadoc"/>
                       </fileset>
                     </copy>
                   </target>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -507,6 +507,8 @@
                         <include name="${additional.artifacts.jar.pattern}"/>
                         <include name="${additional.artifacts.config.pattern}"/>
                         <exclude name="${additional.artifacts.exclude.pattern}"/>
+                        <exclude name="*:sources"/>
+                        <exclude name="*:javadoc"/>
                       </fileset>
                     </copy>
                   </target>


### PR DESCRIPTION
Due to change in the hydrator-plugins build process source and javadoc artifacts are being created which are then included into the CDAP SDK and Distributed builds. This change is to not include javadoc and sources during the build process.