### PR TITLE
CDAP-5155: Add InvalidPrincipalTypeException

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/GrantActionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/GrantActionCommand.java
@@ -49,7 +49,8 @@ public class GrantActionCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
     String principalName = arguments.get("principal-name");
-    Principal.PrincipalType principalType = Principal.PrincipalType.valueOf(arguments.get("principal-type"));
+    Principal.PrincipalType principalType = Principal.PrincipalType.valueOf(
+      arguments.get("principal-type").toUpperCase());
     Principal principal = new Principal(principalName, principalType);
     Set<Action> actions = fromStrings(Splitter.on(",").split(arguments.get("actions")));
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionCommand.java
@@ -52,7 +52,7 @@ public abstract class RevokeActionCommand extends AbstractAuthCommand {
     String principalName = arguments.getOptional("principal-name", null);
     String type = arguments.getOptional("principal-type", null);
     Principal.PrincipalType principalType =
-      type != null ? Principal.PrincipalType.valueOf(arguments.get("principal-type")) : null;
+      type != null ? Principal.PrincipalType.valueOf(arguments.get("principal-type").toUpperCase()) : null;
     Principal principal = type != null ? new Principal(principalName, principalType) : null;
     String actionsString = arguments.getOptional("actions", null);
     Set<Action> actions = actionsString == null ? null : fromStrings(Splitter.on(",").split(actionsString));


### PR DESCRIPTION
This adds  an InvalidPrincipalType exception which will be thrown is the principal type is not supported y the operation being performed. 

Build: http://builds.cask.co/browse/CDAP-DUT3757-1