### PR TITLE
Update to latest IntelliJ version, previous version unavailable

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -89,7 +89,7 @@
         },
         "idea": {
           "setup_dir": "/opt",
-          "version": "15.0.2"
+          "version": "2016.1"
         },
         "hadoop": {
           "distribution": "hdp",

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
@@ -87,7 +87,7 @@
         },
         "idea": {
           "setup_dir": "/opt",
-          "version": "15.0.2"
+          "version": "2016.1"
         },
         "hadoop": {
           "distribution": "hdp",

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -20,7 +20,7 @@
 
 # Grab cookbooks using knife
 for cb in hadoop idea maven nodejs cdap ; do
-  knife cookbook site install $cb || (echo "Cannot fetch cookbook $cb" && exit 1)
+  knife cookbook site install --force $cb || echo "Cannot fetch cookbook $cb" && exit 1
 done
 
 # Do not change HOME for cdap user


### PR DESCRIPTION
The previous download gives a 403 forbidden error when attempting to fetch.