### PR TITLE
(CDAP-4253) Added authorization enforcement in Namespace HTTP APIs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -52,7 +52,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   private final NamespaceAdmin namespaceAdmin;
 
   @Inject
-  public NamespaceHttpHandler(CConfiguration cConf, NamespaceAdmin namespaceAdmin) {
+  NamespaceHttpHandler(CConfiguration cConf, NamespaceAdmin namespaceAdmin) {
     this.cConf = cConf;
     this.namespaceAdmin = namespaceAdmin;
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -39,6 +39,7 @@ import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
 import co.cask.tephra.TransactionManager;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
@@ -99,6 +100,7 @@ public class AppFabricTestHelper {
       injector.getInstance(StreamCoordinatorClient.class).startAndWait();
       injector.getInstance(NotificationService.class).startAndWait();
       injector.getInstance(MetricsCollectionService.class).startAndWait();
+      injector.getInstance(AuthorizerInstantiatorService.class).startAndWait();
     }
     return injector;
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -95,7 +95,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 /**
- *
+ * Tests for {@link DefaultStore}.
  */
 public class DefaultStoreTest {
   private static final Gson GSON = new Gson();

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/ETLWorkerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -42,7 +42,6 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,9 +55,6 @@ import java.util.concurrent.TimeUnit;
  */
 public class ETLWorkerTest extends ETLRealtimeBaseTest {
   private static final Logger LOG = LoggerFactory.getLogger(ETLWorkerTest.class);
-
-  @ClassRule
-  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
 
   @ClassRule
   public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli;
+
+import co.cask.cdap.StandaloneTester;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.twill.LocalLocationFactory;
+import co.cask.cdap.gateway.handlers.InMemoryAuthorizer;
+import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Role;
+import co.cask.common.cli.CLI;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests authorization CLI commands. These tests are in their own class because they need authorization enabled.
+ */
+public class AuthorizationCLITest extends CLITestBase {
+
+  /**
+   * An {@link ExternalResource} that wraps a {@link TemporaryFolder} and {@link StandaloneTester} to execute them in
+   * a chain.
+   */
+  private static final class StandaloneTesterWithAuthorization extends ExternalResource {
+    private final TemporaryFolder tmpFolder = new TemporaryFolder();
+    private StandaloneTester standaloneTester;
+
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+      // Apply the TemporaryFolder on a Statement that creates a StandaloneTester and applies on base
+      return tmpFolder.apply(new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+          standaloneTester = new StandaloneTester(getAuthConfigs(tmpFolder.newFolder()));
+          standaloneTester.apply(base, description).evaluate();
+        }
+      }, description);
+    }
+
+    /**
+     * Return the base URI of Standalone for use in tests.
+     * @return
+     */
+    public URI getBaseURI() {
+      return standaloneTester.getBaseURI();
+    }
+
+    private static String[] getAuthConfigs(File tmpDir) throws IOException {
+      LocationFactory locationFactory = new LocalLocationFactory(tmpDir);
+      Location authExtensionJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);
+      return new String[] {
+        Constants.Security.Authorization.ENABLED, "true",
+        Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath()
+      };
+    }
+  }
+
+  @ClassRule
+  public static final StandaloneTesterWithAuthorization AUTH_STANDALONE = new StandaloneTesterWithAuthorization();
+
+  private static CLI cli;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    CLIConfig cliConfig = createCLIConfig(AUTH_STANDALONE.getBaseURI());
+    LaunchOptions launchOptions = new LaunchOptions(LaunchOptions.DEFAULT.getUri(), true, true, false);
+    CLIMain cliMain = new CLIMain(launchOptions, cliConfig);
+    cli = cliMain.getCLI();
+    testCommandOutputContains(cli, "connect " + AUTH_STANDALONE.getBaseURI(), "Successfully connected");
+  }
+
+
+  @Test
+  public void testAuthorizationCLI() throws Exception {
+    Role role = new Role("admins");
+    Principal principal = new Principal("spiderman", Principal.PrincipalType.USER);
+    NamespaceId namespaceId = new NamespaceId("ns1");
+
+    // test creating role
+    testCommandOutputContains(cli, "create role " + role.getName(), String.format("Successfully created role '%s'",
+                                                                                  role.getName()));
+
+    // test add role to principal
+    testCommandOutputContains(cli, String.format("add role %s to %s %s", role.getName(), principal.getType(),
+                                                 principal.getName()),
+                              String.format("Successfully added role '%s' to '%s' '%s'", role.getName(),
+                                            principal.getType(), principal.getName()));
+
+    // test listing all roles
+    String output = getCommandOutput(cli, "list roles");
+    List<String> lines = Arrays.asList(output.split("\\r?\\n"));
+    Assert.assertEquals(2, lines.size());
+    Assert.assertEquals(role.getName(), lines.get(1)); // 0 is just the table headers
+
+    // test listing roles for a principal
+    output = getCommandOutput(cli, String.format("list roles for %s %s", principal.getType(), principal.getName()));
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    Assert.assertEquals(2, lines.size());
+    Assert.assertEquals(role.getName(), lines.get(1));
+
+    // test grant action
+    testCommandOutputContains(cli, String.format("grant actions %s on entity %s to %s %s", Action.READ,
+                                                 namespaceId.toString(), principal.getType(), principal.getName()),
+                              String.format("Successfully granted action(s) '%s' on entity '%s' to %s '%s'",
+                                            Action.READ, namespaceId.toString(), principal.getType(),
+                                            principal.getName()));
+
+    // test listing privilege
+    output = getCommandOutput(cli, String.format("list privileges for %s %s", principal.getType(),
+                                                 principal.getName()));
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    Assert.assertEquals(2, lines.size());
+    Assert.assertArrayEquals(new String[]{namespaceId.toString(), Action.READ.name()}, lines.get(1).split(","));
+
+
+    // test revoke actions
+    testCommandOutputContains(cli, String.format("revoke actions %s on entity %s from %s %s", Action.READ,
+                                                 namespaceId.toString(), principal.getType(), principal.getName()),
+                              String.format("Successfully revoked action(s) '%s' on entity '%s' for %s '%s'",
+                                            Action.READ, namespaceId.toString(), principal.getType(),
+                                            principal.getName()));
+
+    // grant and perform revoke on the entity
+    testCommandOutputContains(cli, String.format("grant actions %s on entity %s to %s %s", Action.READ,
+                                                 namespaceId.toString(), principal.getType(), principal.getName()),
+                              String.format("Successfully granted action(s) '%s' on entity '%s' to %s '%s'",
+                                            Action.READ, namespaceId.toString(), principal.getType(),
+                                            principal.getName()));
+
+    testCommandOutputContains(cli, String.format("revoke all on entity %s ", namespaceId.toString()),
+                              String.format("Successfully revoked all actions on entity '%s' for all principals",
+                                            namespaceId.toString()));
+
+
+    // test remove role from principal
+    testCommandOutputContains(cli, String.format("remove role %s from %s %s", role.getName(), principal.getType(),
+                                                 principal.getName()),
+                              String.format("Successfully removed role '%s' from %s '%s'", role.getName(),
+                                            principal.getType(), principal.getName()));
+  }
+}

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLITestBase.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLITestBase.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli;
+
+import co.cask.cdap.cli.util.InstanceURIParser;
+import co.cask.cdap.cli.util.table.CsvTableRenderer;
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.config.ConnectionConfig;
+import co.cask.common.cli.CLI;
+import com.google.common.base.Function;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.URI;
+import javax.annotation.Nullable;
+
+/**
+ * Base class for CLI Tests.
+ */
+public class CLITestBase {
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  protected static CLIConfig createCLIConfig(URI standaloneUri) throws Exception {
+    ConnectionConfig connectionConfig = InstanceURIParser.DEFAULT.parse(standaloneUri.toString());
+    ClientConfig clientConfig = new ClientConfig.Builder().setConnectionConfig(connectionConfig).build();
+    clientConfig.setAllTimeouts(60000);
+    return new CLIConfig(clientConfig, System.out, new CsvTableRenderer());
+  }
+
+  protected static void testCommandOutputContains(CLI cli, String command,
+                                                  final String expectedOutput) throws Exception {
+    testCommand(cli, command, new Function<String, Void>() {
+      @Nullable
+      @Override
+      public Void apply(@Nullable String output) {
+        Assert.assertTrue(String.format("Expected output '%s' to contain '%s'", output, expectedOutput),
+                          output != null && output.contains(expectedOutput));
+        return null;
+      }
+    });
+  }
+
+  protected static void testCommandOutputNotContains(CLI cli, String command,
+                                                   final String expectedOutput) throws Exception {
+    testCommand(cli, command, new Function<String, Void>() {
+      @Nullable
+      @Override
+      public Void apply(@Nullable String output) {
+        Assert.assertTrue(String.format("Expected output '%s' to not contain '%s'", output, expectedOutput),
+                          output != null && !output.contains(expectedOutput));
+        return null;
+      }
+    });
+  }
+
+  protected static void testCommand(CLI cli, String command, Function<String, Void> outputValidator) throws Exception {
+    String output = getCommandOutput(cli, command);
+    outputValidator.apply(output);
+  }
+
+  protected static String getCommandOutput(CLI cli, String command) throws Exception {
+    try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+         PrintStream printStream = new PrintStream(outputStream)) {
+      cli.execute(command, printStream);
+      return outputStream.toString();
+    }
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/GrantActionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/GrantActionCommand.java
@@ -54,7 +54,7 @@ public class GrantActionCommand extends AbstractAuthCommand {
     Set<Action> actions = fromStrings(Splitter.on(",").split(arguments.get("actions")));
 
     client.grant(entity, principal, actions);
-    output.printf("Successfully granted action(s) '%s' on entity '%s' to principal '%s' '%s'\n",
+    output.printf("Successfully granted action(s) '%s' on entity '%s' to %s '%s'\n",
                   Joiner.on(",").join(actions), entity.toString(), principal.getType(), principal.getName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RemoveRoleFromPrincipalCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RemoveRoleFromPrincipalCommand.java
@@ -47,7 +47,7 @@ public class RemoveRoleFromPrincipalCommand extends AbstractAuthCommand {
     String principalName = arguments.get("principal-name");
     client.removeRoleFromPrincipal(new Role(roleName), new Principal(principalName, Principal.PrincipalType.valueOf
       (principalType.toUpperCase())));
-    output.printf("Successfully removed role '%s' from '%s' '%s'\n", roleName, principalType, principalName);
+    output.printf("Successfully removed role '%s' from %s '%s'\n", roleName, principalType, principalName);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionCommand.java
@@ -61,7 +61,7 @@ public abstract class RevokeActionCommand extends AbstractAuthCommand {
     if (principal == null && actions == null) {
       output.printf("Successfully revoked all actions on entity '%s' for all principals", entity.toString());
     } else {
-      output.printf("Successfully revoked action(s) '%s' on entity '%s' for '%s' '%s'\n",
+      output.printf("Successfully revoked action(s) '%s' on entity '%s' for %s '%s'\n",
                     Joiner.on(",").join(actions), entity.toString(), principal.getType(), principal.getName());
     }
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -43,6 +43,8 @@ public final class Constants {
   public static final String COLLECT_CONTAINER_LOGS = "master.collect.containers.log";
   public static final String COLLECT_APP_CONTAINER_LOG_LEVEL = "master.collect.app.containers.log.level";
   public static final String HTTP_CLIENT_TIMEOUT_MS = "http.client.connection.timeout.ms";
+  /** Uniquely identifies a CDAP instance */
+  public static final String INSTANCE_NAME = "instance.name";
 
   /**
    * Configuration for Master startup.

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -44,6 +44,16 @@
   </property>
 
   <property>
+    <name>instance.name</name>
+    <value>${root.namespace}</value>
+    <description>
+      Determines a unique identifier for a CDAP instance. It is used for providing authorization to a particular CDAP
+      instance. Must be alphanumeric, and should not be changed after CDAP has been started. If it is changed, there is
+      a risk of losing data (for example, authorization policies).
+    </description>
+  </property>
+
+  <property>
     <name>local.data.dir</name>
     <value>data</value>
     <description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="bbc2499fa2329f34b090f99f8afadcd6"
+DEFAULT_XML_MD5_HASH="4d0656eaf5758c7b65ca7515054fe217"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -73,7 +73,7 @@ import java.util.jar.Manifest;
 import javax.annotation.Nullable;
 
 /**
- *
+ * {@link TestManager} for integration tests.
  */
 public class IntegrationTestManager implements TestManager {
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/element/EntityType.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/element/EntityType.java
@@ -23,6 +23,7 @@ import co.cask.cdap.proto.id.DatasetTypeId;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.FlowletId;
 import co.cask.cdap.proto.id.FlowletQueueId;
+import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedArtifactId;
 import co.cask.cdap.proto.id.NotificationFeedId;
@@ -40,6 +41,7 @@ import java.lang.invoke.MethodType;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Represents a type of CDAP element. E.g. namespace, application, datasets, streams.
@@ -48,6 +50,7 @@ import java.util.Map;
 @SuppressWarnings("unchecked")
 public enum EntityType {
 
+  INSTANCE(InstanceId.class, null),
   NAMESPACE(NamespaceId.class, Id.Namespace.class),
   APPLICATION(ApplicationId.class, Id.Application.class),
   PROGRAM(ProgramId.class, Id.Program.class),
@@ -75,13 +78,16 @@ public enum EntityType {
     Map<Class<? extends Id>, EntityType> byOldIdClassMap = new LinkedHashMap<>();
     for (EntityType type : EntityType.values()) {
       byIdClassMap.put(type.getIdClass(), type);
-      byOldIdClassMap.put(type.getOldIdClass(), type);
+      if (type.getOldIdClass() != null) {
+        byOldIdClassMap.put(type.getOldIdClass(), type);
+      }
     }
     byIdClass = Collections.unmodifiableMap(byIdClassMap);
     byOldIdClass = Collections.unmodifiableMap(byOldIdClassMap);
   }
 
   private final Class<? extends EntityId> idClass;
+  @Nullable
   private final Class<? extends Id> oldIdClass;
   private final MethodHandle fromIdParts;
 
@@ -100,6 +106,7 @@ public enum EntityType {
     return idClass;
   }
 
+  @Nullable
   public Class<? extends Id> getOldIdClass() {
     return oldIdClass;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/InstanceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/InstanceId.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.id;
+
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.element.EntityType;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * Uniquely identifies a CDAP instance.
+ */
+public class InstanceId extends EntityId {
+  private final String instance;
+
+  public InstanceId(String instance) {
+    super(EntityType.INSTANCE);
+    this.instance = instance;
+  }
+
+  public String getInstance() {
+    return instance;
+  }
+
+  @Override
+  protected Iterable<String> toIdParts() {
+    return Collections.singletonList(instance);
+  }
+
+  @Override
+  public Id toId() {
+    throw new UnsupportedOperationException(
+      String.format("%s does not have old %s class", InstanceId.class.getName(), Id.class.getName()));
+  }
+
+  @SuppressWarnings("unused")
+  public static InstanceId fromIdParts(Iterable<String> idString) {
+    Iterator<String> iterator = idString.iterator();
+    return new InstanceId(nextAndEnd(iterator, "instance"));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    InstanceId other = (InstanceId) o;
+    return Objects.equals(instance, other.instance);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(instance);
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/Principal.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/Principal.java
@@ -19,6 +19,8 @@ package co.cask.cdap.proto.security;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.proto.id.EntityId;
 
+import java.util.Objects;
+
 /**
  * Identifies a user, group or role which can be authorized to perform an {@link Action} on a {@link EntityId}.
  */
@@ -59,16 +61,14 @@ public class Principal {
       return false;
     }
 
-    Principal principal = (Principal) o;
+    Principal other = (Principal) o;
 
-    return name.equals(principal.name) && type == principal.type;
+    return Objects.equals(name, other.name) && Objects.equals(type, other.type);
   }
 
   @Override
   public int hashCode() {
-    int result = name.hashCode();
-    result = 31 * result + type.hashCode();
-    return result;
+    return Objects.hash(name, type);
   }
 
   @Override

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
@@ -226,6 +226,12 @@ public class EntityIdTest {
     Assert.assertEquals(expectedHierarchy, program.getHierarchy());
   }
 
+  @Test(expected = UnsupportedOperationException.class)
+  public void testInstanceId() {
+    InstanceId instanceId = new InstanceId("mycdap");
+    instanceId.toId();
+  }
+
   @Test
   @Ignore
   public void printToString() {

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorService.java
@@ -26,6 +26,7 @@ import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.NoOpAuthorizer;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.reflect.TypeToken;
@@ -144,6 +145,7 @@ public class AuthorizerInstantiatorService extends AbstractIdleService implement
    */
   @Override
   public Authorizer get() {
+    Preconditions.checkState(isRunning(), "Authorization Service has not yet started. Authorizer not available.");
     return authorizer;
   }
 

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
@@ -36,7 +37,7 @@ import java.util.jar.Manifest;
 import javax.annotation.Nullable;
 
 /**
- *
+ * Class that provides utility methods for writing tests for CDAP Applications.
  */
 public interface TestManager {
 
@@ -281,16 +282,18 @@ public interface TestManager {
    * Creates a namespace.
    *
    * @param namespaceMeta the namespace to create
-   * @throws Exception
+   * @deprecated since 3.4.0. Use {@link NamespaceAdmin} exposed by TestBase for namespace operations.
    */
+  @Deprecated
   void createNamespace(NamespaceMeta namespaceMeta) throws Exception;
 
   /**
    * Deletes a namespace.
    *
    * @param namespace the namespace to delete
-   * @throws Exception
+   * @deprecated since 3.4.0. Use {@link NamespaceAdmin} exposed by TestBase for namespace operations.
    */
+  @Deprecated
   void deleteNamespace(Id.Namespace namespace) throws Exception;
 
   /**

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.test;
 
 import co.cask.cdap.api.Config;
+import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.app.Application;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
@@ -67,6 +68,7 @@ import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.executor.ExploreExecutorService;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.explore.guice.ExploreRuntimeModule;
+import co.cask.cdap.gateway.handlers.AuthorizationHandler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
@@ -78,6 +80,13 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
+import co.cask.cdap.security.authorization.InvalidAuthorizerException;
+import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
+import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.cdap.test.internal.ApplicationManagerFactory;
 import co.cask.cdap.test.internal.DefaultApplicationManager;
@@ -87,6 +96,7 @@ import co.cask.cdap.test.internal.StreamManagerFactory;
 import co.cask.tephra.TransactionManager;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
@@ -135,7 +145,10 @@ public class TestBase {
   private static final Logger LOG = LoggerFactory.getLogger(TestBase.class);
 
   @ClassRule
-  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  @Deprecated
+  @SuppressWarnings("unused")
+  public static TemporaryFolder tmpFolder = TMP_FOLDER;
 
   private static CConfiguration cConf;
   private static int startCount;
@@ -151,6 +164,7 @@ public class TestBase {
   private static MetricsManager metricsManager;
   private static TestManager testManager;
   private static NamespaceAdmin namespaceAdmin;
+  private static AuthorizerInstantiatorService authorizerInstantiatorService;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -160,7 +174,7 @@ public class TestBase {
     if (startCount++ > 0) {
       return;
     }
-    File localDataDir = tmpFolder.newFolder();
+    File localDataDir = TMP_FOLDER.newFolder();
 
     cConf = createCConf(localDataDir);
 
@@ -173,7 +187,7 @@ public class TestBase {
 
     // Windows specific requirements
     if (OSDetector.isWindows()) {
-      File tmpDir = tmpFolder.newFolder();
+      File tmpDir = TMP_FOLDER.newFolder();
       File binDir = new File(tmpDir, "bin");
       Assert.assertTrue(binDir.mkdirs());
 
@@ -226,7 +240,8 @@ public class TestBase {
                     .build(ApplicationManagerFactory.class));
           install(new FactoryModuleBuilder().implement(StreamManager.class, DefaultStreamManager.class)
                     .build(StreamManagerFactory.class));
-          bind(TemporaryFolder.class).toInstance(tmpFolder);
+          bind(TemporaryFolder.class).toInstance(TMP_FOLDER);
+          bind(AuthorizationHandler.class).in(Scopes.SINGLETON);
         }
       }
     );
@@ -251,8 +266,15 @@ public class TestBase {
     streamCoordinatorClient = injector.getInstance(StreamCoordinatorClient.class);
     streamCoordinatorClient.startAndWait();
     testManager = injector.getInstance(UnitTestManager.class);
-    namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
     metricsManager = injector.getInstance(MetricsManager.class);
+    authorizerInstantiatorService = injector.getInstance(AuthorizerInstantiatorService.class);
+    authorizerInstantiatorService.startAndWait();
+    // This is needed so the logged-in user can successfully create the default namespace
+    if (cConf.getBoolean(Constants.Security.Authorization.ENABLED)) {
+      InstanceId instance = new InstanceId(cConf.get(Constants.INSTANCE_NAME));
+      Principal principal = new Principal(SecurityRequestContext.getUserId(), Principal.PrincipalType.USER);
+      authorizerInstantiatorService.get().grant(instance, principal, ImmutableSet.of(Action.ADMIN));
+    }
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
     namespaceAdmin.create(NamespaceMeta.DEFAULT);
   }
@@ -316,7 +338,7 @@ public class TestBase {
 
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, localDataDir.getAbsolutePath());
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
-    cConf.set(Constants.Explore.LOCAL_DATA_DIR, tmpFolder.newFolder("hive").getAbsolutePath());
+    cConf.set(Constants.Explore.LOCAL_DATA_DIR, TMP_FOLDER.newFolder("hive").getAbsolutePath());
     return cConf;
   }
 
@@ -353,6 +375,7 @@ public class TestBase {
     }
 
     namespaceAdmin.delete(Id.Namespace.DEFAULT);
+    authorizerInstantiatorService.stopAndWait();
     streamCoordinatorClient.stopAndWait();
     metricsQueryService.stopAndWait();
     metricsCollectionService.startAndWait();
@@ -376,8 +399,9 @@ public class TestBase {
    * Creates a Namespace.
    *
    * @param namespace the namespace to create
-   * @throws Exception
+   * @deprecated since 3.4.0. Use {@link #getNamespaceAdmin()} to perform namespace operations instead.
    */
+  @Deprecated
   protected static void createNamespace(Id.Namespace namespace) throws Exception {
     getTestManager().createNamespace(new NamespaceMeta.Builder().setName(namespace).build());
   }
@@ -385,9 +409,10 @@ public class TestBase {
   /**
    * Deletes a Namespace.
    *
-   * @param namespace the namespace to create
-   * @throws Exception
+   * @param namespace the namespace to delete
+   * @deprecated since 3.4.0. Use {@link #getNamespaceAdmin()} to perform namespace operations instead.
    */
+  @Deprecated
   protected static void deleteNamespace(Id.Namespace namespace) throws Exception {
     getTestManager().deleteNamespace(namespace);
   }
@@ -585,7 +610,6 @@ public class TestBase {
     getTestManager().deployDatasetModule(namespace, moduleName, datasetModule);
   }
 
-
   /**
    * Deploys {@link DatasetModule}.
    *
@@ -597,6 +621,7 @@ public class TestBase {
                                             Class<? extends DatasetModule> datasetModule) throws Exception {
     deployDatasetModule(Id.Namespace.DEFAULT, moduleName, datasetModule);
   }
+
 
   /**
    * Adds an instance of a dataset.
@@ -612,7 +637,6 @@ public class TestBase {
     return getTestManager().addDatasetInstance(namespace, datasetTypeName, datasetInstanceName, props);
   }
 
-
   /**
    * Adds an instance of a dataset.
    *
@@ -626,6 +650,7 @@ public class TestBase {
                                                                  DatasetProperties props) throws Exception {
     return addDatasetInstance(Id.Namespace.DEFAULT, datasetTypeName, datasetInstanceName, props);
   }
+
 
   /**
    * Adds an instance of dataset.
@@ -714,5 +739,27 @@ public class TestBase {
 
   protected TransactionManager getTxService() {
     return txService;
+  }
+
+  /**
+   * Returns a {@link NamespaceAdmin} to interact with namespaces.
+   */
+  protected final NamespaceAdmin getNamespaceAdmin() {
+    return namespaceAdmin;
+  }
+
+  /**
+   * Returns an {@link Authorizer} for performing authorization operations.
+   */
+  @Beta
+  protected final Authorizer getAuthorizer() throws IOException, InvalidAuthorizerException {
+    return authorizerInstantiatorService.get();
+  }
+
+  /**
+   * Returns the {@link CConfiguration} used in tests.
+   */
+  protected final CConfiguration getConfiguration() {
+    return cConf;
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -73,7 +73,7 @@ import java.util.jar.Manifest;
 import javax.annotation.Nullable;
 
 /**
- *
+ * {@link TestManager} for use in unit tests.
  */
 public class UnitTestManager implements TestManager {
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.twill.LocalLocationFactory;
+import co.cask.cdap.gateway.handlers.InMemoryAuthorizer;
+import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
+import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
+import com.google.common.collect.ImmutableSet;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Unit tests with authorization enabled.
+ */
+public class AuthorizationTest extends TestBase {
+
+  private static final String oldUser = SecurityRequestContext.getUserId();
+  private static final Principal alice = new Principal("alice", Principal.PrincipalType.USER);
+
+  private InstanceId instance;
+
+  /**
+   * An {@link ExternalResource} that wraps a {@link TemporaryFolder} and {@link TestConfiguration} to execute them in
+   * a chain.
+   */
+  private static final class AuthTestConf extends ExternalResource {
+    private final TemporaryFolder tmpFolder = new TemporaryFolder();
+    private TestConfiguration testConf;
+
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+      // Apply the TemporaryFolder on a Statement that creates a TestConfiguration and applies on base
+      return tmpFolder.apply(new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+          testConf = new TestConfiguration(getAuthConfigs(tmpFolder.newFolder()));
+          testConf.apply(base, description).evaluate();
+        }
+      }, description);
+    }
+
+    private static String[] getAuthConfigs(File tmpDir) throws IOException {
+      LocationFactory locationFactory = new LocalLocationFactory(tmpDir);
+      Location authExtensionJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);
+      return new String[] {
+        Constants.Security.Authorization.ENABLED, "true",
+        Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath()
+      };
+    }
+  }
+
+  @ClassRule
+  public static final AuthTestConf AUTH_TEST_CONF = new AuthTestConf();
+
+  @BeforeClass
+  public static void setup() {
+    SecurityRequestContext.setUserId(alice.getName());
+  }
+
+  @Before
+  public void setupTest() throws Exception {
+    instance = new InstanceId(getConfiguration().get(Constants.INSTANCE_NAME));
+    getAuthorizer().grant(NamespaceId.DEFAULT, alice, ImmutableSet.of(Action.ADMIN));
+    Assert.assertEquals(
+      ImmutableSet.of(new Privilege(NamespaceId.DEFAULT, Action.ADMIN)),
+      getAuthorizer().listPrivileges(alice)
+    );
+  }
+
+  @Test
+  public void testNamespaces() throws Exception {
+    NamespaceId namespace = new NamespaceId("authorization");
+    NamespaceAdmin namespaceAdmin = getNamespaceAdmin();
+    Authorizer authorizer = getAuthorizer();
+    NamespaceMeta meta = new NamespaceMeta.Builder().setName(namespace.getNamespace()).build();
+    try {
+      namespaceAdmin.create(meta);
+      Assert.fail("Namespace create should have failed because alice is not authorized on " + instance);
+    } catch (UnauthorizedException expected) {
+      // expected
+    }
+    authorizer.grant(instance, alice, ImmutableSet.of(Action.ADMIN));
+    Assert.assertEquals(
+      ImmutableSet.of(new Privilege(NamespaceId.DEFAULT, Action.ADMIN), new Privilege(instance, Action.ADMIN)),
+      authorizer.listPrivileges(alice)
+    );
+    namespaceAdmin.create(meta);
+    // create should grant all privileges
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new Privilege(NamespaceId.DEFAULT, Action.ADMIN),
+        new Privilege(instance, Action.ADMIN),
+        new Privilege(namespace, Action.ALL)
+      ),
+      authorizer.listPrivileges(alice)
+    );
+    // No authorization currently for listing and retrieving namespace
+    namespaceAdmin.list();
+    namespaceAdmin.get(namespace.toId());
+    // revoke privileges
+    authorizer.revoke(namespace);
+    Assert.assertEquals(
+      ImmutableSet.of(new Privilege(NamespaceId.DEFAULT, Action.ADMIN), new Privilege(instance, Action.ADMIN)),
+      authorizer.listPrivileges(alice)
+    );
+    try {
+      namespaceAdmin.deleteDatasets(namespace.toId());
+      Assert.fail("Namespace delete datasets should have failed because alice's privileges on the namespace have " +
+                    "been revoked");
+    } catch (UnauthorizedException expected) {
+      // expected
+    }
+    // grant privileges again
+    authorizer.grant(namespace, alice, ImmutableSet.of(Action.ADMIN));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new Privilege(NamespaceId.DEFAULT, Action.ADMIN),
+        new Privilege(instance, Action.ADMIN),
+        new Privilege(namespace, Action.ADMIN)
+      ),
+      authorizer.listPrivileges(alice)
+    );
+    namespaceAdmin.deleteDatasets(namespace.toId());
+    // deleting datasets does not revoke privileges.
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new Privilege(NamespaceId.DEFAULT, Action.ADMIN),
+        new Privilege(instance, Action.ADMIN),
+        new Privilege(namespace, Action.ADMIN)
+      ),
+      authorizer.listPrivileges(alice)
+    );
+    NamespaceMeta updated = new NamespaceMeta.Builder(meta).setDescription("new desc").build();
+    namespaceAdmin.updateProperties(namespace.toId(), updated);
+    namespaceAdmin.delete(namespace.toId());
+    // once the namespace has been deleted, privileges on that namespace should be revoked
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new Privilege(NamespaceId.DEFAULT, Action.ADMIN),
+        new Privilege(instance, Action.ADMIN)
+      ),
+      authorizer.listPrivileges(alice)
+    );
+  }
+
+  @AfterClass
+  public static void cleanup() throws Exception {
+    // we want to execute TestBase's @AfterClass before unsetting userid
+    finish();
+    SecurityRequestContext.setUserId(oldUser);
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -41,6 +41,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.WorkflowTokenDetail;
@@ -122,7 +123,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
   @Before
   public void setUp() throws Exception {
-    createNamespace(testSpace);
+    getNamespaceAdmin().create(new NamespaceMeta.Builder().setName(testSpace).build());
   }
 
   @Test
@@ -514,8 +515,8 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     throws Exception {
     WorkflowManager wfManager = applicationManager.getWorkflowManager(WorkflowAppWithLocalDatasets.WORKFLOW_NAME);
     Map<String, String> runtimeArgs = new HashMap<>();
-    File waitFile = new File(tmpFolder.newFolder(), "/wait.file");
-    File doneFile = new File(tmpFolder.newFolder(), "/done.file");
+    File waitFile = new File(TMP_FOLDER.newFolder(), "/wait.file");
+    File doneFile = new File(TMP_FOLDER.newFolder(), "/done.file");
 
     runtimeArgs.put("input.path", "input");
     runtimeArgs.put("output.path", "output");


### PR DESCRIPTION
- Added a new ``EntityId`` - ``InstanceId`` to represent a CDAP instance
- Namespace create needs *ADMIN* privilege on the CDAP instance
- Namespace delete needs *ADMIN* privilege on the namespace being deleted
- Also added initial support for authorization in ``TestBase``. Currently only supports granting and revoking privileges
- Added support for listing and retrieving namespaces as well as retrieving ``CConfiguration`` in ``TestBase``
- Refactored ``CLIMainTest`` to pull out Authorization CLI Tests into a separate class which can enable authorization

Overall, the PR looks large, but mostly involves adding functionality to ``TestBase`` and refactoring some tests. The core logic of enforcement is contained in ``DefaultNamespaceAdmin``, while test is in ``AuthorizationTest``

Jira: [CDAP-4253](https://issues.cask.co/browse/CDAP-4253)
Build: http://builds.cask.co/browse/CDAP-DUT3742