### PR TITLE
CDAP-5126 Checking incompatible version of java before running CLI

### DIFF
--- a/cdap-cli/bin/cdap-cli.sh
+++ b/cdap-cli/bin/cdap-cli.sh
@@ -31,6 +31,34 @@ while [ -h "$PRG" ] ; do
     fi
 done
 
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        echo "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+        exit 1
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# java version check
+JAVA_VERSION=`$JAVACMD -version 2>&1 | grep "java version" | awk '{print $3}' | awk -F '.' '{print $2}'`
+if [ $JAVA_VERSION -ne 7 ] && [ $JAVA_VERSION -ne 8 ]; then
+  echo "ERROR: Java version not supported. Please install Java 7 or 8 - other versions of Java are not supported."
+  exit -1
+fi
+
 bin=`dirname "${PRG}"`
 bin=`cd "$bin"; pwd`
 lib="$bin"/../lib
@@ -56,4 +84,4 @@ fi
 
 CDAP_HOME="$bin"/..
 export CDAP_HOME
-java $JAVA_OPTS -cp ${CLASSPATH} -Dscript=$script co.cask.cdap.cli.CLIMain "$@"
+$JAVACMD $JAVA_OPTS -cp ${CLASSPATH} -Dscript=$script co.cask.cdap.cli.CLIMain "$@"


### PR DESCRIPTION
The issue was that we were not checking the JDK version and that was causing the issue running on CDH cluster. The default JDK configured in JDK cluster is 1.6. We need to figure out how we can change that, but for now the script makes sure that it has the right environment before running.