### PR TITLE
Fix VM/Docker compiles

### DIFF
--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -18,9 +18,11 @@
 # Download cookbooks from Chef Supermarket
 #
 
+die() { echo $*; exit 1; }
+
 # Grab cookbooks using knife
 for cb in hadoop idea maven nodejs cdap ; do
-  knife cookbook site install $cb || echo "Cannot fetch cookbook $cb" && exit 1
+  knife cookbook site install $cb || die "Cannot fetch cookbook $cb"
 done
 
 # Do not change HOME for cdap user

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -20,7 +20,7 @@
 
 # Grab cookbooks using knife
 for cb in hadoop idea maven nodejs cdap ; do
-  knife cookbook site install --force $cb || echo "Cannot fetch cookbook $cb" && exit 1
+  knife cookbook site install $cb || echo "Cannot fetch cookbook $cb" && exit 1
 done
 
 # Do not change HOME for cdap user


### PR DESCRIPTION
Remove `--force` from knife, as it's not supported on all versions. Also, use `die()` function over directly calling `exit 1` to prevent erroneous failures.

Build: http://builds.cask.co/browse/CDAP-BUT821-5