### PR TITLE
CDAP-4987 Fix Describe Artifact to search in both scope

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
@@ -88,9 +88,9 @@ public class DescribeArtifactCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Shows information about %s. If no scope is given, the artifact is looked up in all " +
-                           "the scopes. Includes information about application and plugin classes contained " +
-                           "in the artifact.",
+    return String.format("Shows information about %s. If no scope is given, the artifact is looked up first in " +
+                           "SYSTEM and then in USER scope. Includes information about application and plugin " +
+                           "classes contained in the artifact.",
       Fragment.of(Article.A, ElementType.ARTIFACT.getName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
@@ -25,6 +25,7 @@ import co.cask.cdap.cli.english.Fragment;
 import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.ArtifactClient;
+import co.cask.cdap.common.ArtifactNotFoundException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactInfo;
 import co.cask.common.cli.Arguments;
@@ -59,7 +60,12 @@ public class DescribeArtifactCommand extends AbstractAuthCommand {
 
     ArtifactInfo info;
     if (scopeStr == null) {
-      info = artifactClient.getArtifactInfo(artifactId);
+      // When scope is null, then look it up in both SYSTEM and USER scope.
+      try {
+        info = artifactClient.getArtifactInfo(artifactId, ArtifactScope.SYSTEM);
+      } catch (ArtifactNotFoundException e) {
+        info = artifactClient.getArtifactInfo(artifactId, ArtifactScope.USER);
+      }
     } else {
       ArtifactScope scope = ArtifactScope.valueOf(scopeStr.toUpperCase());
       info = artifactClient.getArtifactInfo(artifactId, scope);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
@@ -60,12 +60,7 @@ public class DescribeArtifactCommand extends AbstractAuthCommand {
 
     ArtifactInfo info;
     if (scopeStr == null) {
-      // When scope is null, then look it up in both SYSTEM and USER scope.
-      try {
-        info = artifactClient.getArtifactInfo(artifactId, ArtifactScope.SYSTEM);
-      } catch (ArtifactNotFoundException e) {
-        info = artifactClient.getArtifactInfo(artifactId, ArtifactScope.USER);
-      }
+      info = artifactClient.getArtifactInfo(artifactId);
     } else {
       ArtifactScope scope = ArtifactScope.valueOf(scopeStr.toUpperCase());
       info = artifactClient.getArtifactInfo(artifactId, scope);
@@ -93,8 +88,9 @@ public class DescribeArtifactCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Shows information about %s. If no scope is given, the user scope will be used. " +
-      "Includes information about application and plugin classes contained in the artifact.",
+    return String.format("Shows information about %s. If no scope is given, the artifact is looked up in all " +
+                           "the scopes. Includes information about application and plugin classes contained " +
+                           "in the artifact.",
       Fragment.of(Article.A, ElementType.ARTIFACT.getName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactPluginCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactPluginCommand.java
@@ -24,6 +24,7 @@ import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.ArtifactClient;
+import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.PluginInfo;
 import co.cask.common.cli.Arguments;
@@ -57,7 +58,7 @@ public class DescribeArtifactPluginCommand extends AbstractAuthCommand {
     String pluginType = arguments.get(ArgumentName.PLUGIN_TYPE.toString());
     String pluginName = arguments.get(ArgumentName.PLUGIN_NAME.toString());
 
-    final List<PluginInfo> pluginInfos;
+    List<PluginInfo> pluginInfos;
     String scopeStr = arguments.getOptional(ArgumentName.SCOPE.toString());
     if (scopeStr == null) {
       pluginInfos = artifactClient.getPluginInfo(artifactId, pluginType, pluginName);
@@ -88,7 +89,7 @@ public class DescribeArtifactPluginCommand extends AbstractAuthCommand {
   public String getDescription() {
     return String.format("Describes all plugins of a specific type and name available to a specific %s. " +
       "Can return multiple details if the plugin exists in multiple %s. " +
-      "If no scope is given, the user scope will be used.",
+      "If no scope is given, then plugins are looked up in all the scopes.",
       ElementType.ARTIFACT.getName(), ElementType.ARTIFACT.getNamePlural());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactPluginCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactPluginCommand.java
@@ -89,7 +89,7 @@ public class DescribeArtifactPluginCommand extends AbstractAuthCommand {
   public String getDescription() {
     return String.format("Describes all plugins of a specific type and name available to a specific %s. " +
       "Can return multiple details if the plugin exists in multiple %s. " +
-      "If no scope is given, then plugins are looked up in all the scopes.",
+      "If no scope is given, then plugins are looked up first in SYSTEM and then in USER scope.",
       ElementType.ARTIFACT.getName(), ElementType.ARTIFACT.getNamePlural());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.ArtifactClient;
+import co.cask.cdap.common.ArtifactNotFoundException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactInfo;
 import co.cask.common.cli.Arguments;
@@ -89,7 +90,7 @@ public class GetArtifactPropertiesCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Gets properties of %s. If no scope is given, the user scope will be used. ",
+    return String.format("Gets properties of %s. If no scope is given, properties are looked up in all scopes.",
                          Fragment.of(Article.A, ElementType.ARTIFACT.getName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
@@ -90,7 +90,8 @@ public class GetArtifactPropertiesCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Gets properties of %s. If no scope is given, properties are looked up in all scopes.",
+    return String.format("Gets properties of %s. If no scope is given, properties are looked first in SYSTEM and " +
+                           "then in USER scope.",
                          Fragment.of(Article.A, ElementType.ARTIFACT.getName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginTypesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginTypesCommand.java
@@ -80,6 +80,7 @@ public class ListArtifactPluginTypesCommand extends AbstractAuthCommand {
   @Override
   public String getDescription() {
     return String.format("Lists all plugin types usable by the specified %s. " +
-      "If no scope is given, the user scope will be used.", ElementType.ARTIFACT.getName());
+      "If no scope is given, properties are looked first in SYSTEM and then in USER scope.", 
+                         ElementType.ARTIFACT.getName());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginsCommand.java
@@ -85,7 +85,8 @@ public class ListArtifactPluginsCommand extends AbstractAuthCommand {
   public String getDescription() {
     return String.format("Lists all plugins of a specific type available to a specific %s. " +
       "Includes the type, name, classname, and description of the plugin, " +
-      "as well as the %s the plugin came from. If no scope is given, the user scope will be used.",
+      "as well as the %s the plugin came from. If no scope is given, properties are looked first in " +
+                           "SYSTEM and then in USER scope.",
       ElementType.ARTIFACT.getName(), ElementType.ARTIFACT.getName());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactVersionsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactVersionsCommand.java
@@ -75,7 +75,8 @@ public class ListArtifactVersionsCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Lists all versions of a specific %s. If no scope is given, the user scope will be used.",
+    return String.format("Lists all versions of a specific %s. If no scope is given, properties are looked " +
+                           "first in SYSTEM and then in USER scope.",
                          ElementType.ARTIFACT.getName());
   }
 }

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -408,8 +408,8 @@ public class ArtifactClient {
                                         ArtifactScope scope)
     throws IOException, UnauthenticatedException, NotFoundException {
 
-    String path = String.format("artifacts/%s/versions/%s/extensions/%s/plugins/%s",
-      artifactId.getName(), artifactId.getVersion().getVersion(), pluginType, pluginName);
+    String path = String.format("artifacts/%s/versions/%s/extensions/%s/plugins/%s?scope=%s",
+      artifactId.getName(), artifactId.getVersion().getVersion(), pluginType, pluginName, scope.name());
     URL url = config.resolveNamespacedURLV3(artifactId.getNamespace(), path);
 
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -176,7 +176,13 @@ public class ArtifactClient {
    */
   public ArtifactInfo getArtifactInfo(Id.Artifact artifactId)
     throws IOException, UnauthenticatedException, ArtifactNotFoundException {
-    return getArtifactInfo(artifactId, ArtifactScope.USER);
+    ArtifactInfo info;
+    try {
+      info = getArtifactInfo(artifactId, ArtifactScope.SYSTEM);
+    } catch (ArtifactNotFoundException e) {
+      info = getArtifactInfo(artifactId, ArtifactScope.USER);
+    }
+    return info;
   }
 
   /**
@@ -191,11 +197,14 @@ public class ArtifactClient {
    */
   public ArtifactInfo getArtifactInfo(Id.Artifact artifactId, ArtifactScope scope)
     throws IOException, UnauthenticatedException, ArtifactNotFoundException {
-
-    String path = String.format("artifacts/%s/versions/%s?scope=%s",
-      artifactId.getName(), artifactId.getVersion().getVersion(), scope.name());
+    
+    String path = String.format("artifacts/%s/versions/%s",
+      artifactId.getName(), artifactId.getVersion().getVersion());
+    if(scope != null) {
+      path = String.format("%s?scope=%s", path, scope.name());
+    }
+    
     URL url = config.resolveNamespacedURLV3(artifactId.getNamespace(), path);
-
     HttpResponse response =
       restClient.execute(HttpMethod.GET, url, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -365,7 +374,13 @@ public class ArtifactClient {
    */
   public List<PluginInfo> getPluginInfo(Id.Artifact artifactId, String pluginType, String pluginName)
     throws IOException, UnauthenticatedException, NotFoundException {
-    return getPluginInfo(artifactId, pluginType, pluginName, ArtifactScope.USER);
+    List<PluginInfo> pluginInfo;
+    try {
+      pluginInfo = getPluginInfo(artifactId, pluginType, pluginName, ArtifactScope.SYSTEM);
+    } catch (NotFoundException e) {
+      pluginInfo = getPluginInfo(artifactId, pluginType, pluginName, ArtifactScope.USER);
+    }
+    return pluginInfo;
   }
 
   /**
@@ -384,8 +399,11 @@ public class ArtifactClient {
                                         ArtifactScope scope)
     throws IOException, UnauthenticatedException, NotFoundException {
 
-    String path = String.format("artifacts/%s/versions/%s/extensions/%s/plugins/%s?scope=%s",
-      artifactId.getName(), artifactId.getVersion().getVersion(), pluginType, pluginName, scope.name());
+    String path = String.format("artifacts/%s/versions/%s/extensions/%s/plugins/%s",
+      artifactId.getName(), artifactId.getVersion().getVersion(), pluginType, pluginName);
+    if(scope != null) {
+      path = String.format("%s?scope=%s", path, scope.name());
+    }
     URL url = config.resolveNamespacedURLV3(artifactId.getNamespace(), path);
 
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -198,12 +198,9 @@ public class ArtifactClient {
   public ArtifactInfo getArtifactInfo(Id.Artifact artifactId, ArtifactScope scope)
     throws IOException, UnauthenticatedException, ArtifactNotFoundException {
     
-    String path = String.format("artifacts/%s/versions/%s",
-      artifactId.getName(), artifactId.getVersion().getVersion());
-    if (scope != null) {
-      path = String.format("%s?scope=%s", path, scope.name());
-    }
-    
+    String path = String.format("artifacts/%s/versions/%s?scope=%s",
+      artifactId.getName(), artifactId.getVersion().getVersion(), scope.name());
+
     URL url = config.resolveNamespacedURLV3(artifactId.getNamespace(), path);
     HttpResponse response =
       restClient.execute(HttpMethod.GET, url, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
@@ -292,7 +289,13 @@ public class ArtifactClient {
    */
   public List<String> getPluginTypes(Id.Artifact artifactId)
     throws IOException, UnauthenticatedException, ArtifactNotFoundException {
-    return getPluginTypes(artifactId, ArtifactScope.USER);
+    List<String> pluginTypes;
+    try {
+      pluginTypes = getPluginTypes(artifactId, ArtifactScope.SYSTEM);
+    } catch (ArtifactNotFoundException e) {
+      pluginTypes = getPluginTypes(artifactId, ArtifactScope.USER);
+    }
+    return pluginTypes;
   }
 
   /**
@@ -332,7 +335,13 @@ public class ArtifactClient {
    */
   public List<PluginSummary> getPluginSummaries(Id.Artifact artifactId, String pluginType)
     throws IOException, UnauthenticatedException, ArtifactNotFoundException {
-    return getPluginSummaries(artifactId, pluginType, ArtifactScope.USER);
+    List<PluginSummary> pluginSummary;
+    try {
+      pluginSummary = getPluginSummaries(artifactId, pluginType, ArtifactScope.SYSTEM);
+    } catch (ArtifactNotFoundException e) {
+      pluginSummary = getPluginSummaries(artifactId, pluginType, ArtifactScope.USER);
+    }
+    return pluginSummary;
   }
 
   /**
@@ -401,9 +410,6 @@ public class ArtifactClient {
 
     String path = String.format("artifacts/%s/versions/%s/extensions/%s/plugins/%s",
       artifactId.getName(), artifactId.getVersion().getVersion(), pluginType, pluginName);
-    if (scope != null) {
-      path = String.format("%s?scope=%s", path, scope.name());
-    }
     URL url = config.resolveNamespacedURLV3(artifactId.getNamespace(), path);
 
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -200,7 +200,7 @@ public class ArtifactClient {
     
     String path = String.format("artifacts/%s/versions/%s",
       artifactId.getName(), artifactId.getVersion().getVersion());
-    if(scope != null) {
+    if (scope != null) {
       path = String.format("%s?scope=%s", path, scope.name());
     }
     
@@ -401,7 +401,7 @@ public class ArtifactClient {
 
     String path = String.format("artifacts/%s/versions/%s/extensions/%s/plugins/%s",
       artifactId.getName(), artifactId.getVersion().getVersion(), pluginType, pluginName);
-    if(scope != null) {
+    if (scope != null) {
       path = String.format("%s?scope=%s", path, scope.name());
     }
     URL url = config.resolveNamespacedURLV3(artifactId.getNamespace(), path);


### PR DESCRIPTION
Currently when you describe artifact, the artifact is searched only in USER namespace. This creates confusion and forces one to know the SCOPE before describing. With this change when no scope is provided it would search in both SCOPE in the order SYSTEM and the USER. 

Following are all the commands that have been fixed. 

- [x] describe artifact &lt;name&gt; &lt;version&gt; [&lt;scope&gt;]
- [x] describe artifact-plugin &lt;name&gt; &lt;version&gt; &lt;plugin-type&gt; &lt;plugin-name&gt; [&lt;scope>]
- [x] get artifact properties &lt;artifact-name&gt; &lt;artifact-version&gt; [&lt;scope&gt;]
- [x] list artifact plugin-types &lt;artifact-name&gt; &lt;artifact-version&gt; [&lt;scope&gt;]
- [x] list artifact plugins &lt;artifact-name&gt; &lt;artifact-version&gt; &lt;plugin-type&gt; [&lt;scope&gt;]
- [x] list artifact versions &lt;artifact-name&gt;  [&lt;scope&gt;]
