### PR TITLE
CDAP-4997 Allow filtering metadata search on mulitple target types

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -33,7 +33,6 @@ import com.google.inject.Inject;
 
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 /**
  * Implementation of {@link MetadataAdmin} that interacts directly with {@link MetadataStore}.
@@ -146,20 +145,14 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
 
   @Override
   public Set<MetadataSearchResultRecord> searchMetadata(String namespaceId, String searchQuery,
-                                                        @Nullable MetadataSearchTargetType type) {
-    if (type == null) {
-      return metadataStore.searchMetadata(namespaceId, searchQuery);
-    }
-    return metadataStore.searchMetadataOnType(namespaceId, searchQuery, type);
+                                                        Set<MetadataSearchTargetType> types) {
+    return metadataStore.searchMetadataOnType(namespaceId, searchQuery, types);
   }
 
   @Override
   public Set<MetadataSearchResultRecord> searchMetadata(MetadataScope scope, String namespaceId, String searchQuery,
-                                                        @Nullable final MetadataSearchTargetType type) {
-    if (type == null) {
-      return metadataStore.searchMetadata(scope, namespaceId, searchQuery);
-    }
-    return metadataStore.searchMetadataOnType(scope, namespaceId, searchQuery, type);
+                                                        Set<MetadataSearchTargetType> types) {
+    return metadataStore.searchMetadataOnType(scope, namespaceId, searchQuery, types);
   }
 
   // Helper methods to validate the metadata entries.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -26,7 +26,6 @@ import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 /**
  * Interface that the {@link MetadataHttpHandler} uses to interact with Metadata.
@@ -151,27 +150,28 @@ public interface MetadataAdmin {
   void removeTags(Id.NamespacedId entityId, String ... tags) throws NotFoundException;
 
   /**
-   * Executes a search for CDAP entities in the specified namespace with the specified search query and an optional
-   * {@link MetadataSearchTargetType entity type} in both {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
+   * Executes a search for CDAP entities in the specified namespace with the specified search query and
+   * an optional set of {@link MetadataSearchTargetType entity types} in both
+   * {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
    *
    * @param namespaceId The namespace to filter the search by
    * @param searchQuery The search query
-   * @param type The particular type of CDAP entity to be searched. If null all possible types will be searched
+   * @param types The types of CDAP entity to be searched. If empty all possible types will be searched
    * @return a {@link Set} containing a {@link MetadataSearchResultRecord} for each matching entity
    */
   Set<MetadataSearchResultRecord> searchMetadata(String namespaceId, String searchQuery,
-                                                 @Nullable MetadataSearchTargetType type);
+                                                 Set<MetadataSearchTargetType> types);
 
   /**
-   * Executes a search for CDAP entities in the specified namespace with the specified search query and an optional
-   * {@link MetadataSearchTargetType entity type} in the specified {@link MetadataScope}.
+   * Executes a search for CDAP entities in the specified namespace with the specified search query and
+   * an optional set of {@link MetadataSearchTargetType entity types} in the specified {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope} to restrict the search to
    * @param namespaceId The namespace id to filter the search by
    * @param searchQuery The search query
-   * @param type The particular type of CDAP entity to be searched. If null all possible types will be searched
+   * @param types The types of CDAP entity to be searched. If empty all possible types will be searched
    * @return a {@link Set} containing a {@link MetadataSearchResultRecord} for each matching entity
    */
   Set<MetadataSearchResultRecord> searchMetadata(MetadataScope scope, String namespaceId, String searchQuery,
-                                                 @Nullable MetadataSearchTargetType type);
+                                                 Set<MetadataSearchTargetType> types);
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
@@ -442,8 +442,9 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
   }
 
   protected Set<MetadataSearchResultRecord> searchMetadata(Id.Namespace namespaceId, String query,
-                                                           @Nullable MetadataSearchTargetType target) throws Exception {
-    return metadataClient.searchMetadata(namespaceId, query, target);
+                                                           Set<MetadataSearchTargetType> targets)
+    throws Exception {
+    return metadataClient.searchMetadata(namespaceId, query, targets);
   }
 
   protected Set<String> getTags(Id.Application app, MetadataScope scope) throws Exception {

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -610,6 +610,14 @@ public class CLIMainTest {
     expected = ImmutableList.of("Entity", fakeFlowId.toString(), pingServiceId.toString(),
                                 prefixedEchoHandlerId.toString());
     Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
+    output = getCommandOutput(cli, "search metadata fake* filtered by target-type dataset,stream");
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    expected = ImmutableList.of("Entity", fakeDsId.toString(), fakeStreamId.toString());
+    Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
+    output = getCommandOutput(cli, "search metadata fake* filtered by target-type dataset,stream,app");
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    expected = ImmutableList.of("Entity", fakeDsId.toString(), fakeStreamId.toString(), fakeAppId.toString());
+    Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
   }
 
   @Test

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -512,9 +512,10 @@ public class MetadataDataset extends AbstractDataset {
    * @param namespaceId the namespace to search in
    * @param searchQuery the search query, which could be of two forms: [key]:[value] or just [value] and can have '*'
    *                    at the end for a prefix search
-   * @param type the {@link MetadataSearchTargetType} to restrict the search to.
+   * @param types the {@link MetadataSearchTargetType} to restrict the search to, if empty all types are searched
    */
-  public List<MetadataEntry> search(String namespaceId, String searchQuery, MetadataSearchTargetType type) {
+  public List<MetadataEntry> search(String namespaceId, String searchQuery, Set<MetadataSearchTargetType> types) {
+    boolean includeAllTypes = types.isEmpty() || types.contains(MetadataSearchTargetType.ALL);
     List<MetadataEntry> results = new ArrayList<>();
     for (String searchTerm : getSearchTerms(namespaceId, searchQuery)) {
       Scanner scanner;
@@ -538,9 +539,9 @@ public class MetadataDataset extends AbstractDataset {
           final byte[] rowKey = next.getRow();
           String targetType = MdsKey.getTargetType(rowKey);
 
-          // Filter on target type if not ALL
-          if ((type != MetadataSearchTargetType.ALL) &&
-            (type != MetadataSearchTargetType.valueOfSerializedForm(targetType))) {
+          // Filter on target type if not set to include all types
+          if (!includeAllTypes &&
+            !types.contains(MetadataSearchTargetType.valueOfSerializedForm(targetType))) {
             continue;
           }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -360,28 +360,28 @@ public class DefaultMetadataStore implements MetadataStore {
 
   @Override
   public Set<MetadataSearchResultRecord> searchMetadata(MetadataScope scope, String namespaceId, String searchQuery) {
-    return searchMetadataOnType(scope, namespaceId, searchQuery, MetadataSearchTargetType.ALL);
+    return searchMetadataOnType(scope, namespaceId, searchQuery, ImmutableSet.of(MetadataSearchTargetType.ALL));
   }
 
   @Override
   public Set<MetadataSearchResultRecord> searchMetadataOnType(String namespaceId, String searchQuery,
-                                                              MetadataSearchTargetType type) {
+                                                              Set<MetadataSearchTargetType> types) {
     return ImmutableSet.<MetadataSearchResultRecord>builder()
-      .addAll(searchMetadataOnType(MetadataScope.USER, namespaceId, searchQuery, type))
-      .addAll(searchMetadataOnType(MetadataScope.SYSTEM, namespaceId, searchQuery, type))
+      .addAll(searchMetadataOnType(MetadataScope.USER, namespaceId, searchQuery, types))
+      .addAll(searchMetadataOnType(MetadataScope.SYSTEM, namespaceId, searchQuery, types))
       .build();
   }
 
   @Override
   public Set<MetadataSearchResultRecord> searchMetadataOnType(final MetadataScope scope, final String namespaceId,
                                                               final String searchQuery,
-                                                              final MetadataSearchTargetType type) {
+                                                              final Set<MetadataSearchTargetType> types) {
     // Execute search query
     Iterable<MetadataEntry> results = execute(new TransactionExecutor.Function<MetadataDataset,
       Iterable<MetadataEntry>>() {
       @Override
       public Iterable<MetadataEntry> apply(MetadataDataset input) throws Exception {
-        return input.search(namespaceId, searchQuery, type);
+        return input.search(namespaceId, searchQuery, types);
       }
     }, scope);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -176,26 +176,26 @@ public interface MetadataStore {
   Set<MetadataSearchResultRecord> searchMetadata(MetadataScope scope, String namespaceId, String searchQuery);
 
   /**
-   * Search the Metadata Dataset for the specified target type in both {@link MetadataScope#USER} and
+   * Search the Metadata Dataset for the specified target types in both {@link MetadataScope#USER} and
    * {@link MetadataScope#SYSTEM}.
    *
    * @param namespaceId the namespace to search in
    * @param searchQuery the search query, which could be of two forms: [key]:[value] or just [value]
-   * @param type the {@link MetadataSearchTargetType} to restrict the search to
+   * @param types the {@link MetadataSearchTargetType} to restrict the search to, if empty all types are searched
    */
   Set<MetadataSearchResultRecord> searchMetadataOnType(String namespaceId, String searchQuery,
-                                                       MetadataSearchTargetType type);
+                                                       Set<MetadataSearchTargetType> types);
 
   /**
-   * Search the Metadata Dataset for the specified target type in the specified {@link MetadataScope}.
+   * Search the Metadata Dataset for the specified target types in the specified {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope} to restrict the search to
    * @param namespaceId the namespace to search in
    * @param searchQuery the search query, which could be of two forms: [key]:[value] or just [value]
-   * @param type the {@link MetadataSearchTargetType} to restrict the search to
+   * @param types the {@link MetadataSearchTargetType} to restrict the search to, if empty all types are searched
    */
   Set<MetadataSearchResultRecord> searchMetadataOnType(MetadataScope scope, String namespaceId, String searchQuery,
-                                                       MetadataSearchTargetType type);
+                                                       Set<MetadataSearchTargetType> types);
 
   /**
    * Returns the snapshot of the metadata for entities on or before the given time in both {@link MetadataScope#USER}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -126,13 +126,13 @@ public class NoOpMetadataStore implements MetadataStore {
 
   @Override
   public Set<MetadataSearchResultRecord> searchMetadataOnType(String namespaceId, String searchQuery,
-                                                              MetadataSearchTargetType type) {
+                                                              Set<MetadataSearchTargetType> types) {
     return Collections.emptySet();
   }
 
   @Override
   public Set<MetadataSearchResultRecord> searchMetadataOnType(MetadataScope scope, String namespaceId,
-                                                              String searchQuery, MetadataSearchTargetType type) {
+                                                              String searchQuery, Set<MetadataSearchTargetType> types) {
     return Collections.emptySet();
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -214,46 +214,46 @@ public class MetadataDatasetTest {
 
     // Try to search on all tags
     List<MetadataEntry> results =
-      dataset.search("ns1", "tags:*", MetadataSearchTargetType.ALL);
+      dataset.search("ns1", "tags:*", ImmutableSet.of(MetadataSearchTargetType.ALL));
     // results for dataset1 - ns1:tags:tag12, ns1:tags:tag2, ns1:tags:tag3, ns1:tags:tag33, ns1:tags:tag12-tag33
     Assert.assertEquals(11, results.size());
 
     // Try to search for tag1*
-    results = dataset.search("ns1", "tags:tag1*", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "tags:tag1*", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(4, results.size());
 
     // Try to search for tag1 with spaces in search query and mixed case of tags keyword
-    results = dataset.search("ns1", "  tAGS  :  tag1  ", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "  tAGS  :  tag1  ", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(2, results.size());
 
     // Try to search for tag4
-    results = dataset.search("ns1", "tags:tag4", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "tags:tag4", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(1, results.size());
 
     // Try to search for tag33
-    results = dataset.search("ns1", "tags:tag33", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "tags:tag33", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(1, results.size());
 
     // Try to search for a tag which has - in it
-    results = dataset.search("ns1", "tag12-tag33", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "tag12-tag33", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(1, results.size());
 
     // Try to search for tag33 with spaces in query
-    results = dataset.search("ns1", "  tag33  ", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "  tag33  ", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(1, results.size());
 
     // Try to search for tag3
-    results = dataset.search("ns1", "tags:tag3*", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "tags:tag3*", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(3, results.size());
 
     // try search in another namespace
-    results = dataset.search("ns2", "tags:tag1", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns2", "tags:tag1", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(1, results.size());
 
-    results = dataset.search("ns2", "tag3", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns2", "tag3", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(1, results.size());
 
-    results = dataset.search("ns2", "tag*", MetadataSearchTargetType.APP);
+    results = dataset.search("ns2", "tag*", ImmutableSet.of(MetadataSearchTargetType.APP));
     // 9 due to matches of type ns2:tag1, ns2:tags:tag1, and splitting of tag3_more
     Assert.assertEquals(9, results.size());
 
@@ -263,7 +263,7 @@ public class MetadataDatasetTest {
     dataset.removeTags(dataset1);
     dataset.removeTags(stream1);
     // Search should be empty after deleting tags
-    results = dataset.search("ns1", "tags:tag3*", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "tags:tag3*", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(0, results.size());
     Assert.assertEquals(0, dataset.getTags(app1).size());
     Assert.assertEquals(0, dataset.getTags(flow1).size());
@@ -284,36 +284,36 @@ public class MetadataDatasetTest {
 
     // Search for it based on value
     List<MetadataEntry> results =
-      dataset.search("ns1", "value1", MetadataSearchTargetType.PROGRAM);
+      dataset.search("ns1", "value1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     Assert.assertEquals(ImmutableList.of(entry), results);
 
     // Search for it based on a word in value with spaces in search query
-    results = dataset.search("ns1", "  aV1   ", MetadataSearchTargetType.PROGRAM);
+    results = dataset.search("ns1", "  aV1   ", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     Assert.assertEquals(ImmutableList.of(multiWordEntry), results);
 
     // Search for it based split patterns to make sure nothing is matched
-    results = dataset.search("ns1", "-", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "-", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertTrue(results.isEmpty());
-    results = dataset.search("ns1", ",", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", ",", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertTrue(results.isEmpty());
-    results = dataset.search("ns1", "_", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "_", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertTrue(results.isEmpty());
-    results = dataset.search("ns1", ", ,", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", ", ,", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertTrue(results.isEmpty());
-    results = dataset.search("ns1", ", - ,", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", ", - ,", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertTrue(results.isEmpty());
 
     // Search for it based on a word in value
-    results = dataset.search("ns1", "av5", MetadataSearchTargetType.PROGRAM);
+    results = dataset.search("ns1", "av5", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     Assert.assertEquals(ImmutableList.of(multiWordEntry), results);
 
     // Case insensitive
-    results = dataset.search("ns1", "ValUe1", MetadataSearchTargetType.PROGRAM);
+    results = dataset.search("ns1", "ValUe1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     Assert.assertEquals(ImmutableList.of(entry), results);
 
     // Search based on value
     dataset.setProperty(flow1, "key3", "value1");
-    results = dataset.search("ns1", "value1", MetadataSearchTargetType.PROGRAM);
+    results = dataset.search("ns1", "value1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     Assert.assertEquals(2, results.size());
     for (MetadataEntry result : results) {
       Assert.assertEquals("value1", result.getValue());
@@ -321,14 +321,14 @@ public class MetadataDatasetTest {
 
     // Search based on value prefix
     dataset.setProperty(stream1, "key21", "value21");
-    results = dataset.search("ns1", "value2*", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "value2*", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(2, results.size());
     for (MetadataEntry result : results) {
       Assert.assertTrue(result.getValue().startsWith("value2"));
     }
 
     // Search based on value prefix in the wrong namespace
-    results = dataset.search("ns12", "value2*", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns12", "value2*", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertTrue(results.isEmpty());
   }
 
@@ -352,12 +352,13 @@ public class MetadataDatasetTest {
 
     // Search for it based on value
     List<MetadataEntry> results =
-      dataset.search("ns1", "key1" + MetadataDataset.KEYVALUE_SEPARATOR + "value1", MetadataSearchTargetType.PROGRAM);
+      dataset.search("ns1", "key1" + MetadataDataset.KEYVALUE_SEPARATOR + "value1",
+                     ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     Assert.assertEquals(ImmutableList.of(flowEntry1), results);
 
     // Search for it based on a word in value with spaces in search query
     results = dataset.search("ns1", "  multiword" + MetadataDataset.KEYVALUE_SEPARATOR + "aV1   ",
-                             MetadataSearchTargetType.PROGRAM);
+                             ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
 
     MetadataEntry flowMultiWordEntry = new MetadataEntry(flow1, multiWordKey, multiWordValue);
     Assert.assertEquals(ImmutableList.of(flowMultiWordEntry), results);
@@ -365,29 +366,33 @@ public class MetadataDatasetTest {
     // Search for it based on a word in value
     results =
       dataset.search("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
-                     MetadataSearchTargetType.PROGRAM);
+                     ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     Assert.assertEquals(ImmutableList.of(flowMultiWordEntry), results);
 
     dataset.removeProperties(flow1, multiWordKey);
     results = dataset.search("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
-                             MetadataSearchTargetType.PROGRAM);
+                             ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     // search results should be empty after removing this key as the indexes are deleted
     Assert.assertTrue(results.isEmpty());
 
     // Test wrong ns
     List<MetadataEntry> results2  =
       dataset.search("ns12", "key1" + MetadataDataset.KEYVALUE_SEPARATOR + "value1",
-                               MetadataSearchTargetType.PROGRAM);
+                               ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     Assert.assertTrue(results2.isEmpty());
 
     // Test multi word query
-    results = dataset.search("ns1", "  value1  av2 ", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "  value1  av2 ", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(Sets.newHashSet(flowEntry1, streamEntry1), Sets.newHashSet(results));
 
-    results = dataset.search("ns1", "  value1  sValue1 ", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "  value1  sValue1 ", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(Sets.newHashSet(flowEntry1, streamEntry1, streamEntry2), Sets.newHashSet(results));
 
-    results = dataset.search("ns1", "  valu*  sVal* ", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns1", "  valu*  sVal* ", ImmutableSet.of(MetadataSearchTargetType.ALL));
+    Assert.assertEquals(Sets.newHashSet(flowEntry1, flowEntry2, streamEntry1, streamEntry2), Sets.newHashSet(results));
+
+    // Using empty filter should also search for all target types
+    results = dataset.search("ns1", "  valu*  sVal* ", ImmutableSet.<MetadataSearchTargetType>of());
     Assert.assertEquals(Sets.newHashSet(flowEntry1, flowEntry2, streamEntry1, streamEntry2), Sets.newHashSet(results));
   }
 
@@ -407,30 +412,30 @@ public class MetadataDatasetTest {
     MetadataEntry flowMultiWordEntry = new MetadataEntry(flow1, multiWordKey, multiWordValue);
     MetadataEntry systemArtifactEntry = new MetadataEntry(sysArtifact, multiWordKey, multiWordValue);
     MetadataEntry ns2ArtifactEntry = new MetadataEntry(ns2Artifact, multiWordKey, multiWordValue);
-    List<MetadataEntry> results = dataset.search("ns1", "aV5", MetadataSearchTargetType.ALL);
+    List<MetadataEntry> results = dataset.search("ns1", "aV5", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(Sets.newHashSet(flowMultiWordEntry, systemArtifactEntry), Sets.newHashSet(results));
     // search only programs - should only return flow
     results = dataset.search("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
-                             MetadataSearchTargetType.PROGRAM);
+                             ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     Assert.assertEquals(ImmutableList.of(flowMultiWordEntry), results);
     // search only artifacts - should only return system artifact
     results = dataset.search("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + multiWordValue,
-                             MetadataSearchTargetType.ARTIFACT);
+                             ImmutableSet.of(MetadataSearchTargetType.ARTIFACT));
     // this query returns the system artifact 4 times, since the dataset returns a list with duplicates for scoring
     // purposes. Convert to a Set for comparison.
     Assert.assertEquals(Sets.newHashSet(systemArtifactEntry), Sets.newHashSet(results));
     // search all entities in namespace 'ns2' - should return the system artifact and the same artifact in ns2
     results = dataset.search("ns2", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV4",
-                             MetadataSearchTargetType.ALL);
+                             ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(Sets.newHashSet(systemArtifactEntry, ns2ArtifactEntry), Sets.newHashSet(results));
     // search only programs in a namespace 'ns2'. Should return empty
-    results = dataset.search("ns2", "aV*", MetadataSearchTargetType.PROGRAM);
+    results = dataset.search("ns2", "aV*", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     Assert.assertTrue(results.isEmpty());
     // search all entities in namespace 'ns3'. Should return only the system artifact
-    results = dataset.search("ns3", "av*", MetadataSearchTargetType.ALL);
+    results = dataset.search("ns3", "av*", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(Sets.newHashSet(systemArtifactEntry), Sets.newHashSet(results));
     // search the system namespace for all entities. Should return only the system artifact
-    results = dataset.search(Id.Namespace.SYSTEM.getId(), "av*", MetadataSearchTargetType.ALL);
+    results = dataset.search(Id.Namespace.SYSTEM.getId(), "av*", ImmutableSet.of(MetadataSearchTargetType.ALL));
     Assert.assertEquals(Sets.newHashSet(systemArtifactEntry), Sets.newHashSet(results));
     // clean up
     dataset.removeProperties(flow1);

--- a/cdap-docs/reference-manual/source/cli-api.rst
+++ b/cdap-docs/reference-manual/source/cli-api.rst
@@ -164,9 +164,9 @@ These are the available commands:
     |       ``""className"": ""com.mysql.jdbc.Driver""``
     |     ``}``
     |   ``],``
-    |   ``""plugins"":{``
-    |     ``""prop1"": ""val1"",``
-    |   ``},``
+    |   ``""properties"":{``
+    |     ``""prop1"": ""val1""``
+    |   ``}``
     | ``}``
 
    This config specifies that the artifact contains one JDBC third-party plugin that should be available to the app1 artifact (versions 1.0.0 inclusive to 2.0.0 exclusive) and app2 artifact (versions 1.2.0 inclusive to 1.3.0 inclusive). The config may also include a 'properties' field specifying properties for the artifact."
@@ -184,7 +184,7 @@ These are the available commands:
    ``remove metadata-property <entity-id> <property>``,"Removes a metadata property for an entity"
    ``remove metadata-tag <entity-id> <tag>``,"Removes a metadata tag for an entity"
    ``remove metadata-tags <entity-id>``,"Removes all metadata tags for an entity"
-   ``search metadata <search-query> [filtered by target-type <target-type>]``,"Allows users to search CDAP entities based on the metadata annotated on them."
+   ``search metadata <search-query> [filtered by target-type <target-type>]``,"Searches CDAP entities based on the metadata annotated on them. The search can be restricted by adding a comma-separated list of target types: artifact, app, dataset, program, stream, or view."
    **Application Lifecycle**
    ``create app <app-id> <artifact-name> <artifact-version> <scope> [<app-config-file>]``,"Creates an application from an artifact with optional configuration. If configuration is needed, it must be given as a file whose contents are a JSON object containing the application config. For example, the file contents could contain: '{ ""config"": { ""stream"": ""purchases"" } }'. In this case, the application would receive '{ ""stream"": ""purchases"" }' as its config object."
    ``delete app <app-id>``,"Deletes an application."
@@ -197,6 +197,7 @@ These are the available commands:
    ``delete preferences spark [<app-id.spark-id>]``,"Deletes the preferences of a Spark program."
    ``delete preferences worker [<app-id.worker-id>]``,"Deletes the preferences of a worker."
    ``delete preferences workflow [<app-id.workflow-id>]``,"Deletes the preferences of a workflow."
+   ``delete workflow local datasets <app-id.workflow-id> <runid>``,"Deletes the local datasets associated with the workflow for a given run id."
    ``deploy app <app-jar-file> [<app-config>]``,"Deploys an application optionally with a serialized configuration string."
    ``describe app <app-id>``,"Shows information about an application."
    ``get app <app-id> programs status [of type <program-types>]``,"Command to get status of one or more programs of an application. By default, get status of all flows, services, and workers. A comma separated list of program types can be specified, which will start all programs of those types. For example, specifying ""flow,workflow"" will get status of all flows and workflows in the application."
@@ -245,6 +246,7 @@ These are the available commands:
    ``get worker runtimeargs <app-id.worker-id>``,"Gets the runtime arguments of a worker."
    ``get worker status <app-id.worker-id>``,"Gets the status of a worker."
    ``get workflow current <app-id.workflow-id> <runid>``,"Gets the currently running nodes of a workflow for a given run id."
+   ``get workflow local datasets <app-id.workflow-id> <runid>``,"Gets the local datasets associated with the workflow for a given run id."
    ``get workflow logs <app-id.workflow-id> [<start-time>] [<end-time>]``,"Gets the logs of a workflow."
    ``get workflow runs <app-id.workflow-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,"Gets the run history of a workflow."
    ``get workflow runtimeargs <app-id.workflow-id>``,"Gets the runtime arguments of a workflow."
@@ -318,7 +320,7 @@ These are the available commands:
    ``describe dataset instance <dataset-name>``,"Shows information about a dataset."
    ``describe dataset module <dataset-module>``,"Shows information about a dataset module."
    ``describe dataset type <dataset-type>``,"Shows information about a dataset type."
-   ``get dataset instance properties <dataset-name>``,"Gets the properties with which a dataset was created or updated."
+   ``get dataset instance properties <dataset-name>``,"Gets the properties used to create or update a dataset."
    ``list dataset instances``,"Lists all datasets."
    ``list dataset modules``,"Lists all dataset modules."
    ``list dataset types``,"Lists all dataset types."
@@ -351,6 +353,13 @@ These are the available commands:
    **Egress**
    ``call service <app-id.service-id> <http-method> <endpoint> [headers <headers>] [body <body>] [body:file <local-file-path>]``,"Calls a service endpoint. The <headers> are formatted as ""{'key':'value', ...}"". The request body may be provided either as a string or a file. To provide the body as a string, use ""body <body>"". To provide the body as a file, use ""body:file <local-file-path>""."
    **Security**
-   ``security access entity <entity-id> user <user> actions <actions>``,"Checks whether a user has permission to perform certain actions on an entity. <actions> is a comma-separated list."
-   ``security grant entity <entity-id> user <user> actions <actions>``,"Grants a user permission to perform certain actions on an entity. <actions> is a comma-separated list."
-   ``security revoke entity <entity-id> [user <user>] [actions <actions>]``,"Revokes a user's permission to perform certain actions on an entity. <actions> is a comma-separated list."
+   ``add role <role-name> to <principal-type> <principal-name>``,"Adds a role to a principal in authorization system for role based access control."
+   ``create role <role-name>``,"Creates a role in authorization system for role based access control."
+   ``drop role <role-name>``,"Drops a role from authorization system for role based access control."
+   ``grant actions <actions> on entity <entity-id> to <principal-type> <principal-name>``,"Grants a principal permission to perform certain actions on an entity. <actions> is a comma-separated list."
+   ``list privileges for <principal-type> <principal-name>``,"Lists privileges for a principal"
+   ``list roles [for <principal-type> <principal-name>]``,"Lists all roles, optionally for a particular principal in authorization system for role based access control."
+   ``remove role <role-name> from <principal-type> <principal-name>``,"Removes a role from a principal in authorization system for role based access control."
+   ``revoke actions <actions> on entity <entity-id> from <principal-type> <principal-name>``,"Revokes a user's permission to perform certain actions on an entity. <actions> is a comma-separated list."
+   ``revoke all on entity <entity-id>``,"Revokes all privileges for all users on the entity."
+   ``security access entity <entity-id> principal-type <principal-type> principal-name <principal-name> action <action>``,"Checks whether a principal is authorized to perform an action on an entity."

--- a/cdap-docs/reference-manual/source/http-restful-api/metadata.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/metadata.rst
@@ -494,7 +494,7 @@ Searching for Metadata
 CDAP supports searching metadata of entities. To find which applications, datasets, streams, etc. have a particular
 metadata property or metadata tag, submit an HTTP GET request::
 
-  GET <base-url>/namespaces/<namespace>/metadata/search?query=<term>&target=<entity-type>
+  GET <base-url>/namespaces/<namespace>/metadata/search?query=<term>[&target=<entity-type>&target=<entity-type2>...]
 
 Entities that match the specified query and entity type are returned in the body of the response in JSON format::
 
@@ -556,7 +556,8 @@ Entities that match the specified query and entity type are returned in the body
    * - ``<namespace>``
      - Namespace ID
    * - ``<entity-type>``
-     - One of ``all``, ``artifact``, ``app``, ``dataset``, ``program``, ``stream`` or ``view``
+     - Restricts the search to either all or specified entity types: ``all``, ``artifact``, ``app``, ``dataset``,
+       ``program``, ``stream``, or ``view``
    * - ``<term>``
      - Query term, as described below. Query terms are case-insensitive
 
@@ -569,7 +570,7 @@ Entities that match the specified query and entity type are returned in the body
    * - Status Codes
      - Description
    * - ``200 OK``
-     - Entity ID and metadata of entities that match the query and entity type are returned in the body of the response
+     - Entity ID and metadata of entities that match the query and entity type(s) are returned in the body of the response
 
 .. rubric:: Query Terms
 


### PR DESCRIPTION
Build - http://builds.cask.co/browse/CDAP-DUT3762-5
Passes [Doc Quick Build 4](http://builds.cask.co/browse/CDAP-DOB154-4)

Revised documentation: 
- [Metadata Searching](http://builds.cask.co/artifact/CDAP-DOB154/shared/build-4/Docs-HTML/3.4.0-SNAPSHOT/en/reference-manual/http-restful-api/metadata.html#http-restful-api-metadata-searching)
- [CLI Documentation](http://builds.cask.co/artifact/CDAP-DOB154/shared/build-4/Docs-HTML/3.4.0-SNAPSHOT/en/reference-manual/cli-api.html#available-commands) (fixes an error in the existing CLI documentation, and updates it to the latest version)