### PR TITLE
CDAP-4075 Using Throwable as failureCause in the WorkflowNodeState instead of String.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/common/DefaultThrowable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/DefaultThrowable.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api.common;
+
+import javax.annotation.Nullable;
+
+/**
+ * Default implementation of {@link Throwable}.
+ */
+public final class DefaultThrowable implements Throwable {
+  private final String className;
+  private final String message;
+  private final StackTraceElement[] stackTraces;
+  private Throwable cause;
+
+  /**
+   * Creates a serializable instance of Throwable.
+   */
+  public DefaultThrowable(java.lang.Throwable throwable) {
+    this.className = throwable.getClass().getName();
+    this.message = throwable.getMessage();
+
+    StackTraceElement[] stackTraceElements = throwable.getStackTrace();
+    this.stackTraces = new StackTraceElement[stackTraceElements.length];
+    System.arraycopy(stackTraceElements, 0, stackTraces, 0, stackTraceElements.length);
+
+    cause = (throwable.getCause() == null) ? null : new DefaultThrowable(throwable.getCause());
+  }
+
+  /**
+   * Return the class name for the Throwable.
+   */
+  @Override
+  public String getClassName() {
+    return className;
+  }
+
+  /**
+   * Return the detail message associated with the Throwable.
+   */
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Return the stack traces.
+   */
+  @Override
+  public StackTraceElement[] getStackTraces() {
+    return stackTraces;
+  }
+
+  /**
+   * Return the cause of Throwable if it is available, otherwise {@code null}.
+   */
+  @Nullable
+  @Override
+  public Throwable getCause() {
+    return cause;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/common/Throwable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/Throwable.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api.common;
+
+/**
+ * Carries {@link java.lang.Throwable} information for serialization and deserialization purpose.
+ */
+public interface Throwable {
+  /**
+   * Returns the name of the Throwable class.
+   */
+  String getClassName();
+
+  /**
+   * Returns the message contained inside the Throwable.
+   *
+   * @return A {@link String} message or {@code null} if such message is not available.
+   */
+  String getMessage();
+
+  /**
+   * Returns the stack trace of the Throwable.
+   */
+  StackTraceElement[] getStackTraces();
+
+  /**
+   * Returns the cause of this {@link Throwable}.
+   *
+   * @return The {@link Throwable} cause or {@code null} if no cause is available.
+   */
+  Throwable getCause();
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowNodeState.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowNodeState.java
@@ -16,6 +16,9 @@
 
 package co.cask.cdap.api.workflow;
 
+import co.cask.cdap.api.common.DefaultThrowable;
+import co.cask.cdap.api.common.Throwable;
+
 import javax.annotation.Nullable;
 
 /**
@@ -36,7 +39,7 @@ public final class WorkflowNodeState {
   private final String nodeId;
   private final NodeStatus nodeStatus;
   private final String runId;
-  private final String failureCause;
+  private final Throwable failureCause;
 
   /**
    * Create a new instance.
@@ -46,11 +49,11 @@ public final class WorkflowNodeState {
    * @param failureCause cause of failure, null if execution of the node succeeded
    */
   public WorkflowNodeState(String nodeId, NodeStatus nodeStatus, @Nullable String runId,
-                           @Nullable String failureCause) {
+                           @Nullable java.lang.Throwable failureCause) {
     this.nodeId = nodeId;
     this.nodeStatus = nodeStatus;
     this.runId = runId;
-    this.failureCause = failureCause;
+    this.failureCause = (failureCause == null) ? null : new DefaultThrowable(failureCause);
   }
 
   /**
@@ -77,10 +80,10 @@ public final class WorkflowNodeState {
   }
 
   /**
-   * Return the detail message string for failure if node execution failed, otherwise {@code null} is returned.
+   * Return the {@link Throwable} for failure if node execution failed, otherwise {@code null} is returned.
    */
   @Nullable
-  public String getFailureCause() {
+  public Throwable getFailureCause() {
     return failureCause;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.common.Throwable;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.api.flow.FlowSpecification;
@@ -37,6 +38,7 @@ import co.cask.cdap.proto.codec.FlowletSpecificationCodec;
 import co.cask.cdap.proto.codec.MapReduceSpecificationCodec;
 import co.cask.cdap.proto.codec.ScheduleSpecificationCodec;
 import co.cask.cdap.proto.codec.SparkSpecificationCodec;
+import co.cask.cdap.proto.codec.ThrowableCodec;
 import co.cask.cdap.proto.codec.WorkerSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkflowActionSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkflowNodeCodec;
@@ -92,6 +94,7 @@ public final class ApplicationSpecificationAdapter {
       .registerTypeAdapter(ScheduleSpecification.class, new ScheduleSpecificationCodec())
       .registerTypeAdapter(ServiceSpecification.class, new ServiceSpecificationCodec())
       .registerTypeAdapter(WorkerSpecification.class, new WorkerSpecificationCodec())
+      .registerTypeAdapter(Throwable.class, new ThrowableCodec())
       .registerTypeAdapterFactory(new AppSpecTypeAdapterFactory());
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -182,9 +182,8 @@ public class AppMetadataStore extends MetadataStoreDataset {
     properties.put(workflowNodeId, pid);
 
     RunRecordMeta runRecordMeta = new RunRecordMeta(record, properties);
-    String failureMsg = failureCause == null ? null : Throwables.getRootCause(failureCause).getMessage();
     WorkflowNodeState nodeState = new WorkflowNodeState(workflowNodeId, ProgramRunStatus.toNodeStatus(status),
-                                                        pid, failureMsg);
+                                                        pid, failureCause);
 
     RunRecordMeta meta = updateRunRecordWithWorkflowNodeState(runRecordMeta, nodeState);
     write(key, meta);

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/ThrowableCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/ThrowableCodec.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.api.common.DefaultThrowable;
+import co.cask.cdap.api.common.Throwable;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+
+import java.lang.reflect.Type;
+
+/**
+ * Codec for {@link Throwable}.
+ */
+public final class ThrowableCodec extends AbstractSpecificationCodec<Throwable> {
+
+  @Override
+  public JsonElement serialize(Throwable src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject json = new JsonObject();
+    json.addProperty("className", src.getClassName());
+    json.addProperty("message", src.getMessage());
+    json.add("stackTraces", context.serialize(src.getStackTraces(), StackTraceElement[].class));
+
+    Throwable cause = src.getCause();
+    if (cause != null) {
+      json.add("cause", context.serialize(cause, Throwable.class));
+    }
+
+    return json;
+  }
+
+  @Override
+  public Throwable deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+    throws JsonParseException {
+    return context.deserialize(json, DefaultThrowable.class);
+  }
+}


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-4075

Added `Throwable` interface in the cdap-api for the serialization/deserialization of the `java.lang.Throwable`.