### PR TITLE
(CDAP-5382) Added authorization for application lifecycle. When autho…

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -44,6 +44,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.remote.RemoteApplicationManager;
 import co.cask.cdap.test.remote.RemoteStreamManager;
 import com.google.common.base.Joiner;
@@ -336,6 +337,11 @@ public class IntegrationTestManager implements TestManager {
   @Override
   public StreamManager getStreamManager(Id.Stream streamId) {
     return new RemoteStreamManager(clientConfig, restClient, streamId);
+  }
+
+  @Override
+  public void deleteAllApplications(NamespaceId namespaceId) throws Exception {
+    applicationClient.deleteAll(namespaceId.toId());
   }
 
   /**

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,11 +20,13 @@ import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
+import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
+import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.test.AbstractApplicationManager;
 import co.cask.cdap.test.DefaultMapReduceManager;
 import co.cask.cdap.test.DefaultSparkManager;
@@ -41,7 +43,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- *
+ * {@link AbstractApplicationManager} for use in integration tests.
  */
 public class RemoteApplicationManager extends AbstractApplicationManager {
   private final ClientConfig clientConfig;
@@ -147,5 +149,20 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  @Override
+  public void update(AppRequest appRequest) throws Exception {
+    applicationClient.update(application, appRequest);
+  }
+
+  @Override
+  public void delete() throws Exception {
+    applicationClient.delete(application);
+  }
+
+  @Override
+  public ApplicationDetail getInfo() throws Exception {
+    return applicationClient.get(application);
   }
 }

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authentication/SecurityRequestContext.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authentication/SecurityRequestContext.java
@@ -15,6 +15,8 @@
  */
 package co.cask.cdap.security.spi.authentication;
 
+import co.cask.cdap.proto.security.Principal;
+
 import javax.annotation.Nullable;
 
 /**
@@ -59,5 +61,12 @@ public final class SecurityRequestContext {
    */
   public static void setUserIP(String userIPParam) {
     userIP.set(userIPParam);
+  }
+
+  /**
+   * Returns a {@link Principal} for the user set on the current thread
+   */
+  public static Principal toPrincipal() {
+    return new Principal(userId.get(), Principal.PrincipalType.USER);
   }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
@@ -16,9 +16,11 @@
 
 package co.cask.cdap.test;
 
+import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
+import co.cask.cdap.proto.artifact.AppRequest;
 
 import java.util.List;
 import java.util.Map;
@@ -105,4 +107,21 @@ public interface ApplicationManager {
    * @return list of {@link RunRecord} history
    */
   List<RunRecord> getHistory(Id.Program programId, ProgramRunStatus status);
+
+  /**
+   * Updates this application
+   *
+   * @param appRequest the {@link AppRequest} to update the application with
+   */
+  void update(AppRequest appRequest) throws Exception;
+
+  /**
+   * Deletes the application;
+   */
+  void delete() throws Exception;
+
+  /**
+   * Returns the application's details.
+   */
+  ApplicationDetail getInfo() throws Exception;
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -29,6 +29,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.NamespaceId;
 
 import java.io.File;
 import java.sql.Connection;
@@ -300,4 +301,11 @@ public interface TestManager {
    * Returns a {@link StreamManager} for the specified {@link Id.Stream}.
    */
   StreamManager getStreamManager(Id.Stream streamId);
+
+  /**
+   * Removes all apps in the specified namespace.
+   *
+   * @param namespaceId the specified namespace from which to remove all apps
+   */
+  void deleteAllApplications(NamespaceId namespaceId) throws Exception;
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -81,6 +81,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
@@ -744,7 +745,7 @@ public class TestBase {
   /**
    * Returns a {@link NamespaceAdmin} to interact with namespaces.
    */
-  protected final NamespaceAdmin getNamespaceAdmin() {
+  protected static NamespaceAdmin getNamespaceAdmin() {
     return namespaceAdmin;
   }
 
@@ -752,14 +753,23 @@ public class TestBase {
    * Returns an {@link Authorizer} for performing authorization operations.
    */
   @Beta
-  protected final Authorizer getAuthorizer() throws IOException, InvalidAuthorizerException {
+  protected static Authorizer getAuthorizer() throws IOException, InvalidAuthorizerException {
     return authorizerInstantiatorService.get();
   }
 
   /**
    * Returns the {@link CConfiguration} used in tests.
    */
-  protected final CConfiguration getConfiguration() {
+  protected static CConfiguration getConfiguration() {
     return cConf;
+  }
+
+  /**
+   * Deletes all applications in the specified namespace.
+   *
+   * @param namespaceId the namespace from which to delete all applications
+   */
+  protected static void deleteAllApplications(NamespaceId namespaceId) throws Exception {
+    getTestManager().deleteAllApplications(namespaceId);
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -41,6 +41,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.internal.ApplicationManagerFactory;
 import co.cask.cdap.test.internal.StreamManagerFactory;
 import co.cask.tephra.TransactionAware;
@@ -358,6 +359,11 @@ public class UnitTestManager implements TestManager {
   @Override
   public StreamManager getStreamManager(Id.Stream streamId) {
     return streamManagerFactory.create(streamId);
+  }
+
+  @Override
+  public void deleteAllApplications(NamespaceId namespaceId) throws Exception {
+    appFabricClient.deleteAllApplications(namespaceId);
   }
 
   private Manifest createManifest(Class<?> cls, Class<?>... classes) {

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,10 +17,12 @@
 package co.cask.cdap.test.internal;
 
 import co.cask.cdap.internal.AppFabricClient;
+import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
+import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.test.AbstractApplicationManager;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DefaultMapReduceManager;
@@ -166,5 +168,20 @@ public class DefaultApplicationManager extends AbstractApplicationManager {
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  @Override
+  public void update(AppRequest appRequest) throws Exception {
+    appFabricClient.updateApplication(application.toEntityId(), appRequest);
+  }
+
+  @Override
+  public void delete() throws Exception {
+    appFabricClient.deleteApplication(application.toEntityId());
+  }
+
+  @Override
+  public ApplicationDetail getInfo() throws Exception {
+    return appFabricClient.getInfo(application.toEntityId());
   }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -16,12 +16,17 @@
 
 package co.cask.cdap.security;
 
+import co.cask.cdap.AllProgramsApp;
+import co.cask.cdap.WorkflowApp;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.twill.LocalLocationFactory;
 import co.cask.cdap.gateway.handlers.InMemoryAuthorizer;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
@@ -30,6 +35,7 @@ import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.TestBase;
 import co.cask.cdap.test.TestConfiguration;
 import com.google.common.collect.ImmutableSet;
@@ -54,10 +60,14 @@ import java.io.IOException;
  */
 public class AuthorizationTest extends TestBase {
 
-  private static final String oldUser = SecurityRequestContext.getUserId();
-  private static final Principal alice = new Principal("alice", Principal.PrincipalType.USER);
+  private static final String OLD_USER = SecurityRequestContext.getUserId();
+  private static final Principal ALICE = new Principal("alice", Principal.PrincipalType.USER);
+  private static final Principal BOB = new Principal("bob", Principal.PrincipalType.USER);
+  private static final NamespaceId AUTH_NAMESPACE = new NamespaceId("authorization");
+  private static final NamespaceMeta AUTH_NAMESPACE_META =
+    new NamespaceMeta.Builder().setName(AUTH_NAMESPACE.getNamespace()).build();
 
-  private InstanceId instance;
+  private static InstanceId instance;
 
   /**
    * An {@link ExternalResource} that wraps a {@link TemporaryFolder} and {@link TestConfiguration} to execute them in
@@ -94,99 +104,202 @@ public class AuthorizationTest extends TestBase {
 
   @BeforeClass
   public static void setup() {
-    SecurityRequestContext.setUserId(alice.getName());
+    instance = new InstanceId(getConfiguration().get(Constants.INSTANCE_NAME));
+    SecurityRequestContext.setUserId(ALICE.getName());
   }
 
   @Before
   public void setupTest() throws Exception {
-    instance = new InstanceId(getConfiguration().get(Constants.INSTANCE_NAME));
-    getAuthorizer().grant(NamespaceId.DEFAULT, alice, ImmutableSet.of(Action.ADMIN));
-    Assert.assertEquals(
-      ImmutableSet.of(new Privilege(NamespaceId.DEFAULT, Action.ADMIN)),
-      getAuthorizer().listPrivileges(alice)
-    );
+    Assert.assertEquals(ImmutableSet.of(), getAuthorizer().listPrivileges(ALICE));
   }
 
   @Test
   public void testNamespaces() throws Exception {
-    NamespaceId namespace = new NamespaceId("authorization");
     NamespaceAdmin namespaceAdmin = getNamespaceAdmin();
     Authorizer authorizer = getAuthorizer();
-    NamespaceMeta meta = new NamespaceMeta.Builder().setName(namespace.getNamespace()).build();
     try {
-      namespaceAdmin.create(meta);
+      namespaceAdmin.create(AUTH_NAMESPACE_META);
       Assert.fail("Namespace create should have failed because alice is not authorized on " + instance);
     } catch (UnauthorizedException expected) {
       // expected
     }
-    authorizer.grant(instance, alice, ImmutableSet.of(Action.ADMIN));
-    Assert.assertEquals(
-      ImmutableSet.of(new Privilege(NamespaceId.DEFAULT, Action.ADMIN), new Privilege(instance, Action.ADMIN)),
-      authorizer.listPrivileges(alice)
-    );
-    namespaceAdmin.create(meta);
+    authorizer.grant(instance, ALICE, ImmutableSet.of(Action.ADMIN));
+    Assert.assertEquals(ImmutableSet.of(new Privilege(instance, Action.ADMIN)), authorizer.listPrivileges(ALICE));
+    namespaceAdmin.create(AUTH_NAMESPACE_META);
     // create should grant all privileges
     Assert.assertEquals(
-      ImmutableSet.of(
-        new Privilege(NamespaceId.DEFAULT, Action.ADMIN),
-        new Privilege(instance, Action.ADMIN),
-        new Privilege(namespace, Action.ALL)
-      ),
-      authorizer.listPrivileges(alice)
+      ImmutableSet.of(new Privilege(instance, Action.ADMIN), new Privilege(AUTH_NAMESPACE, Action.ALL)),
+      authorizer.listPrivileges(ALICE)
     );
     // No authorization currently for listing and retrieving namespace
     namespaceAdmin.list();
-    namespaceAdmin.get(namespace.toId());
+    namespaceAdmin.get(AUTH_NAMESPACE.toId());
     // revoke privileges
-    authorizer.revoke(namespace);
-    Assert.assertEquals(
-      ImmutableSet.of(new Privilege(NamespaceId.DEFAULT, Action.ADMIN), new Privilege(instance, Action.ADMIN)),
-      authorizer.listPrivileges(alice)
-    );
+    authorizer.revoke(AUTH_NAMESPACE);
+    Assert.assertEquals(ImmutableSet.of(new Privilege(instance, Action.ADMIN)), authorizer.listPrivileges(ALICE));
     try {
-      namespaceAdmin.deleteDatasets(namespace.toId());
+      namespaceAdmin.deleteDatasets(AUTH_NAMESPACE.toId());
       Assert.fail("Namespace delete datasets should have failed because alice's privileges on the namespace have " +
                     "been revoked");
     } catch (UnauthorizedException expected) {
       // expected
     }
     // grant privileges again
-    authorizer.grant(namespace, alice, ImmutableSet.of(Action.ADMIN));
+    authorizer.grant(AUTH_NAMESPACE, ALICE, ImmutableSet.of(Action.ADMIN));
     Assert.assertEquals(
-      ImmutableSet.of(
-        new Privilege(NamespaceId.DEFAULT, Action.ADMIN),
-        new Privilege(instance, Action.ADMIN),
-        new Privilege(namespace, Action.ADMIN)
-      ),
-      authorizer.listPrivileges(alice)
+      ImmutableSet.of(new Privilege(instance, Action.ADMIN), new Privilege(AUTH_NAMESPACE, Action.ADMIN)),
+      authorizer.listPrivileges(ALICE)
     );
-    namespaceAdmin.deleteDatasets(namespace.toId());
+    namespaceAdmin.deleteDatasets(AUTH_NAMESPACE.toId());
     // deleting datasets does not revoke privileges.
     Assert.assertEquals(
-      ImmutableSet.of(
-        new Privilege(NamespaceId.DEFAULT, Action.ADMIN),
-        new Privilege(instance, Action.ADMIN),
-        new Privilege(namespace, Action.ADMIN)
-      ),
-      authorizer.listPrivileges(alice)
+      ImmutableSet.of(new Privilege(instance, Action.ADMIN), new Privilege(AUTH_NAMESPACE, Action.ADMIN)),
+      authorizer.listPrivileges(ALICE)
     );
-    NamespaceMeta updated = new NamespaceMeta.Builder(meta).setDescription("new desc").build();
-    namespaceAdmin.updateProperties(namespace.toId(), updated);
-    namespaceAdmin.delete(namespace.toId());
+    NamespaceMeta updated = new NamespaceMeta.Builder(AUTH_NAMESPACE_META).setDescription("new desc").build();
+    namespaceAdmin.updateProperties(AUTH_NAMESPACE.toId(), updated);
+    namespaceAdmin.delete(AUTH_NAMESPACE.toId());
     // once the namespace has been deleted, privileges on that namespace should be revoked
+    Assert.assertEquals(ImmutableSet.of(new Privilege(instance, Action.ADMIN)), authorizer.listPrivileges(ALICE));
+    // revoke alice's ADMIN privilege on the instance, so we get back to the same state as at the beginning of the test
+    authorizer.revoke(instance);
+    Assert.assertEquals(ImmutableSet.of(), authorizer.listPrivileges(ALICE));
+  }
+
+  @Test
+  public void testApps() throws Exception {
+    try {
+      deployApplication(NamespaceId.DEFAULT.toId(), AllProgramsApp.class);
+      Assert.fail("App deployment should fail because alice does not have WRITE access on the default namespace");
+    } catch (IllegalStateException expected) {
+      // expected
+    }
+    Authorizer authorizer = getAuthorizer();
+    authorizer.grant(instance, ALICE, ImmutableSet.of(Action.ADMIN));
+    getNamespaceAdmin().create(AUTH_NAMESPACE_META);
+    Assert.assertEquals(
+      ImmutableSet.of(new Privilege(instance, Action.ADMIN), new Privilege(AUTH_NAMESPACE, Action.ALL)),
+      authorizer.listPrivileges(ALICE)
+    );
+    // deployment should succeed in the authorized namespace because alice has all privileges on it
+    ApplicationManager appManager = deployApplication(AUTH_NAMESPACE.toId(), AllProgramsApp.class);
+    // alice should get all privileges on the app after deployment succeeds
+    ApplicationId app = AUTH_NAMESPACE.app(AllProgramsApp.NAME);
     Assert.assertEquals(
       ImmutableSet.of(
-        new Privilege(NamespaceId.DEFAULT, Action.ADMIN),
-        new Privilege(instance, Action.ADMIN)
+        new Privilege(instance, Action.ADMIN),
+        new Privilege(AUTH_NAMESPACE, Action.ALL),
+        new Privilege(app, Action.ALL)
       ),
-      authorizer.listPrivileges(alice)
+      authorizer.listPrivileges(ALICE)
     );
+    // Bob should not have any privileges on Alice's app
+    Assert.assertTrue("Bob should not have any privileges on alice's app", authorizer.listPrivileges(BOB).isEmpty());
+    // This is necessary because in tests, artifacts have auto-generated versions when an app is deployed without f
+    // irst creating an artifact
+    String version = appManager.getInfo().getArtifact().getVersion();
+    // update should succeed because alice has admin privileges on the app
+    appManager.update(new AppRequest(new ArtifactSummary(AllProgramsApp.class.getSimpleName(), version)));
+    // Update should fail for Bob
+    SecurityRequestContext.setUserId(BOB.getName());
+    try {
+      appManager.update(new AppRequest(new ArtifactSummary(AllProgramsApp.class.getSimpleName(), version)));
+      Assert.fail("App update should have failed because Alice does not have admin privileges on the app.");
+    } catch (UnauthorizedException expected) {
+      // expected
+    }
+    // grant READ and WRITE to Bob
+    authorizer.grant(app, BOB, ImmutableSet.of(Action.READ, Action.WRITE));
+    // delete should fail
+    try {
+      appManager.delete();
+    } catch (UnauthorizedException expected) {
+      // expected
+    }
+    // grant ADMIN to Bob. Now delete should succeed
+    authorizer.grant(app, BOB, ImmutableSet.of(Action.ADMIN));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new Privilege(app, Action.READ),
+        new Privilege(app, Action.WRITE),
+        new Privilege(app, Action.ADMIN)
+      ),
+      authorizer.listPrivileges(BOB)
+    );
+    appManager.delete();
+    // All privileges on the app should have been revoked
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new Privilege(instance, Action.ADMIN),
+        new Privilege(AUTH_NAMESPACE, Action.ALL)
+      ),
+      authorizer.listPrivileges(ALICE)
+    );
+    Assert.assertTrue("Bob should not have any privileges because all privileges on the app have been revoked " +
+                        "since the app got deleted", authorizer.listPrivileges(BOB).isEmpty());
+    // switch back to Alice
+    SecurityRequestContext.setUserId(ALICE.getName());
+    // Deploy a couple of apps in the namespace
+    deployApplication(AUTH_NAMESPACE.toId(), AllProgramsApp.class);
+    deployApplication(AUTH_NAMESPACE.toId(), WorkflowApp.class);
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new Privilege(instance, Action.ADMIN),
+        new Privilege(AUTH_NAMESPACE, Action.ALL),
+        new Privilege(AUTH_NAMESPACE.app(AllProgramsApp.NAME), Action.ALL),
+        new Privilege(AUTH_NAMESPACE.app(WorkflowApp.class.getSimpleName()), Action.ALL)
+      ),
+      authorizer.listPrivileges(ALICE)
+    );
+    // revoke all privileges on an app.
+    authorizer.revoke(AUTH_NAMESPACE.app(WorkflowApp.class.getSimpleName()));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new Privilege(instance, Action.ADMIN),
+        new Privilege(AUTH_NAMESPACE, Action.ALL),
+        new Privilege(AUTH_NAMESPACE.app(AllProgramsApp.NAME), Action.ALL)
+      ),
+      authorizer.listPrivileges(ALICE)
+    );
+    // deleting all apps should fail because alice does not have admin privileges on the Workflow app
+    try {
+      deleteAllApplications(AUTH_NAMESPACE);
+      Assert.fail("Deleting all applications in the namespace should have failed because alice does not have ADMIN " +
+                    "privilege on the workflow app.");
+    } catch (UnauthorizedException expected) {
+      // expected
+    }
+    // grant admin privilege on the WorkflowApp. deleting all applications should succeed.
+    authorizer.grant(AUTH_NAMESPACE.app(WorkflowApp.class.getSimpleName()), ALICE, ImmutableSet.of(Action.ADMIN));
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new Privilege(instance, Action.ADMIN),
+        new Privilege(AUTH_NAMESPACE, Action.ALL),
+        new Privilege(AUTH_NAMESPACE.app(WorkflowApp.class.getSimpleName()), Action.ADMIN)
+      ),
+      authorizer.listPrivileges(ALICE)
+    );
+    deleteAllApplications(AUTH_NAMESPACE);
+    // deleting all apps should remove all privileges on all apps, but the privilege on the namespace should still exist
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new Privilege(instance, Action.ADMIN),
+        new Privilege(AUTH_NAMESPACE, Action.ALL)
+      ),
+      authorizer.listPrivileges(ALICE)
+    );
+    // clean up. remove the namespace. all privileges on the namespace should be revoked
+    getNamespaceAdmin().delete(AUTH_NAMESPACE.toId());
+    Assert.assertEquals(ImmutableSet.of(new Privilege(instance, Action.ADMIN)), authorizer.listPrivileges(ALICE));
+    // revoke privileges on the instance
+    authorizer.revoke(instance);
+    Assert.assertEquals(ImmutableSet.of(), authorizer.listPrivileges(ALICE));
   }
 
   @AfterClass
   public static void cleanup() throws Exception {
-    // we want to execute TestBase's @AfterClass before unsetting userid
+    // we want to execute TestBase's @AfterClass after unsetting userid
+    SecurityRequestContext.setUserId(OLD_USER);
     finish();
-    SecurityRequestContext.setUserId(oldUser);
   }
 }


### PR DESCRIPTION
…rization is enabled,

- To deploy an app, a user needs WRITE permissions on the namespace in which the app is being deployed
- If the user is authorized, and if app deployment succeeds, the user gets ALL privileges on that app
- To update an app (redeploy the jar), the user needs ADMIN privileges on the app
- To delete an app, the user needs ADMIN privileges on the app
- The first step in delete is to revoke all privileges on the app, so even if the delete operation fails, we're taking the safe route of revoking privileges

Jira: [CDAP-5382](https://issues.cask.co/browse/CDAP-5382)
Build: http://builds.cask.co/browse/CDAP-DUT3783