### PR TITLE
Refactor ProgramWorkflowRunner

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/WorkflowTokenProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/WorkflowTokenProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime;
+
+import co.cask.cdap.api.workflow.WorkflowToken;
+
+/**
+ * An interface for classes that can provide {@link WorkflowToken} instance.
+ */
+public interface WorkflowTokenProvider {
+
+  /**
+   * Returns a {@link WorkflowToken}.
+   */
+  WorkflowToken getWorkflowToken();
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -44,6 +44,7 @@ import co.cask.cdap.internal.app.runtime.batch.dataset.DatasetOutputFormatProvid
 import co.cask.cdap.internal.app.runtime.batch.dataset.input.MapperInput;
 import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.logging.context.MapReduceLoggingContext;
 import co.cask.cdap.proto.Id;
@@ -159,7 +160,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
    */
   @Override
   @Nullable
-  public WorkflowToken getWorkflowToken() {
+  public BasicWorkflowToken getWorkflowToken() {
     return workflowProgramInfo == null ? null : workflowProgramInfo.getWorkflowToken();
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,7 +18,9 @@ package co.cask.cdap.internal.app.runtime.spark;
 
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.spark.SparkContext;
+import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.runtime.ProgramController;
+import co.cask.cdap.app.runtime.WorkflowTokenProvider;
 import co.cask.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
 import com.google.common.util.concurrent.Service;
 
@@ -26,7 +28,7 @@ import com.google.common.util.concurrent.Service;
  * A {@link ProgramController} for {@link Spark} jobs. This class acts as an adapter for reflecting state changes
  * happening in {@link SparkRuntimeService}
  */
-public final class SparkProgramController extends ProgramControllerServiceAdapter {
+final class SparkProgramController extends ProgramControllerServiceAdapter implements WorkflowTokenProvider {
 
   private final SparkContext context;
 
@@ -35,10 +37,14 @@ public final class SparkProgramController extends ProgramControllerServiceAdapte
     this.context = context;
   }
 
-  /**
-   * Returns the {@link SparkContext} for Spark run represented by this controller.
-   */
-  public SparkContext getContext() {
-    return context;
+  @Override
+  public WorkflowToken getWorkflowToken() {
+    WorkflowToken workflowToken = context.getWorkflowToken();
+    if (workflowToken == null) {
+      throw new IllegalStateException("WorkflowToken cannot be null when the " +
+                                        "Spark program is started by Workflow.");
+    }
+
+    return workflowToken;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ProgramWorkflowRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ProgramWorkflowRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,13 +17,11 @@ package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.workflow.Workflow;
-import co.cask.cdap.app.program.Program;
-import co.cask.cdap.app.runtime.ProgramOptions;
 
 /**
  * An interface for Programs which can run in a {@link Workflow}. Please see {@link SchedulableProgramType}.
  */
-public interface ProgramWorkflowRunner {
+interface ProgramWorkflowRunner {
 
   /**
    * Programs which want to support running in Workflow should give the implementation to get a {@link Runnable} of
@@ -33,14 +31,4 @@ public interface ProgramWorkflowRunner {
    * @return {@link Runnable} which will be called to execute the program
    */
   Runnable create(String name);
-
-  /**
-   * Programs which want to run in Workflow should give an implementation to run the given {@link Program} with
-   * {@link ProgramOptions}.
-   *
-   * @param program {@link Program} to run
-   * @param options {@link ProgramOptions} with which this program should run
-   * @throws Exception if the execution of the program fails.
-   */
-  void runAndWait(Program program, ProgramOptions options) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/SparkProgramWorkflowRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/SparkProgramWorkflowRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,17 +17,13 @@ package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.spark.Spark;
-import co.cask.cdap.api.spark.SparkContext;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.program.Program;
-import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
-import co.cask.cdap.internal.app.runtime.spark.SparkProgramController;
-import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
 
 /**
@@ -59,33 +55,5 @@ final class SparkProgramWorkflowRunner extends AbstractProgramWorkflowRunner {
 
     final Program sparkProgram = new WorkflowSparkProgram(workflowProgram, sparkSpec);
     return getProgramRunnable(name, sparkProgram);
-  }
-
-  /**
-   * Executes given {@link Program} with the given {@link ProgramOptions} and block until it completed.
-   *
-   * @throws Exception if execution failed.
-   */
-  @Override
-  public void runAndWait(Program program, ProgramOptions options) throws Exception {
-    ProgramController controller = programRunnerFactory.create(ProgramType.SPARK).run(program, options);
-
-    if (controller instanceof SparkProgramController) {
-      SparkContext sparkContext = ((SparkProgramController) controller).getContext();
-      executeProgram(controller, sparkContext);
-      updateWorkflowToken(sparkContext);
-    } else {
-      throw new IllegalStateException("Failed to run program. The controller is not an instance of " +
-                                        "SparkProgramController");
-    }
-  }
-
-  private void updateWorkflowToken(SparkContext sparkContext) {
-    WorkflowToken workflowTokenFromContext = sparkContext.getWorkflowToken();
-    if (workflowTokenFromContext == null) {
-      throw new IllegalStateException("WorkflowToken cannot be null when the Spark program is started by Workflow.");
-    }
-
-    ((BasicWorkflowToken) token).mergeToken((BasicWorkflowToken) workflowTokenFromContext);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -411,7 +411,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
           Map.Entry<String, WorkflowToken> retValue = forkBranchResult.get();
           String branchInfo = retValue.getKey();
           WorkflowToken branchToken = retValue.getValue();
-          ((BasicWorkflowToken) token).mergeToken((BasicWorkflowToken) branchToken);
+          ((BasicWorkflowToken) token).mergeToken(branchToken);
           LOG.info("Execution of branch {} for fork {} completed", branchInfo, fork);
         } catch (Throwable t) {
           Throwable rootCause = Throwables.getRootCause(t);


### PR DESCRIPTION
- Remove unnecessary method from the ProgramWorkflowRunner
- Introduce a new WorkflowTokenProvider interface
  - Unify the way how a ProgramController return a WorkflowToken
    back to WorkflowDriver to merge
- Move logic of setting MapReduce counters into BasicWorkflowToken
- Make BasicWorkflowToken.merge work against WorkflowToken to reduce the need of casting.