### PR TITLE
Modify the Spark Yarn Client rewrite logic

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkConfUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkConfUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import scala.Tuple2;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * An isolated utility for creating a configuration zip file that the Spark runtime needed. It is a
+ * workaround for Spark bug (SPARK-13441, CDAP-5019). This class will be added to the spark assembly jar
+ * during rewrite of the yarn.Client class.
+ *
+ * IMPORTANT: This class should only use Java SDK and Scala classes and shouldn't use any inner class.
+ *
+ * @see {@link SparkUtils#getRewrittenSparkAssemblyJar(CConfiguration)}.
+ */
+public final class SparkConfUtils {
+
+  /**
+   * Creates a zip file which contains a serialized {@link Properties} with a given zip entry name, together with
+   * all files under the given directory.
+   *
+   * @param props properties to serialize
+   * @param propertiesEntryName name of the zip entry for the properties
+   * @param confDir directory to scan for files to include in the zip file
+   * @param outputZipFile output file
+   */
+  public static File createZip(Tuple2<String, String>[] props, String propertiesEntryName,
+                               String confDir, String outputZipFile) {
+    final Properties properties = new Properties();
+    for (Tuple2<String, String> tuple : props) {
+      properties.put(tuple._1(), tuple._2());
+    }
+
+    File zipFile = new File(outputZipFile);
+    try (ZipOutputStream zipOutput = new ZipOutputStream(new FileOutputStream(zipFile))) {
+      zipOutput.putNextEntry(new ZipEntry(propertiesEntryName));
+      properties.store(zipOutput, "Spark configuration.");
+      zipOutput.closeEntry();
+
+      // Add all files under the confDir to the zip
+      File dir = new File(confDir);
+      URI baseURI = dir.toURI();
+
+      File[] files = dir.listFiles();
+      if (files != null) {
+        for (File file : files) {
+          if (file.isDirectory()) {
+            continue;
+          }
+          zipOutput.putNextEntry(new ZipEntry(baseURI.relativize(file.toURI()).getPath()));
+          Files.copy(file.toPath(), zipOutput);
+          zipOutput.closeEntry();
+        }
+      }
+      return zipFile;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private SparkConfUtils() {
+    // no-op
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramWrapper.java
@@ -84,16 +84,6 @@ public class SparkProgramWrapper {
 
     sparkConf.setAppName(sparkContext.getProgramId().getId());
 
-    if (!sparkContext.getContextConfig().isLocal()) {
-      // Create the __spark_conf.zip conf archive. It's for bug CDAP-5019 (SPARK-13441)
-      Properties properties = new Properties();
-      for (Tuple2<String, String> tuple : sparkConf.getAll()) {
-        properties.put(tuple._1(), tuple._2());
-      }
-
-      SparkUtils.createSparkConfZip(properties);
-    }
-
     if (JavaSparkProgram.class.isAssignableFrom(sparkProgramClass)) {
       sparkContext.setSparkFacade(new JavaSparkFacade(sparkConf));
     } else if (ScalaSparkProgram.class.isAssignableFrom(sparkProgramClass)) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -127,6 +127,7 @@ public final class Constants {
     public static final String PROGRAM_RUNID_CORRECTOR_INTERVAL_SECONDS = "app.program.runid.corrector.interval";
     public static final String SYSTEM_ARTIFACTS_DIR = "app.artifact.dir";
     public static final String PROGRAM_EXTRA_CLASSPATH = "app.program.extra.classpath";
+    public static final String SPARK_YARN_CLIENT_REWRITE = "app.program.spark.yarn.client.rewrite.enabled";
 
     /**
      * Guice named bindings.

--- a/cdap-common/src/main/java/co/cask/cdap/internal/asm/Methods.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/asm/Methods.java
@@ -16,9 +16,6 @@
 
 package co.cask.cdap.internal.asm;
 
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
-import com.google.common.collect.Iterators;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.Method;
 
@@ -28,19 +25,12 @@ import org.objectweb.asm.commons.Method;
 public final class Methods {
 
   public static Method getMethod(Class<?> returnType, String name, Class<?>...args) {
-    StringBuilder builder = new StringBuilder(returnType.getName())
-      .append(' ').append(name).append(" (");
-    Joiner.on(',').appendTo(builder, Iterators.transform(Iterators.forArray(args), new Function<Class<?>, String>() {
-      @Override
-      public String apply(Class<?> input) {
-        if (input.isArray()) {
-          return Type.getType(input.getName()).getClassName();
-        }
-        return input.getName();
-      }
-    }));
-    builder.append(')');
-    return Method.getMethod(builder.toString());
+    Type[] argTypes = new Type[args.length];
+    for (int i = 0; i < args.length; i++) {
+      argTypes[i] = Type.getType(args[i]);
+    }
+
+    return new Method(name, Type.getType(returnType), argTypes);
   }
 
   private Methods() {}

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -269,6 +269,15 @@
   </property>
 
   <property>
+    <name>app.program.spark.yarn.client.rewrite.enabled</name>
+    <value>true</value>
+    <description>
+      Specify whether to rewrite the yarn.Client class in Spark to work
+      around the issue SPARK-13441 in CDM clusters.
+    </description>
+  </property>
+
+  <property>
     <name>app.temp.dir</name>
     <value>/tmp</value>
     <description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="4d0656eaf5758c7b65ca7515054fe217"
+DEFAULT_XML_MD5_HASH="acb8e1410495b1af417298c43eeb2177"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"


### PR DESCRIPTION
- No longer requires the __spark_conf__.zip file generated externally
- Can optionally turn off the rewrite