### PR TITLE
Feature/ui hydrator++ backend integration phase2

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -93,7 +93,7 @@ angular.module(PKG.name + '.commons')
 
      We need to be able to separate render of graph from data and incremental user interactions.
      - Programmatically it should be possible to provide data and should be able to ask dag to render it at any time post-rendering of the directive
-     - User should be able interact with the dag and add incremental changes.
+     - User should be able interact with the dag and  incremental changes.
     */
     function init() {
       $scope.nodes = DAGPlusPlusNodesStore.getNodes();

--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -109,8 +109,14 @@ angular.module(PKG.name + '.commons')
           if (!sourceNode.length || !targetNode.length) {
             return;
           }
-          var sourceId = sourceNode[0].type === 'transform' ? 'Left' + conn.from : conn.from;
-          var targetId = targetNode[0].type === 'transform' ? 'Right' + conn.to : conn.to;
+          let batch = GLOBALS.etlBatch, realtime = GLOBALS.etlRealtime;
+          let pluginTypes = GLOBALS.pluginTypes;
+          let notATransformTypeNode = [
+            pluginTypes[batch].source, pluginTypes[batch].sink,
+            pluginTypes[realtime].source,  pluginTypes[realtime].sink
+          ];
+          var sourceId = notATransformTypeNode.indexOf(sourceNode[0].type) === -1 ? 'Left' + conn.from : conn.from;
+          var targetId = notATransformTypeNode.indexOf(targetNode[0].type) === -1 ? 'Right' + conn.to : conn.to;
           var connObj = {
             uuids: [sourceId, targetId]
           };

--- a/cdap-ui/app/directives/dag-plus/services/actions/nodes-actions.js
+++ b/cdap-ui/app/directives/dag-plus/services/actions/nodes-actions.js
@@ -52,14 +52,6 @@ class DAGPlusPlusNodesActionsFactory {
         };
         this.nodesDispatcher.dispatch('onAddSourceCount');
         break;
-      case 'transform':
-        let transformOffset = this.DAGPlusPlusNodesStore.getTransformCount() * offset;
-        config._uiPosition = {
-          top: (transformPosition.top + transformOffset) + 'px',
-          left: (transformPosition.left + transformOffset) + 'px'
-        };
-        this.nodesDispatcher.dispatch('onAddTransformCount');
-        break;
       case 'sink':
         let sinkOffset = this.DAGPlusPlusNodesStore.getSinkCount() * offset;
         config._uiPosition = {
@@ -67,6 +59,14 @@ class DAGPlusPlusNodesActionsFactory {
           left: (sinkPosition.left + sinkOffset) + 'px'
         };
         this.nodesDispatcher.dispatch('onAddSinkCount');
+        break;
+      default:
+        let transformOffset = this.DAGPlusPlusNodesStore.getTransformCount() * offset;
+        config._uiPosition = {
+          top: (transformPosition.top + transformOffset) + 'px',
+          left: (transformPosition.left + transformOffset) + 'px'
+        };
+        this.nodesDispatcher.dispatch('onAddTransformCount');
         break;
     }
 

--- a/cdap-ui/app/features/apps/applications.less
+++ b/cdap-ui/app/features/apps/applications.less
@@ -35,7 +35,7 @@ body {
         position: relative;
       }
 
-      my-dag {
+      my-dag-plus {
         width: 100%;
         height: 300px;
       }

--- a/cdap-ui/app/features/apps/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/apps/controllers/detail-ctrl.js
@@ -18,7 +18,7 @@ class AppDetailController {
   constructor(rAppData, GLOBALS, myHydratorFactory, $state) {
     this.myHydratorFactory = myHydratorFactory;
 
-    this.isHydrator = ([GLOBALS.etlBatch, GLOBALS.etlRealtime, GLOBALS.etlDataPipeline].indexOf(rAppData.artifact.name) !== -1);
+    this.isHydrator = (GLOBALS.etlBatchPipelines.concat([GLOBALS.etlRealtime]).indexOf(rAppData.artifact.name) !== -1);
     this.artifact = {
       name: rAppData.artifact.name
     };

--- a/cdap-ui/app/features/apps/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/apps/controllers/detail-ctrl.js
@@ -18,7 +18,7 @@ class AppDetailController {
   constructor(rAppData, GLOBALS, myHydratorFactory, $state) {
     this.myHydratorFactory = myHydratorFactory;
 
-    this.isHydrator = ([GLOBALS.etlBatch, GLOBALS.etlRealtime].indexOf(rAppData.artifact.name) !== -1);
+    this.isHydrator = ([GLOBALS.etlBatch, GLOBALS.etlRealtime, GLOBALS.etlDataPipeline].indexOf(rAppData.artifact.name) !== -1);
     this.artifact = {
       name: rAppData.artifact.name
     };

--- a/cdap-ui/app/features/apps/controllers/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/apps/controllers/tabs/status-ctrl.js
@@ -15,22 +15,22 @@
 */
 
 class AppDetailStatusController {
-  constructor(DetailNonRunsStore, NodesActionsFactory, NodeConfigStore, rPipelineDetail, $scope) {
-    DetailNonRunsStore.init(rPipelineDetail);
-    NodeConfigStore.init();
+  constructor(HydratorPlusPlusDetailNonRunsStore, DAGPlusPlusNodesActionsFactory, HydratorPlusPlusNodeConfigStore, rPipelineDetail, $scope) {
+    HydratorPlusPlusDetailNonRunsStore.init(rPipelineDetail);
+    HydratorPlusPlusNodeConfigStore.init();
 
-    var obj = DetailNonRunsStore.getCloneConfig();
-    NodesActionsFactory.createGraphFromConfig(obj.__ui__.nodes, obj.config.connections);
+    var obj = HydratorPlusPlusDetailNonRunsStore.getCloneConfig();
+    DAGPlusPlusNodesActionsFactory.createGraphFromConfig(obj.__ui__.nodes, obj.config.connections);
 
     $scope.$on('$destroy', function() {
       // FIXME: This should essentially be moved to a scaffolding service that will do stuff for a state/view
-      DetailNonRunsStore.reset();
-      NodeConfigStore.reset();
+      HydratorPlusPlusDetailNonRunsStore.reset();
+      HydratorPlusPlusNodeConfigStore.reset();
     });
   }
 }
 
-AppDetailStatusController.$inject = ['DetailNonRunsStore', 'NodesActionsFactory', 'NodeConfigStore', 'rPipelineDetail', '$scope'];
+AppDetailStatusController.$inject = ['HydratorPlusPlusDetailNonRunsStore', 'DAGPlusPlusNodesActionsFactory', 'HydratorPlusPlusNodeConfigStore', 'rPipelineDetail', '$scope'];
 
 angular.module(PKG.name + '.feature.apps')
   .controller('AppDetailStatusController', AppDetailStatusController);

--- a/cdap-ui/app/features/apps/templates/detail.html
+++ b/cdap-ui/app/features/apps/templates/detail.html
@@ -25,7 +25,7 @@
                 tooltip-append-to-body="true"></span>
         </span>
         <span ng-if="DetailController.myHydratorFactory.isETLApp(DetailController.artifact.name)">
-          <span ng-if="[DetailController.GLOBALS.etlBatch, DetailController.GLOBALS.etlDataPipeline].indexOf(DetailController.artifact.name) !== -1">
+          <span ng-if="DetailController.GLOBALS.etlBatchPipelines.indexOf(DetailController.artifact.name) !== -1">
             <span class="icon-ETLBatch pull-left"
                   uib-tooltip="Type: ETL Batch"
                   tooltip-placement="top"

--- a/cdap-ui/app/features/apps/templates/detail.html
+++ b/cdap-ui/app/features/apps/templates/detail.html
@@ -25,7 +25,7 @@
                 tooltip-append-to-body="true"></span>
         </span>
         <span ng-if="DetailController.myHydratorFactory.isETLApp(DetailController.artifact.name)">
-          <span ng-if="DetailController.artifact.name === DetailController.GLOBALS.etlBatch">
+          <span ng-if="[DetailController.GLOBALS.etlBatch, DetailController.GLOBALS.etlDataPipeline].indexOf(DetailController.artifact.name) !== -1">
             <span class="icon-ETLBatch pull-left"
                   uib-tooltip="Type: ETL Batch"
                   tooltip-placement="top"
@@ -43,7 +43,7 @@
       <my-metadata-tags tag-limit="5" params="DetailController.metadataParams" type="apps"></my-metadata-tags>
     </div>
     <div class="col-sm-6 text-right">
-      <a ui-sref="hydrator.detail({ pipelineId: $state.params.appId })"
+      <a ui-sref="hydratorplusplus.detail({ pipelineId: $state.params.appId })"
         class="btn btn-hydrator"
         ng-if="DetailController.isHydrator"
         title="View in Hydrator">

--- a/cdap-ui/app/features/apps/templates/list.html
+++ b/cdap-ui/app/features/apps/templates/list.html
@@ -104,7 +104,7 @@
               <span class="icon-ETLRealtime"></span>
               <span> ETL Real-time</span>
             </span>
-            <span ng-if="[ListController.GLOBALS.etlBatch, ListController.GLOBALS.etlDataPipeline].indexOf(app.artifact.name) !== -1">
+            <span ng-if="ListController.GLOBALS.etlBatchPipelines.indexOf(app.artifact.name) !== -1">
               <span class="icon-ETLBatch"></span>
               <span>ETL Batch</span>
             </span>

--- a/cdap-ui/app/features/apps/templates/list.html
+++ b/cdap-ui/app/features/apps/templates/list.html
@@ -104,7 +104,7 @@
               <span class="icon-ETLRealtime"></span>
               <span> ETL Real-time</span>
             </span>
-            <span ng-if="app.artifact.name === ListController.GLOBALS.etlBatch">
+            <span ng-if="[ListController.GLOBALS.etlBatch, ListController.GLOBALS.etlDataPipeline].indexOf(app.artifact.name) !== -1">
               <span class="icon-ETLBatch"></span>
               <span>ETL Batch</span>
             </span>

--- a/cdap-ui/app/features/apps/templates/tabs/status.html
+++ b/cdap-ui/app/features/apps/templates/tabs/status.html
@@ -16,8 +16,8 @@
 
 <br />
 <div class="dag-view">
-  <my-dag
+  <my-dag-plus
     data-is-disabled="true"
     disable-node-click="true"
-  ></my-dag>
+  ></my-dag-plus>
 </div>

--- a/cdap-ui/app/features/hydrator/services/hydrator-service.js
+++ b/cdap-ui/app/features/hydrator/services/hydrator-service.js
@@ -39,7 +39,12 @@ class HydratorService {
     let nodes = [];
     let connections = [];
     config.stages.forEach( node => {
-      nodes.push(node);
+      let nodeInfo = angular.extend(node, {
+        type: node.plugin.type,
+        label: node.plugin.label,
+        icon: this.MyDAGFactory.getIcon(node.plugin.name)
+      });
+      nodes.push(nodeInfo);
     });
     connections = config.connections;
     // Obtaining layout of graph with Dagre
@@ -61,7 +66,7 @@ class HydratorService {
     let nodes = [];
     let connections = [];
     let config = pipeline.config;
-    
+
     let artifact = this.GLOBALS.pluginTypes[pipeline.artifact.name];
 
     let source = angular.copy(config.source);

--- a/cdap-ui/app/features/hydrator/services/hydrator-service.js
+++ b/cdap-ui/app/features/hydrator/services/hydrator-service.js
@@ -28,20 +28,51 @@ class HydratorService {
   }
 
   getNodesAndConnectionsFromConfig(pipeline) {
+    if (pipeline.config.stages) {
+      return this._parseNewConfigStages(pipeline.config);
+    } else {
+      return this._parseOldConfig(pipeline);
+    }
+  }
+
+  _parseNewConfigStages(config) {
     let nodes = [];
     let connections = [];
+    config.stages.forEach( node => {
+      nodes.push(node);
+    });
+    connections = config.connections;
+    // Obtaining layout of graph with Dagre
+    var graph = this.MyDAGFactory.getGraphLayout(nodes, connections);
+    angular.forEach(nodes, function (node) {
+      node._uiPosition = {
+        'top': graph._nodes[node.name].y + 'px' ,
+        'left': graph._nodes[node.name].x + 'px'
+      };
+    });
 
+    return {
+      nodes: nodes,
+      connections: connections
+    };
+  }
+
+  _parseOldConfig(pipeline) {
+    let nodes = [];
+    let connections = [];
+    let config = pipeline.config;
+    
     let artifact = this.GLOBALS.pluginTypes[pipeline.artifact.name];
 
-    let source = angular.copy(pipeline.config.source);
-    let transforms = angular.copy(pipeline.config.transforms || [])
+    let source = angular.copy(config.source);
+    let transforms = angular.copy(config.transforms || [])
       .map( node => {
         node.type = artifact.transform;
         node.label = node.label || node.name;
         node.icon = this.MyDAGFactory.getIcon(node.plugin.name);
         return node;
       });
-    let sinks = angular.copy(pipeline.config.sinks)
+    let sinks = angular.copy(config.sinks)
       .map( node => {
         node.type = artifact.sink;
         node.icon = this.MyDAGFactory.getIcon(node.plugin.name);
@@ -58,7 +89,7 @@ class HydratorService {
     nodes = nodes.concat(transforms);
     nodes = nodes.concat(sinks);
 
-    connections = pipeline.config.connections;
+    connections = config.connections;
 
     // Obtaining layout of graph with Dagre
     var graph = this.MyDAGFactory.getGraphLayout(nodes, connections);

--- a/cdap-ui/app/features/hydrator/templates/list.html
+++ b/cdap-ui/app/features/hydrator/templates/list.html
@@ -83,7 +83,7 @@
               </a>
             </td>
             <td>
-              <span ng-if="pipeline.artifact.name === ListController.GLOBALS.etlBatch">
+              <span ng-if="[ListController.GLOBALS.etlBatch, ListController.GLOBALS.etlDataPipeline].indexOf(pipeline.artifact.name) !== -1">
                 <span class="icon-ETLBatch"></span>
                 <span>ETL Batch</span>
               </span>

--- a/cdap-ui/app/features/hydrator/templates/list.html
+++ b/cdap-ui/app/features/hydrator/templates/list.html
@@ -75,7 +75,7 @@
         <tbody>
           <tr ng-repeat="pipeline in ListController.filtered = (ListController.pipelineList | filter: ListController.searchText ) | orderBy:sortable.predicate:sortable.reverse | myPaginate:ListController.currentPage">
             <td>
-              <a ui-sref="hydrator.detail({ pipelineId: pipeline.name })" ng-if="!pipeline.isDraft">
+              <a ui-sref="hydratorplusplus.detail({ pipelineId: pipeline.name })" ng-if="!pipeline.isDraft">
                 {{pipeline.name}}
               </a>
               <a ui-sref="hydrator.create.studio({ draftId: pipeline.id, type:pipeline.artifact.name })" ng-if="pipeline.isDraft">

--- a/cdap-ui/app/features/hydratorplusplus/adapters.less
+++ b/cdap-ui/app/features/hydratorplusplus/adapters.less
@@ -107,7 +107,7 @@ body.theme-cdap {
     }
   }
 
-  &.state-hydrator-detail, &.state-hydratorplusplus-create {
+  &.state-hydratorplusplus-detail, &.state-hydratorplusplus-create {
     .btn {
       &.btn-orange, &.btn-grey {
         color: white;
@@ -122,7 +122,7 @@ body.theme-cdap {
     }
   }
 
-  &.state-hydrator-detail {
+  &.state-hydratorplusplus-detail {
     .detail-canvas-container {
       position: relative;
     }
@@ -145,7 +145,7 @@ body.theme-cdap {
       z-index: 1029;
     }
   }
-  &.state-hydrator-detail {
+  &.state-hydratorplusplus-detail {
     .alerts {
       top: 120px;
       z-index: 1028;

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/create-studio-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/create-studio-ctrl.js
@@ -16,13 +16,13 @@
 
 class HydratorPlusPlusStudioCtrl {
   // Holy cow. Much DI. Such angular.
-  constructor(HydratorPlusPlusLeftPanelStore, HydratorPlusPlusConfigActions, $stateParams, rConfig, $rootScope, $scope, DetailNonRunsStore, HydratorPlusPlusNodeConfigStore, DAGPlusPlusNodesActionsFactory, HydratorPlusPlusHydratorService, HydratorPlusPlusConsoleActions, rSelectedArtifact, rArtifacts) {
+  constructor(HydratorPlusPlusLeftPanelStore, HydratorPlusPlusConfigActions, $stateParams, rConfig, $rootScope, $scope, HydratorPlusPlusDetailNonRunsStore, HydratorPlusPlusNodeConfigStore, DAGPlusPlusNodesActionsFactory, HydratorPlusPlusHydratorService, HydratorPlusPlusConsoleActions, rSelectedArtifact, rArtifacts) {
     // This is required because before we fireup the actions related to the store, the store has to be initialized to register for any events.
 
     this.isExpanded = true;
     // FIXME: This should essentially be moved to a scaffolding service that will do stuff for a state/view
     $scope.$on('$destroy', () => {
-      DetailNonRunsStore.reset();
+      HydratorPlusPlusDetailNonRunsStore.reset();
       HydratorPlusPlusNodeConfigStore.reset();
       HydratorPlusPlusConsoleActions.resetMessages();
     });
@@ -67,7 +67,7 @@ class HydratorPlusPlusStudioCtrl {
   }
 }
 
-HydratorPlusPlusStudioCtrl.$inject = ['HydratorPlusPlusLeftPanelStore', 'HydratorPlusPlusConfigActions', '$stateParams', 'rConfig', '$rootScope', '$scope', 'DetailNonRunsStore', 'HydratorPlusPlusNodeConfigStore', 'DAGPlusPlusNodesActionsFactory', 'HydratorPlusPlusHydratorService', 'HydratorPlusPlusConsoleActions','rSelectedArtifact', 'rArtifacts'];
+HydratorPlusPlusStudioCtrl.$inject = ['HydratorPlusPlusLeftPanelStore', 'HydratorPlusPlusConfigActions', '$stateParams', 'rConfig', '$rootScope', '$scope', 'HydratorPlusPlusDetailNonRunsStore', 'HydratorPlusPlusNodeConfigStore', 'DAGPlusPlusNodesActionsFactory', 'HydratorPlusPlusHydratorService', 'HydratorPlusPlusConsoleActions','rSelectedArtifact', 'rArtifacts'];
 
 angular.module(PKG.name + '.feature.hydratorplusplus')
   .controller('HydratorPlusPlusStudioCtrl', HydratorPlusPlusStudioCtrl);

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
@@ -136,9 +136,9 @@ class HydratorPlusPlusLeftPanelCtrl {
       return connections;
     };
 
-    let isValidArtifact = (importArtifact) => {
-      return this.artifacts.filter( artifact => angular.equals(artifact, importArtifact)).length;
-    };
+    // let isValidArtifact = (importArtifact) => {
+    //   return this.artifacts.filter( artifact => angular.equals(artifact, importArtifact)).length;
+    // };
 
     var reader = new FileReader();
     reader.readAsText(files[0], 'UTF-8');
@@ -155,23 +155,29 @@ class HydratorPlusPlusLeftPanelCtrl {
         });
         return;
       }
-      let isNotValid = this.NonStorePipelineErrorFactory.validateImportJSON(jsonData);
-      if (isNotValid) {
-        this.myAlertOnValium.show({
-          type: 'danger',
-          content: isNotValid
-        });
-      } else if (!isValidArtifact(jsonData.artifact)) {
-        this.myAlertOnValium.show({
-          type: 'danger',
-          content: 'Temporary message indicating invalid artifact. This should be fixed.'
-        });
-      } else {
-        if (!jsonData.config.connections) {
-          jsonData.config.connections = generateLinearConnections(jsonData.config);
-        }
-        this.$state.go('hydratorplusplus.create', { data: jsonData });
+      if (!jsonData.config.connections) {
+        jsonData.config.connections = generateLinearConnections(jsonData.config);
       }
+      this.$state.go('hydratorplusplus.create', { data: jsonData });
+      return;
+
+      // let isNotValid = this.NonStorePipelineErrorFactory.validateImportJSON(jsonData);
+      // if (isNotValid) {
+      //   this.myAlertOnValium.show({
+      //     type: 'danger',
+      //     content: isNotValid
+      //   });
+      // } else if (!isValidArtifact(jsonData.artifact)) {
+      //   this.myAlertOnValium.show({
+      //     type: 'danger',
+      //     content: 'Temporary message indicating invalid artifact. This should be fixed.'
+      //   });
+      // } else {
+      //   if (!jsonData.config.connections) {
+      //     jsonData.config.connections = generateLinearConnections(jsonData.config);
+      //   }
+      //   this.$state.go('hydratorplusplus.create', { data: jsonData });
+      // }
     };
   }
 

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/nodeconfig-ctrl.js
@@ -15,13 +15,12 @@
  */
 
 class HydratorPlusPlusNodeConfigCtrl {
-  constructor(HydratorPlusPlusNodeConfigStore, $scope, $timeout, $state, DetailNonRunsStore, HydratorPlusPlusPluginConfigFactory, EventPipe, GLOBALS, HydratorPlusPlusConfigActions, myHelpers, NonStorePipelineErrorFactory) {
+  constructor(HydratorPlusPlusNodeConfigStore, $scope, $timeout, $state, HydratorPlusPlusPluginConfigFactory, EventPipe, GLOBALS, HydratorPlusPlusConfigActions, myHelpers, NonStorePipelineErrorFactory) {
 
     this.$scope = $scope;
     this.$timeout = $timeout;
     this.$state = $state;
     this.EventPipe = EventPipe;
-    this.DetailNonRunsStore = DetailNonRunsStore;
     this.HydratorPlusPlusPluginConfigFactory = HydratorPlusPlusPluginConfigFactory;
     this.GLOBALS = GLOBALS;
     this.myHelpers = myHelpers;
@@ -252,7 +251,7 @@ class HydratorPlusPlusNodeConfigCtrl {
   }
 }
 
-HydratorPlusPlusNodeConfigCtrl.$inject = ['HydratorPlusPlusNodeConfigStore', '$scope', '$timeout', '$state', 'DetailNonRunsStore', 'HydratorPlusPlusPluginConfigFactory', 'EventPipe', 'GLOBALS', 'HydratorPlusPlusConfigActions', 'myHelpers', 'NonStorePipelineErrorFactory'];
+HydratorPlusPlusNodeConfigCtrl.$inject = ['HydratorPlusPlusNodeConfigStore', '$scope', '$timeout', '$state', 'HydratorPlusPlusPluginConfigFactory', 'EventPipe', 'GLOBALS', 'HydratorPlusPlusConfigActions', 'myHelpers', 'NonStorePipelineErrorFactory'];
 
 angular.module(PKG.name + '.feature.hydratorplusplus')
   .controller('HydratorPlusPlusNodeConfigCtrl', HydratorPlusPlusNodeConfigCtrl);

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/settings-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/settings-ctrl.js
@@ -21,7 +21,7 @@ class HydratorPlusPlusSettingsCtrl {
     this.templateType = HydratorPlusPlusConfigStore.getArtifact().name;
 
     // If ETL Batch
-    if (this.templateType === GLOBALS.etlBatch) {
+    if ([GLOBALS.etlBatch, GLOBALS.etlDataPipeline].indexOf(this.templateType) !== -1) {
       // Initialiting ETL Batch Schedule
       this.initialCron = HydratorPlusPlusConfigStore.getSchedule();
       this.cron = this.initialCron;

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/settings-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/settings-ctrl.js
@@ -21,7 +21,7 @@ class HydratorPlusPlusSettingsCtrl {
     this.templateType = HydratorPlusPlusConfigStore.getArtifact().name;
 
     // If ETL Batch
-    if ([GLOBALS.etlBatch, GLOBALS.etlDataPipeline].indexOf(this.templateType) !== -1) {
+    if (GLOBALS.etlBatchPipelines.indexOf(this.templateType) !== -1) {
       // Initialiting ETL Batch Schedule
       this.initialCron = HydratorPlusPlusConfigStore.getSchedule();
       this.cron = this.initialCron;

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail-ctrl.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .controller('HydratorPlusPlusDetailCtrl', function(HydratorPlusPlusDetailRunsStore, rPipelineDetail, HydratorPlusPlusDetailActions, $scope, HydratorPlusPlusDetailNonRunsStore, HydratorPlusPlusNodeConfigStore, HydratorPlusPlusDetailMetricsActions) {
+    // FIXME: This should essentially be moved to a scaffolding service that will do stuff for a state/view
+    HydratorPlusPlusDetailRunsStore.init(rPipelineDetail);
+    HydratorPlusPlusDetailNonRunsStore.init(rPipelineDetail);
+    HydratorPlusPlusNodeConfigStore.init();
+
+    var params = angular.copy(HydratorPlusPlusDetailRunsStore.getParams());
+    params.scope = $scope;
+    var currentRunId;
+
+    HydratorPlusPlusDetailRunsStore.registerOnChangeListener(function () {
+
+      var latestRunId = HydratorPlusPlusDetailRunsStore.getLatestMetricRunId();
+
+      if (currentRunId === latestRunId) {
+        return;
+      }
+
+      currentRunId = latestRunId;
+
+      if (latestRunId) {
+        var appParams = angular.copy(HydratorPlusPlusDetailRunsStore.getParams());
+        var logsParams = angular.copy(HydratorPlusPlusDetailRunsStore.getLogsParams());
+        var metricParams = {
+          namespace: appParams.namespace,
+          app: appParams.app,
+          run: latestRunId
+        };
+        var programType = HydratorPlusPlusDetailRunsStore.getMetricProgramType();
+        metricParams[programType] = logsParams.programId;
+
+        HydratorPlusPlusDetailMetricsActions.pollForMetrics(metricParams);
+      }
+
+    });
+
+    HydratorPlusPlusDetailActions.pollRuns(
+      HydratorPlusPlusDetailRunsStore.getApi(),
+      params
+    );
+
+    $scope.$on('$destroy', function() {
+      // FIXME: This should essentially be moved to a scaffolding service that will do stuff for a state/view
+      HydratorPlusPlusDetailRunsStore.reset();
+      HydratorPlusPlusDetailNonRunsStore.reset();
+      HydratorPlusPlusNodeConfigStore.reset();
+      HydratorPlusPlusDetailMetricsActions.reset();
+    });
+  });

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/bottom-panel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/bottom-panel-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/bottom-panel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/bottom-panel-ctrl.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .controller('HydratorPlusPlusDetailBottomPanelCtrl', function(HydratorPlusPlusBottomPanelStore , DAGPlusPlusNodesStore, $scope, PipelineDetailBottomPanelActionFactory) {
+    this.tabs = [
+      {
+        title: 'History',
+        template: '/assets/features/hydratorplusplus/templates/detail/tabs/history.html'
+      },
+      {
+        title: 'Log',
+        template: '/assets/features/hydratorplusplus/templates/detail/tabs/log.html'
+      },
+      {
+        title: 'Metrics',
+        template: '/assets/features/hydratorplusplus/templates/detail/tabs/metrics.html'
+      },
+      {
+        title: 'Configuration',
+        template: '/assets/features/hydratorplusplus/templates/detail/tabs/configuration.html'
+      },
+      {
+        title: 'Datasets',
+        template: '/assets/features/hydratorplusplus/templates/detail/tabs/datasets.html'
+      },
+      {
+        title: 'Node Configuration',
+        template: '/assets/features/hydratorplusplus/templates/detail/tabs/node-configuration.html'
+      }
+    ];
+
+    this.setIsCollapsed = function() {
+      this.bottomPanelState = HydratorPlusPlusBottomPanelStore.getPanelState();
+    };
+    this.setIsCollapsed();
+    this.selectTab = function(tab) {
+      this.activeTab = this.tabs[tab];
+      PipelineDetailBottomPanelActionFactory.expand();
+    };
+    this.selectTab(0);
+
+    this.toggleCollapse = function(expanded) {
+      if(expanded) {
+        PipelineDetailBottomPanelActionFactory.collapse();
+      } else {
+        PipelineDetailBottomPanelActionFactory.expand();
+      }
+    };
+    this.toggleMaximized = function(maximized) {
+      if (maximized !== 2) {
+        PipelineDetailBottomPanelActionFactory.maximize();
+      } else {
+        PipelineDetailBottomPanelActionFactory.expand();
+      }
+    };
+    HydratorPlusPlusBottomPanelStore.registerOnChangeListener(this.setIsCollapsed.bind(this));
+    PipelineDetailBottomPanelActionFactory.expand();
+    DAGPlusPlusNodesStore.registerOnChangeListener(function() {
+      this.selectTab(5);
+    }.bind(this));
+
+    $scope.$on('$destroy', function() {
+      PipelineDetailBottomPanelActionFactory.reset();
+    });
+  });

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/canvas-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/canvas-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/canvas-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/canvas-ctrl.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .controller('HydratorPlusPlusDetailCanvasCtrl', function(rPipelineDetail, HydratorPlusPlusBottomPanelStore, DAGPlusPlusNodesActionsFactory, HydratorService, DAGPlusPlusNodesStore, ConfigStore, HydratorPlusPlusNodeConfigActions, HydratorPlusPlusDetailNonRunsStore, HydratorPlusPlusDetailMetricsStore) {
+    this.ConfigStore = ConfigStore;
+    this.DAGPlusPlusNodesStore = DAGPlusPlusNodesStore;
+    this.HydratorPlusPlusDetailNonRunsStore = HydratorPlusPlusDetailNonRunsStore;
+    this.HydratorPlusPlusNodeConfigActions = HydratorPlusPlusNodeConfigActions;
+    this.HydratorService = HydratorService;
+    this.HydratorPlusPlusDetailMetricsStore = HydratorPlusPlusDetailMetricsStore;
+
+    try{
+      rPipelineDetail.config = JSON.parse(rPipelineDetail.configuration);
+    } catch(e) {
+      console.log('ERROR in configuration from backend: ', e);
+      return;
+    }
+    this.setState = function() {
+      this.setScroll = (HydratorPlusPlusBottomPanelStore.getPanelState() === 0 ? false: true);
+    };
+    this.setState();
+    HydratorPlusPlusBottomPanelStore.registerOnChangeListener(this.setState.bind(this));
+    var obj = HydratorPlusPlusDetailNonRunsStore.getCloneConfig();
+
+    DAGPlusPlusNodesActionsFactory.createGraphFromConfig(obj.__ui__.nodes, obj.config.connections, obj.config.comments);
+
+    this.updateNodesAndConnections = function () {
+      var activeNode = this.DAGPlusPlusNodesStore.getActiveNodeId();
+      if (!activeNode) {
+        this.deleteNode();
+      } else {
+        this.setActiveNode();
+      }
+    };
+
+    this.setActiveNode = function() {
+      var nodeId = this.DAGPlusPlusNodesStore.getActiveNodeId();
+      if (!nodeId) {
+        return;
+      }
+      this.HydratorPlusPlusNodeConfigActions.choosePlugin(this.HydratorPlusPlusDetailNonRunsStore.getPluginObject(nodeId));
+    };
+
+    this.deleteNode = function() {
+      this.HydratorPlusPlusNodeConfigActions.removePlugin();
+    };
+
+    this.generateSchemaOnEdge = function (sourceId) {
+      return this.HydratorService.generateSchemaOnEdge(sourceId);
+    };
+
+    function convertMetricsArrayIntoObject(arr) {
+      var obj = {};
+
+      angular.forEach(arr, function (item) {
+        obj[item.nodeName] = {
+          recordsOut: item.recordsOut,
+          recordsIn: item.recordsIn
+        };
+      });
+
+      return obj;
+    }
+    this.metrics = convertMetricsArrayIntoObject(this.HydratorPlusPlusDetailMetricsStore.getMetrics());
+
+    this.HydratorPlusPlusDetailMetricsStore.registerOnChangeListener(function () {
+      this.metrics = convertMetricsArrayIntoObject(this.HydratorPlusPlusDetailMetricsStore.getMetrics());
+    }.bind(this));
+
+
+    DAGPlusPlusNodesStore.registerOnChangeListener(this.updateNodesAndConnections.bind(this));
+  });

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/datasets-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/datasets-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/datasets-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/datasets-ctrl.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .controller('HydratorPlusPlusDetailDatasetCtrl', function(HydratorPlusPlusDetailNonRunsStore) {
+    this.setDefaults = function() {
+      this.state = {
+        data: HydratorPlusPlusDetailNonRunsStore.getDatasets().concat(HydratorPlusPlusDetailNonRunsStore.getStreams())
+      };
+    };
+    this.setDefaults();
+
+    this.setState = function() {
+      this.state.datasets =  HydratorPlusPlusDetailNonRunsStore.getDatasets().concat(HydratorPlusPlusDetailNonRunsStore.getStreams());
+    };
+
+    HydratorPlusPlusDetailNonRunsStore.registerOnChangeListener(this.setState.bind(this));
+  });

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/history-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/history-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/history-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/history-ctrl.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .controller('HydratorPlusPlusDetailHistoryCtrl', function(HydratorPlusPlusDetailRunsStore) {
+    var vm = this;
+
+    vm.history = [];
+
+    vm.setState = function() {
+      vm.history = HydratorPlusPlusDetailRunsStore.getRuns();
+      var params = HydratorPlusPlusDetailRunsStore.getParams();
+      vm.programType = params.programType.toUpperCase();
+      vm.programId = params.programName;
+      vm.appId = params.app;
+    };
+    vm.setState();
+    HydratorPlusPlusDetailRunsStore.registerOnChangeListener(vm.setState);
+  });

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/log-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/log-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/log-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/log-ctrl.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ angular.module(PKG.name + '.feature.hydratorplusplus')
+  .controller('HydratorPlusPlusDetailLogCtrl', function(HydratorPlusPlusDetailRunsStore) {
+    this.setState = function() {
+      this.logsParams =  HydratorPlusPlusDetailRunsStore.getLogsParams();
+    };
+    this.setState();
+    HydratorPlusPlusDetailRunsStore.registerOnChangeListener(this.setState.bind(this));
+  });

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/metrics-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/metrics-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/metrics-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/metrics-ctrl.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .controller('HydratorPlusPlusDetailMetricsCtrl', function(HydratorPlusPlusDetailMetricsStore, DAGPlusPlusNodesStore) {
+
+    this.setState = function() {
+      this.state = {
+        metrics: HydratorPlusPlusDetailMetricsStore.getMetrics(),
+        nodes: DAGPlusPlusNodesStore.getNodesAsObjects()
+      };
+    };
+
+    this.setState();
+
+    HydratorPlusPlusDetailMetricsStore.registerOnChangeListener(this.setState.bind(this));
+  });

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/pipeline-config-tab-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/pipeline-config-tab-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/pipeline-config-tab-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/tabs/pipeline-config-tab-ctrl.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .controller('HydratorPlusPlusDetailConfigCtrl', function(HydratorPlusPlusDetailNonRunsStore, $timeout, $scope) {
+    this.setState = function() {
+      this.config = HydratorPlusPlusDetailNonRunsStore.getConfigJson();
+    };
+    this.setState();
+
+    this.exportConfig = function () {
+      var exportConfigJson = angular.copy(HydratorPlusPlusDetailNonRunsStore.getCloneConfig());
+      var blob = new Blob([JSON.stringify(exportConfigJson, null, 4)], { type: 'application/json'});
+      this.url = URL.createObjectURL(blob);
+      this.exportFileName = (exportConfigJson.name ? exportConfigJson.name : 'noname') + '-' + exportConfigJson.artifact.name;
+      $scope.$on('$destroy', function () {
+        URL.revokeObjectURL(this.url);
+      }.bind(this));
+      $timeout(function() {
+        document.getElementById('pipeline-export-config-link').click();
+      });
+    };
+
+    HydratorPlusPlusDetailNonRunsStore.registerOnChangeListener(this.setState.bind(this));
+  });

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/top-panel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/top-panel-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/top-panel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/top-panel-ctrl.js
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .controller('HydratorDetailTopPanelController', function(HydratorPlusPlusDetailRunsStore, HydratorPlusPlusDetailNonRunsStore, HydratorPlusPlusDetailActions, GLOBALS, $state, myLoadingService, $timeout, $scope, moment, myAlertOnValium) {
+    this.GLOBALS = GLOBALS;
+    this.myAlertOnValium = myAlertOnValium;
+    this.config = HydratorPlusPlusDetailNonRunsStore.getCloneConfig();
+    this.app = {
+      name: this.config.name,
+      description: this.config.description,
+      type: this.config.artifact.name
+    };
+
+    this.tooltipDescription = (this.app.description && this.app.description.replace(/\n/g, '<br />')) || '' ;
+
+    var params;
+    this.setState = function() {
+      this.runsCount = HydratorPlusPlusDetailRunsStore.getRunsCount();
+      var runs = HydratorPlusPlusDetailRunsStore.getRuns();
+      var status, i;
+      var lastRunDuration;
+      var nextRunTime = HydratorPlusPlusDetailRunsStore.getNextRunTime();
+      if (nextRunTime && nextRunTime.length) {
+        this.nextRunTime = nextRunTime[0].time? nextRunTime[0].time: null;
+      } else {
+        this.nextRunTime = 'N/A';
+      }
+      for (i=0 ; i<runs.length; i++) {
+        status = runs[i].status;
+        if (['RUNNING', 'STARTING', 'STOPPING'].indexOf(status) === -1) {
+          this.lastFinished = runs[i];
+          break;
+        }
+      }
+      if (this.lastFinished) {
+        lastRunDuration = this.lastFinished.end - this.lastFinished.start;
+        this.lastRunTime = moment.utc(lastRunDuration * 1000).format('HH:mm:ss');
+      } else {
+        this.lastRunTime = 'N/A';
+      }
+      var averageRunTime = HydratorPlusPlusDetailRunsStore.getStatistics().avgRunTime;
+      // We get time as seconds from backend. So multiplying it by 1000 to give moment.js in milliseconds.
+      if (averageRunTime) {
+        this.avgRunTime = moment.utc( averageRunTime * 1000 ).format('HH:mm:ss');
+      } else {
+        this.avgRunTime = 'N/A';
+      }
+      this.config = HydratorPlusPlusDetailNonRunsStore.getCloneConfig();
+    };
+    this.setState();
+
+    this.pipelineType = HydratorPlusPlusDetailNonRunsStore.getPipelineType();
+    if ([GLOBALS.etlBatch, GLOBALS.etlDataPipeline].indexOf(this.pipelineType) !== -1) {
+      params = angular.copy(HydratorPlusPlusDetailRunsStore.getParams());
+      params.scope = $scope;
+      HydratorPlusPlusDetailActions.pollStatistics(
+        HydratorPlusPlusDetailRunsStore.getApi(),
+        params
+      );
+      HydratorPlusPlusDetailActions.pollNextRunTime(
+        HydratorPlusPlusDetailRunsStore.getApi(),
+        HydratorPlusPlusDetailRunsStore.getParams()
+      );
+    }
+
+    this.setAppStatus = function() {
+      this.appStatus = HydratorPlusPlusDetailRunsStore.getStatus();
+      this.config = HydratorPlusPlusDetailNonRunsStore.getCloneConfig();
+    };
+    this.setScheduleStatus = function() {
+      this.scheduleStatus = HydratorPlusPlusDetailNonRunsStore.getScheduleStatus();
+    };
+    this.setAppStatus();
+    var appType = HydratorPlusPlusDetailNonRunsStore.getAppType();
+
+    if ([GLOBALS.etlBatch, GLOBALS.etlDataPipeline].indexOf(appType) !== -1) {
+      HydratorPlusPlusDetailActions.fetchScheduleStatus(
+        HydratorPlusPlusDetailRunsStore.getApi(),
+        HydratorPlusPlusDetailRunsStore.getScheduleParams()
+      );
+    }
+
+    var greenStatus = ['COMPLETED', 'RUNNING', 'SCHEDULED', 'STARTING'];
+    this.isGreenStatus = function () {
+      if (greenStatus.indexOf(this.appStatus) > -1) {
+        return true;
+      } else {
+        return false;
+      }
+    };
+
+    this.do = function(action) {
+      switch(action) {
+        case 'Start':
+          this.appStatus = 'STARTING';
+          HydratorPlusPlusDetailActions.startPipeline(
+            HydratorPlusPlusDetailRunsStore.getApi(),
+            HydratorPlusPlusDetailRunsStore.getParams()
+          ).then(
+            () => {},
+            (err) => {
+              this.myAlertOnValium.show({
+                type: 'danger',
+                title: 'Unable to start a new run',
+                content: angular.isObject(err)? err.data: err
+              });
+            }
+          );
+          break;
+        case 'Schedule':
+          this.scheduleStatus = 'SCHEDULING';
+          HydratorPlusPlusDetailActions.schedulePipeline(
+            HydratorPlusPlusDetailRunsStore.getApi(),
+            HydratorPlusPlusDetailRunsStore.getScheduleParams()
+          )
+            .then(
+              () => {
+                HydratorPlusPlusDetailActions.fetchScheduleStatus(
+                  HydratorPlusPlusDetailRunsStore.getApi(),
+                  HydratorPlusPlusDetailRunsStore.getScheduleParams()
+                );
+              },
+              (err) => {
+                this.myAlertOnValium.show({
+                  type: 'danger',
+                  title: 'Unable to schedule the pipeline',
+                  content: angular.isObject(err)? err.data: err
+                });
+              }
+            );
+          break;
+        case 'Suspend':
+          this.scheduleStatus = 'SUSPENDING';
+          HydratorPlusPlusDetailActions.suspendSchedule(
+            HydratorPlusPlusDetailRunsStore.getApi(),
+            HydratorPlusPlusDetailRunsStore.getScheduleParams()
+          )
+            .then(
+              () => {
+                HydratorPlusPlusDetailActions.fetchScheduleStatus(
+                  HydratorPlusPlusDetailRunsStore.getApi(),
+                  HydratorPlusPlusDetailRunsStore.getScheduleParams()
+                );
+              },
+              (err) => {
+                this.myAlertOnValium.show({
+                  type: 'danger',
+                  title: 'Unable to suspend the pipeline',
+                  content: angular.isObject(err)? err.data: err
+                });
+              }
+            );
+          break;
+        case 'Stop':
+          this.appStatus = 'STOPPING';
+          HydratorPlusPlusDetailActions.stopPipeline(
+            HydratorPlusPlusDetailRunsStore.getApi(),
+            HydratorPlusPlusDetailRunsStore.getParams()
+          ).then(
+            () => {},
+            (err) => {
+              this.myAlertOnValium.show({
+                type: 'danger',
+                title: 'Unable to stop the current run',
+                content: angular.isObject(err)? err.data: err
+              });
+            }
+          );
+          break;
+        case 'Delete':
+          myLoadingService.showLoadingIcon();
+          var params = angular.copy(HydratorPlusPlusDetailRunsStore.getParams());
+          params = {
+            namespace: params.namespace,
+            pipeline: params.app
+          };
+          HydratorPlusPlusDetailActions
+            .deletePipeline(params)
+            .then(
+              function success() {
+                $state.go('hydrator.list');
+                myLoadingService.hideLoadingIcon();
+              },
+              function error(err) {
+                myLoadingService.hideLoadingIcon();
+                $timeout(() => {
+                  this.myAlertOnValium.show({
+                    type: 'danger',
+                    title: 'Unable to delete Pipeline',
+                    content: err.data
+                  });
+                });
+              }
+            );
+      }
+    };
+
+    HydratorPlusPlusDetailRunsStore.registerOnChangeListener(this.setAppStatus.bind(this));
+    HydratorPlusPlusDetailNonRunsStore.registerOnChangeListener(this.setScheduleStatus.bind(this));
+    HydratorPlusPlusDetailRunsStore.registerOnChangeListener(this.setState.bind(this));
+  });

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/top-panel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/top-panel-ctrl.js
@@ -63,7 +63,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
     this.setState();
 
     this.pipelineType = HydratorPlusPlusDetailNonRunsStore.getPipelineType();
-    if ([GLOBALS.etlBatch, GLOBALS.etlDataPipeline].indexOf(this.pipelineType) !== -1) {
+    if (GLOBALS.etlBatchPipelines.indexOf(this.pipelineType) !== -1) {
       params = angular.copy(HydratorPlusPlusDetailRunsStore.getParams());
       params.scope = $scope;
       HydratorPlusPlusDetailActions.pollStatistics(
@@ -86,7 +86,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
     this.setAppStatus();
     var appType = HydratorPlusPlusDetailNonRunsStore.getAppType();
 
-    if ([GLOBALS.etlBatch, GLOBALS.etlDataPipeline].indexOf(appType) !== -1) {
+    if (GLOBALS.etlBatchPipelines.indexOf(appType) !== -1) {
       HydratorPlusPlusDetailActions.fetchScheduleStatus(
         HydratorPlusPlusDetailRunsStore.getApi(),
         HydratorPlusPlusDetailRunsStore.getScheduleParams()

--- a/cdap-ui/app/features/hydratorplusplus/routes.js
+++ b/cdap-ui/app/features/hydratorplusplus/routes.js
@@ -124,6 +124,49 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
           onExit: function($uibModalStack) {
             $uibModalStack.dismissAll();
           }
+        })
+
+        .state('hydratorplusplus.detail', {
+          url: '/view/:pipelineId',
+          data: {
+            authorizedRoles: MYAUTH_ROLE.all,
+            highlightTab: 'hydratorList'
+          },
+          resolve : {
+            rPipelineDetail: function($stateParams, $q, myPipelineApi) {
+              var params = {
+                namespace: $stateParams.namespace,
+                pipeline: $stateParams.pipelineId
+              };
+
+              return myPipelineApi.get(params).$promise;
+            }
+          },
+          ncyBreadcrumb: {
+            parent: 'apps.list',
+            label: '{{$state.params.pipelineId}}'
+          },
+          views: {
+            '': {
+              templateUrl: '/assets/features/hydratorplusplus/templates/detail.html',
+              controller: 'HydratorPlusPlusDetailCtrl'
+            },
+            'toppanel@hydratorplusplus.detail': {
+              templateUrl: '/assets/features/hydratorplusplus/templates/detail/top-panel.html',
+              controller: 'HydratorDetailTopPanelController',
+              controllerAs: 'TopPanelCtrl'
+            },
+            'bottompanel@hydratorplusplus.detail': {
+              templateUrl: '/assets/features/hydratorplusplus/templates/detail/bottom-panel.html',
+              controller: 'HydratorPlusPlusDetailBottomPanelCtrl',
+              controllerAs: 'BottomPanelCtrl'
+            },
+            'canvas@hydratorplusplus.detail': {
+              templateUrl: '/assets/features/hydratorplusplus/templates/detail/canvas.html',
+              controller: 'HydratorPlusPlusDetailCanvasCtrl',
+              controllerAs: 'CanvasCtrl'
+            }
+          }
         });
 
   });

--- a/cdap-ui/app/features/hydratorplusplus/routes.js
+++ b/cdap-ui/app/features/hydratorplusplus/routes.js
@@ -62,7 +62,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
               myPipelineApi.fetchArtifacts({
                 namespace: $stateParams.namespace
               }).$promise.then((res) => {
-                let uiSupportedArtifacts = ['cdap-etl-batch', 'cdap-etl-realtime'];
+                let uiSupportedArtifacts = ['cdap-etl-batch', 'cdap-etl-realtime', 'cdap-etl-data-pipeline'];
                 let filteredRes;
                 if ($stateParams.artifactType) {
                   filteredRes = res.filter( r => r.name === $stateParams.artifactType );
@@ -85,7 +85,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
                 namespace: $stateParams.namespace
               }).$promise
               .then((res) => {
-                let uiSupportedArtifacts = ['cdap-etl-batch', 'cdap-etl-realtime'];
+                let uiSupportedArtifacts = ['cdap-etl-batch', 'cdap-etl-realtime', 'cdap-etl-data-pipeline'];
                 let filteredRes = res.filter( r => uiSupportedArtifacts.indexOf(r.name) !== -1 );
                 defer.resolve(filteredRes);
               });

--- a/cdap-ui/app/features/hydratorplusplus/services/canvas-factory.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/canvas-factory.js
@@ -26,7 +26,7 @@
       returnConfig.template = {
         type: template
       };
-      if (template === GLOBALS.etlBatch) {
+      if (GLOBALS.etlBatchPipelines.indexOf(template) !== -1) {
         returnConfig.template.schedule = {};
         returnConfig.template.schedule.cron = myHelpers.objectQuery(data.config, 'schedule') || '* * * * *';
       } else if (template === GLOBALS.etlRealtime) {

--- a/cdap-ui/app/features/hydratorplusplus/services/canvas-factory.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/canvas-factory.js
@@ -210,41 +210,25 @@
 
         return properties;
       }
-      if (myHelpers.objectQuery(config, 'source', 'plugin', 'properties') &&
-          Object.keys(config.source.plugin.properties).length > 0) {
-        config.source.plugin.properties = propertiesIterator(config.source.plugin.properties, config.source.plugin._backendProperties);
+
+      if (angular.isArray(config.stages)) {
+        config.stages.forEach( node => {
+          if (myHelpers.objectQuery( node, 'plugin', 'properties', 'length') > 0) {
+            node.plugin.properties = propertiesIterator(node.plugin.properties, node.plugin._backendProperties);
+          }
+        });
       }
-
-      config.sinks.forEach(function(sink) {
-        if (myHelpers.objectQuery(sink, 'plugin', 'properties') &&
-            Object.keys(sink.plugin.properties).length > 0) {
-          sink.plugin.properties = propertiesIterator(sink.plugin.properties, sink.plugin._backendProperties);
-        }
-      });
-
-      config.transforms.forEach(function(transform) {
-        if (myHelpers.objectQuery(transform, 'plugin', 'properties') &&
-            Object.keys(transform.plugin.properties).length > 0) {
-          transform.plugin.properties = propertiesIterator(transform.plugin.properties, transform.plugin._backendProperties);
-        }
-      });
     }
 
     function pruneProperties(config) {
 
       pruneNonBackEndProperties(config);
 
-      if (config.source.plugin && (config.source.name || config.source.plugin._backendProperties)) {
-        delete config.source.plugin._backendProperties;
+      if(angular.isArray(config.stages)) {
+        config.stages.forEach( node => {
+          delete node.plugin._backendProperties;
+        });
       }
-
-      config.sinks.forEach(function(sink) {
-        delete sink.plugin._backendProperties;
-      });
-
-      config.transforms.forEach(function(t) {
-        delete t.plugin._backendProperties;
-      });
       return config;
     }
 

--- a/cdap-ui/app/features/hydratorplusplus/services/create/actions/config-actions.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/actions/config-actions.js
@@ -95,7 +95,7 @@ class HydratorPlusPlusConfigActions {
         .then(
           () => {
             this.EventPipe.emit('hideLoadingIcon.immediate');
-            this.$state.go('hydrator.detail', { pipelineId: adapterName });
+            this.$state.go('hydratorplusplus.detail', { pipelineId: adapterName });
           }
         );
     };

--- a/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
@@ -185,7 +185,7 @@ class HydratorPlusPlusConfigStore {
     config.connections = connections;
 
     let appType = this.getAppType();
-    if ( appType=== this.GLOBALS.etlBatch || appType === this.GLOBALS.etlDataPipeline) {
+    if ( this.GLOBALS.etlBatchPipelines.indexOf(appType) !== -1) {
       config.schedule = this.getSchedule();
       config.engine = this.getEngine();
     } else if (appType === this.GLOBALS.etlRealtime) {
@@ -291,7 +291,7 @@ class HydratorPlusPlusConfigStore {
     this.emitChange();
   }
   setEngine(engine) {
-    if (this.state.config.artifact === this.GLOBALS.etlBatch) {
+    if (this.GLOBALS.etlBatchPipelines.indexOf(this.state.config.artifact) !== -1) {
       this.state.config.engine = engine || 'mapreduce';
     }
   }
@@ -303,7 +303,7 @@ class HydratorPlusPlusConfigStore {
     this.state.artifact.version = artifact.version;
     this.state.artifact.scope = artifact.scope;
 
-    if ([this.GLOBALS.etlBatch, this.GLOBALS.etlDataPipeline].indexOf(artifact.name) !== -1) {
+    if (this.GLOBALS.etlBatchPipelines.indexOf(artifact.name) !== -1) {
       this.state.config.schedule = '* * * * *';
     } else if (artifact.name === this.GLOBALS.etlRealtime) {
       this.state.config.instance = 1;

--- a/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
@@ -303,7 +303,7 @@ class HydratorPlusPlusConfigStore {
     this.state.artifact.version = artifact.version;
     this.state.artifact.scope = artifact.scope;
 
-    if (artifact.name === this.GLOBALS.etlBatch) {
+    if ([this.GLOBALS.etlBatch, this.GLOBALS.etlDataPipeline].indexOf(artifact.name) !== -1) {
       this.state.config.schedule = '* * * * *';
     } else if (artifact.name === this.GLOBALS.etlRealtime) {
       this.state.config.instance = 1;

--- a/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
@@ -81,12 +81,6 @@ class HydratorPlusPlusConfigStore {
   }
   getDefaultConfig() {
     return {
-      source: {
-        name: '',
-        plugin: {}
-      },
-      sinks: [],
-      transforms: [],
       connections: [],
       comments: []
     };
@@ -118,7 +112,6 @@ class HydratorPlusPlusConfigStore {
   }
   generateConfigFromState() {
     var config = this.getDefaultConfig();
-    var artifactTypeExtension = this.GLOBALS.pluginTypes[this.state.artifact.name];
     var nodesMap = {};
     this.state.__ui__.nodes.forEach(function(n) {
       nodesMap[n.name] = angular.copy(n);
@@ -145,48 +138,21 @@ class HydratorPlusPlusConfigStore {
         } catch(e) {}
       }
       node.plugin.properties = stripFormatSchemas(node.watchProperty, node.outputSchemaProperty, angular.copy(node.plugin.properties));
-      var pluginConfig =  {
-        // Solely adding id and _backendProperties for validation.
-        // Should be removed while saving it to backend.
-        name: node.plugin.name,
-        label: node.plugin.label,
-        artifact: node.plugin.artifact,
-        properties: node.plugin.properties ,
-        _backendProperties: node._backendProperties
-      };
-
-      if (node.type === artifactTypeExtension.source) {
-        config['source'] = {
-          name: node.plugin.label,
-          plugin: pluginConfig,
-          outputSchema: node.outputSchema,
-          inputSchema: node.inputSchema
-        };
-      } else if (node.type === 'transform') {
-        if (node.plugin.validationFields) {
-          pluginConfig.validationFields = node.plugin.validationFields;
-        }
-        pluginConfig = {
-          name: node.plugin.label,
-          plugin: pluginConfig,
-          outputSchema: node.outputSchema,
-          inputSchema: node.inputSchema
-        };
-
-        if (node.errorDatasetName && node.errorDatasetName.length > 0) {
-          pluginConfig.errorDatasetName = node.errorDatasetName;
-        }
-
-        config['transforms'].push(pluginConfig);
-      } else if (node.type === artifactTypeExtension.sink) {
-        pluginConfig = {
-          name: node.plugin.label,
-          plugin: pluginConfig,
-          outputSchema: node.outputSchema,
-          inputSchema: node.inputSchema
-        };
-        config['sinks'].push(pluginConfig);
-      }
+      config.stages.push({
+        name: node.plugin.label,
+        plugin: {
+          // Solely adding id and _backendProperties for validation.
+          // Should be removed while saving it to backend.
+          name: node.plugin.name,
+          type: node.type,
+          label: node.plugin.label,
+          artifact: node.plugin.artifact,
+          properties: node.plugin.properties ,
+          _backendProperties: node._backendProperties
+        },
+        outputSchema: node.outputSchema,
+        inputSchema: node.inputSchema
+      });
       delete nodesMap[id];
     };
 
@@ -195,7 +161,7 @@ class HydratorPlusPlusConfigStore {
       this.state.artifact.name,
       this.state.__ui__.nodes
     );
-
+    config.stages = [];
     connections.forEach( connection => {
       let fromConnectionName, toConnectionName;
 
@@ -219,7 +185,7 @@ class HydratorPlusPlusConfigStore {
     config.connections = connections;
 
     let appType = this.getAppType();
-    if ( appType=== this.GLOBALS.etlBatch) {
+    if ( appType=== this.GLOBALS.etlBatch || appType === this.GLOBALS.etlDataPipeline) {
       config.schedule = this.getSchedule();
       config.engine = this.getEngine();
     } else if (appType === this.GLOBALS.etlRealtime) {
@@ -270,24 +236,10 @@ class HydratorPlusPlusConfigStore {
       return false;
     }
     var stateCopy = this.getConfigForExport();
-    var source = stateCopy.config.source;
-    var sinks = stateCopy.config.sinks;
-    var transforms = stateCopy.config.transforms;
-
-    if (source.plugin) {
-      delete source.outputSchema;
-      delete source.inputSchema;
-    }
-    angular.forEach(sinks, (sink) => {
-      if (sink.plugin) {
-        delete sink.outputSchema;
-        delete sink.inputSchema;
-      }
-    });
-    angular.forEach(transforms, (transform) =>  {
-      if (transform.plugin) {
-        delete transform.outputSchema;
-        delete transform.inputSchema;
+    angular.forEach(stateCopy.config.stages, (node) => {
+      if (node.plugin) {
+        delete node.outputSchema;
+        delete node.inputSchema;
       }
     });
     delete stateCopy.__ui__;

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/actions/pipeline-detail-actions.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/actions/pipeline-detail-actions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/actions/pipeline-detail-actions.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/actions/pipeline-detail-actions.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .service('HydratorPlusPlusDetailActions', function(HydratorPlusPlusDetailDispatcher, myPipelineApi) {
+    var dispatcher = HydratorPlusPlusDetailDispatcher.getDispatcher();
+    this.startPipeline = function (api, params) {
+      return api.start(params).$promise;
+    };
+    this.schedulePipeline = function(api, scheduleParams) {
+      return api.schedule(scheduleParams).$promise;
+    };
+
+    this.stopPipeline = function (api, params) {
+      return api.stop(params).$promise;
+    };
+    this.suspendSchedule = function(api, params) {
+      return api.suspend(params).$promise;
+    };
+
+    this.deletePipeline = function(params) {
+      return myPipelineApi.delete(params).$promise;
+    };
+    this.pollRuns = function(api, params) {
+      api.pollRuns(params)
+        .$promise
+        .then(function(runs) {
+          dispatcher.dispatch('onRunsChange', runs);
+        });
+    };
+    this.pollNextRunTime = function(api, params) {
+      api.pollNextRunTime(params)
+        .$promise
+        .then(function (nextRuntime) {
+          dispatcher.dispatch('onNextRunTime', nextRuntime);
+        });
+    };
+    this.fetchScheduleStatus = function(api, params) {
+      api.scheduleStatus(params)
+        .$promise
+        .then(
+          function(res) {
+            dispatcher.dispatch('onScheduleStatusFetch', res);
+          },
+          function() {
+            dispatcher.dispatch('onScheduleStatusFetchFail');
+          }
+        );
+    };
+    this.pollStatistics = function(api, params) {
+      api.pollStatistics(params)
+        .$promise
+        .then(function(res) {
+          dispatcher.dispatch('onStatisticsFetch', res);
+        });
+    };
+
+  });

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/actions/pipeline-detail-metrics-actions.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/actions/pipeline-detail-metrics-actions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/actions/pipeline-detail-metrics-actions.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/actions/pipeline-detail-metrics-actions.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .service('HydratorPlusPlusDetailMetricsActions', function(DetailRunsStore, HydratorPlusPlusDetailMetricsDispatcher, MyCDAPDataSource, $filter, MyMetricsQueryHelper, HydratorPlusPlusDetailNonRunsStore, $interval) {
+
+    var dispatcher = HydratorPlusPlusDetailMetricsDispatcher.getDispatcher();
+    var metricsPoll;
+    // FIXME: This is a memory leak. We need to fix this.
+    var dataSrc = new MyCDAPDataSource();
+    var filter = $filter('filter');
+    this.pollForMetrics = function(params) {
+      this.stopMetricsPoll();
+      getMetrics.call(this, params, true);
+    };
+
+    this.requestForMetrics = function (params) {
+      getMetrics.call(this, params, false);
+    };
+
+    function getMetrics(params, isPoll) {
+      var metricParams = params;
+      metricParams = MyMetricsQueryHelper.tagsToParams(metricParams);
+      var metricBasePath = '/metrics/search?target=metric&' + metricParams;
+
+      function request() {
+        dataSrc.request({
+          method: 'POST',
+          _cdapPath: metricBasePath
+        }).then(function (res) {
+          var config = HydratorPlusPlusDetailNonRunsStore.getConfigJson();
+          var source = config.source.name;
+          var transforms = config.transforms.map(function (n) { return n.name; });
+          var sinks = config.sinks.map(function (n) { return n.name; });
+          var stagesArray = [source].concat(transforms, sinks);
+          var metricQuery = [];
+
+          if (res.length > 0) {
+            angular.forEach(stagesArray, function (node) {
+              metricQuery = metricQuery.concat(filter(res, node));
+            });
+
+            if (metricQuery.length === 0) {
+              dispatcher.dispatch('onEmptyMetrics');
+              return;
+            }
+
+            /**
+             *  Since the parent block is already a poll, we don't need another poll for
+             *  the values of each metrics.
+             **/
+            dataSrc.request({
+              method: 'POST',
+              _cdapPath: '/metrics/query?' + metricParams + '&metric=' + metricQuery.join('&metric=')
+            }).then(function(metrics) {
+              dispatcher.dispatch('onMetricsFetch', metrics);
+            });
+          }
+        }.bind(this));
+
+      }
+
+      /**
+       * FIXME:
+       * The reason we are using interval here is because the node server does not send result
+       * if there is no change in data. Since we were only polling for the list of available metrics
+       * there won't be change of data, thus the metrics is not updating.
+       **/
+      if (isPoll) {
+        request();
+        metricsPoll = $interval(request, 10000);
+      } else {
+        request();
+      }
+
+    }
+
+    this.stopMetricsPoll = function() {
+      if (metricsPoll) {
+        $interval.cancel(metricsPoll);
+        metricsPoll = null;
+      }
+    };
+
+    this.reset = function() {
+      this.stopMetricsPoll();
+      dispatcher.dispatch('onReset');
+    };
+
+  });

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/dispatchers/pipeline-detail-dispatcher.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/dispatchers/pipeline-detail-dispatcher.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/dispatchers/pipeline-detail-dispatcher.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/dispatchers/pipeline-detail-dispatcher.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .service('HydratorPlusPlusDetailDispatcher', function(CaskAngularDispatcher) {
+    this.__dispatcher__ = null;
+    this.destroyDispatcher = function() {
+      delete this.__dispatcher__;
+    };
+
+    this.getDispatcher = function() {
+      if (!this.__dispatcher__) {
+         this.__dispatcher__ = new CaskAngularDispatcher();
+      }
+      return this.__dispatcher__;
+    };
+  });

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/dispatchers/pipeline-detail-metrics-dispatcher.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/dispatchers/pipeline-detail-metrics-dispatcher.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/dispatchers/pipeline-detail-metrics-dispatcher.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/dispatchers/pipeline-detail-metrics-dispatcher.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .service('HydratorPlusPlusDetailMetricsDispatcher', function(CaskAngularDispatcher) {
+    this.__dispatcher__ = null;
+    this.destroyDispatcher = function() {
+      delete this.__dispatcher__;
+    };
+
+    this.getDispatcher = function() {
+      if (!this.__dispatcher__) {
+         this.__dispatcher__ = new CaskAngularDispatcher();
+      }
+      return this.__dispatcher__;
+    };
+  });

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-metrics-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-metrics-store.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-metrics-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-metrics-store.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .service('HydratorPlusPlusDetailMetricsStore', function(HydratorPlusPlusDetailMetricsDispatcher) {
+
+    var dispatcher = HydratorPlusPlusDetailMetricsDispatcher.getDispatcher();
+    this.changeListeners = [];
+    this.setDefaults = function() {
+      this.state = {
+        metrics: []
+      };
+    };
+    this.setDefaults();
+    this.getMetrics = function() {
+      return this.state.metrics;
+    };
+    this.registerOnChangeListener = function(callback) {
+      this.changeListeners.push(callback);
+    };
+    this.emitChange = function() {
+      this.changeListeners.forEach(function(listener) {
+        listener(this.state);
+      }.bind(this));
+    };
+
+    this.emptyMetrics = function () {
+      this.state.metrics = [];
+      this.emitChange();
+    };
+
+    this.setState = function(metrics) {
+      var metricObj = {};
+      angular.forEach(metrics.series, function (metric) {
+        var split = metric.metricName.split('.');
+        var key = split[1];
+
+        if (!metricObj[key]) {
+          metricObj[key] = {
+            nodeName: split[1]
+          };
+        }
+
+        if (split[split.length - 1] === 'in') {
+          metricObj[key].recordsIn = metric.data[0].value;
+        } else if (split[split.length - 1] === 'out') {
+          metricObj[key].recordsOut = metric.data[0].value;
+        }
+
+      });
+
+      var metricsArr = [];
+      angular.forEach(metricObj, function (val) {
+        metricsArr.push(val);
+      });
+
+      this.state.metrics = metricsArr;
+      this.emitChange();
+    };
+    dispatcher.register('onMetricsFetch', this.setState.bind(this));
+    dispatcher.register('onEmptyMetrics', this.emptyMetrics.bind(this));
+    dispatcher.register('onReset', this.setDefaults.bind(this));
+  });

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-nodeconfig-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-nodeconfig-store.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.hydratorplusplus')
-  .service('HydratorPlusPlusNodeConfigStore', function(HydratorPlusPlusConfigDispatcher, $q, $filter, IMPLICIT_SCHEMA, GLOBALS, myPipelineApi, $state, $rootScope, HydratorPlusPlusConfigStore, DetailNonRunsStore, HydratorPlusPlusNodeConfigActions, HydratorPlusPlusHydratorService) {
+  .service('HydratorPlusPlusNodeConfigStore', function(HydratorPlusPlusConfigDispatcher, $q, $filter, IMPLICIT_SCHEMA, GLOBALS, myPipelineApi, $state, $rootScope, HydratorPlusPlusConfigStore, HydratorPlusPlusDetailNonRunsStore, HydratorPlusPlusNodeConfigActions, HydratorPlusPlusHydratorService) {
 
     var dispatcher;
     this.changeListeners = [];
@@ -58,7 +58,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
     };
 
     this.reset = function() {
-      // This is done here as NodeConfigStore is being reused between create and view pipelines states.
+      // This is done here as DAGPlusPlusNodesStore is being reused between create and view pipelines states.
       // So we need to destroy the dispatcher updating all listeners of the store so when we switch states
       // one does not get notified if out of context.
       HydratorPlusPlusConfigDispatcher.destroyDispatcher();
@@ -68,7 +68,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
       if ($state.includes('hydratorplusplus.create.**')) {
         this.ConfigStore = HydratorPlusPlusConfigStore;
       } else if ($state.includes('hydratorplusplus.detail.**')) {
-        this.ConfigStore = DetailNonRunsStore;
+        this.ConfigStore = HydratorPlusPlusDetailNonRunsStore;
       }
       dispatcher = HydratorPlusPlusConfigDispatcher.getDispatcher();
       dispatcher.register('onPluginChange', this.setState.bind(this));

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-nonruns-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-nonruns-store.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-nonruns-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-nonruns-store.js
@@ -1,0 +1,216 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .service('HydratorPlusPlusDetailNonRunsStore', function(HydratorPlusPlusDetailDispatcher, HydratorService) {
+    this.HydratorService = HydratorService;
+    this.setDefaults = function(app) {
+      this.state = {
+        scheduleStatus: null,
+        name: app.name || '',
+        type: app.type,
+        description: app.description,
+
+        datasets: app.datasets || [],
+        streams: app.streams || [],
+
+        configJson: app.configJson || {},
+        cloneConfig: app.cloneConfig || {},
+        DAGConfig: app.DAGConfig || {nodes: [], connections: []}
+      };
+    };
+    this.changeListeners = [];
+    var dispatcher = HydratorPlusPlusDetailDispatcher.getDispatcher();
+
+    this.setDefaults({});
+    this.getScheduleStatus = function() {
+      return this.state.scheduleStatus;
+    };
+
+    this.registerOnChangeListener = function(callback) {
+      this.changeListeners.push(callback);
+    };
+    this.emitChange = function() {
+      this.changeListeners.forEach(function(callback) {
+        callback(this.state);
+      }.bind(this));
+    };
+    this.setState = function(schedule) {
+      this.state.scheduleStatus = schedule.status || schedule;
+      this.emitChange();
+    };
+    this.getCloneConfig = function() {
+      return this.state.cloneConfig;
+    };
+    this.getPipelineType = function() {
+      return this.state.type;
+    };
+    this.getPipelineName = function() {
+      return this.state.name;
+    };
+    this.getPipelineDescription = function() {
+      return this.state.description;
+    };
+    this.getDAGConfig = function() {
+      var config = angular.copy(this.state.DAGConfig);
+      angular.forEach(config.nodes, (node) => {
+        if (node.plugin){
+          node.label = node.plugin.label;
+        }
+      });
+      return config;
+    };
+    this.getConnections = function() {
+      return this.state.DAGConfig.connections;
+    };
+    this.getNodes = function() {
+      return this.state.DAGConfig.nodes;
+    };
+    this.getSourceNodes = function(nodeId) {
+      let nodesMap = {};
+      this.state.DAGConfig.nodes.forEach( node => nodesMap[node.name] = node );
+      return this.state.DAGConfig.connections.filter( conn => conn.to === nodeId ).map( matchedConnection => nodesMap[matchedConnection.from] );
+    };
+    this.getDatasets = function() {
+      return this.state.datasets;
+    };
+    this.getStreams = function() {
+      return this.state.streams;
+    };
+    this.getConfigJson = function() {
+      return this.state.configJson;
+    };
+    this.getAppType = function() {
+      return this.state.type;
+    };
+    this.getPluginObject = function(nodeId) {
+      var nodes = this.getNodes();
+      var match = nodes.filter( node => node.name === nodeId);
+      match = (match.length? match[0]: null);
+      return match;
+    };
+    this.getNode = this.getPluginObject;
+    this.init = function(app) {
+      var appConfig = {};
+      var uiConfig;
+      angular.extend(appConfig, app);
+
+      try {
+        appConfig.configJson = JSON.parse(app.configuration);
+      } catch(e) {
+        appConfig.configJson = e;
+        console.log('ERROR cannot parse configuration');
+        return;
+      }
+      if(appConfig.configJson) {
+        app.config = appConfig.configJson;
+        uiConfig = this.HydratorService.getNodesAndConnectionsFromConfig(app);
+        let setDefaultOutputSchemaForNodes = (node) => {
+          var pluginName = node.plugin.name;
+          var pluginToSchemaMap = {
+            'Stream': [
+              {
+                readonly: true,
+                name: 'ts',
+                type: 'long'
+              },
+              {
+                readonly: true,
+                name: 'headers',
+                type: {
+                  type: 'map',
+                  keys: 'string',
+                  values: 'string'
+                }
+              }
+            ]
+          };
+          if (pluginToSchemaMap[pluginName]){
+            if (!node.plugin.properties.schema) {
+              node.plugin.properties.schema = {
+                fields: [{ name: 'body', type: 'string'}]
+              };
+              node.plugin.properties.schema = JSON.stringify({
+                type: 'record',
+                name: 'etlSchemaBody',
+                fields: angular.isObject(node.outputSchema)?
+                  pluginToSchemaMap[pluginName].concat(node.outputSchema.fields || []):
+                  pluginToSchemaMap[pluginName]
+              });
+            } else {
+              try {
+                let schema = JSON.parse(node.plugin.properties.schema);
+                node.plugin.properties.schema = JSON.stringify({
+                  type: 'record',
+                  name: 'etlSchemaBody',
+                  fields: pluginToSchemaMap[pluginName].concat(schema.fields)
+                });
+              } catch(e) {}
+            }
+          }
+        };
+        uiConfig.nodes.forEach(setDefaultOutputSchemaForNodes);
+        appConfig.DAGConfig = {
+          nodes: uiConfig.nodes,
+          connections: uiConfig.connections
+        };
+
+        appConfig.description = appConfig.configJson.description ? appConfig.configJson.description : appConfig.description;
+      }
+
+      appConfig.type = app.artifact.name;
+
+      // FIXME: TL;DR - Object reference being changed somewhere in the detailed view is affecting the clone behavior.
+      // Longer version -
+      // Right now appConfig.configJson is modified somewhere (modify reference) which affects the 'schema' property of 'Stream'
+      // plugin once the node is opened in the bottom panel. This is causing clone to fail. I am creating a copy so that no matter
+      // what gets changed in the detailed view is not passed on to the clone. This shouldn't be a problem as nothing should be changed
+      // in detailed view. `appConfig.configJson` is the culprit.
+      // One of the worst cases of 2way binding where right now the app is super big that I have no f***ing clue where which one is modified.
+      let appConfigClone = angular.copy(appConfig);
+      appConfig.cloneConfig = {
+        name: app.name,
+        artifact: app.artifact,
+        description: appConfigClone.configJson.description,
+        __ui__: appConfigClone.DAGConfig,
+        config: {
+          source: appConfigClone.configJson.source,
+          sinks: appConfigClone.configJson.sinks,
+          transforms: appConfigClone.configJson.transforms,
+          instances: appConfigClone.configJson.instance,
+          schedule: appConfigClone.configJson.schedule,
+          connections: uiConfig.connections,
+          comments: appConfigClone.configJson.comments
+        }
+      };
+      appConfig.streams = app.streams.map(function (stream) {
+        stream.type = 'Stream';
+        return stream;
+      });
+      appConfig.datasets = app.datasets.map(function (dataset) {
+        dataset.type = 'Dataset';
+        return dataset;
+      });
+      this.setDefaults(appConfig);
+    };
+    this.reset = function() {
+      this.setDefaults({});
+      this.changeListeners = [];
+    };
+    dispatcher.register('onScheduleStatusFetch', this.setState.bind(this));
+    dispatcher.register('onScheduleStatusFetchFail', this.setState.bind(this, {error: 'Failed to fetch schedule for the pipeline.'}));
+    dispatcher.register('onReset', this.reset.bind(this));
+  });

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-runs-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-runs-store.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-runs-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-runs-store.js
@@ -52,7 +52,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
         return false;
       }
 
-      if (appType === GLOBALS.etlBatch) {
+      if (GLOBALS.etlBatchPipelines.indexOf(appType) !== -1) {
         // TODO: Make it generic so that we can choose between spark and mapreduce.
         // We will get a flag from backend called 'engine'. This can be chosen based on that.
         metricRunId = this.state.runs.list[0].properties.ETLMapReduce;
@@ -125,7 +125,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
         runsCount: runs.length,
         nextRunTime: this.state.runs.nextRunTime || null
       };
-      if (this.state.type === GLOBALS.etlBatch) {
+      if (GLOBALS.etlBatchPipelines.indexOf(this.state.type) !== -1) {
         this.state.logsParams.runId = this.state.runs.latest.properties.ETLMapReduce;
       } else {
         this.state.logsParams.runId = this.state.runs.latest.runid;
@@ -154,7 +154,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
         appId: app.name
       };
 
-      programType = app.artifact.name === GLOBALS.etlBatch ? 'WORKFLOWS' : 'WORKER';
+      programType = GLOBALS.etlBatchPipelines.indexOf(app.artifact.name) !== -1 ? 'WORKFLOWS' : 'WORKER';
 
       if (programType === 'WORKFLOWS') {
         let engineType = JSON.parse(app.configuration).engine;

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-runs-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-runs-store.js
@@ -1,0 +1,203 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .service('HydratorPlusPlusDetailRunsStore', function(HydratorPlusPlusDetailDispatcher, $state, myHelpers, GLOBALS, myPipelineCommonApi, HydratorService) {
+
+    var dispatcher = HydratorPlusPlusDetailDispatcher.getDispatcher();
+    this.changeListeners = [];
+    this.HydratorService = HydratorService;
+    this.setDefaults = function(app) {
+      this.state = {
+        runs:{
+          list: [],
+          latest: {},
+          count: 0,
+          nextRunTime: null
+        },
+        params: app.params || {},
+        scheduleParams: app.scheduleParams || {},
+        logsParams: app.logsParams || {},
+        api: app.api,
+        type: app.type,
+        metricProgramType: app.metricProgramType,
+        statistics: ''
+      };
+    };
+    this.setDefaults({});
+
+    this.getRuns = function() {
+      return angular.copy(this.state.runs.list);
+    };
+    this.getLatestRun = function() {
+      return this.state.runs.list[0];
+    };
+    this.getLatestMetricRunId = function() {
+      var appType = this.getAppType();
+      var metricRunId;
+      if (!this.state.runs.count) {
+        return false;
+      }
+
+      if (appType === GLOBALS.etlBatch) {
+        // TODO: Make it generic so that we can choose between spark and mapreduce.
+        // We will get a flag from backend called 'engine'. This can be chosen based on that.
+        metricRunId = this.state.runs.list[0].properties.ETLMapReduce;
+      } else if (appType === GLOBALS.etlRealtime) {
+        metricRunId = this.state.runs.list[0].runid;
+      }
+      return metricRunId;
+    };
+    this.getAppType = function() {
+      return this.state.type;
+    };
+    this.getStatus = function() {
+      var status;
+      if (this.state.runs.list.length === 0) {
+        status = 'STOPPED';
+      } else {
+        status = myHelpers.objectQuery(this.state, 'runs', 'latest', 'status') || '';
+      }
+      return status;
+    };
+    this.getRunsCount = function() {
+      return this.state.runs.count;
+    };
+    this.getNextRunTime = function() {
+      return this.state.runs.nextRunTime;
+    };
+    this.setNextRunTime = function(nextRunTime) {
+      this.state.runs.nextRunTime = nextRunTime;
+      this.emitChange();
+    };
+    this.getApi = function() {
+      return this.state.api;
+    };
+    this.getParams = function() {
+      return this.state.params;
+    };
+    this.getScheduleParams = function() {
+      return this.state.scheduleParams;
+    };
+    this.getLogsParams = function() {
+      var logsParams = angular.extend({runId: this.state.runs.latest.runid}, this.state.logsParams);
+      return logsParams;
+    };
+
+    this.getStatistics = function() {
+      return this.state.statistics;
+    };
+
+    this.getMetricProgramType = function() {
+      return this.state.metricProgramType;
+    };
+
+    this.registerOnChangeListener = function(callback) {
+      this.changeListeners.push(callback);
+    };
+    this.emitChange = function() {
+      this.changeListeners.forEach(function(callback) {
+        callback();
+      });
+    };
+
+    this.setRunsState = function(runs) {
+      if (!runs.length) {
+        return;
+      }
+      this.state.runs = {
+        list: runs,
+        count: runs.length,
+        latest: runs[0],
+        runsCount: runs.length,
+        nextRunTime: this.state.runs.nextRunTime || null
+      };
+      if (this.state.type === GLOBALS.etlBatch) {
+        this.state.logsParams.runId = this.state.runs.latest.properties.ETLMapReduce;
+      } else {
+        this.state.logsParams.runId = this.state.runs.latest.runid;
+      }
+      this.emitChange();
+    };
+    this.setStatistics = function(statistics) {
+      this.state.statistics = statistics;
+      this.emitChange();
+    };
+    this.init = function(app) {
+      var appConfig = {};
+      var appLevelParams,
+          logsLevelParams,
+          metricProgramType,
+          programType;
+
+      angular.extend(appConfig, app);
+      appLevelParams = {
+        namespace: $state.params.namespace,
+        app: app.name
+      };
+
+      logsLevelParams = {
+        namespace: $state.params.namespace,
+        appId: app.name
+      };
+
+      programType = app.artifact.name === GLOBALS.etlBatch ? 'WORKFLOWS' : 'WORKER';
+
+      if (programType === 'WORKFLOWS') {
+        let engineType = JSON.parse(app.configuration).engine;
+        angular.forEach(app.programs, function (program) {
+          if (program.type === 'Workflow') {
+            appLevelParams.programName = program.id;
+            appLevelParams.programType = program.type.toLowerCase() + 's';
+          } else {
+            metricProgramType = program.type.toLowerCase();
+
+            logsLevelParams.programId = program.id;
+            logsLevelParams.programType = engineType || 'mapreduce';
+          }
+        });
+      } else {
+        angular.forEach(app.programs, function (program) {
+          metricProgramType = program.type.toLowerCase();
+          appLevelParams.programName = program.id;
+          appLevelParams.programType = program.type.toLowerCase() + 's';
+
+          logsLevelParams.programId = program.id;
+          logsLevelParams.programType = program.type.toLowerCase() + 's';
+        });
+      }
+      appConfig.type = app.artifact.name;
+      appConfig.logsParams = logsLevelParams;
+      appConfig.params = appLevelParams;
+      appConfig.api = myPipelineCommonApi;
+      appConfig.metricProgramType = metricProgramType;
+      appConfig.scheduleParams = {
+        app: appLevelParams.app,
+        schedule: 'etlWorkflow',
+        namespace: appLevelParams.namespace
+      };
+      this.setDefaults(appConfig);
+    };
+    this.reset = function() {
+      this.setDefaults({});
+      this.changeListeners = [];
+    };
+
+    dispatcher.register('onRunsChange', this.setRunsState.bind(this));
+    dispatcher.register('onStatisticsFetch', this.setStatistics.bind(this));
+    dispatcher.register('onReset', this.setDefaults.bind(this, {}));
+    dispatcher.register('onNextRunTime', this.setNextRunTime.bind(this));
+  });

--- a/cdap-ui/app/features/hydratorplusplus/services/non-store-pipeline-error-factory.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/non-store-pipeline-error-factory.js
@@ -211,7 +211,7 @@ let hasValidConfig = (importConfig) => {
   return importConfig.config;
 };
 let hasValidSchedule = (importConfig, GLOBALS) => {
-  let isBatchPipeline = importConfig.artifact.name === GLOBALS.etlBatch;
+  let isBatchPipeline = GLOBALS.etlBatchPipelines.indexOf(importConfig.artifact.name) !== -1;
   return !isBatchPipeline? true: importConfig.config.schedule;
 };
 let hasValidInstance = (importConfig, GLOBALS) => {

--- a/cdap-ui/app/features/hydratorplusplus/templates/create/toppanel.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/create/toppanel.html
@@ -20,7 +20,7 @@
       <div class="hydrator-metadata" ng-class="{'expanded': HydratorPlusPlusTopPanelCtrl.metadataExpanded}">
         <div ng-click="HydratorPlusPlusTopPanelCtrl.openMetadata()" class="clearfix">
           <div class="pipeline-type">
-            <span ng-if="HydratorPlusPlusTopPanelCtrl.state.artifact.name === HydratorPlusPlusTopPanelCtrl.GLOBALS.etlBatch"
+            <span ng-if="HydratorPlusPlusTopPanelCtrl.GLOBALS.etlBatchPipelines.indexOf(HydratorPlusPlusTopPanelCtrl.state.artifact.name) !== -1"
                   uib-tooltip="Type: Batch"
                   tooltip-placement="right"
                   tooltip-class="toppanel-tooltip icon-tooltip"

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail.html
@@ -1,0 +1,24 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<!-- TOP PANEL -->
+<div ui-view="toppanel"></div>
+
+<!-- DAG DIAGRAM -->
+<div class="detail-canvas-container" ui-view="canvas"></div>
+
+<!-- CONSOLE BOTTOM PANNEL -->
+<div ui-view="bottompanel"></div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/bottom-panel.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/bottom-panel.html
@@ -1,0 +1,73 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<!-- CONSOLE BOTTOM PANNEL -->
+<div class="console"
+      ng-class="{'minimized': BottomPanelCtrl.bottomPanelState === 0, 'maximized': BottomPanelCtrl.bottomPanelState === 2}">
+  <div class="console-tabs clearfix">
+    <ul class="nav nav-tabs pull-left" role="tablist">
+      <li ng-repeat="tab in BottomPanelCtrl.tabs"
+          ng-click="BottomPanelCtrl.selectTab($index)"
+          ng-class="{'active': tab.title == BottomPanelCtrl.activeTab.title}"
+          role="presentation"
+          data-toggle="tab">
+          {{ tab.title }}
+      </li>
+    </ul>
+    <div class="btn-group pull-right">
+      <a ng-click="BottomPanelCtrl.toggleCollapse(BottomPanelCtrl.bottomPanelState)">
+        <span ng-if="BottomPanelCtrl.bottomPanelState !== 0"
+              class="fa fa-minus"
+              uib-tooltip="Minimize"
+              tooltip-class="tooltip-pane"
+              tooltip-placement="top"
+              tooltip-append-to-body="true">
+        </span>
+        <span ng-if="BottomPanelCtrl.bottomPanelState === 0"
+              class="fa fa-expand"
+              uib-tooltip="Grow"
+              tooltip-class="tooltip-pane"
+              tooltip-placement="top"
+              tooltip-append-to-body="true">
+        </span>
+      </a>
+      <a ng-click="BottomPanelCtrl.toggleMaximized(BottomPanelCtrl.bottomPanelState)">
+        <span ng-if="BottomPanelCtrl.bottomPanelState !== 2"
+              class="fa fa-arrows-alt"
+              uib-tooltip="Maximize"
+              tooltip-class="tooltip-pane"
+              tooltip-placement="top"
+              tooltip-append-to-body="true">
+        </span>
+        <span ng-if="BottomPanelCtrl.bottomPanelState === 2"
+              class="fa fa-compress"
+              uib-tooltip="Shrink"
+              tooltip-class="tooltip-pane"
+              tooltip-placement="top"
+              tooltip-append-to-body="true">
+        </span>
+      </a>
+    </div>
+  </div>
+
+  <div class="console-type">
+    <div ng-repeat="tab in BottomPanelCtrl.tabs"
+         ng-include="tab.template"
+         ng-show="BottomPanelCtrl.activeTab.title === tab.title"
+         ng-class="{'p-10': tab.title !== 'Node Configuration', 'node-config': tab.title === 'Node Configuration'}">
+      </div>
+  </div>
+</div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/bottom-panel.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/bottom-panel.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/canvas.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/canvas.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/canvas.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/canvas.html
@@ -1,0 +1,26 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<my-dag-plus data-is-disabled="true"
+        ng-class="{'canvas-scroll': CanvasCtrl.setScroll}"
+        context="CanvasCtrl"
+        template-popover="/assets/features/hydratorplusplus/templates/partial/schema-popover.html"
+        connection-popover-data="CanvasCtrl.generateSchemaOnEdge"
+        show-metrics="true"
+        metrics-data="CanvasCtrl.metrics"
+        node-popover-template="/assets/features/hydratorplusplus/templates/partial/metrics-popover.html"
+        >
+</my-dag-plus>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/configuration.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/configuration.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/configuration.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/configuration.html
@@ -1,0 +1,25 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div ng-controller="HydratorPlusPlusDetailConfigCtrl as PipelineConfigCtrl">
+  <button class="btn btn-grey pull-right"
+          ng-click="PipelineConfigCtrl.exportConfig()">Export</button>
+  <pre>
+    {{ PipelineConfigCtrl.config | json: 4 }}
+  </pre>
+
+  <a class="sr-only" id="pipeline-export-config-link" href="{{PipelineConfigCtrl.url}}" download="{{PipelineConfigCtrl.exportFileName}}.json">Export</a>
+</div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/datasets.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/datasets.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/datasets.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/datasets.html
@@ -1,0 +1,48 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div ng-controller="HydratorPlusPlusDetailDatasetCtrl as DatasetCtrl">
+  <div class="table-responsive" ng-if="DatasetCtrl.state.data.length > 0">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr ng-repeat="data in DatasetCtrl.state.data">
+          <td>
+            <a ui-sref="datasets.detail.overview.status({ datasetId: data.name })"
+              ng-if="data.type === 'Dataset'">
+              {{ data.name }}
+            </a>
+            <a ui-sref="streams.detail.overview.status({ streamId: data.name})"
+              ng-if="data.type === 'Stream'">
+              {{ data.name }}
+            </a>
+          </td>
+          <td>{{ data.type }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="well well-lg text-center" ng-if="DatasetCtrl.state.data.length === 0">
+    <h4>There is no dataset for this pipeline</h4>
+  </div>
+</div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/history.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/history.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/history.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/history.html
@@ -1,0 +1,24 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div ng-controller="HydratorPlusPlusDetailHistoryCtrl as HistoryCtrl">
+  <my-program-history
+    data-runs="HistoryCtrl.history"
+    data-type="{{ HistoryCtrl.programType }}"
+    data-app-id="HistoryCtrl.appId"
+    data-program-id="HistoryCtrl.programId"
+    class="history-table"></my-program-history>
+</div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/instance.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/instance.html
@@ -1,0 +1,20 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<br/>
+<div class="col-xs-12">
+  <h3>Instance: {{ instances }}</h3>
+</div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/instance.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/instance.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/log.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/log.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/log.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/log.html
@@ -1,0 +1,19 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div ng-controller="HydratorPlusPlusDetailLogCtrl as LogsCtrl">
+  <my-log-viewer data-params="LogsCtrl.logsParams"></my-log-viewer>
+</div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/metrics.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/metrics.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/metrics.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/metrics.html
@@ -1,0 +1,52 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div ng-controller="HydratorPlusPlusDetailMetricsCtrl as MetricsCtrl">
+  <div class="table-responsive" ng-if="MetricsCtrl.state.metrics.length > 0">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Node Name</th>
+          <th>Node Type</th>
+          <th>Metric</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr ng-repeat="metric in MetricsCtrl.state.metrics | orderBy:'stage'">
+          <td>{{ metric.nodeName }}</td>
+          <td>{{ MetricsCtrl.state.nodes[metric.nodeName].type }}</td>
+          <td class="metric-cell">
+            <table class="table metric-table">
+              <tr ng-if="metric.nodeType !== 'sink'">
+                <td>Records In</td>
+                <td>{{ metric.recordsIn }}</td>
+              </tr>
+              <tr>
+                <td>Records Out</td>
+                <td>{{ metric.recordsOut }}</td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="well well-lg text-center" ng-if="MetricsCtrl.state.metrics.length === 0">
+    <h4>No metrics for this pipeline</h4>
+  </div>
+</div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/node-configuration.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/node-configuration.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/node-configuration.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/node-configuration.html
@@ -1,0 +1,19 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div ng-init="isDisabled=true">
+  <div ng-include="'/assets/features/hydratorplusplus/templates/partial/node-config.html'"></div>
+</div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/schedule.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/schedule.html
@@ -1,0 +1,35 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<br/>
+<div class="col-xs-12">
+  <fieldset disabled>
+    <div class="basic-cron" ng-if="isBasic">
+      <cron-selection init="schedule"></cron-selection>
+    </div>
+
+    <div class="form-group" ng-if="!isBasic">
+      <div class="col-sm-10">
+        <div data-name="field"
+             class="my-widget-container"
+             data-model="schedule"
+             data-myconfig="{properties: {}, widget: 'schedule'}"
+             widget-container>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/schedule.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/tabs/schedule.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/top-panel.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/top-panel.html
@@ -1,0 +1,249 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<!-- TOP PANEL -->
+
+<div class="side-panel top text-center">
+<div class="tbl" ng-class="{'batch': [TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1, 'realtime': TopPanelCtrl.app.type === TopPanelCtrl.GLOBALS.etlRealtime}">
+  <div class="tbl-cell">
+    <div class="clearfix">
+      <div class="hydrator-detail-metadata">
+        <div class="pipeline-type">
+          <span ng-if="[TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1"
+                class="icon-ETLBatch"
+                uib-tooltip="Type: Batch"
+                tooltip-placement="right"
+                tooltip-append-to-body="true"
+                tooltip-class="toppanel-tooltip"></span>
+          <span ng-if="TopPanelCtrl.app.type === TopPanelCtrl.GLOBALS.etlRealtime"
+                class="icon-ETLRealtime"
+                uib-tooltip="Type: Realtime"
+                tooltip-placement="right"
+                tooltip-append-to-body="true"
+                tooltip-class="toppanel-tooltip"></span>
+        </div>
+        <div class="pipeline-name text-left">
+          <h1 uib-tooltip="{{ TopPanelCtrl.app.name }}"
+              tooltip-placement="right"
+              tooltip-enable="TopPanelCtrl.app.name.length > 25"
+              tooltip-append-to-body="true"
+              tooltip-class="toppanel-tooltip">
+            {{ ::TopPanelCtrl.app.name | myEllipsis: 25 }}
+          </h1>
+          <p tooltip-placement="right"
+             tooltip-enable="TopPanelCtrl.app.description.length > 48"
+             tooltip-append-to-body="true"
+             tooltip-class="toppanel-tooltip"
+             uib-tooltip-html="TopPanelCtrl.tooltipDescription">
+            {{ ::TopPanelCtrl.app.description | myEllipsis: 48 }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="tbl-cell">
+    <div class="app-status text-center" ng-class="{'status-green': TopPanelCtrl.isGreenStatus(), 'status-red': !TopPanelCtrl.isGreenStatus() }">
+      <span class="fa fa-circle metric-value"></span>
+      <span class="metric-label">{{ TopPanelCtrl.appStatus }}</span>
+    </div>
+  </div>
+  <div class="tbl-cell last-run">
+    <strong>Last Run</strong>
+    <div class="clearfix">
+      <div class="metric pull-left">
+        <span class="metric-value" ng-if="TopPanelCtrl.lastFinished">{{ TopPanelCtrl.lastFinished.start * 1000 | amDateFormat: 'h:mm:ss A'}} <small>{{ TopPanelCtrl.lastFinished.start * 1000 | amDateFormat: 'MM/DD/YYYY'}}</small></span>
+        <span class="metric-value" ng-if="!TopPanelCtrl.lastFinished"> &mdash; </span>
+        <span class="metric-label">Start</span>
+      </div>
+      <div class="metric pull-left">
+        <span class="metric-value" ng-if="TopPanelCtrl.lastRunTime === 'N/A'"> &mdash; </span>
+        <span class="metric-value" ng-if="TopPanelCtrl.lastRunTime !== 'N/A'">{{ TopPanelCtrl.lastRunTime }}</span>
+        <span class="metric-label">Duration</span>
+      </div>
+    </div>
+  </div>
+  <div class="tbl-cell all-runs">
+    <strong>All Runs</strong>
+    <div class="clearfix">
+      <div class="metric pull-left" ng-if="[TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1">
+        <span class="metric-value" ng-if="TopPanelCtrl.avgRunTime === 'N/A'"> &mdash; </span>
+        <span class="metric-value" ng-if="TopPanelCtrl.avgRunTime !== 'N/A'"> {{ TopPanelCtrl.avgRunTime}}</span>
+        <span class="metric-label">Avg Duration</span>
+      </div>
+      <div class="metric pull-left">
+        <span class="metric-value">{{ TopPanelCtrl.runsCount }}</span>
+        <span class="metric-label">Total Runs</span>
+      </div>
+    </div>
+  </div>
+  <div class="tbl-cell next-run" ng-if="[TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1">
+    <strong>Next Run</strong>
+    <div class="clearfix">
+      <div class="metric pull-left">
+        <span class="metric-value" ng-if="TopPanelCtrl.nextRunTime === 'N/A'"> &mdash; </span>
+        <span class="metric-value" ng-if="TopPanelCtrl.nextRunTime !== 'N/A'">
+          {{ TopPanelCtrl.nextRunTime | amDateFormat:'h:mm:ss A'}}
+          <small> {{ TopPanelCtrl.nextRunTime | amDateFormat:'MM/DD/YYYY'}}</small>
+        </span>
+        <span class="metric-label" ng-if="TopPanelCtrl.nextRunTime !== 'N/A'">Start</span>
+        <span class="metric-label" ng-if="TopPanelCtrl.nextRunTime === 'N/A'">Not Scheduled</span>
+      </div>
+    </div>
+  </div>
+  <div class="tbl-cell">
+    <!-- Right Buttons Actions -->
+    <div class="btn-group action-buttons clearfix" ng-class="{'batch': [TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1, 'realtime': TopPanelCtrl.app.type === TopPanelCtrl.GLOBALS.etlRealtime}">
+      <!-- IF ETL REALTIME -->
+      <div class="pull-left"
+        ng-if="TopPanelCtrl.app.type === TopPanelCtrl.GLOBALS.etlRealtime && (['KILLED', 'STOPPED', 'COMPLETED', 'FAILED', 'STARTING'].indexOf(TopPanelCtrl.appStatus) !== -1)">
+        <div class="btn"
+          ng-click="TopPanelCtrl.do('Start')"
+          ng-disabled="TopPanelCtrl.appStatus === 'STARTING'">
+          <span ng-if="TopPanelCtrl.appStatus !=='STARTING'">
+          <span class="icon-start"
+                  uib-tooltip="Run"
+                  tooltip-placement="bottom"
+                  tooltip-append-to-body="true"
+                  tooltip-class="toppanel-tooltip"></span>
+          </span>
+          <span ng-if="TopPanelCtrl.appStatus === 'STARTING'">
+            <span class="fa fa-refresh fa-spin"></span>
+          </span>
+        </div>
+      </div>
+      <div class="pull-left"
+        ng-if="TopPanelCtrl.app.type === TopPanelCtrl.GLOBALS.etlRealtime && ['RUNNING', 'STOPPING'].indexOf(TopPanelCtrl.appStatus) !== -1">
+        <div class="btn"
+          ng-click="TopPanelCtrl.do('Stop')"
+          ng-disabled="TopPanelCtrl.appStatus === 'STOPPING'">
+          <span ng-if="TopPanelCtrl.appStatus !=='STOPPING'">
+            <span class="icon-stopped"
+                  uib-tooltip="Stop"
+                  tooltip-placement="bottom"
+                  tooltip-append-to-body="true"
+                  tooltip-class="toppanel-tooltip"></span>
+          </span>
+          <span ng-if="TopPanelCtrl.appStatus === 'STOPPING'">
+            <span class="fa fa-refresh fa-spin"></span>
+          </span>
+        </div>
+      </div>
+      <!-- IF ETL BATCH -->
+      <div class="pull-left"
+        ng-if="[TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1">
+        <div ng-if="['SUSPENDED', 'SCHEDULING'].indexOf(TopPanelCtrl.scheduleStatus) !== -1 || TopPanelCtrl.scheduleStatus.error">
+
+          <div class="btn"
+            ng-click="TopPanelCtrl.do('Schedule')"
+            ng-disabled="TopPanelCtrl.scheduleStatus === 'SCHEDULING' || TopPanelCtrl.scheduleStatus.error">
+            <span ng-if="TopPanelCtrl.scheduleStatus === 'SUSPENDED' || TopPanelCtrl.scheduleStatus.error">
+              <span class="icon-calendar"
+                    uib-tooltip="Schedule"
+                    tooltip-placement="bottom"
+                    tooltip-append-to-body="true"
+                    tooltip-class="toppanel-tooltip"></span>
+            </span>
+            <span ng-if="TopPanelCtrl.scheduleStatus === 'SCHEDULING'">
+              <span class="fa fa-refresh fa-spin"></span>
+            </span>
+          </div>
+        </div>
+        <div ng-if="['SCHEDULED', 'SUSPENDING'].indexOf(TopPanelCtrl.scheduleStatus) !== -1">
+          <div class="btn"
+            ng-click="TopPanelCtrl.do('Suspend')"
+            ng-disabled="TopPanelCtrl.scheduleStatus === 'SUSPENDING'">
+            <span ng-if="TopPanelCtrl.scheduleStatus ==='SCHEDULED'">
+              <span class="icon-suspend"
+                    uib-tooltip="Suspend"
+                    tooltip-placement="bottom"
+                    tooltip-append-to-body="true"
+                    tooltip-class="toppanel-tooltip"></span>
+            </span>
+            <span ng-if="TopPanelCtrl.scheduleStatus === 'SUSPENDING'">
+              <span class="fa fa-refresh fa-spin"></span>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div class="pull-left"
+           ng-if="[TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1">
+        <div ng-if="['STARTING', 'STOPPED', 'COMPLETED', 'FAILED', 'KILLED'].indexOf(TopPanelCtrl.appStatus) !== -1">
+          <div class="btn"
+               ng-click="TopPanelCtrl.do('Start')"
+               ng-disabled="TopPanelCtrl.appStatus === 'STARTING'">
+            <span ng-if="TopPanelCtrl.appStatus !== 'STARTING'">
+              <span class="icon-start"
+                    uib-tooltip="Run"
+                    tooltip-placement="bottom"
+                    tooltip-append-to-body="true"
+                    tooltip-class="toppanel-tooltip"></span>
+            </span>
+            <span ng-if="TopPanelCtrl.appStatus === 'STARTING'">
+              <span class="fa fa-refresh fa-spin"></span>
+            </span>
+          </div>
+        </div>
+        <div ng-if="['STOPPING', 'RUNNING'].indexOf(TopPanelCtrl.appStatus) !== -1">
+          <div class="btn"
+            ng-click="TopPanelCtrl.do('Stop')"
+            ng-disabled="TopPanelCtrl.appStatus === 'STOPPING'">
+            <span ng-if="TopPanelCtrl.appStatus !== 'STOPPING'">
+            <span class="icon-stopped"
+                  uib-tooltip="Stop"
+                  tooltip-placement="bottom"
+                  tooltip-append-to-body="true"
+                  tooltip-class="toppanel-tooltip"></span>
+            </span>
+            <span ng-if="TopPanelCtrl.appStatus === 'STOPPING'">
+              <span class="fa fa-refresh fa-spin"></span>
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div class="pull-left">
+        <div ui-sref="hydratorplusplus.studio({data: TopPanelCtrl.config, type: TopPanelCtrl.app.type})" class="btn">
+        <span class="icon-clone"
+              uib-tooltip="Clone"
+              tooltip-placement="bottom"
+              tooltip-append-to-body="true"
+              tooltip-class="toppanel-tooltip"></span>
+        </div>
+      </div>
+      <div class="pull-left">
+        <div class="btn"
+             ui-sref="apps.detail.overview.status({ appId: TopPanelCtrl.app.name })">
+             <span class="icon-fist"
+                   uib-tooltip="View in CDAP"
+                   tooltip-placement="bottom"
+                   tooltip-append-to-body="true"
+                   tooltip-class="toppanel-tooltip"></span>
+        </div>
+      </div>
+      <div class="pull-left">
+        <div class="btn"
+          ng-click="caskConfirm()"
+          cask-confirmable="TopPanelCtrl.do('Delete')"
+          data-confirmable-content="Are you sure you want to delete this pipeline?">
+          <span class="icon-delete"
+                uib-tooltip="Delete"
+                tooltip-placement="bottom"
+                tooltip-append-to-body="true"
+                tooltip-class="toppanel-tooltip"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/top-panel.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/top-panel.html
@@ -14,12 +14,12 @@
 <!-- TOP PANEL -->
 
 <div class="side-panel top text-center">
-<div class="tbl" ng-class="{'batch': [TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1, 'realtime': TopPanelCtrl.app.type === TopPanelCtrl.GLOBALS.etlRealtime}">
+<div class="tbl" ng-class="{'batch': TopPanelCtrl.GLOBALS.etlBatchPipelines.indexOf(TopPanelCtrl.app.type) !== -1, 'realtime': TopPanelCtrl.app.type === TopPanelCtrl.GLOBALS.etlRealtime}">
   <div class="tbl-cell">
     <div class="clearfix">
       <div class="hydrator-detail-metadata">
         <div class="pipeline-type">
-          <span ng-if="[TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1"
+          <span ng-if="TopPanelCtrl.GLOBALS.etlBatchPipelines.indexOf(TopPanelCtrl.app.type) !== -1"
                 class="icon-ETLBatch"
                 uib-tooltip="Type: Batch"
                 tooltip-placement="right"
@@ -75,7 +75,7 @@
   <div class="tbl-cell all-runs">
     <strong>All Runs</strong>
     <div class="clearfix">
-      <div class="metric pull-left" ng-if="[TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1">
+      <div class="metric pull-left" ng-if="TopPanelCtrl.GLOBALS.etlBatchPiplines.indexOf(TopPanelCtrl.app.type) !== -1">
         <span class="metric-value" ng-if="TopPanelCtrl.avgRunTime === 'N/A'"> &mdash; </span>
         <span class="metric-value" ng-if="TopPanelCtrl.avgRunTime !== 'N/A'"> {{ TopPanelCtrl.avgRunTime}}</span>
         <span class="metric-label">Avg Duration</span>
@@ -86,7 +86,7 @@
       </div>
     </div>
   </div>
-  <div class="tbl-cell next-run" ng-if="[TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1">
+  <div class="tbl-cell next-run" ng-if="TopPanelCtrl.GLOBALS.etlBatchPipelines.indexOf(TopPanelCtrl.app.type) !== -1">
     <strong>Next Run</strong>
     <div class="clearfix">
       <div class="metric pull-left">
@@ -102,7 +102,7 @@
   </div>
   <div class="tbl-cell">
     <!-- Right Buttons Actions -->
-    <div class="btn-group action-buttons clearfix" ng-class="{'batch': [TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1, 'realtime': TopPanelCtrl.app.type === TopPanelCtrl.GLOBALS.etlRealtime}">
+    <div class="btn-group action-buttons clearfix" ng-class="{'batch': TopPanelCtrl.GLOBALS.etlBatchPipelines.indexOf(TopPanelCtrl.app.type) !== -1, 'realtime': TopPanelCtrl.app.type === TopPanelCtrl.GLOBALS.etlRealtime}">
       <!-- IF ETL REALTIME -->
       <div class="pull-left"
         ng-if="TopPanelCtrl.app.type === TopPanelCtrl.GLOBALS.etlRealtime && (['KILLED', 'STOPPED', 'COMPLETED', 'FAILED', 'STARTING'].indexOf(TopPanelCtrl.appStatus) !== -1)">
@@ -140,7 +140,7 @@
       </div>
       <!-- IF ETL BATCH -->
       <div class="pull-left"
-        ng-if="[TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1">
+        ng-if="TopPanelCtrl.GLOBALS.etlBatchPipelines.indexOf(TopPanelCtrl.app.type) !== -1">
         <div ng-if="['SUSPENDED', 'SCHEDULING'].indexOf(TopPanelCtrl.scheduleStatus) !== -1 || TopPanelCtrl.scheduleStatus.error">
 
           <div class="btn"
@@ -176,7 +176,7 @@
         </div>
       </div>
       <div class="pull-left"
-           ng-if="[TopPanelCtrl.GLOBALS.etlBatch, TopPanelCtrl.GLOBALS.etlDataPipeline].indexOf(TopPanelCtrl.app.type) !== -1">
+           ng-if="TopPanelCtrl.GLOBALS.etlBatchPipelines.indexOf(TopPanelCtrl.app.type) !== -1">
         <div ng-if="['STARTING', 'STOPPED', 'COMPLETED', 'FAILED', 'KILLED'].indexOf(TopPanelCtrl.appStatus) !== -1">
           <div class="btn"
                ng-click="TopPanelCtrl.do('Start')"

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/top-panel.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/top-panel.html
@@ -212,7 +212,7 @@
       </div>
 
       <div class="pull-left">
-        <div ui-sref="hydratorplusplus.studio({data: TopPanelCtrl.config, type: TopPanelCtrl.app.type})" class="btn">
+        <div ui-sref="hydratorplusplus.create({data: TopPanelCtrl.config, type: TopPanelCtrl.app.type})" class="btn">
         <span class="icon-clone"
               uib-tooltip="Clone"
               tooltip-placement="bottom"

--- a/cdap-ui/app/features/hydratorplusplus/templates/detail/top-panel.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/detail/top-panel.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2016 Cask Data, Inc.
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
   the License at

--- a/cdap-ui/app/features/hydratorplusplus/templates/partial/settings.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/partial/settings.html
@@ -17,7 +17,7 @@
 <div ng-controller="HydratorPlusPlusSettingsCtrl as HydratorPlusPlusSettingsCtrl" class="pipeline-schedule">
 
   <div class="bottompanel-header"
-       ng-if="HydratorPlusPlusSettingsCtrl.templateType === HydratorPlusPlusSettingsCtrl.GLOBALS.etlBatch">
+       ng-if="HydratorPlusPlusSettingsCtrl.GLOBALS.etlBatchPipelines.indexOf(HydratorPlusPlusSettingsCtrl.templateType) !== -1">
     <h3>
       <span>Pipeline Schedule</span>
     </h3>
@@ -39,7 +39,7 @@
   </div>
 
   <div class="bottompanel-body">
-    <div ng-if="HydratorPlusPlusSettingsCtrl.templateType === HydratorPlusPlusSettingsCtrl.GLOBALS.etlBatch">
+    <div ng-if="HydratorPlusPlusSettingsCtrl.GLOBALS.etlBatchPipelines.indexOf(HydratorPlusPlusSettingsCtrl.templateType) !== -1">
       <div class="basic-cron" ng-if="HydratorPlusPlusSettingsCtrl.isBasic">
         <cron-selection class="select-wrapper" output="HydratorPlusPlusSettingsCtrl.cron"
           init="HydratorPlusPlusSettingsCtrl.initialCron"></cron-selection>

--- a/cdap-ui/app/features/hydratorplusplus/templates/preconfigured-list.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/preconfigured-list.html
@@ -45,7 +45,7 @@
                   All
                 </button>
                 <button class="btn btn-default text-left"
-                  ng-class="{'active': PreconfiguredController.typeFilter === PreconfiguredController.GLOBALS.etlBatch}"
+                  ng-class="{'active': PreconfiguredController.GLOBALS.etlBatchPipelines.indexOf(PreconfiguredController.typeFilter) !== -1}"
                   ng-click="PreconfiguredController.typeFilter = PreconfiguredController.GLOBALS.etlBatch">
                   Batch
                 </button>

--- a/cdap-ui/app/features/hydratorplusplus/toppanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/toppanel.less
@@ -160,7 +160,7 @@ body.theme-cdap {
       }
     }
   }
-  &.state-hydrator-detail {
+  &.state-hydratorplusplus-detail {
     div.side-panel.top {
       div.tbl {
         display: table;

--- a/cdap-ui/app/features/overview/templates/data-apps.html
+++ b/cdap-ui/app/features/overview/templates/data-apps.html
@@ -134,7 +134,7 @@
               ng-click="AppsSectionCtrl.MyOrderings.appClicked(app.id)">
             <p ng-bind="app.name"> </p>
             <div class="title-type-image">
-              <span ng-if="AppsSectionCtrl.GLOBALS.etlBatch === app.artifact.name">
+              <span ng-if="AppsSectionCtrl.GLOBALS.etlBatchPipelines.indexOf(app.artifact.name) !== -1">
                 <span class="icon-ETLBatch"></span>
                 <span>ETL Batch</span>
               </span>

--- a/cdap-ui/app/services/constants.js
+++ b/cdap-ui/app/services/constants.js
@@ -20,6 +20,7 @@ angular.module(PKG.name + '.services')
     etlBatch: 'cdap-etl-batch',
     etlRealtime: 'cdap-etl-realtime',
     etlDataPipeline: 'cdap-etl-data-pipeline',
+    etlBatchPipelines: ['cdap-etl-batch', 'cdap-etl-data-pipeline'],
     pluginTypes: {
       'cdap-etl-batch': {
         'source': 'batchsource',

--- a/cdap-ui/app/services/constants.js
+++ b/cdap-ui/app/services/constants.js
@@ -19,7 +19,7 @@ angular.module(PKG.name + '.services')
     // Should be under property called 'artifactTypes' to be consistent. GLOBALS.etlBatch doesn't make much sense.
     etlBatch: 'cdap-etl-batch',
     etlRealtime: 'cdap-etl-realtime',
-
+    etlDataPipeline: 'cdap-etl-data-pipeline',
     pluginTypes: {
       'cdap-etl-batch': {
         'source': 'batchsource',
@@ -31,6 +31,12 @@ angular.module(PKG.name + '.services')
         'source': 'realtimesource',
         'sink': 'realtimesink',
         'transform': 'transform'
+      },
+      'cdap-etl-data-pipeline': {
+        'source': 'batchsource',
+        'sink': 'batchsink',
+        'transform': 'transform',
+        'batchaggregator': 'batchaggregator'
       }
     },
     pluginConvert: {

--- a/cdap-ui/app/services/hydrator/my-hydrator-factory.js
+++ b/cdap-ui/app/services/hydrator/my-hydrator-factory.js
@@ -17,11 +17,11 @@
 angular.module(PKG.name + '.services')
   .factory('myHydratorFactory', function(GLOBALS) {
     function isCustomApp(artifactName) {
-      return artifactName !== GLOBALS.etlBatch && artifactName !== GLOBALS.etlRealtime;
+      return !isETLApp(artifactName);
     }
 
     function isETLApp(artifactName) {
-      return artifactName === GLOBALS.etlBatch || artifactName === GLOBALS.etlRealtime;
+      return [GLOBALS.etlBatch, GLOBALS.etlRealtime, GLOBALS.etlDataPipeline].indexOf(artifactName) !== -1;
     }
 
     return {

--- a/cdap-ui/app/services/hydrator/my-pipeline-api.js
+++ b/cdap-ui/app/services/hydrator/my-pipeline-api.js
@@ -19,7 +19,7 @@ angular.module(PKG.name + '.services')
     var templatePath = '/templates',
         pipelinePath = '/namespaces/:namespace/apps/:pipeline',
 
-        listPath = '/namespaces/:namespace/apps?artifactName=' + GLOBALS.etlBatch + ',' + GLOBALS.etlRealtime,
+        listPath = '/namespaces/:namespace/apps?artifactName=' + GLOBALS.etlBatch + ',' + GLOBALS.etlRealtime + ',' + GLOBALS.etlDataPipeline,
         artifactsPath = '/namespaces/:namespace/artifacts?scope=SYSTEM',
         extensionsFetchBase = '/namespaces/:namespace/artifacts/:pipelineType/versions/:version/extensions',
         pluginFetchBase = extensionsFetchBase + '/:extensionType',


### PR DESCRIPTION
- Adds integration to backend (new config json for pipeline)
- Modifies `hydratorplusplus.create` view to publish pipelines in new config.
- Adds detailed view for `hydratorplusplus` feature and makes it the default detailed for all pipelines.
- Fixes app's detailed view.
- Fixes switching between hydrator and cdap.

Bamboo build: http://builds.cask.co/browse/CDAP-DRC3525-3