### PR TITLE
[CDAP-5376] add a way for programs to retrieve the enclosing workflow and run id if they are part of a workflow

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -30,6 +30,7 @@ import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.workflow.Workflow;
+import co.cask.cdap.api.workflow.WorkflowInfo;
 import co.cask.cdap.api.workflow.WorkflowToken;
 
 import java.util.List;
@@ -231,4 +232,11 @@ public interface MapReduceContext
    */
   @Nullable
   WorkflowToken getWorkflowToken();
+
+  /**
+   * @return information about the enclosing {@link Workflow} run, if this {@link MapReduce} program is executed
+   * as a part of the Workflow; returns {@code null} otherwise.
+   */
+  @Nullable
+  WorkflowInfo getWorkflowInfo();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.workflow.Workflow;
+import co.cask.cdap.api.workflow.WorkflowInfo;
 import co.cask.cdap.api.workflow.WorkflowToken;
 
 import java.io.IOException;
@@ -83,6 +84,13 @@ public interface MapReduceTaskContext<KEYOUT, VALUEOUT> extends RuntimeContext, 
    */
   @Nullable
   WorkflowToken getWorkflowToken();
+
+  /**
+   * @return information about the enclosing {@link Workflow} run, if this {@link MapReduce} program is executed
+   * as a part of the Workflow; returns {@code null} otherwise.
+   */
+  @Nullable
+  WorkflowInfo getWorkflowInfo();
 
   /**
    * Returns the name of the input configured for this task.

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowInfo.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowInfo.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.workflow;
+
+import org.apache.twill.api.RunId;
+
+/**
+ * Reveals information about the enclosing workflow to programs running inside that workflow.
+ */
+public interface WorkflowInfo {
+
+  /**
+   * @return the name of the enclosing workflow
+   */
+  String getName();
+
+  /**
+   * @return the node id of the current program within the workflow
+   */
+  String getNodeId();
+
+  /**
+   * @return the run id of the current run of the workflow
+   */
+  RunId getRunId();
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowToken.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowToken.java
@@ -32,9 +32,9 @@ public interface WorkflowToken {
    * Keys in the {@link WorkflowToken} can be added by user, using the
    * {@link WorkflowToken#put} method. These keys are added under the {@link Scope#USER} scope.
    * CDAP also adds some keys to the {@link WorkflowToken}. for e.g. MapReduce counters.
-   * The keys added by CDAP gets added under {@link Scope#SYSTEM} scope.
+   * The keys added by CDAP are added under the {@link Scope#SYSTEM} scope.
    */
-  public enum Scope {
+  enum Scope {
     USER,
     SYSTEM
   }
@@ -45,6 +45,7 @@ public interface WorkflowToken {
    * this key is being set, for example, the unique name of the workflow node.
    * @param key the key representing the entry
    * @param value the value for the key
+   * @throws UnsupportedOperationException if called in a context where the token may not be modified.
    */
   void put(String key, String value);
 
@@ -54,6 +55,7 @@ public interface WorkflowToken {
    * this key is being set, for example, the unique name of the workflow node.
    * @param key the key representing entry
    * @param value the {@link Value} for the key
+   * @throws UnsupportedOperationException if called in a context where the token may not be modified.
    */
   void put(String key, Value value);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -29,7 +29,6 @@ import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.plugin.Plugin;
-import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.metrics.ProgramUserMetrics;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
@@ -356,7 +355,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
    * as a part of it, otherwise {@code null} is returned.
    */
   @Nullable
-  public WorkflowProgramInfo getWorkflowProgramInfo() {
+  public WorkflowProgramInfo getWorkflowInfo() {
     return workflowProgramInfo;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -62,7 +62,6 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -195,6 +194,12 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
   @Nullable
   public WorkflowToken getWorkflowToken() {
     return workflowProgramInfo == null ? null : workflowProgramInfo.getWorkflowToken();
+  }
+
+  @Nullable
+  @Override
+  public WorkflowProgramInfo getWorkflowInfo() {
+    return workflowProgramInfo;
   }
 
   @Nullable

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -87,7 +87,7 @@ public final class MapReduceContextConfig {
   public void set(BasicMapReduceContext context, CConfiguration conf, Transaction tx, URI programJarURI,
                   Map<String, String> localizedUserResources) {
     setRunId(context.getRunId().getId());
-    setWorkflowProgramInfo(context.getWorkflowProgramInfo());
+    setWorkflowProgramInfo(context.getWorkflowInfo());
     setPlugins(context.getPlugins());
     setArguments(context.getRuntimeArguments());
     setProgramJarURI(programJarURI);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -30,6 +30,7 @@ import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.workflow.WorkflowInfo;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import org.apache.twill.api.RunId;
 import org.slf4j.Logger;
@@ -89,6 +90,12 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   @Override
   public WorkflowToken getWorkflowToken() {
     return delegate.getWorkflowToken();
+  }
+
+  @Nullable
+  @Override
+  public WorkflowInfo getWorkflowInfo() {
+    return delegate.getWorkflowInfo();
   }
 
   @Nullable

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/NameMappedDatasetFramework.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/NameMappedDatasetFramework.java
@@ -50,8 +50,8 @@ public class NameMappedDatasetFramework extends ForwardingProgramContextAwareDat
   public static NameMappedDatasetFramework createFromWorkflowProgramInfo(DatasetFramework datasetFramework,
                                                                          WorkflowProgramInfo info,
                                                                          ApplicationSpecification appSpec) {
-    Set<String> localDatasets = appSpec.getWorkflows().get(info.getWorkflowName()).getLocalDatasetSpecs().keySet();
-    return new NameMappedDatasetFramework(datasetFramework, localDatasets, info.getWorkflowRunId().getId());
+    Set<String> localDatasets = appSpec.getWorkflows().get(info.getName()).getLocalDatasetSpecs().keySet();
+    return new NameMappedDatasetFramework(datasetFramework, localDatasets, info.getRunId().getId());
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramInfo.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.workflow.Workflow;
+import co.cask.cdap.api.workflow.WorkflowInfo;
 import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
@@ -28,7 +29,7 @@ import javax.annotation.Nullable;
 /**
  * A container which contains information for a program that runs inside a {@link Workflow}.
  */
-public final class WorkflowProgramInfo {
+public final class WorkflowProgramInfo implements WorkflowInfo {
 
   private static final Gson GSON = new Gson();
 
@@ -71,21 +72,21 @@ public final class WorkflowProgramInfo {
   /**
    * Returns the name of the Workflow.
    */
-  public String getWorkflowName() {
+  public String getName() {
     return workflowName;
   }
 
   /**
    * Returns the node id inside the Workflow for the program.
    */
-  public String getWorkflowNodeId() {
+  public String getNodeId() {
     return workflowNodeId;
   }
 
   /**
    * Returns the {@link RunId} of the Workflow.
    */
-  public RunId getWorkflowRunId() {
+  public RunId getRunId() {
     return RunIds.fromString(workflowRunId);
   }
 


### PR DESCRIPTION
- adds an interface WorkflowInfo and changes internal class WorkflowProgramInfo to implement that
- adds methods getWorkflowInfo() to MapReduceContext and MapReduceTaskContext
- adds validation to existing unit test and the app used by that test
- refactors same unit test and app to run faster, by starting the workflow only once instead of six times.