### PR TITLE
[CDAP-5367] fix fixDatasetProperties() and its unit test

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
 
@@ -116,10 +115,9 @@ public final class DatasetsUtil {
         // TPFS adds the partitioning
       } else if (TimePartitionedFileSet.class.getName().equals(type) || "timePartitionedFileSet".equals(type)) {
         props.remove(PartitionedFileSetProperties.PARTITIONING_FIELDS);
-        Set<String> keys = props.keySet();
-        for (String key : keys) {
+        for (String key : spec.getProperties().keySet()) {
           if (key.startsWith(PartitionedFileSetProperties.PARTITIONING_FIELD_PREFIX)) {
-            keys.remove(key);
+            props.remove(key);
           }
         }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.data2.datafabric.dataset.service;
+package co.cask.cdap.data2.datafabric.dataset;
 
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
@@ -30,7 +30,7 @@ import co.cask.cdap.api.dataset.lib.ObjectMappedTableProperties;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.dataset.table.ConflictDetection;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.datafabric.dataset.service.DatasetServiceTestBase;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.dataset2.TestObject;
 import co.cask.cdap.data2.metadata.lineage.LineageDataset;
@@ -41,7 +41,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
-public class DatasetInstanceServiceTest extends DatasetServiceTestBase {
+public class DatasetsUtilTest extends DatasetServiceTestBase {
 
   @Test
   public void testFixProperties() throws DatasetManagementException, UnsupportedTypeException {
@@ -68,7 +68,7 @@ public class DatasetInstanceServiceTest extends DatasetServiceTestBase {
             DatasetProperties.EMPTY);
     testFix(LineageDataset.class.getName(),
             DatasetProperties.builder().add(Table.PROPERTY_TTL, 1000).build());
-    testFix(UsageDataset.class.getName(),
+    testFix(UsageDataset.class.getSimpleName(),
             DatasetProperties.EMPTY);
 
     testFix("table",
@@ -79,7 +79,7 @@ public class DatasetInstanceServiceTest extends DatasetServiceTestBase {
 
   private void testFix(String type, DatasetProperties props) {
     DatasetDefinition def = DatasetFrameworkTestUtil.getDatasetDefinition(
-      inMemoryDatasetFramework, Id.Namespace.DEFAULT, "fileSet");
+      inMemoryDatasetFramework, Id.Namespace.DEFAULT, type);
     Assert.assertNotNull(def);
     DatasetSpecification spec = def.configure("nn", props);
     Map<String, String> originalProperties = DatasetsUtil.fixOriginalProperties(spec).getOriginalProperties();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -168,7 +168,7 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
     return txManager;
   }
 
-  // helper to make this method accessible to DatasetInstanceServiceTest
+  // helper to make this method accessible to DatasetsUtilTest
   public static DatasetDefinition getDatasetDefinition(InMemoryDatasetFramework framework,
                                                        Id.Namespace namespace, String type) {
     return framework.getDefinitionForType(namespace, type);


### PR DESCRIPTION
- fixes the concurrent modification in fixProperties()
- fixes the unit that also had a bug (always instantiated fileSet)
- renames and moves the unit test to the same package
