### PR TITLE
(CDAP-5085) Added implementation of the new Spark Runtime Core (Part 1)

### DIFF
--- a/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
+++ b/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
@@ -18,7 +18,7 @@ package co.cask.cdap.api.spark;
 
 import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
-import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.dataset.Dataset;
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
 /**
  * Spark program execution context. User Spark program can interact with CDAP through this context.
  */
-public abstract class JavaSparkExecutionContext implements RuntimeContext, DatasetContext {
+public abstract class JavaSparkExecutionContext implements RuntimeContext, Transactional {
 
   /**
    * @return The specification used to configure this {@link Spark} job instance.

--- a/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
+++ b/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
@@ -17,7 +17,7 @@
 package co.cask.cdap.api.spark
 
 import co.cask.cdap.api.data.batch.Split
-import co.cask.cdap.api.{RuntimeContext, ServiceDiscoverer}
+import co.cask.cdap.api.{RuntimeContext, ServiceDiscoverer, TaskLocalizationContext, Transactional}
 import co.cask.cdap.api.data.DatasetContext
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.metrics.Metrics
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
 /**
   * Spark program execution context. User Spark program can interact with CDAP through this context.
   */
-trait SparkExecutionContext extends RuntimeContext with DatasetContext {
+trait SparkExecutionContext extends RuntimeContext with Transactional {
 
   /**
     * @return The specification used to configure this Spark job instance.
@@ -81,6 +81,12 @@ trait SparkExecutionContext extends RuntimeContext with DatasetContext {
   def getWorkflowToken: Option[WorkflowToken]
 
   /**
+    * Returns the [[co.cask.cdap.api.TaskLocalizationContext]] that gives access to files that were localized
+    * by [[co.cask.cdap.api.spark.Spark]] {@code beforeSubmit} method.
+    */
+  def getLocalizationContext: TaskLocalizationContext
+
+  /**
     * Creates a [[org.apache.spark.rdd.RDD]] from the given [[co.cask.cdap.api.dataset.Dataset]].
     * Using the implicit object [[co.cask.cdap.api.spark.SparkMain.SparkProgramContextFunctions]] is preferred.
     *
@@ -125,5 +131,6 @@ trait SparkExecutionContext extends RuntimeContext with DatasetContext {
     * @param arguments arguments for the Dataset
     * @throws co.cask.cdap.api.data.DatasetInstantiationException if the Dataset doesn't exist
     */
-  def saveAsDataset[T: ClassTag](rdd: RDD[T], datasetName: String, arguments: Map[String, String]): Unit
+  def saveAsDataset[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)],
+                                              datasetName: String, arguments: Map[String, String]): Unit
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
@@ -70,10 +70,21 @@ public final class Transactions {
    * {@link TransactionFailureException}.
    */
   public static TransactionFailureException asTransactionFailure(Throwable t) {
+    return asTransactionFailure(t, "Exception raised in transactional execution. Cause: " + t.getMessage());
+  }
+
+  /**
+   * Wraps the given {@link Throwable} as a {@link TransactionFailureException} if it is not already an instance of
+   * {@link TransactionFailureException}.
+   *
+   * @param t the original exception
+   * @param message the exception message to use in case wrapping is needed
+   */
+  public static TransactionFailureException asTransactionFailure(Throwable t, String message) {
     if (t instanceof TransactionFailureException) {
       return (TransactionFailureException) t;
     }
-    return new TransactionFailureException("Exception raised in transactional execution. Cause: " + t.getMessage(), t);
+    return new TransactionFailureException(message, t);
   }
 
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
@@ -39,6 +39,10 @@ public final class Transactions {
 
   private static final Logger LOG = LoggerFactory.getLogger(Transactions.class);
 
+  /**
+   * Aborts the given transaction without throwing any exception. If there is exception raised during abort,
+   * it will get logged as an error.
+   */
   public static void abortQuietly(TransactionSystemClient txClient, Transaction tx) {
     try {
       txClient.abort(tx);
@@ -47,6 +51,10 @@ public final class Transactions {
     }
   }
 
+  /**
+   * Invalidates the given transaction without throwing any exception. If there is exception raised during invalidation,
+   * it will get logged as an error.
+   */
   public static void invalidateQuietly(TransactionSystemClient txClient, Transaction tx) {
     try {
       if (!txClient.invalidate(tx.getWritePointer())) {
@@ -65,7 +73,7 @@ public final class Transactions {
     if (t instanceof TransactionFailureException) {
       return (TransactionFailureException) t;
     }
-    return new TransactionFailureException("Transaction Failure", t);
+    return new TransactionFailureException("Exception raised in transactional execution. Cause: " + t.getMessage(), t);
   }
 
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
@@ -49,11 +49,25 @@ public final class Transactions {
 
   public static void invalidateQuietly(TransactionSystemClient txClient, Transaction tx) {
     try {
-      txClient.invalidate(tx.getWritePointer());
+      if (!txClient.invalidate(tx.getWritePointer())) {
+        LOG.error("Failed to invalidate transaction {}", tx);
+      }
     } catch (Throwable t) {
       LOG.error("Exception when invalidating transaction {}", tx, t);
     }
   }
+
+  /**
+   * Wraps the given {@link Throwable} as a {@link TransactionFailureException} if it is not already an instance of
+   * {@link TransactionFailureException}.
+   */
+  public static TransactionFailureException asTransactionFailure(Throwable t) {
+    if (t instanceof TransactionFailureException) {
+      return (TransactionFailureException) t;
+    }
+    return new TransactionFailureException("Transaction Failure", t);
+  }
+
 
   public static Supplier<TransactionContext>
   constantContextSupplier(final TransactionSystemClient txClient,

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkClassLoader.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkClassLoader.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.api.spark.SparkExecutionContext;
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.common.lang.CombineClassLoader;
+import co.cask.cdap.common.lang.ProgramClassLoader;
+import co.cask.cdap.internal.app.runtime.plugin.PluginClassLoaders;
+import com.google.common.base.Preconditions;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ClassLoader being used in Spark execution context. It is used in driver as well as in executor node.
+ * It load classes from {@link ProgramClassLoader} followed by Plugin classes and then CDAP system ClassLoader.
+ */
+public class SparkClassLoader extends CombineClassLoader {
+
+  private final SparkRuntimeContext runtimeContext;
+  private final SparkExecutionContextFactory contextFactory;
+
+  /**
+   * Finds the SparkClassLoader from the context ClassLoader hierarchy.
+   *
+   * @return the SparkClassLoader found
+   * @throws IllegalStateException if no SparkClassLoader was found
+   */
+  public static SparkClassLoader findFromContext() {
+    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+    SparkClassLoader sparkClassLoader = ClassLoaders.find(contextClassLoader,
+                                                          SparkClassLoader.class);
+    // Should found the Spark ClassLoader
+    Preconditions.checkState(sparkClassLoader != null, "Cannot find SparkClassLoader from context ClassLoader %s",
+                             contextClassLoader);
+    return sparkClassLoader;
+  }
+
+  /**
+   * Creates a new SparkClassLoader from the execution context. It should only be called in distributed mode.
+   */
+  public static SparkClassLoader create() {
+    return new SparkClassLoader(SparkRuntimeContextProvider.get(), createSparkExecutionContextFactory());
+  }
+
+  /**
+   * Creates a new SparkClassLoader with the given {@link SparkRuntimeContext}.
+   */
+  public SparkClassLoader(SparkRuntimeContext runtimeContext, SparkExecutionContextFactory contextFactory) {
+    super(null, createDelegateClassLoaders(runtimeContext));
+    this.runtimeContext = runtimeContext;
+    this.contextFactory = contextFactory;
+  }
+
+  /**
+   * Returns the program ClassLoader.
+   */
+  public ClassLoader getProgramClassLoader() {
+    return runtimeContext.getProgram().getClassLoader();
+  }
+
+  /**
+   * Returns the {@link SparkRuntimeContext}.
+   */
+  public SparkRuntimeContext getRuntimeContext() {
+    return runtimeContext;
+  }
+
+  /**
+   * Creates a new instance of {@link SparkExecutionContext}.
+   */
+  public SparkExecutionContext createExecutionContext() {
+    return contextFactory.create(runtimeContext);
+  }
+
+  /**
+   * Creates a new instance of {@link JavaSparkExecutionContext} by wrapping the given {@link SparkExecutionContext}.
+   */
+  public JavaSparkExecutionContext createJavaExecutionContext(SparkExecutionContext sec) {
+    return new DefaultJavaSparkExecutionContext(sec);
+  }
+
+  /**
+   * Creates the delegating list of ClassLoader. Used by constructor only.
+   */
+  private static List<ClassLoader> createDelegateClassLoaders(SparkRuntimeContext context) {
+    return Arrays.asList(
+      context.getProgram().getClassLoader(),
+      PluginClassLoaders.createFilteredPluginsClassLoader(context.getApplicationSpecification().getPlugins(),
+                                                          context.getPluginInstantiator()),
+      SparkClassLoader.class.getClassLoader()
+    );
+  }
+
+  /**
+   * Creates a {@link SparkExecutionContextFactory} to be used in distributed mode.
+   */
+  private static SparkExecutionContextFactory createSparkExecutionContextFactory() {
+    return new SparkExecutionContextFactory() {
+      @Override
+      public SparkExecutionContext create(SparkRuntimeContext runtimeContext) {
+        SparkRuntimeContextConfig contextConfig = new SparkRuntimeContextConfig(runtimeContext.getConfiguration());
+
+        Map<String, File> localizeResources = new HashMap<>();
+        for (String name : contextConfig.getLocalizeResourceNames()) {
+          // In distributed mode, files will be localized to the container local directory
+          localizeResources.put(name, new File(name));
+        }
+
+        return new DefaultSparkExecutionContext(runtimeContext, localizeResources);
+      }
+    };
+  }
+}
+

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkClassLoader.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkClassLoader.java
@@ -121,7 +121,7 @@ public class SparkClassLoader extends CombineClassLoader {
         SparkRuntimeContextConfig contextConfig = new SparkRuntimeContextConfig(runtimeContext.getConfiguration());
 
         Map<String, File> localizeResources = new HashMap<>();
-        for (String name : contextConfig.getLocalizeResourceNames()) {
+        for (String name : contextConfig.getLocalizedResourceNames()) {
           // In distributed mode, files will be localized to the container local directory
           localizeResources.put(name, new File(name));
         }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkExecutionContextFactory.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkExecutionContextFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.spark.SparkExecutionContext;
+
+/**
+ * Factory for creating {@link SparkExecutionContext}.
+ */
+public interface SparkExecutionContextFactory {
+
+  /**
+   * Creates a new instance of {@link SparkExecutionContext} from the given {@link SparkRuntimeContext}.
+   */
+  SparkExecutionContext create(SparkRuntimeContext runtimeContext);
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkPluginContext.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkPluginContext.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.plugin.PluginProperties;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+/**
+ * A {@link Externalizable} implementation of {@link PluginContext} used in Spark program execution.
+ * It has no-op for serialize/deserialize operation, with all operations delegated to the {@link SparkRuntimeContext}
+ * of the current execution context.
+ */
+public final class SparkPluginContext implements PluginContext, Externalizable {
+
+  private final PluginContext delegate;
+
+  /**
+   * Constructor. It delegates plugin context operations to the current {@link SparkRuntimeContext}.
+   */
+  public SparkPluginContext() {
+    this(SparkRuntimeContextProvider.get());
+  }
+
+  /**
+   * Creates an instance that delegates all plugin context operations to the give {@link PluginContext} delegate.
+   */
+  SparkPluginContext(PluginContext delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public PluginProperties getPluginProperties(String pluginId) {
+    return delegate.getPluginProperties(pluginId);
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginId) {
+    return delegate.loadPluginClass(pluginId);
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return delegate.newPluginInstance(pluginId);
+  }
+
+  @Override
+  public void writeExternal(ObjectOutput out) throws IOException {
+    // no-op
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    // no-op
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -226,7 +226,7 @@ public final class SparkRuntimeContext extends AbstractServiceDiscoverer
    * Returns the {@link WorkflowProgramInfo} if the spark program is running inside a workflow.
    */
   @Nullable
-  WorkflowProgramInfo getWorkflowProgramInfo() {
+  WorkflowProgramInfo getWorkflowInfo() {
     return workflowProgramInfo;
   }
 

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.RuntimeContext;
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.spark.SparkSpecification;
+import co.cask.cdap.app.metrics.ProgramUserMetrics;
+import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.services.AbstractServiceDiscoverer;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.logging.LoggingContext;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
+import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.internal.app.program.ProgramTypeMetricTag;
+import co.cask.cdap.internal.app.runtime.DefaultAdmin;
+import co.cask.cdap.internal.app.runtime.DefaultPluginContext;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
+import co.cask.cdap.logging.context.SparkLoggingContext;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.tephra.TransactionSystemClient;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.api.RunId;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Context to be used at Spark runtime to provide common functionality that are needed at both the driver and
+ * the executors.
+ */
+public final class SparkRuntimeContext extends AbstractServiceDiscoverer
+                                       implements RuntimeContext, Metrics, PluginContext, Closeable {
+
+  private final Configuration hConf;
+  private final Program program;
+  private final RunId runId;
+  private final Map<String, String> runtimeArguments;
+  private final long logicalStartTime;
+  private final TransactionSystemClient txClient;
+  private final MultiThreadDatasetCache datasetCache;
+  private final DiscoveryServiceClient discoveryServiceClient;
+  private final MetricsContext metricsContext;
+  private final Metrics userMetrics;
+  private final StreamAdmin streamAdmin;
+  private final WorkflowProgramInfo workflowProgramInfo;
+  private final PluginInstantiator pluginInstantiator;
+  private final PluginContext pluginContext;
+  private final Admin admin;
+  private final LoggingContext loggingContext;
+
+  SparkRuntimeContext(Configuration hConf, Program program, RunId runId, Map<String, String> runtimeArguments,
+                      TransactionSystemClient txClient,
+                      DatasetFramework datasetFramework,
+                      DiscoveryServiceClient discoveryServiceClient,
+                      MetricsCollectionService metricsCollectionService,
+                      StreamAdmin streamAdmin,
+                      @Nullable WorkflowProgramInfo workflowProgramInfo,
+                      @Nullable PluginInstantiator pluginInstantiator) {
+    super(program.getId().toEntityId());
+
+    this.hConf = hConf;
+    this.program = program;
+    this.runId = runId;
+
+    Map<String, String> args = new HashMap<>(runtimeArguments);
+    this.logicalStartTime = ProgramRunners.updateLogicalStartTime(args);
+    this.runtimeArguments = Collections.unmodifiableMap(args);
+    this.txClient = txClient;
+
+    ProgramId programId = program.getId().toEntityId();
+    this.metricsContext = createMetricsContext(metricsCollectionService, programId, runId);
+
+    this.datasetCache = new MultiThreadDatasetCache(
+      new SystemDatasetInstantiator(datasetFramework, program.getClassLoader(),
+                                    Collections.singleton(programId.toId())),
+      txClient, programId.getNamespaceId(), runtimeArguments, metricsContext, null);
+
+    this.discoveryServiceClient = discoveryServiceClient;
+    this.userMetrics = new ProgramUserMetrics(metricsContext);
+    this.streamAdmin = streamAdmin;
+    this.workflowProgramInfo = workflowProgramInfo;
+    this.pluginInstantiator = pluginInstantiator;
+    this.pluginContext = new DefaultPluginContext(pluginInstantiator, programId,
+                                                  program.getApplicationSpecification().getPlugins());
+    this.admin = new DefaultAdmin(datasetFramework, programId.getNamespaceId());
+    this.loggingContext = new SparkLoggingContext(programId.getNamespace(), programId.getApplication(),
+                                                  programId.getProgram(), runId.getId());
+  }
+
+  @Override
+  public ApplicationSpecification getApplicationSpecification() {
+    return program.getApplicationSpecification();
+  }
+
+  @Override
+  public Map<String, String> getRuntimeArguments() {
+    return runtimeArguments;
+  }
+
+  @Override
+  public String getNamespace() {
+    return program.getNamespaceId();
+  }
+
+  @Override
+  public RunId getRunId() {
+    return runId;
+  }
+
+  @Override
+  public Admin getAdmin() {
+    return admin;
+  }
+
+  @Override
+  public void count(String metricName, int delta) {
+    userMetrics.count(metricName, delta);
+  }
+
+  @Override
+  public void gauge(String metricName, long value) {
+    userMetrics.gauge(metricName, value);
+  }
+
+  @Override
+  public PluginProperties getPluginProperties(String pluginId) {
+    return pluginContext.getPluginProperties(pluginId);
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginId) {
+    return pluginContext.loadPluginClass(pluginId);
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return pluginContext.newPluginInstance(pluginId);
+  }
+
+  @Override
+  protected DiscoveryServiceClient getDiscoveryServiceClient() {
+    return discoveryServiceClient;
+  }
+
+  /**
+   * Returns the {@link SparkSpecification} of the spark program of this context.
+   */
+  public SparkSpecification getSparkSpecification() {
+    SparkSpecification spec = getApplicationSpecification().getSpark().get(getProgram().getName());
+    // Spec shouldn't be null, otherwise the spark program won't even get started
+    Preconditions.checkState(spec != null, "SparkSpecification not found for %s", getProgram().getId());
+    return spec;
+  }
+
+  /**
+   * Returns the {@link Program} of this context.
+   */
+  public Program getProgram() {
+    return program;
+  }
+
+  /**
+   * Returns the logical start of this run.
+   */
+  long getLogicalStartTime() {
+    return logicalStartTime;
+  }
+
+  /**
+   * Returns the {@link TransactionSystemClient} for this execution.
+   */
+  TransactionSystemClient getTransactionSystemClient() {
+    return txClient;
+  }
+
+  /**
+   * Returns the {@link Configuration} used for the execution.
+   */
+  Configuration getConfiguration() {
+    return hConf;
+  }
+
+  /**
+   * Returns the {@link DynamicDatasetCache} to be used throughout the execution.
+   */
+  DynamicDatasetCache getDatasetCache() {
+    return datasetCache;
+  }
+
+  /**
+   * Returns the {@link WorkflowProgramInfo} if the spark program is running inside a workflow.
+   */
+  @Nullable
+  WorkflowProgramInfo getWorkflowProgramInfo() {
+    return workflowProgramInfo;
+  }
+
+  /**
+   * Returns the {@link PluginInstantiator} if plugin is used.
+   */
+  @Nullable
+  PluginInstantiator getPluginInstantiator() {
+    return pluginInstantiator;
+  }
+
+  /**
+   * Returns the {@link LoggingContext} representing the program.
+   */
+  LoggingContext getLoggingContext() {
+    return loggingContext;
+  }
+
+  /**
+   * Returns the {@link MetricsContext} for the program. It can be used to emit either user or system metrics.
+   */
+  MetricsContext getMetricsContext() {
+    return metricsContext;
+  }
+
+  /**
+   * Returns the {@link StreamAdmin} used for this execution.
+   */
+  StreamAdmin getStreamAdmin() {
+    return streamAdmin;
+  }
+
+  private static MetricsContext createMetricsContext(MetricsCollectionService service,
+                                                     ProgramId programId, RunId runId) {
+    Map<String, String> tags = Maps.newHashMap();
+    tags.put(Constants.Metrics.Tag.NAMESPACE, programId.getNamespace());
+    tags.put(Constants.Metrics.Tag.APP, programId.getApplication());
+    tags.put(ProgramTypeMetricTag.getTagName(ProgramType.SPARK), programId.getProgram());
+    tags.put(Constants.Metrics.Tag.RUN_ID, runId.getId());
+
+    // todo: use proper spark instance id. For now we have to emit smth for test framework's waitFor metric to work
+    tags.put(Constants.Metrics.Tag.INSTANCE_ID, "0");
+    return service.getContext(tags);
+  }
+
+  @Override
+  public void close() throws IOException {
+    datasetCache.close();
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(SparkRuntimeContext.class)
+      .add("id", getProgram().getId())
+      .add("runId", getRunId())
+      .toString();
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
+import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.ProgramId;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.api.RunId;
+
+import java.io.File;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Helper class for getting and setting configurations that are needed for recreating the runtime context
+ * in each Spark executor.
+ */
+public class SparkRuntimeContextConfig {
+
+  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
+  private static final Type ARGS_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+
+  /**
+   * Configuration key for boolean value to tell whether Spark program is executed on a cluster or not.
+   */
+  static final String HCONF_ATTR_CLUSTER_MODE = "cdap.spark.cluster.mode";
+  static final String HCONF_ATTR_LOCAL_RESOURCES = "cdap.spark.local.resources";
+
+  private static final String HCONF_ATTR_APP_SPEC = "cdap.spark.app.spec";
+  private static final String HCONF_ATTR_PROGRAM_ID = "cdap.spark.program.id";
+  private static final String HCONF_ATTR_RUN_ID = "cdap.spark.run.id";
+  private static final String HCONF_ATTR_ARGS = "cdap.spark.program.args";
+  private static final String HCONF_ATTR_WORKFLOW_INFO = "cdap.spark.program.workflow.info";
+
+  private final Configuration hConf;
+
+  /**
+   * Returns {@code true} if running in local mode.
+   */
+  static boolean isLocal(Configuration hConf) {
+    return !hConf.getBoolean(HCONF_ATTR_CLUSTER_MODE, false);
+  }
+
+  /**
+   * Creates a new instance from the given configuration.
+   */
+  SparkRuntimeContextConfig(Configuration hConf) {
+    this.hConf = hConf;
+  }
+
+  /**
+   * Returns the configuration.
+   */
+  public Configuration getConfiguration() {
+    return hConf;
+  }
+
+  /**
+   * Returns true if in local mode.
+   */
+  public boolean isLocal() {
+    return isLocal(hConf);
+  }
+
+  /**
+   * Sets configurations based on the given context.
+   */
+  public SparkRuntimeContextConfig set(SparkRuntimeContext context, Set<String> localizeResourceNames,
+                                       @Nullable File pluginArchive) {
+    setApplicationSpecification(context.getApplicationSpecification());
+    setProgramId(context.getProgram().getId().toEntityId());
+    setRunId(context.getRunId().getId());
+    setArguments(context.getRuntimeArguments());
+    setWorkflowProgramInfo(context.getWorkflowProgramInfo());
+    setLocalizeResourceNames(localizeResourceNames);
+    setPluginArchive(pluginArchive);
+
+    return this;
+  }
+
+  /**
+   * @return the {@link ApplicationSpecification} stored in the configuration.
+   */
+  public ApplicationSpecification getApplicationSpecification() {
+    return GSON.fromJson(hConf.get(HCONF_ATTR_APP_SPEC), ApplicationSpecification.class);
+  }
+
+  /**
+   * @return the {@link ProgramId} stored in the configuration.
+   */
+  public ProgramId getProgramId() {
+    return GSON.fromJson(hConf.get(HCONF_ATTR_PROGRAM_ID), ProgramId.class);
+  }
+
+  /**
+   * @return the {@link RunId} stored in the configuration.
+   */
+  public RunId getRunId() {
+    return RunIds.fromString(hConf.get(HCONF_ATTR_RUN_ID));
+  }
+
+  /**
+   * @return the runtime arguments stored in the configuration.
+   */
+  public Map<String, String> getArguments() {
+    return GSON.fromJson(hConf.get(HCONF_ATTR_ARGS), ARGS_TYPE);
+  }
+
+  /**
+   * @return the {@link WorkflowProgramInfo} if it is running inside Workflow or {@code null} if not.
+   */
+  @Nullable
+  public WorkflowProgramInfo getWorkflowProgramInfo() {
+    String info = hConf.get(HCONF_ATTR_WORKFLOW_INFO);
+    if (info == null) {
+      return null;
+    }
+    WorkflowProgramInfo workflowProgramInfo = GSON.fromJson(info, WorkflowProgramInfo.class);
+    workflowProgramInfo.getWorkflowToken().disablePut();
+    return workflowProgramInfo;
+  }
+
+  /**
+   * @return the set of localized resource names stored in the configuration.
+   */
+  public Set<String> getLocalizeResourceNames() {
+    return GSON.fromJson(hConf.get(HCONF_ATTR_LOCAL_RESOURCES), new TypeToken<Set<String>>(){ }.getType());
+  }
+
+  /**
+   * @return the name of the plugin archive file stored in the configuration.
+   */
+  @Nullable
+  public String getPluginArchive() {
+    return hConf.get(Constants.Plugin.ARCHIVE);
+  }
+
+  /**
+   * Serialize the {@link ApplicationSpecification} to the configuration.
+   */
+  private void setApplicationSpecification(ApplicationSpecification spec) {
+    hConf.set(HCONF_ATTR_APP_SPEC, GSON.toJson(spec, ApplicationSpecification.class));
+  }
+
+  /**
+   * Serialize the {@link ProgramId} to the configuration.
+   */
+  private void setProgramId(ProgramId programId) {
+    hConf.set(HCONF_ATTR_PROGRAM_ID, GSON.toJson(programId));
+  }
+
+  /**
+   * Serialize the {@link RunId} to the configuration.
+   */
+  private void setRunId(String runId) {
+    hConf.set(HCONF_ATTR_RUN_ID, runId);
+  }
+
+  /**
+   * Serialize the runtime arguments to the configuration.
+   */
+  private void setArguments(Map<String, String> runtimeArgs) {
+    hConf.set(HCONF_ATTR_ARGS, GSON.toJson(runtimeArgs, ARGS_TYPE));
+  }
+
+  /**
+   * Serialize the {@link WorkflowProgramInfo} to the configuration if available.
+   */
+  private void setWorkflowProgramInfo(@Nullable WorkflowProgramInfo info) {
+    if (info != null) {
+      hConf.set(HCONF_ATTR_WORKFLOW_INFO, GSON.toJson(info));
+    }
+  }
+
+  /**
+   * Serialize the set of localize resource names to the configuration.
+   */
+  private void setLocalizeResourceNames(Set<String> names) {
+    hConf.set(HCONF_ATTR_LOCAL_RESOURCES, GSON.toJson(names));
+  }
+
+  /**
+   * Saves the plugin archive file name to the configuration.
+   */
+  private void setPluginArchive(@Nullable File pluginArchive) {
+    if (pluginArchive != null) {
+      hConf.set(Constants.Plugin.ARCHIVE, pluginArchive.getName());
+    }
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
@@ -21,7 +21,6 @@ import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.ProgramId;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -95,8 +94,8 @@ public class SparkRuntimeContextConfig {
     setProgramId(context.getProgram().getId().toEntityId());
     setRunId(context.getRunId().getId());
     setArguments(context.getRuntimeArguments());
-    setWorkflowProgramInfo(context.getWorkflowProgramInfo());
-    setLocalizeResourceNames(localizeResourceNames);
+    setWorkflowProgramInfo(context.getWorkflowInfo());
+    setLocalizedResourceNames(localizeResourceNames);
     setPluginArchive(pluginArchive);
 
     return this;
@@ -147,7 +146,7 @@ public class SparkRuntimeContextConfig {
   /**
    * @return the set of localized resource names stored in the configuration.
    */
-  public Set<String> getLocalizeResourceNames() {
+  public Set<String> getLocalizedResourceNames() {
     return GSON.fromJson(hConf.get(HCONF_ATTR_LOCAL_RESOURCES), new TypeToken<Set<String>>(){ }.getType());
   }
 
@@ -199,7 +198,7 @@ public class SparkRuntimeContextConfig {
   /**
    * Serialize the set of localize resource names to the configuration.
    */
-  private void setLocalizeResourceNames(Set<String> names) {
+  private void setLocalizedResourceNames(Set<String> names) {
     hConf.set(HCONF_ATTR_LOCAL_RESOURCES, GSON.toJson(names));
   }
 

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
@@ -147,7 +147,7 @@ public class SparkRuntimeContextConfig {
    * @return the set of localized resource names stored in the configuration.
    */
   public Set<String> getLocalizedResourceNames() {
-    return GSON.fromJson(hConf.get(HCONF_ATTR_LOCAL_RESOURCES), new TypeToken<Set<String>>(){ }.getType());
+    return GSON.fromJson(hConf.get(HCONF_ATTR_LOCAL_RESOURCES), new TypeToken<Set<String>>() { }.getType());
   }
 
   /**

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.program.Programs;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
+import co.cask.cdap.common.guice.IOModule;
+import co.cask.cdap.common.guice.KafkaClientModule;
+import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.common.lang.ProgramClassLoader;
+import co.cask.cdap.data.runtime.DataFabricModules;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.stream.StreamAdminModules;
+import co.cask.cdap.data.stream.StreamCoordinatorClient;
+import co.cask.cdap.data.view.ViewAdminModules;
+import co.cask.cdap.data2.audit.AuditModule;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.explore.guice.ExploreClientModule;
+import co.cask.cdap.internal.app.program.ForwardingProgram;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.internal.app.runtime.workflow.NameMappedDatasetFramework;
+import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
+import co.cask.cdap.logging.appender.LogAppenderInitializer;
+import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
+import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.tephra.TransactionSystemClient;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.AbstractService;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.Service;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.internal.Services;
+import org.apache.twill.kafka.client.KafkaClientService;
+import org.apache.twill.zookeeper.ZKClientService;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Helper class for locating or creating {@link SparkRuntimeContext} from the execution context.
+ */
+public final class SparkRuntimeContextProvider {
+
+  // Constants defined for file names used for files localization done by the SparkRuntimeService.
+  // They are needed for recreating the SparkRuntimeContext in this class.
+  static final String CCONF_FILE_NAME = "cConf.xml";
+  static final String HCONF_FILE_NAME = "hConf.xml";
+  static final String PROGRAM_JAR_NAME = "program.jar";
+
+  private static volatile SparkRuntimeContext sparkRuntimeContext;
+
+  /**
+   * Returns the current {@link SparkRuntimeContext}.
+   */
+  public static SparkRuntimeContext get() {
+    if (sparkRuntimeContext != null) {
+      return sparkRuntimeContext;
+    }
+
+    // Try to find it from the context classloader
+    SparkClassLoader sparkClassLoader = ClassLoaders.find(Thread.currentThread().getContextClassLoader(),
+                                                          SparkClassLoader.class);
+    if (sparkClassLoader != null) {
+      // Shouldn't set the sparkContext field. It is because in Standalone, the SparkContext instance will be different
+      // for different runs, hence it shouldn't be cached in the static field.
+      // In distributed mode, in the driver, the SparkContext will always come from ClassLoader (like in Standalone).
+      // Although it can be cached, finding it from ClassLoader with a very minimal performance impact is ok.
+      // In the executor process, the static field will be set through the createIfNotExists() call
+      // when get called for the first time.
+      return sparkClassLoader.getRuntimeContext();
+    }
+    return createIfNotExists();
+  }
+
+  /**
+   * Creates a singleton {@link SparkRuntimeContext}.
+   * It has assumption on file location that are localized by the SparkRuntimeService.
+   */
+  private static synchronized SparkRuntimeContext createIfNotExists() {
+    if (sparkRuntimeContext != null) {
+      return sparkRuntimeContext;
+    }
+
+    try {
+      CConfiguration cConf = createCConf();
+      Configuration hConf = createHConf();
+
+      SparkRuntimeContextConfig contextConfig = new SparkRuntimeContextConfig(hConf);
+
+      // Should be yarn only and only for executor node, not the driver node.
+      Preconditions.checkState(!contextConfig.isLocal() && Boolean.parseBoolean(System.getenv("SPARK_YARN_MODE")),
+                               "SparkContextProvider.getSparkContext should only be called in Spark executor process.");
+
+      // Create the program
+      Program program = createProgram(cConf, contextConfig);
+
+      Injector injector = createInjector(cConf, hConf);
+
+      final Service logAppenderService = new LogAppenderService(injector.getInstance(LogAppenderInitializer.class));
+      final ZKClientService zkClientService = injector.getInstance(ZKClientService.class);
+      final KafkaClientService kafkaClientService = injector.getInstance(KafkaClientService.class);
+      final MetricsCollectionService metricsCollectionService = injector.getInstance(MetricsCollectionService.class);
+      final StreamCoordinatorClient streamCoordinatorClient = injector.getInstance(StreamCoordinatorClient.class);
+
+      // Use the shutdown hook to shutdown services, since this class should only be loaded from System classloader
+      // of the spark executor, hence there should be exactly one instance only.
+      // The problem with not shutting down nicely is that some logs/metrics might be lost
+      Services.chainStart(logAppenderService, zkClientService,
+                          kafkaClientService, metricsCollectionService, streamCoordinatorClient);
+      Runtime.getRuntime().addShutdownHook(new Thread() {
+        @Override
+        public void run() {
+          // The logger may already been shutdown. Use System.out/err instead
+          System.out.println("Shutting SparkClassLoader services");
+          Future<List<ListenableFuture<Service.State>>> future = Services.chainStop(logAppenderService,
+                                                                                    streamCoordinatorClient,
+                                                                                    metricsCollectionService,
+                                                                                    kafkaClientService,
+                                                                                    zkClientService);
+          try {
+            List<ListenableFuture<Service.State>> futures = future.get(5, TimeUnit.SECONDS);
+            System.out.println("SparkClassLoader services shutdown completed: " + futures);
+          } catch (Exception e) {
+            System.err.println("Exception when shutting down services");
+            e.printStackTrace(System.err);
+          }
+        }
+      });
+
+      // Constructor the DatasetFramework
+      DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
+      WorkflowProgramInfo workflowInfo = contextConfig.getWorkflowProgramInfo();
+      DatasetFramework programDatasetFramework = workflowInfo == null ?
+        datasetFramework :
+        NameMappedDatasetFramework.createFromWorkflowProgramInfo(datasetFramework, workflowInfo,
+                                                                 contextConfig.getApplicationSpecification());
+
+      // Setup dataset framework context, if required
+      if (programDatasetFramework instanceof ProgramContextAware) {
+        Id.Run id = new Id.Run(contextConfig.getProgramId().toId(), contextConfig.getRunId().getId());
+        ((ProgramContextAware) programDatasetFramework).initContext(id);
+      }
+
+      PluginInstantiator pluginInstantiator = createPluginInstantiator(cConf, hConf, program.getClassLoader());
+
+      // Create the context object
+      sparkRuntimeContext = new SparkRuntimeContext(
+        contextConfig.getConfiguration(),
+        program, contextConfig.getRunId(), contextConfig.getArguments(),
+        injector.getInstance(TransactionSystemClient.class),
+        programDatasetFramework,
+        injector.getInstance(DiscoveryServiceClient.class),
+        metricsCollectionService,
+        injector.getInstance(StreamAdmin.class),
+        contextConfig.getWorkflowProgramInfo(),
+        pluginInstantiator
+      );
+      return sparkRuntimeContext;
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private static CConfiguration createCConf() throws MalformedURLException {
+    return CConfiguration.create(new File(CCONF_FILE_NAME));
+  }
+
+  private static Configuration createHConf() throws MalformedURLException {
+    Configuration hConf = new Configuration();
+    hConf.clear();
+    hConf.addResource(new File(HCONF_FILE_NAME).toURI().toURL());
+    return hConf;
+  }
+
+  private static Program createProgram(CConfiguration cConf,
+                                       SparkRuntimeContextConfig contextConfig) throws IOException {
+    File programDir = new File(PROGRAM_JAR_NAME);
+    ProgramClassLoader classLoader = ProgramClassLoader.create(cConf, programDir,
+                                                               SparkClassLoader.class.getClassLoader(),
+                                                               ProgramType.SPARK);
+    final Id.Program programId = contextConfig.getProgramId().toId();
+    return new ForwardingProgram(Programs.create(Locations.toLocation(programDir), classLoader)) {
+      @Override
+      public Id.Program getId() {
+        return programId;
+      }
+
+      @Override
+      public String getName() {
+        return getId().getId();
+      }
+
+      @Override
+      public ProgramType getType() {
+        return ProgramType.SPARK;
+      }
+    };
+  }
+
+  @Nullable
+  private static PluginInstantiator createPluginInstantiator(CConfiguration cConf, Configuration hConf,
+                                                             ClassLoader parentClassLoader) {
+    String pluginArchive = hConf.get(Constants.Plugin.ARCHIVE);
+    if (pluginArchive == null) {
+      return null;
+    }
+    return new PluginInstantiator(cConf, parentClassLoader, new File(pluginArchive));
+  }
+
+  private static Injector createInjector(CConfiguration cConf, Configuration hConf) {
+    return Guice.createInjector(
+      new ConfigModule(cConf, hConf),
+      new IOModule(),
+      new ZKClientModule(),
+      new KafkaClientModule(),
+      new LocationRuntimeModule().getDistributedModules(),
+      new DiscoveryRuntimeModule().getDistributedModules(),
+      new DataFabricModules().getDistributedModules(),
+      new DataSetsModules().getDistributedModules(),
+      new MetricsClientRuntimeModule().getDistributedModules(),
+      new LoggingModules().getDistributedModules(),
+      new ExploreClientModule(),
+      new ViewAdminModules().getDistributedModules(),
+      new StreamAdminModules().getDistributedModules(),
+      new NotificationFeedServiceRuntimeModule().getDistributedModules(),
+      new AuditModule().getDistributedModules()
+    );
+  }
+
+  /**
+   * A guava {@link Service} implementation for starting and stopping {@link LogAppenderInitializer}.
+   */
+  private static final class LogAppenderService extends AbstractService {
+
+    private final LogAppenderInitializer initializer;
+
+    private LogAppenderService(LogAppenderInitializer initializer) {
+      this.initializer = initializer;
+    }
+
+    @Override
+    protected void doStart() {
+      try {
+        initializer.initialize();
+        notifyStarted();
+      } catch (Throwable t) {
+        notifyFailed(t);
+      }
+    }
+
+    @Override
+    protected void doStop() {
+      try {
+        initializer.close();
+        notifyStopped();
+      } catch (Throwable t) {
+        notifyFailed(t);
+      }
+    }
+  }
+
+  private SparkRuntimeContextProvider() {
+    // no-op
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkServiceDiscoverer.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkServiceDiscoverer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.ServiceDiscoverer;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.net.URL;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link Externalizable} implementation of {@link ServiceDiscoverer} used in Spark program execution.
+ * It has no-op for serialize/deserialize operation, with all operations delegated to the {@link SparkRuntimeContext}
+ * of the current execution context.
+ */
+public final class SparkServiceDiscoverer implements ServiceDiscoverer, Externalizable {
+
+  private final ServiceDiscoverer delegate;
+
+  /**
+   * Constructor. It delegates service discovery to the current {@link SparkRuntimeContext}.
+   */
+  public SparkServiceDiscoverer() {
+    this(SparkRuntimeContextProvider.get());
+  }
+
+  /**
+   * Creates an instance that delegates all service discovery operations to the give {@link ServiceDiscoverer} delegate.
+   */
+  SparkServiceDiscoverer(ServiceDiscoverer delegate) {
+    this.delegate = delegate;
+  }
+
+  @Nullable
+  @Override
+  public URL getServiceURL(String applicationId, String serviceId) {
+    return delegate.getServiceURL(applicationId, serviceId);
+  }
+
+  @Nullable
+  @Override
+  public URL getServiceURL(String serviceId) {
+    return delegate.getServiceURL(serviceId);
+  }
+
+  @Override
+  public void writeExternal(ObjectOutput out) throws IOException {
+    // no-op
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    // no-op
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTaskLocalizationContext.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTaskLocalizationContext.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.TaskLocalizationContext;
+import co.cask.cdap.internal.app.runtime.DefaultTaskLocalizationContext;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * A {@link TaskLocalizationContext} that is {@link Serializable}.
+ */
+public class SparkTaskLocalizationContext extends DefaultTaskLocalizationContext implements Serializable {
+
+  public SparkTaskLocalizationContext(Map<String, File> localizedResources) {
+    super(localizedResources);
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionClient.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionClient.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionCodec;
+import co.cask.tephra.TransactionFailureException;
+import com.google.common.base.Stopwatch;
+import com.google.common.io.ByteStreams;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
+
+/**
+ * Client class to interact with {@link SparkTransactionService} through HTTP. It is used by tasks execute inside
+ * executor processes.
+ */
+final class SparkTransactionClient {
+
+  private static final TransactionCodec TX_CODEC = new TransactionCodec();
+  private static final long DEFAULT_TX_POLL_INTERVAL_MS = 50;
+
+  private final URI txServiceBaseURI;
+  private final long txPollIntervalMillis;
+
+  SparkTransactionClient(URI txServiceBaseURI) {
+    this(txServiceBaseURI, DEFAULT_TX_POLL_INTERVAL_MS);
+  }
+
+  SparkTransactionClient(URI txServiceBaseURI, long txPollIntervalMillis) {
+    this.txServiceBaseURI = txServiceBaseURI;
+    this.txPollIntervalMillis = txPollIntervalMillis;
+  }
+
+  /**
+   * Returns the {@link Transaction} for the given stage.
+   *
+   * @param stageId the stage id to query for {@link Transaction}.
+   * @param timeout the maximum time to wait
+   * @param timeUnit the time unit of the timeout argument
+   * @return the {@link Transaction} to be used for the given stage.
+   *
+   * @throws TimeoutException if the wait timed out
+   * @throws InterruptedException if the current thread was interrupted while waiting
+   * @throws TransactionFailureException if failed to get transaction for the given stage. Calling this method again
+   *                                     with the same stage id will result in the same exception
+   */
+  Transaction getTransaction(int stageId, long timeout,
+                             TimeUnit timeUnit) throws TimeoutException, InterruptedException,
+                                                       TransactionFailureException {
+    long timeoutMillis = Math.max(0L, timeUnit.toMillis(timeout) - txPollIntervalMillis);
+    Stopwatch stopwatch = new Stopwatch().start();
+    Transaction transaction = getTransaction(stageId);
+
+    while (transaction == null && stopwatch.elapsedMillis() < timeoutMillis) {
+      TimeUnit.MILLISECONDS.sleep(txPollIntervalMillis);
+      transaction = getTransaction(stageId);
+    }
+    if (transaction == null) {
+      throw new TimeoutException("Cannot get transaction for stage " + stageId + " after " + timeout + " " + timeUnit);
+    }
+    return transaction;
+  }
+
+  @Nullable
+  private Transaction getTransaction(int stageId) throws TransactionFailureException {
+    try {
+      URL url = txServiceBaseURI.resolve("/spark/stages/" + stageId + "/transaction").toURL();
+      HttpURLConnection urlConn = (HttpURLConnection) url.openConnection();
+      try {
+        int responseCode = urlConn.getResponseCode();
+        if (responseCode == 200) {
+          return TX_CODEC.decode(ByteStreams.toByteArray(urlConn.getInputStream()));
+        }
+        if (responseCode == 404) {
+          return null;
+        }
+        throw new TransactionFailureException(
+          String.format("No transaction for stage %d. Reason: %s", stageId,
+                        Bytes.toString(ByteStreams.toByteArray(urlConn.getErrorStream()))));
+      } finally {
+        urlConn.disconnect();
+      }
+    } catch (IOException e) {
+      // If not able to talk to the tx service, just treat it the same as 404 so that there could be retry.
+      return null;
+    }
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionClient.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionClient.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 
 /**
- * Client class to interact with {@link SparkTransactionService} through HTTP. It is used by tasks execute inside
+ * Client class to interact with {@link SparkTransactionService} through HTTP. It is used by tasks executed inside
  * executor processes.
  */
 final class SparkTransactionClient {

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionService.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionService.java
@@ -324,7 +324,8 @@ final class SparkTransactionService extends AbstractIdleService {
           try {
             if (!txClient.commit(jobTx)) {
               // If failed to commit (which it shouldn't since there is no conflict detection), throw exception
-              throw new TransactionFailureException("Failed to commit transaction " + jobTx);
+              throw new TransactionFailureException("Failed to commit transaction on job success. JobId: "
+                                                      + jobId + ", transaction: " + jobTx);
             }
             transactionInfo.onTransactionCompleted(succeeded, null);
           } catch (Throwable t) {
@@ -336,7 +337,8 @@ final class SparkTransactionService extends AbstractIdleService {
         } else {
           LOG.debug("Invalidating transaction for job {}", jobId);
           if (!txClient.invalidate(jobTx.getWritePointer())) {
-            throw new TransactionFailureException("Failed to invalid traction " + jobTx);
+            throw new TransactionFailureException("Failed to invalid transaction on job failure. JobId: "
+                                                    + jobId + ", transaction: " + jobTx);
           }
         }
       } catch (Throwable t) {

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionService.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionService.java
@@ -22,13 +22,13 @@ import co.cask.http.HttpResponder;
 import co.cask.http.NettyHttpService;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionCodec;
+import co.cask.tephra.TransactionFailureException;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.AbstractIdleService;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.jboss.netty.util.internal.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.annotation.Nullable;
 import javax.ws.rs.GET;
@@ -53,6 +54,28 @@ import javax.ws.rs.PathParam;
 final class SparkTransactionService extends AbstractIdleService {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkTransactionService.class);
+  private static final TransactionInfo IMPLICIT_TX_INFO = new TransactionInfo() {
+    @Nullable
+    @Override
+    public Transaction getTransaction() {
+      return null;
+    }
+
+    @Override
+    public boolean commitOnJobEnded() {
+      return true;
+    }
+
+    @Override
+    public void onJobStarted() {
+      // no-op
+    }
+
+    @Override
+    public void onTransactionCompleted(boolean jobSucceeded, @Nullable TransactionFailureException failureCause) {
+      // no-op
+    }
+  };
 
   private final TransactionSystemClient txClient;
 
@@ -94,34 +117,26 @@ final class SparkTransactionService extends AbstractIdleService {
   }
 
   /**
-   * Notifies the given job execution started.
+   * Notifies the given job execution started without any active transaction. A transaction will be started
+   * on demand and commit when the job ended.
    *
    * @param jobId the unique id that identifies the job.
    * @param stageIds set of stage ids that are associated with the given job.
    */
   void jobStarted(Integer jobId, Set<Integer> stageIds) {
-    jobStarted(new JobTransaction(jobId, stageIds, null));
+    jobStarted(jobId, stageIds, IMPLICIT_TX_INFO);
   }
 
   /**
-   * Notifies the given job execution started with an explicit {@link Transaction}.
+   * Notifies the given job execution started.
    *
    * @param jobId the unique id that identifies the job.
    * @param stageIds set of stage ids that are associated with the given job.
-   * @param transaction the {@link Transaction} to use for the job.
+   * @param transactionInfo information about the transaction to be used for the job.
    */
-  void jobStarted(Integer jobId, Set<Integer> stageIds, Transaction transaction) {
-    if (transaction == null) {
-      throw new IllegalArgumentException("Transaction cannot be null for explicit transaction");
-    }
-    jobStarted(new JobTransaction(jobId, stageIds, transaction));
-  }
-
-  /**
-   * Notifies the job represented by the given {@link JobTransaction} started.
-   */
-  private void jobStarted(JobTransaction jobTransaction) {
-    Integer jobId = jobTransaction.getJobId();
+  void jobStarted(Integer jobId, Set<Integer> stageIds, TransactionInfo transactionInfo) {
+    JobTransaction jobTransaction = new JobTransaction(jobId, stageIds, transactionInfo);
+    LOG.debug("Spark job started: {}", jobTransaction);
 
     // Remember the job Id. We won't start a new transaction here until a stage requested for it.
     // This is because there can be job that doesn't need transaction or explicit transaction is being used
@@ -135,7 +150,7 @@ final class SparkTransactionService extends AbstractIdleService {
 
     // Build the stageId => jobId map first instead of putting to the concurrent map one by one
     Map<Integer, Integer> stageToJob = new HashMap<>();
-    for (Integer stageId : jobTransaction.getStageIds()) {
+    for (Integer stageId : stageIds) {
       stageToJob.put(stageId, jobId);
     }
     this.stageToJob.putAll(stageToJob);
@@ -147,7 +162,7 @@ final class SparkTransactionService extends AbstractIdleService {
    * @param jobId the unique id that identifies the job.
    * @param succeeded {@code true} if the job execution completed successfully.
    */
-  void jobEnded(Integer jobId, boolean succeeded) {
+  void jobEnded(Integer jobId, boolean succeeded) throws TransactionFailureException {
     JobTransaction jobTransaction = jobTransactions.remove(jobId);
     if (jobTransaction == null) {
       // Shouldn't happen, otherwise something very wrong. Can't do much, just log and return
@@ -222,20 +237,35 @@ final class SparkTransactionService extends AbstractIdleService {
   private final class JobTransaction {
     private final Integer jobId;
     private final Set<Integer> stageIds;
-    private final boolean ownTransaction;
+    private final TransactionInfo transactionInfo;
     private volatile Optional<Transaction> transaction;
 
-    JobTransaction(Integer jobId, Set<Integer> stageIds, @Nullable Transaction transaction) {
+    /**
+     * Creates a {@link JobTransaction}.
+     *
+     * @param jobId the Spark job id
+     * @param stageIds set of stage ids that are part of the job.
+     * @param transactionInfo transaction information associated with this job.
+     */
+    JobTransaction(Integer jobId, Set<Integer> stageIds, TransactionInfo transactionInfo) {
       this.jobId = jobId;
       this.stageIds = ImmutableSet.copyOf(stageIds);
-      this.ownTransaction = transaction == null;
-      this.transaction = transaction == null ? null : Optional.of(transaction);
+      this.transactionInfo = transactionInfo;
+
+      Transaction tx = transactionInfo.getTransaction();
+      this.transaction = tx == null ? null : Optional.of(tx);
     }
 
+    /**
+     * Returns the job id.
+     */
     Integer getJobId() {
       return jobId;
     }
 
+    /**
+     * Returns id of all stages of the job.
+     */
     Set<Integer> getStageIds() {
       return stageIds;
     }
@@ -258,6 +288,8 @@ final class SparkTransactionService extends AbstractIdleService {
               tx = transaction = Optional.of(txClient.startLong());
             } catch (Throwable t) {
               LOG.error("Failed to start transaction for job {}", jobId, t);
+              // Set the transaction to an absent Optional to indicate the starting of transaction failed.
+              // This will prevent future call to this method to attempt to start a transaction again
               tx = transaction = Optional.absent();
             }
           }
@@ -272,32 +304,45 @@ final class SparkTransactionService extends AbstractIdleService {
      *
      * @param succeeded {@code true} if the job execution completed successfully.
      */
-    public void completed(boolean succeeded) {
-      // If this service doesn't own the transaction, then nothing to do. It is for the explicit transaction case.
-      if (!ownTransaction) {
+    public void completed(boolean succeeded) throws TransactionFailureException {
+      // Return if doesn't need to commit the transaction
+      if (!transactionInfo.commitOnJobEnded()) {
         return;
       }
 
-      try {
-        Optional<Transaction> tx = transaction;
-        if (tx == null || !tx.isPresent()) {
-          // No transaction was started for the job, hence nothing to do.
-          return;
-        }
+      // Get the transaction to commit.
+      Optional<Transaction> tx = transaction;
+      if (tx == null || !tx.isPresent()) {
+        // No transaction was started for the job, hence nothing to do.
+        return;
+      }
 
-        Transaction jobTx = tx.get();
+      Transaction jobTx = tx.get();
+      try {
         if (succeeded) {
           LOG.debug("Committing transaction for job {}", jobId);
-          if (!txClient.commit(jobTx)) {
-            // If failed to commit (which it shouldn't since there is no conflict detection), invalidate the tx
+          try {
+            if (!txClient.commit(jobTx)) {
+              // If failed to commit (which it shouldn't since there is no conflict detection), throw exception
+              throw new TransactionFailureException("Failed to commit transaction " + jobTx);
+            }
+            transactionInfo.onTransactionCompleted(succeeded, null);
+          } catch (Throwable t) {
+            // Any failure will invalidate the transaction
             Transactions.invalidateQuietly(txClient, jobTx);
+            // Since the failure is unexpected, propagate it
+            throw t;
           }
         } else {
-          LOG.debug("Aborting transaction for job {}", jobId);
-          txClient.invalidate(jobTx.getWritePointer());
+          LOG.debug("Invalidating transaction for job {}", jobId);
+          if (!txClient.invalidate(jobTx.getWritePointer())) {
+            throw new TransactionFailureException("Failed to invalid traction " + jobTx);
+          }
         }
       } catch (Throwable t) {
-        LOG.error("Failed to {} transaction for job {}", succeeded ? "commit" : "invalidate", jobId, t);
+        TransactionFailureException failureCause = Transactions.asTransactionFailure(t);
+        transactionInfo.onTransactionCompleted(succeeded, failureCause);
+        throw failureCause;
       }
     }
 
@@ -306,7 +351,6 @@ final class SparkTransactionService extends AbstractIdleService {
       return "JobTransaction{" +
         "jobId=" + jobId +
         ", stageIds=" + stageIds +
-        ", ownTransaction=" + ownTransaction +
         ", transaction=" + (transaction == null ? null : transaction.orNull()) +
         '}';
     }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionAware;
+import co.cask.tephra.TransactionFailureException;
+import co.cask.tephra.TransactionSystemClient;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A {@link Transactional} for managing transactions for Spark job execution.
+ */
+final class SparkTransactional implements Transactional {
+
+  /**
+   * Property key for storing the key to lookup active transaction
+   */
+  static final String ACTIVE_TRANSACTION_KEY = "cdap.spark.active.transaction";
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkTransactional.class);
+
+  private final ThreadLocal<TransactionalDatasetContext> activeDatasetContext =
+    new ThreadLocal<TransactionalDatasetContext>() {
+      @Override
+      public void set(TransactionalDatasetContext value) {
+        String txKey = Long.toString(value.getTransaction().getWritePointer());
+        if (SparkContextCache.setLocalProperty(ACTIVE_TRANSACTION_KEY, txKey)) {
+          transactionInfos.put(txKey, value);
+        }
+
+        super.set(value);
+      }
+
+      @Override
+      public void remove() {
+        String txKey = SparkContextCache.getLocalProperty(ACTIVE_TRANSACTION_KEY);
+        if (txKey != null && !txKey.isEmpty()) {
+          // Spark doesn't support unsetting of property. Hence set it to empty.
+          SparkContextCache.setLocalProperty(ACTIVE_TRANSACTION_KEY, "");
+          transactionInfos.remove(txKey);
+        }
+        super.remove();
+      }
+  };
+
+  private final TransactionSystemClient txClient;
+  private final DynamicDatasetCache datasetCache;
+  private final Map<String, TransactionalDatasetContext> transactionInfos;
+
+  SparkTransactional(TransactionSystemClient txClient, DynamicDatasetCache datasetCache) {
+    this.txClient = txClient;
+    this.datasetCache = datasetCache;
+    this.transactionInfos = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Executes the given {@link TxRunnable} with a long {@link Transaction}. All Spark RDD operations performed
+   * inside the given {@link TxRunnable} will be using the same {@link Transaction}.
+   *
+   * @param runnable the runnable to be executed in the transaction
+   * @throws TransactionFailureException if there is failure during execution. The actual cause of the failure
+   *                                     maybe wrapped inside the {@link TransactionFailureException} (both
+   *                                     user exception from the {@link TxRunnable#run(DatasetContext)} method
+   *                                     or transaction exception from Tephra).
+   */
+  @Override
+  public void execute(TxRunnable runnable) throws TransactionFailureException {
+    executeLong(runnable, false);
+  }
+
+  @Nullable
+  TransactionInfo getTransactionInfo(String key) {
+    return transactionInfos.get(key);
+  }
+
+  void executeWithActiveOrLongTx(TxRunnable runnable) throws TransactionFailureException {
+    executeWithActiveOrLongTx(runnable, false);
+  }
+
+  void executeWithActiveOrLongTx(TxRunnable runnable, boolean asyncCommit) throws TransactionFailureException {
+    if (!tryExecuteWithActiveTransaction(runnable)) {
+      executeLong(runnable, asyncCommit);
+    }
+  }
+
+  /**
+   * Attempts to execute the given {@link TxRunnable} with an active transaction. If there is no active transaction,
+   * the {@link TxRunnable#run(DatasetContext)} will not be called.
+   *
+   * @param runnable the {@link TxRunnable} to run
+   * @return {@code true} if there is an active transaction and the {@link TxRunnable} was executed
+   * @throws TransactionFailureException if execute of the {@link TxRunnable} failed.
+   */
+  private boolean tryExecuteWithActiveTransaction(TxRunnable runnable) throws TransactionFailureException {
+    try {
+      TransactionalDatasetContext datasetContext = activeDatasetContext.get();
+      if (datasetContext == null || !datasetContext.canUse()) {
+        return false;
+      }
+
+      // Call the runnable
+      runnable.run(datasetContext);
+
+      // Persist all changes.
+      datasetContext.flush();
+
+      // Successfully execute with the current active transaction
+      return true;
+    } catch (Throwable t) {
+      Throwables.propagateIfInstanceOf(t, TransactionFailureException.class);
+      throw new TransactionFailureException("Failed to execute TxRunnable in transaction", t);
+    }
+  }
+
+  /**
+   * Executes the given runnable with a new long transaction. It will check for nested transaction and throws a
+   * {@link TransactionFailureException} if it finds one.
+   *
+   * @param runnable The {@link TxRunnable} to be executed inside a transaction
+   * @param asyncCommit if {@code true}, the transaction will be left open and it is expected to be committed
+   *                    by external entity asynchronously after this method returns;
+   *                    if {@code false}, the transaction will be committed when the runnable returned.
+   *
+   */
+  private void executeLong(TxRunnable runnable, boolean asyncCommit) throws TransactionFailureException {
+    TransactionalDatasetContext transactionalDatasetContext = activeDatasetContext.get();
+    if (transactionalDatasetContext != null) {
+      try {
+        if (!transactionalDatasetContext.commitOnJobEnded()) {
+          throw new TransactionFailureException("Nested transaction not supported. Active transaction is "
+                                                  + transactionalDatasetContext.getTransaction());
+        }
+
+        // Wait for the completion of the active transaction. This is needed because the commit is done
+        // asynchronously through the SparkListener.
+        transactionalDatasetContext.awaitCompletion();
+      } catch (InterruptedException e) {
+        // Don't execute the runnable. Reset the interrupt flag and return
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+
+    // Start a new long transaction
+    Transaction transaction = txClient.startLong();
+    try {
+      // Create a DatasetContext that uses the newly created transaction
+      TransactionalDatasetContext datasetContext = new TransactionalDatasetContext(transaction, datasetCache,
+                                                                                   asyncCommit);
+      activeDatasetContext.set(datasetContext);
+
+      // Call the runnable
+      runnable.run(datasetContext);
+
+      // Persist the changes
+      datasetContext.flush();
+
+      if (!asyncCommit) {
+        // Commit transaction
+        txClient.commit(datasetContext.getTransaction());
+        activeDatasetContext.remove();
+        datasetContext.postCommit();
+        datasetContext.discardDatasets();
+      }
+    } catch (Throwable t) {
+      // Any exception will cause invalidation of the transaction
+      activeDatasetContext.remove();
+      Transactions.invalidateQuietly(txClient, transaction);
+      Throwables.propagateIfInstanceOf(t, TransactionFailureException.class);
+      throw new TransactionFailureException("Failed to execute TxRunnable in transaction", t);
+    }
+  }
+
+  /**
+   * A {@link DatasetContext} to be used for the transactional execution. All {@link Dataset} instance
+   * created through instance of this class will be using the same transaction.
+   *
+   * Instance of this class is safe to use from multiple threads concurrently. This is for supporting Spark program
+   * with multiple threads that drive computation concurrently within the same transaction.
+   */
+  @ThreadSafe
+  private final class TransactionalDatasetContext implements DatasetContext, TransactionInfo {
+
+    private final Transaction transaction;
+    private final DynamicDatasetCache datasetCache;
+    private final Set<Dataset> datasets;
+    private final Set<Dataset> discardDatasets;
+    private final CountDownLatch completion;
+    private volatile boolean jobStarted;
+
+    private TransactionalDatasetContext(Transaction transaction,
+                                        DynamicDatasetCache datasetCache, boolean asyncCommit) {
+      this.transaction = transaction;
+      this.datasetCache = datasetCache;
+      this.datasets = Collections.synchronizedSet(new HashSet<Dataset>());
+      this.discardDatasets = Collections.synchronizedSet(new HashSet<Dataset>());
+      this.completion = asyncCommit ? new CountDownLatch(1) : null;
+    }
+
+    @Override
+    @Nonnull
+    public Transaction getTransaction() {
+      return transaction;
+    }
+
+    @Override
+    public boolean commitOnJobEnded() {
+      return completion != null;
+    }
+
+    @Override
+    public void onJobStarted() {
+      jobStarted = true;
+    }
+
+    @Override
+    public void onTransactionCompleted(boolean jobSucceeded, @Nullable TransactionFailureException failureCause) {
+      // Shouldn't happen
+      Preconditions.checkState(commitOnJobEnded(), "Not expecting transaction to be completed");
+      transactionInfos.remove(Long.toString(transaction.getWritePointer()));
+      if (failureCause == null) {
+        postCommit();
+      }
+      discardDatasets();
+      completion.countDown();
+    }
+
+    @Override
+    public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
+      return getDataset(name, Collections.<String, String>emptyMap());
+    }
+
+    @Override
+    public <T extends Dataset> T getDataset(String name,
+                                            Map<String, String> arguments) throws DatasetInstantiationException {
+      T dataset = datasetCache.getDataset(name, arguments);
+
+      // Only call startTx if the dataset hasn't been seen before
+      // It is ok because there is only one transaction in this DatasetContext
+      // If a dataset instance is being reused, we don't need to call startTx again.
+      // It's also true for the case when a dataset instance was released and reused.
+      if (datasets.add(dataset) && dataset instanceof TransactionAware) {
+        ((TransactionAware) dataset).startTx(transaction);
+      }
+
+      return dataset;
+    }
+
+    @Override
+    public void releaseDataset(Dataset dataset) {
+      discardDataset(dataset);
+    }
+
+    @Override
+    public void discardDataset(Dataset dataset) {
+      discardDatasets.add(dataset);
+    }
+
+    /**
+     * Flushes all {@link TransactionAware} that were acquired through this {@link DatasetContext} by calling
+     * {@link TransactionAware#commitTx()}.
+     *
+     * @throws TransactionFailureException if any {@link TransactionAware#commitTx()} call throws exception
+     */
+    private void flush() throws TransactionFailureException {
+      for (TransactionAware txAware : Iterables.filter(datasets, TransactionAware.class)) {
+        try {
+          if (!txAware.commitTx()) {
+            throw new TransactionFailureException("Failed to persist changes for " + txAware);
+          }
+        } catch (Throwable t) {
+          throw Transactions.asTransactionFailure(t);
+        }
+      }
+    }
+
+    /**
+     * Calls {@link TransactionAware#postTxCommit()} methods on all {@link TransactionAware} acquired through this
+     * {@link DatasetContext}.
+     */
+    private void postCommit() {
+      for (TransactionAware txAware : Iterables.filter(datasets, TransactionAware.class)) {
+        try {
+          txAware.postTxCommit();
+        } catch (Exception e) {
+          LOG.warn("Exception raised in postTxCommit call on dataset {}", txAware, e);
+        }
+      }
+    }
+
+    /**
+     * Discards all datasets that has {@link #discardDataset(Dataset)} called before
+     */
+    private void discardDatasets() {
+      for (Dataset dataset : discardDatasets) {
+        datasetCache.discardDataset(dataset);
+      }
+    }
+
+    /**
+     * Block until the transaction used by this context is completed (either commit or invalidate).
+     *
+     * @throws InterruptedException if current thread is interrupted while waiting
+     */
+    private void awaitCompletion() throws InterruptedException {
+      LOG.debug("Awaiting completiong for {}", transaction.getWritePointer());
+      if (completion != null) {
+        completion.await();
+      }
+    }
+
+    /**
+     * Returns {@code true} if this context can be used for executing {@link TxRunnable}.
+     */
+    private boolean canUse() {
+      // If the commit is done when a Spark job end and the job already started, then this context cannot be used
+      // anymore. This is to guard against case like this:
+      //
+      // sc.fromDataset("dataset1")
+      //   .map(...)
+      //   .reduce(...)   <-- This will start a transaction (tx1) that will commit on job end (due to fromDataset)
+      //                      it will also start a spark job.
+      //
+      // sc.fromDataset("dataset2")
+      //   .join(sc.fromDataset("dataset3"))  <-- This needs a transaction to get partitions from "dataset2"
+      //                                          and "dataset3". However, we will get "tx1" from the thread local,
+      //                                          which we shouldn't use for this job. In fact, we need to block on
+      //                                          completion on "tx1", which is done asynchronously by the
+      //                                          SparkListener callback, until we start another transaction in this
+      //                                          thread.
+      return !commitOnJobEnded() || !jobStarted;
+    }
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkUserMetrics.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkUserMetrics.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.metrics.Metrics;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+/**
+ * A {@link Externalizable} implementation of {@link Metrics} used in Spark program execution.
+ * It has no-op for serialize/deserialize operation, with all operations delegated to the {@link SparkRuntimeContext}
+ * of the current execution context.
+ */
+public final class SparkUserMetrics implements Metrics, Externalizable {
+
+  private final Metrics delegate;
+
+  /**
+   * Constructor. It delegates metrics operations to the current {@link SparkRuntimeContext}.
+   */
+  public SparkUserMetrics() {
+    this(SparkRuntimeContextProvider.get());
+  }
+
+  /**
+   * Creates an instance that delegates all metrics operations to the give {@link Metrics} delegate.
+   */
+  SparkUserMetrics(Metrics delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void count(String metricName, int delta) {
+    delegate.count(metricName, delta);
+  }
+
+  @Override
+  public void gauge(String metricName, long value) {
+    delegate.gauge(metricName, value);
+  }
+
+  @Override
+  public void writeExternal(ObjectOutput out) throws IOException {
+    // no-op
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    // no-op
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/TransactionInfo.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/TransactionInfo.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionFailureException;
+import org.apache.spark.scheduler.SparkListener;
+
+import javax.annotation.Nullable;
+
+/**
+ * Interface containing information about {@link Transaction} being used for the Spark job execution.
+ * It is used as a communicate channel between the {@link SparkTransactional} and the {@link SparkListener} inside
+ * {@link DefaultSparkExecutionContext}.
+ */
+interface TransactionInfo {
+
+  /**
+   * Returns the active transaction or {@code null} if there is no active transaction.
+   */
+  @Nullable
+  Transaction getTransaction();
+
+  /**
+   * Returns {@code true} if the transaction needs to be committed when the job ended.
+   */
+  boolean commitOnJobEnded();
+
+  /**
+   * Callback when a job started.
+   */
+  void onJobStarted();
+
+  /**
+   * Callback when a job completed and the transaction is committed. This method only gets called if
+   * {@link #commitOnJobEnded()} returns {@code true}.
+   *
+   * @param jobSucceeded {@code true} if the job execution succeeded or {@code false} otherwise.
+   * @param failureCause The {@link TransactionFailureException} if failed to commit or invalidate the transaction;
+   *                     otherwise it will be {@code null}.
+   */
+  void onTransactionCompleted(boolean jobSucceeded, @Nullable TransactionFailureException failureCause);
+}

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/BatchReadablePartition.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/BatchReadablePartition.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark
+
+import java.io.{Externalizable, ObjectInput, ObjectOutput}
+
+import co.cask.cdap.api.data.batch.Split
+import com.google.gson.Gson
+import org.apache.spark.Partition
+
+/**
+  * Represents one [[org.apache.spark.Partition]] in the [[co.cask.cdap.app.runtime.spark.BatchReadableRDD]], which
+  * corresponds to one [[co.cask.cdap.api.data.batch.Split]].
+  */
+class BatchReadablePartition(private var _rddId: Int,
+                             private var _index: Int,
+                             private var _split: Split) extends Partition with Externalizable {
+
+  /**
+    * Default constructor. It is only for the deserialization
+    */
+  def this() = this(0, 0, null)
+
+  /**
+    * @return the [[co.cask.cdap.api.data.batch.Split]] contained inside this [[org.apache.spark.Partition]].
+    */
+  def split = _split
+
+  override def index = _index
+
+  override def writeExternal(out: ObjectOutput): Unit = {
+    // Write the index, split class name and gson serialize the split
+    out.writeInt(_rddId)
+    out.writeInt(_index);
+    out.writeUTF(_split.getClass.getName)
+    out.writeUTF(new Gson().toJson(_split))
+  }
+
+  override def readExternal(in: ObjectInput): Unit = {
+    // Read the index, split class name and gson deserialize the split
+    _rddId = in.readInt()
+    _index = in.readInt()
+    var classLoader = Option(Thread.currentThread.getContextClassLoader).getOrElse(getClass.getClassLoader)
+    val splitClass = classLoader.loadClass(in.readUTF()).asInstanceOf[Class[Split]]
+    _split = new Gson().fromJson(in.readUTF(), splitClass)
+  }
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[BatchReadablePartition]
+
+  override def equals(other: Any): Boolean = {
+    other match {
+      case that: BatchReadablePartition =>
+        (that canEqual this) &&
+          _rddId == that._rddId &&
+          _index == that._index &&
+          _split == that._split
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = {
+    val state = Seq(super.hashCode(), _rddId, _index, _split)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
+}

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/BatchReadableRDD.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/BatchReadableRDD.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark
+
+import java.net.URI
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+import co.cask.cdap.api.data.batch.{BatchReadable, Split, SplitReader}
+import co.cask.cdap.api.dataset.Dataset
+import co.cask.tephra.TransactionAware
+import org.apache.spark._
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.executor.InputMetrics
+import org.apache.spark.rdd.RDD
+
+import scala.collection.JavaConversions._
+import scala.reflect.ClassTag
+
+/**
+  * A [[org.apache.spark.rdd.RDD]] implementation that reads data through [[co.cask.cdap.api.data.batch.BatchReadable]].
+  */
+class BatchReadableRDD[K: ClassTag, V: ClassTag](@transient sc: SparkContext,
+                                                 @transient batchReadable: BatchReadable[K, V],
+                                                 datasetName: String,
+                                                 arguments: Map[String, String],
+                                                 @transient splits: Option[Iterable[_ <: Split]],
+                                                 txServiceBaseURI: Broadcast[URI]) extends RDD[(K, V)](sc, Nil) {
+
+  override protected def getPartitions: Array[Partition] = {
+    val inputSplits: Iterable[_ <: Split] = splits.getOrElse(batchReadable.getSplits.toIterable)
+    inputSplits.zipWithIndex.map(t => new BatchReadablePartition(id, t._2, t._1)).toArray
+  }
+
+  override def compute(partition: Partition, context: TaskContext): Iterator[(K, V)] = {
+    val inputMetrics = context.taskMetrics.inputMetrics
+    val split = partition.asInstanceOf[BatchReadablePartition].split
+    val sparkTxClient = new SparkTransactionClient(txServiceBaseURI.value)
+
+    val datasetCache = SparkRuntimeContextProvider.get().getDatasetCache
+    val dataset: Dataset = datasetCache.getDataset(datasetName, arguments, false)
+
+    // Get the Transaction of the dataset if it is TransactionAware
+    dataset match {
+      case txAware: TransactionAware => {
+        // Try to get the transaction for this stage. Hardcoded the timeout to 10 seconds for now
+        txAware.startTx(sparkTxClient.getTransaction(context.stageId(), 10, TimeUnit.SECONDS))
+      }
+      case _ => // Nothing happen
+    }
+
+    // Creates the split reader and use it to construct the Iterator to result
+    val splitReader = dataset.asInstanceOf[BatchReadable[K, V]].createSplitReader(split)
+    splitReader.initialize(split)
+    val iterator = new SplitReaderIterator[K, V](context, splitReader, inputMetrics, () => {
+      try {
+        splitReader.close()
+      } finally {
+        datasetCache.releaseDataset(dataset)
+      }
+    })
+
+    context.addTaskCompletionListener(context => iterator.close)
+    iterator
+  }
+
+  /**
+    * An [[scala.Iterator]] that is backed by a [[co.cask.cdap.api.data.batch.SplitReader]].
+    */
+  private class SplitReaderIterator[K, V](context: TaskContext,
+                                          splitReader: SplitReader[K, V],
+                                          inputMetrics: Option[InputMetrics],
+                                          closeable: () => Unit) extends Iterator[(K, V)] {
+    val done = new AtomicBoolean
+
+    override def hasNext: Boolean = {
+      if (done.get()) {
+        return false
+      }
+      if (context.isInterrupted()) {
+        close
+        throw new TaskKilledException
+      }
+      val result = splitReader.nextKeyValue()
+      if (!result) {
+        close
+      }
+      result
+    }
+
+    override def next: (K, V) = {
+      // TODO: Add metrics for size being read. It requires dataset to expose it.
+      inputMetrics.foreach(_.incRecordsRead(1L))
+      (splitReader.getCurrentKey, splitReader.getCurrentValue)
+    }
+
+    def close: Unit = {
+      if (done.compareAndSet(false, true)) {
+        closeable()
+      }
+    }
+  }
+}

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DatasetCompute.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DatasetCompute.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark
+
+import co.cask.cdap.api.dataset.Dataset
+
+import scala.reflect.ClassTag
+
+/**
+  * A trait for [[co.cask.cdap.app.runtime.spark.DatasetRDD]] to acquire [[co.cask.cdap.api.dataset.Dataset]] instance
+  * and performs computation on it.
+  */
+private[spark] trait DatasetCompute {
+
+  /**
+    * Performs computation on a [[co.cask.cdap.api.dataset.Dataset]] instance.
+    *
+    * @param datasetName name of the dataset
+    * @param arguments arguments for the dataset
+    * @param computeFunc function to operate on the dataset instance
+    * @tparam T type of the result
+    * @return result of the computation by the function
+    */
+  def apply[T: ClassTag](datasetName: String, arguments: Map[String, String], computeFunc: Dataset => T): T
+}

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DatasetRDD.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DatasetRDD.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark
+
+import java.net.URI
+
+import co.cask.cdap.api.data.DatasetInstantiationException
+import co.cask.cdap.api.data.batch.{BatchReadable, InputFormatProvider, Split}
+import co.cask.cdap.api.dataset.Dataset
+import co.cask.cdap.common.conf.ConfigurationUtil
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapreduce.InputFormat
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+
+import scala.reflect.ClassTag
+
+/**
+  * A [[org.apache.spark.rdd.RDD]] for reading data from [[co.cask.cdap.api.dataset.Dataset]].
+  */
+class DatasetRDD[K: ClassTag, V: ClassTag](@transient sc: SparkContext,
+                                           @transient datasetCompute: DatasetCompute,
+                                           @transient hConf: Configuration,
+                                           datasetName: String,
+                                           arguments: Map[String, String],
+                                           @transient splits: Option[Iterable[_ <: Split]],
+                                           txServiceBaseURI: Broadcast[URI]) extends RDD[(K, V)](sc, Nil) {
+
+  var delegateRDD: Option[RDD[(K, V)]] = None
+
+  @DeveloperApi
+  override def compute(split: Partition, context: TaskContext): Iterator[(K, V)] =
+    delegateRDD.get.compute(split, context)
+
+  override protected def getPartitions: Array[Partition] = {
+    if (delegateRDD.isEmpty) {
+      delegateRDD = Some(datasetCompute(datasetName, arguments, (dataset: Dataset) => {
+        // Depends on whether it is a BatchReadable or an InputFormatProvider, constructs a corresponding
+        // RDD that this RDD delegates to
+        dataset match {
+          case batchReadable: BatchReadable[K, V] => {
+            new BatchReadableRDD[K, V](sc, batchReadable, datasetName, arguments, splits, txServiceBaseURI)
+          }
+
+          case inputFormatProvider: InputFormatProvider => {
+            // Use the Spark newAPIHadoopRDD
+            val inputFormatClassName = Option(inputFormatProvider.getInputFormatClassName).getOrElse(
+              throw new DatasetInstantiationException("No input format class from dataset '" + datasetName + "'"))
+            val conf = ConfigurationUtil.setAll(inputFormatProvider.getInputFormatConfiguration,
+                                                new Configuration(hConf))
+            val inputFormatClass = SparkClassLoader.findFromContext()
+                                                   .loadClass(inputFormatClassName)
+                                                   .asInstanceOf[Class[InputFormat[K, V]]]
+
+            val keyClass: Class[K] = implicitly[ClassManifest[K]].runtimeClass.asInstanceOf[Class[K]]
+            val valueClass: Class[V] = implicitly[ClassManifest[V]].runtimeClass.asInstanceOf[Class[V]]
+            sc.newAPIHadoopRDD(conf, inputFormatClass, keyClass, valueClass)
+          }
+
+          case _ => throw new IllegalArgumentException("Unsupport dataset type " + dataset.getClass)
+        }
+      }))
+    }
+
+    delegateRDD.get.partitions
+  }
+}

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark
+
+import java.lang.Iterable
+import java.util
+
+import co.cask.cdap.api.app.ApplicationSpecification
+import co.cask.cdap.api.data.batch.Split
+import co.cask.cdap.api.flow.flowlet.StreamEvent
+import co.cask.cdap.api.metrics.Metrics
+import co.cask.cdap.api.plugin.PluginContext
+import co.cask.cdap.api.spark.{JavaSparkExecutionContext, SparkExecutionContext, SparkSpecification}
+import co.cask.cdap.api.workflow.WorkflowToken
+import co.cask.cdap.api.{Admin, ServiceDiscoverer, TxRunnable}
+import org.apache.spark.api.java.{JavaPairRDD, JavaRDD}
+import org.apache.twill.api.RunId
+
+import scala.collection.JavaConversions._
+import scala.reflect.ClassTag
+
+/**
+  * Implementation of [[co.cask.cdap.api.spark.JavaSparkExecutionContext]] that simply delegates all calls to
+  * a [[co.cask.cdap.api.spark.SparkExecutionContext]].
+  */
+class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaSparkExecutionContext {
+
+  override def getSpecification: SparkSpecification = sec.getSpecification
+
+  override def getMetrics: Metrics = sec.getMetrics
+
+  override def getServiceDiscoverer: ServiceDiscoverer = sec.getServiceDiscoverer
+
+  override def getLogicalStartTime: Long = sec.getLogicalStartTime
+
+  override def getPluginContext: PluginContext = sec.getPluginContext
+
+  override def getWorkflowToken: WorkflowToken = sec.getWorkflowToken.orNull
+
+  override def getRuntimeArguments: util.Map[String, String] = sec.getRuntimeArguments
+
+  override def getRunId: RunId = sec.getRunId
+
+  override def getNamespace: String = sec.getNamespace
+
+  override def getApplicationSpecification: ApplicationSpecification = sec.getApplicationSpecification
+
+  override def getAdmin: Admin = sec.getAdmin
+
+  override def execute(runnable: TxRunnable): Unit = sec.execute(runnable)
+
+  override def fromDataset[K, V](datasetName: String, arguments: util.Map[String, String],
+                                 splits: Iterable[_ <: Split]): JavaPairRDD[K, V] = {
+    // Create the implicit fake ClassTags to satisfy scala type system at compilation time.
+    implicit val kTag: ClassTag[K] = createClassTag
+    implicit val vTag: ClassTag[V] = createClassTag
+    JavaPairRDD.fromRDD(sec.fromDataset(SparkContextCache.getContext, datasetName, arguments.toMap, Some(splits)))
+  }
+
+  override def fromStream(streamName: String, startTime: Long, endTime: Long) : JavaRDD[StreamEvent] = {
+    val ct: ClassTag[StreamEvent] = createClassTag
+    JavaRDD.fromRDD(
+      sec.fromStream(SparkContextCache.getContext, streamName, startTime, endTime)(ct, (e: StreamEvent) => e))
+  }
+
+  override def saveAsDataset[K, V](rdd: JavaPairRDD[K, V], datasetName: String,
+                                   arguments: util.Map[String, String]): Unit = {
+    // Create the implicit fake ClassTags to satisfy scala type system at compilation time.
+    implicit val kTag: ClassTag[K] = createClassTag
+    implicit val vTag: ClassTag[V] = createClassTag
+    sec.saveAsDataset(JavaPairRDD.toRDD(rdd), datasetName, arguments.toMap)
+  }
+
+  /**
+    * Creates a [[scala.reflect.ClassTag]] for the parameterized type T.
+    */
+  private def createClassTag[T]: ClassTag[T] = ClassTag.AnyRef.asInstanceOf[ClassTag[T]]
+}

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
@@ -1,0 +1,335 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark
+
+import java.io.File
+import java.net.URI
+import java.util
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import co.cask.cdap.api._
+import co.cask.cdap.api.app.ApplicationSpecification
+import co.cask.cdap.api.data.DatasetContext
+import co.cask.cdap.api.data.batch.{BatchWritable, DatasetOutputCommitter, OutputFormatProvider, Split}
+import co.cask.cdap.api.dataset.Dataset
+import co.cask.cdap.api.flow.flowlet.StreamEvent
+import co.cask.cdap.api.metrics.Metrics
+import co.cask.cdap.api.plugin.PluginContext
+import co.cask.cdap.api.spark.{SparkExecutionContext, SparkSpecification}
+import co.cask.cdap.api.workflow.WorkflowToken
+import co.cask.cdap.common.conf.ConfigurationUtil
+import co.cask.cdap.data.stream.{StreamInputFormat, StreamUtils}
+import co.cask.cdap.data2.metadata.lineage.AccessType
+import co.cask.cdap.proto.Id
+import co.cask.tephra.TransactionAware
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.LongWritable
+import org.apache.spark
+import org.apache.spark.TaskContext
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.executor.{DataWriteMethod, OutputMetrics}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.scheduler._
+import org.apache.twill.api.RunId
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConversions._
+import scala.reflect.ClassTag
+
+/**
+  * Default implementation of [[co.cask.cdap.api.spark.SparkExecutionContext]].
+  *
+  * @param runtimeContext provides access to CDAP internal services
+  * @param localizeResources a Map from name to local file that the user requested to localize during the
+  *                          beforeSubmit call.
+  */
+class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
+                                   localizeResources: util.Map[String, File]) extends SparkExecutionContext
+                                                                              with AutoCloseable {
+  // Import the companion object for static fields
+  import DefaultSparkExecutionContext._
+
+  private val taskLocalizationContext = new SparkTaskLocalizationContext(localizeResources)
+  private val transactional = new SparkTransactional(runtimeContext.getTransactionSystemClient,
+                                                     runtimeContext.getDatasetCache)
+  private val workflowToken = Option(runtimeContext.getWorkflowProgramInfo).map(_.getWorkflowToken)
+  private val sparkTxService = new SparkTransactionService(runtimeContext.getTransactionSystemClient)
+  private val applicationEndLatch = new CountDownLatch(1)
+
+  // Start the Spark TX service
+  sparkTxService.startAndWait();
+
+  // Attach a listener to the SparkContextCache, which will in turn listening to events from SparkContext.
+  SparkContextCache.addSparkListener(new SparkListener {
+
+    override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd) = applicationEndLatch.countDown
+
+    override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
+      val jobId = Integer.valueOf(jobStart.jobId)
+      val stageIds = jobStart.stageInfos.map(info => info.stageId: Integer).toSet
+      val sparkTransaction = Option(jobStart.properties.getProperty(SparkTransactional.ACTIVE_TRANSACTION_KEY))
+          .flatMap(key => if (key.isEmpty) None else Option(transactional.getTransactionInfo(key)))
+
+      sparkTransaction.fold({
+        LOG.debug("Spark program={}, runId={}, jobId={} starts without transaction",
+                  runtimeContext.getProgram.getId.toEntityId, getRunId, jobId);
+        sparkTxService.jobStarted(jobId, stageIds)
+      })(info => {
+        LOG.debug("Spark program={}, runId={}, jobId={} starts with transaction {}",
+                  runtimeContext.getProgram.getId.toEntityId, getRunId, jobId, info.getTransaction);
+        sparkTxService.jobStarted(jobId, stageIds, info)
+        info.onJobStarted()
+      })
+    }
+
+    override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+      sparkTxService.jobEnded(jobEnd.jobId, jobEnd.jobResult == JobSucceeded)
+    }
+  })
+
+  override def close() = {
+    try {
+      // If there is a SparkContext, wait for the ApplicationEnd callback
+      // This make sure all jobs' transactions are committed/invalidated
+      SparkContextCache.stop.foreach(sc => applicationEndLatch.await())
+    } finally {
+      sparkTxService.stopAndWait()
+    }
+  };
+
+  override def getApplicationSpecification: ApplicationSpecification = runtimeContext.getApplicationSpecification
+
+  override def getRuntimeArguments: util.Map[String, String] = runtimeContext.getRuntimeArguments
+
+  override def getRunId: RunId = runtimeContext.getRunId
+
+  override def getNamespace: String = runtimeContext.getProgram.getId.getNamespaceId
+
+  override def getAdmin: Admin = runtimeContext.getAdmin
+
+  override def getSpecification: SparkSpecification = runtimeContext.getSparkSpecification
+
+  override def getLogicalStartTime: Long = runtimeContext.getLogicalStartTime
+
+  override def getServiceDiscoverer: ServiceDiscoverer = return new SparkServiceDiscoverer(runtimeContext)
+
+  override def getMetrics: Metrics = new SparkUserMetrics(runtimeContext)
+
+  override def getPluginContext: PluginContext = new SparkPluginContext(runtimeContext)
+
+  override def getWorkflowToken: Option[WorkflowToken] = workflowToken
+
+  override def getLocalizationContext: TaskLocalizationContext = taskLocalizationContext
+
+  override def execute(runnable: TxRunnable): Unit = {
+    transactional.execute(runnable)
+  }
+
+  override def fromDataset[K: ClassTag, V: ClassTag](sc: spark.SparkContext,
+                                                     datasetName: String,
+                                                     arguments: Map[String, String],
+                                                     splits: Option[Iterable[_ <: Split]]): RDD[(K, V)] = {
+    new DatasetRDD[K, V](sc, createDatasetCompute, runtimeContext.getConfiguration(), datasetName, arguments, splits,
+                         getTxServiceBaseURI(sc, sparkTxService.getBaseURI))
+  }
+
+  override def fromStream[T: ClassTag](sc: spark.SparkContext, streamName: String, startTime: Long, endTime: Long)
+                                      (implicit decoder: StreamEvent => T): RDD[T] = {
+    val streamId: Id.Stream = Id.Stream.from(getNamespace, streamName)
+
+    // Clone the configuration since it's dataset specification and shouldn't affect the global hConf
+    val configuration = configureStreamInput(new Configuration(runtimeContext.getConfiguration),
+                                             streamId, startTime, endTime)
+    val rdd = sc.newAPIHadoopRDD(configuration, classOf[StreamInputFormat[LongWritable, StreamEvent]],
+                                 classOf[LongWritable], classOf[StreamEvent])
+
+    // Register for stream usage for the Spark program
+    val oldProgramId = runtimeContext.getProgram.getId
+    val owners = List(oldProgramId)
+    try {
+      runtimeContext.getStreamAdmin.register(owners, streamId)
+      runtimeContext.getStreamAdmin.addAccess(new Id.Run(oldProgramId, getRunId.getId), streamId, AccessType.READ)
+    }
+    catch {
+      case e: Exception => {
+        LOG.warn("Failed to registry usage of {} -> {}", streamId, owners, e)
+      }
+    }
+
+    rdd.values.map(decoder)
+  }
+
+  override def saveAsDataset[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)], datasetName: String,
+                                                       arguments: Map[String, String]): Unit = {
+    transactional.executeWithActiveOrLongTx(new TxRunnable {
+      override def run(context: DatasetContext) = {
+        val sc = rdd.sparkContext
+        val dataset: Dataset = context.getDataset(datasetName, arguments)
+        val outputCommitter = dataset match {
+          case outputCommitter: DatasetOutputCommitter => Some(outputCommitter)
+          case _ => None
+        }
+
+        try {
+          dataset match {
+            case outputFormatProvider: OutputFormatProvider => {
+              val conf = new Configuration(runtimeContext.getConfiguration)
+              ConfigurationUtil.setAll(outputFormatProvider.getOutputFormatConfiguration, conf)
+              rdd.saveAsNewAPIHadoopDataset(conf)
+            }
+            case batchWritable: BatchWritable[K, V] => {
+              val txServiceBaseURI = getTxServiceBaseURI(sc, sparkTxService.getBaseURI)
+              sc.runJob(rdd, createBatchWritableFunc(datasetName, arguments, txServiceBaseURI))
+            }
+            case _ => {
+              throw new IllegalArgumentException("Dataset is neither a OutputFormatProvider nor a BatchWritable")
+            }
+          }
+          outputCommitter.foreach(_.onSuccess())
+        } catch {
+          case t: Throwable => outputCommitter.foreach(_.onFailure())
+        }
+      }
+    })
+  }
+
+  private def configureStreamInput(configuration: Configuration, streamId: Id.Stream,
+                                   startTime: Long, endTime: Long): Configuration = {
+    val streamConfig = runtimeContext.getStreamAdmin.getConfig(streamId)
+    val streamPath = StreamUtils.createGenerationLocation(streamConfig.getLocation,
+                                                          StreamUtils.getGeneration(streamConfig))
+
+    StreamInputFormat.setTTL(configuration, streamConfig.getTTL)
+    StreamInputFormat.setStreamPath(configuration, streamPath.toURI)
+    StreamInputFormat.setTimeRange(configuration, startTime, endTime)
+    StreamInputFormat.inferDecoderClass(configuration, classOf[StreamEvent])
+
+    configuration
+  }
+
+  /**
+    * Creates a [[co.cask.cdap.app.runtime.spark.DatasetCompute]] for the DatasetRDD to use.
+    */
+  private def createDatasetCompute: DatasetCompute = {
+    new DatasetCompute {
+      override def apply[T: ClassTag](datasetName: String, arguments: Map[String, String], f: (Dataset) => T): T = {
+        val result = new Array[T](1)
+
+        // For RDD to compute partitions, a transaction is needed in order to gain access to dataset instance.
+        // It should either be using the active transaction (explicit transaction), or create a new transaction
+        // but leave it open so that it will be used for all stages in same job execution and get committed when
+        // the job ended.
+        transactional.executeWithActiveOrLongTx(new TxRunnable {
+          override def run(context: DatasetContext) = {
+            val dataset: Dataset = context.getDataset(datasetName, arguments)
+            try {
+              result(0) = f(dataset)
+            } finally {
+              context.releaseDataset(dataset)
+            }
+          }
+        }, true)
+        result(0)
+      }
+    }
+  }
+}
+
+/**
+  * Companion object for holding static fields and methods.
+  */
+object DefaultSparkExecutionContext {
+
+  private val LOG = LoggerFactory.getLogger(classOf[DefaultSparkExecutionContext])
+  private var txServiceBaseURI: Option[Broadcast[URI]] = None
+
+  /**
+    * Creates a [[org.apache.spark.broadcast.Broadcast]] for the base URI
+    * of the [[co.cask.cdap.app.runtime.spark.SparkTransactionService]]
+    */
+  private def getTxServiceBaseURI(sc: spark.SparkContext, baseURI: URI): Broadcast[URI] = {
+    this.synchronized {
+      this.txServiceBaseURI match {
+        case Some(uri) => uri
+        case None => {
+          val broadcast = sc.broadcast(baseURI)
+          txServiceBaseURI = Some(broadcast)
+          broadcast
+        }
+      }
+    }
+  }
+
+  /**
+    * Creates a function used by [[org.apache.spark.SparkContext]] runJob for writing data to a
+    * Dataset that implements [[co.cask.cdap.api.data.batch.BatchWritable]]. The returned function
+    * will be executed in executor nodes.
+    */
+  private def createBatchWritableFunc[K, V]
+      (datasetName: String,
+       arguments: Map[String, String],
+       txServiceBaseURI: Broadcast[URI]) = (context: TaskContext, itor: Iterator[(K, V)]) => {
+
+    val sparkTxClient = new SparkTransactionClient(txServiceBaseURI.value)
+    val datasetCache = SparkRuntimeContextProvider.get().getDatasetCache
+    val dataset: Dataset = datasetCache.getDataset(datasetName, arguments)
+    val outputMetrics = new BatchWritableMetrics
+
+    context.taskMetrics.outputMetrics = Option(outputMetrics)
+
+    // Creates an Option[TransactionAware] if the dataset is a TransactionAware
+    val txAware = dataset match {
+      case txAware: TransactionAware => Some(txAware)
+      case _ => None
+    }
+
+    // Try to get the transaction for this stage. Hardcoded the timeout to 10 seconds for now
+    txAware.foreach(_.startTx(sparkTxClient.getTransaction(context.stageId(), 10, TimeUnit.SECONDS)));
+
+    // Write through BatchWritable.
+    val writable = dataset.asInstanceOf[BatchWritable[K, V]]
+    var records = 0;
+    while (itor.hasNext) {
+      val pair = itor.next()
+      writable.write(pair._1, pair._2)
+      outputMetrics.incrementRecordWrite(1)
+
+      // Periodically calling commitTx to flush changes. Hardcoded to 1000 records for now
+      if (records > 1000) {
+        txAware.foreach(_.commitTx())
+        records = 0
+      }
+      records += 1
+    }
+
+    // Flush all writes
+    txAware.foreach(_.commitTx())
+    datasetCache.releaseDataset(dataset)
+  }
+
+  /**
+    * Implementation of [[org.apache.spark.executor.OutputMetrics]] for recording metrics output from
+    * [[co.cask.cdap.api.data.batch.BatchWritable]].
+    */
+  private class BatchWritableMetrics extends OutputMetrics(DataWriteMethod.Hadoop) {
+    private var records = 0
+
+    def incrementRecordWrite(records: Int) = this.records += records
+
+    override def recordsWritten = records
+  }
+}

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
@@ -66,7 +66,7 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
   private val taskLocalizationContext = new SparkTaskLocalizationContext(localizeResources)
   private val transactional = new SparkTransactional(runtimeContext.getTransactionSystemClient,
                                                      runtimeContext.getDatasetCache)
-  private val workflowToken = Option(runtimeContext.getWorkflowProgramInfo).map(_.getWorkflowToken)
+  private val workflowToken = Option(runtimeContext.getWorkflowInfo).map(_.getWorkflowToken)
   private val sparkTxService = new SparkTransactionService(runtimeContext.getTransactionSystemClient)
   private val applicationEndLatch = new CountDownLatch(1)
 

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
@@ -201,7 +201,10 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
           }
           outputCommitter.foreach(_.onSuccess())
         } catch {
-          case t: Throwable => outputCommitter.foreach(_.onFailure())
+          case t: Throwable => {
+            outputCommitter.foreach(_.onFailure())
+            throw t
+          }
         }
       }
     })

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SparkContextCache.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SparkContextCache.scala
@@ -67,13 +67,15 @@ object SparkContextCache {
     * Sets the [[org.apache.spark.streaming.StreamingContext]] that is currently in use.
     */
   def setContext(context: StreamingContext): Unit = {
-    if (stopped) {
-      context.stop(false)
-      throw new IllegalStateException("Spark program is already stopped")
-    }
+    this.synchronized {
+      if (stopped) {
+        context.stop(false)
+        throw new IllegalStateException("Spark program is already stopped")
+      }
 
-    // Spark doesn't allow multiple StreamingContext instances concurrently, hence we don't need to check in here
-    streamingContext = Some(context)
+      // Spark doesn't allow multiple StreamingContext instances concurrently, hence we don't need to check in here
+      streamingContext = Some(context)
+    }
   }
 
   /**

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SparkContextCache.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SparkContextCache.scala
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import javax.annotation.Nullable
+
+import org.apache.spark.SparkContext
+import org.apache.spark.scheduler._
+import org.apache.spark.streaming.StreamingContext
+
+import scala.collection.JavaConversions._
+
+/**
+  * A singleton cache for [[org.apache.spark.SparkContext]] and [[org.apache.spark.streaming.StreamingContext]]
+  * to provide universal access to those contexts created by the user Spark program within CDAP.
+  *
+  * With ClassLoader isolation, there will be one instance of this class per one Spark program execution.
+  */
+object SparkContextCache {
+
+  private var stopped = false
+  private var sparkContext: Option[SparkContext] = None
+  private var streamingContext: Option[StreamingContext] = None
+  private val sparkListeners = new ConcurrentLinkedQueue[SparkListener]()
+
+  /**
+    * Adds a [[org.apache.spark.scheduler.SparkListener]]. The given listener will be added to
+    * [[org.apache.spark.SparkContext]] when it becomes available.
+    */
+  def addSparkListener(listener: SparkListener): Unit = sparkListeners.add(listener)
+
+  /**
+    * Sets the [[org.apache.spark.SparkContext]] for the execution.
+    */
+  def setContext(context: SparkContext): Unit = {
+    this.synchronized {
+      if (stopped) {
+        context.stop()
+        throw new IllegalStateException("Spark program is already stopped")
+      }
+
+      if (sparkContext.isDefined) {
+        throw new IllegalStateException("SparkContext was already created")
+      }
+
+      sparkContext = Some(context)
+      context.addSparkListener(new DelegatingSparkListener)
+    }
+  }
+
+  /**
+    * Sets the [[org.apache.spark.streaming.StreamingContext]] that is currently in use.
+    */
+  def setContext(context: StreamingContext): Unit = {
+    if (stopped) {
+      context.stop(false)
+      throw new IllegalStateException("Spark program is already stopped")
+    }
+
+    // Spark doesn't allow multiple StreamingContext instances concurrently, hence we don't need to check in here
+    streamingContext = Some(context)
+  }
+
+  /**
+    * Returns the current [[org.apache.spark.SparkContext]].
+    *
+    * @throws IllegalStateException if there is no SparkContext available.
+    */
+  def getContext: SparkContext = {
+    this.synchronized {
+      sparkContext.getOrElse(throw new IllegalStateException("SparkContext is not available"))
+    }
+  }
+
+  /**
+    * Sets a local property on the [[org.apache.spark.SparkContext]] object if available.
+    *
+    * @param key key of the property
+    * @param value value of the property
+    * @return `true` if successfully set the property; `false` otherwise
+    */
+  def setLocalProperty(key: String, value: String): Boolean = {
+    this.synchronized {
+      sparkContext.fold(false)(context => {
+        context.setLocalProperty(key, value)
+        true
+      })
+    }
+  }
+
+  /**
+    * Gets a local property from the [[org.apache.spark.SparkContext]] object if available.
+    *
+    * @param key key of the property
+    * @return the value of property of `null` if either there is no SparkContext or the key doesn't exist
+    */
+  @Nullable
+  def getLocalProperty(key: String): String = {
+    this.synchronized {
+      sparkContext.map(_.getLocalProperty(key)).orNull
+    }
+  }
+
+  /**
+    * Stop this cache. It will stop the [[org.apache.spark.SparkContext]] in the cache and also prevent any
+    * future setting of new [[org.apache.spark.SparkContext]].
+    *
+    * @return [[scala.Some]] [[org.apache.spark.SparkContext]] if there is a one
+    */
+  def stop: Option[SparkContext] = {
+    this.synchronized {
+      if (!stopped) {
+        stopped = true
+        try {
+          streamingContext.foreach(ssc => {
+            ssc.stop(false)
+            ssc.awaitTermination()
+          })
+        } finally {
+          sparkContext.foreach(_.stop())
+        }
+      }
+      sparkContext;
+    }
+  }
+
+  /**
+    * A delegating [[org.apache.spark.scheduler.SparkListener]] that simply dispatch all callbacks to a list
+    * of [[org.apache.spark.scheduler.SparkListener]].
+    */
+  private class DelegatingSparkListener extends SparkListener {
+
+    override def onStageCompleted(stageCompleted: SparkListenerStageCompleted) =
+      sparkListeners.foreach(_.onStageCompleted(stageCompleted))
+
+    override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted) =
+      sparkListeners.foreach(_.onStageSubmitted(stageSubmitted))
+
+    override def onTaskStart(taskStart: SparkListenerTaskStart) =
+      sparkListeners.foreach(_.onTaskStart(taskStart))
+
+    override def onTaskGettingResult(taskGettingResult: SparkListenerTaskGettingResult) =
+      sparkListeners.foreach(_.onTaskGettingResult(taskGettingResult))
+
+    override def onTaskEnd(taskEnd: SparkListenerTaskEnd) =
+      sparkListeners.foreach(_.onTaskEnd(taskEnd))
+
+    override def onJobStart(jobStart: SparkListenerJobStart) =
+      sparkListeners.foreach(_.onJobStart(jobStart))
+
+    override def onJobEnd(jobEnd: SparkListenerJobEnd) =
+      sparkListeners.foreach(_.onJobEnd(jobEnd))
+
+    override def onEnvironmentUpdate(environmentUpdate: SparkListenerEnvironmentUpdate) =
+      sparkListeners.foreach(_.onEnvironmentUpdate(environmentUpdate))
+
+    override def onBlockManagerAdded(blockManagerAdded: SparkListenerBlockManagerAdded) =
+      sparkListeners.foreach(_.onBlockManagerAdded(blockManagerAdded))
+
+    override def onBlockManagerRemoved(blockManagerRemoved: SparkListenerBlockManagerRemoved) =
+      sparkListeners.foreach(_.onBlockManagerRemoved(blockManagerRemoved))
+
+    override def onUnpersistRDD(unpersistRDD: SparkListenerUnpersistRDD) =
+      sparkListeners.foreach(_.onUnpersistRDD(unpersistRDD))
+
+    override def onApplicationStart(applicationStart: SparkListenerApplicationStart) =
+      sparkListeners.foreach(_.onApplicationStart(applicationStart))
+
+    override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd) =
+      sparkListeners.foreach(_.onApplicationEnd(applicationEnd))
+
+    override def onExecutorMetricsUpdate(executorMetricsUpdate: SparkListenerExecutorMetricsUpdate) =
+      sparkListeners.foreach(_.onExecutorMetricsUpdate(executorMetricsUpdate))
+
+    override def onExecutorAdded(executorAdded: SparkListenerExecutorAdded) =
+      sparkListeners.foreach(_.onExecutorAdded(executorAdded))
+
+    override def onExecutorRemoved(executorRemoved: SparkListenerExecutorRemoved) =
+      sparkListeners.foreach(_.onExecutorRemoved(executorRemoved))
+  }
+}

--- a/cdap-spark-core/src/test/resources/logback-test.xml
+++ b/cdap-spark-core/src/test/resources/logback-test.xml
@@ -24,6 +24,13 @@
     </encoder>
   </appender>
 
+  <!--Supressing some chatty loggers -->
+  <logger name="org.apache.commons.beanutils" level="ERROR"/>
+  <logger name="org.apache.spark" level="WARN"/>
+  <logger name="org.apache.hadoop" level="WARN"/>
+  <logger name="org.eclipse.jetty" level="WARN"/>
+  <logger name="org.mortbay.log" level="WARN"/>
+
   <logger name="co.cask.cdap" level="DEBUG" />
 
   <root level="INFO">


### PR DESCRIPTION
- Mainly contains new classes and implementation of cdap-api-spark objects
- It doesn't hooked up with app-fabric runtime system yet
  - Many of the test cases are actually running Spark program, which requires hooking up with app-fabric runtime system, hence will come in future PR.