### PR TITLE
CDAP-5362 Spark MLLib Plugin Type

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
@@ -153,7 +153,8 @@ public class DefaultPluginConfigurer extends DefaultDatasetConfigurer implements
                             PluginProperties properties, PluginSelector selector)
     throws PluginNotExistsException, ArtifactNotFoundException {
     Preconditions.checkArgument(!plugins.containsKey(pluginId),
-                                "Plugin of type %s, name %s was already added.", pluginType, pluginName);
+                                "Plugin of type %s, name %s was already added as id %s.",
+                                pluginType, pluginName, pluginId);
     return FindPluginHelper.findPlugin(artifactRepository, pluginInstantiator, deployNamespace.toEntityId(), artifactId,
                                        pluginType, pluginName, properties, selector);
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2016 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap-etl</artifactId>
+    <version>3.4.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cdap-etl-api-spark</artifactId>
+  <name>CDAP ETL App Template Spark API</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api-spark</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.10</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/batch/SparkPluginContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/batch/SparkPluginContext.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api.batch;
+
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.data.stream.StreamBatchReadable;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.stream.StreamEventDecoder;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.spark.api.java.JavaPairRDD;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Context passed to spark plugin types.
+ */
+@Beta
+public interface SparkPluginContext extends BatchContext {
+
+  /**
+   * Returns the logical start time of this Spark job. Logical start time is the time when this Spark
+   * job is supposed to start if this job is started by the scheduler. Otherwise it would be the current time when the
+   * job runs.
+   *
+   * @return Time in milliseconds since epoch time (00:00:00 January 1, 1970 UTC).
+   */
+  long getLogicalStartTime();
+
+  /**
+   * Create a Spark RDD that uses {@link Dataset} as input source
+   *
+   * @param datasetName the name of the {@link Dataset} to be read as an RDD
+   * @param kClass      the key class
+   * @param vClass      the value class
+   * @param <K>        type of RDD key
+   * @param <V>        type of RDD value
+   * @return the RDD created from Dataset
+   * @throws UnsupportedOperationException if the SparkContext is not yet initialized
+   */
+  <K, V> JavaPairRDD<K, V> readFromDataset(String datasetName, Class<? extends K> kClass, Class<? extends V> vClass);
+
+  /**
+   * Create a Spark RDD that uses {@link Dataset} instantiated using the provided arguments as an input source.
+   *
+   * @param datasetName the name of the {@link Dataset} to be read as an RDD
+   * @param kClass      the key class
+   * @param vClass      the value class
+   * @param datasetArgs arguments for the dataset
+   * @param <K>        type of RDD key
+   * @param <V>        type of RDD value
+   * @return the RDD created from Dataset
+   * @throws UnsupportedOperationException if the SparkContext is not yet initialized
+   */
+  <K, V> JavaPairRDD<K, V> readFromDataset(String datasetName, Class<? extends K> kClass, Class<? extends V> vClass,
+                                           Map<String, String> datasetArgs);
+
+  /**
+   * Writes a Spark RDD to {@link Dataset}
+   *
+   * @param rdd         the rdd to be stored
+   * @param datasetName the name of the {@link Dataset} where the RDD should be stored
+   * @param kClass      the key class
+   * @param vClass      the value class
+   * @param <K>        type of RDD key
+   * @param <V>        type of RDD value
+   * @throws UnsupportedOperationException if the SparkContext is not yet initialized
+   */
+  <K, V> void writeToDataset(JavaPairRDD<K, V> rdd, String datasetName,
+                             Class<? extends K> kClass, Class<? extends V> vClass);
+
+  /**
+   * Writes a Spark RDD to {@link Dataset} instantiated using the provided arguments.
+   *
+   * @param rdd         the rdd to be stored
+   * @param datasetName the name of the {@link Dataset} where the RDD should be stored
+   * @param kClass      the key class
+   * @param vClass      the value class
+   * @param datasetArgs arguments for the dataset
+   * @param <K>        type of RDD key
+   * @param <V>        type of RDD value
+   * @throws UnsupportedOperationException if the SparkContext is not yet initialized
+   */
+  <K, V> void writeToDataset(JavaPairRDD<K, V> rdd, String datasetName,
+                             Class<? extends K> kClass, Class<? extends V> vClass,
+                             Map<String, String> datasetArgs);
+
+  /**
+   * Create a Spark RDD that uses complete {@link Stream} as input source
+   *
+   * @param streamName the name of the {@link Stream} to be read as an RDD
+   * @param vClass     the value class
+   * @param <V>        type of RDD value
+   * @return the RDD created from {@link Stream}
+   */
+  <V> JavaPairRDD<LongWritable, V> readFromStream(String streamName, Class<? extends V> vClass);
+
+  /**
+   * Create a Spark RDD that uses {@link Stream} as input source
+   *
+   * @param streamName the name of the {@link Stream} to be read as an RDD
+   * @param vClass     the value class
+   * @param startTime  the starting time of the stream to be read in milliseconds. To read from the starting of the
+   *                   stream set this to 0
+   * @param endTime    the ending time of the streams to be read in milliseconds. To read up to the end of the stream
+   *                   set this to Long.MAX_VALUE
+   * @param <K>        type of RDD key
+   * @param <V>        type of RDD value
+   * @return the RDD created from {@link Stream}
+   */
+  <K, V> JavaPairRDD<K, V> readFromStream(String streamName, Class<? extends V> vClass, long startTime, long endTime);
+
+  /**
+   * Create a Spark RDD that uses {@link Stream} as input source according to the given {@link StreamEventDecoder}
+   *
+   * @param streamName  the name of the {@link Stream} to be read as an RDD
+   * @param vClass      the value class
+   * @param startTime   the starting time of the stream to be read in milliseconds. To read from the starting of the
+   *                    stream set this to 0
+   * @param endTime     the ending time of the streams to be read in milliseconds. To read up to the end of the stream
+   *                    set this to Long.MAX_VALUE
+   * @param decoderType the decoder to use while reading streams
+   * @param <V>        type of RDD value
+   * @return the RDD created from {@link Stream}
+   */
+  <V> JavaPairRDD<LongWritable, V> readFromStream(String streamName, Class<? extends V> vClass,
+                                                  long startTime, long endTime,
+                                                  Class<? extends StreamEventDecoder> decoderType);
+
+  /**
+   * Create a Spark RDD that uses {@link Stream} as input source according to the given {@link StreamBatchReadable}.
+   *
+   * @param stream a {@link StreamBatchReadable} containing information on the stream to read from
+   * @param vClass the value class
+   * @param <V>        type of RDD value
+   * @return the RDD created from {@link Stream}
+   */
+  <V> JavaPairRDD<LongWritable, V> readFromStream(StreamBatchReadable stream, Class<? extends V> vClass);
+
+  /**
+   * Returns
+   * <a href="http://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.api.java.JavaSparkContext">
+   * JavaSparkContext</a> or
+   * <a href="http://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.SparkContext">SparkContext</a>
+   * depending on user's job type.
+   *
+   * @param <T> the type of Spark Context
+   * @return the Spark Context
+   */
+  <T> T getOriginalSparkContext();
+
+  /**
+   * Returns a {@link Serializable} {@link PluginContext} which can be used to request for plugins instances. The
+   * instance returned can also be used in Spark program's closures.
+   *
+   * @return A {@link Serializable} {@link PluginContext}.
+   */
+  PluginContext getPluginContext();
+
+  /**
+   * Sets a
+   * <a href="http://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.SparkConf">SparkConf</a>
+   * to be used for the Spark execution. Only configurations set inside the
+   * {@link SparkSink#prepareRun} call will affect the Spark execution.
+   *
+   * @param <T> the SparkConf type
+   */
+  <T> void setSparkConf(T sparkConf);
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/batch/SparkSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/batch/SparkSink.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api.batch;
+
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.spark.SparkContext;
+import org.apache.spark.api.java.JavaRDD;
+
+import java.io.Serializable;
+
+
+/**
+ * SparkSink composes a final, optional stage of a Batch ETL Pipeline. In addition to configuring the Batch run, it
+ * can also perform RDD operations on the key value pairs provided by the Batch run.
+ *
+ * {@link SparkSink#run} method is called inside the Batch Run while {@link SparkSink#prepareRun} and
+ * {@link SparkSink#onRunFinish} methods are called on the client side, which launches the Batch run, before the
+ * Batch run starts and after it finishes respectively.
+ *
+ * @param <IN> The type of input record to the SparkSink.
+ */
+@Beta
+public abstract class SparkSink<IN> extends BatchConfigurable<SparkPluginContext> implements Serializable {
+
+  public static final String PLUGIN_TYPE = "sparksink";
+
+  private static final long serialVersionUID = -8600555200583639593L;
+
+  /**
+   * User Spark job which will be executed and is responsible for persisting any data.
+   *
+   * @param context {@link SparkContext} for this job
+   * @param input the input from previous stages of the Batch run.
+   */
+  public abstract void run(SparkPluginContext context, JavaRDD<IN> input) throws Exception;
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/batch/package-info.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/batch/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Interfaces for Spark plugins.
+ */
+package co.cask.cdap.etl.api.batch;

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
@@ -42,6 +42,11 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-api-spark</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-core</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -74,17 +79,17 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.10</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>mail</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>dumbster</groupId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/ETLBatchApplication.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/ETLBatchApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -57,7 +57,8 @@ public class ETLBatchApplication extends AbstractApplication<ETLBatchConfig> {
     setDescription(DEFAULT_DESCRIPTION);
 
     PipelineSpecGenerator specGenerator =
-      new PipelineSpecGenerator(getConfigurer(), BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE,
+      new PipelineSpecGenerator(getConfigurer(),
+                                ImmutableSet.of(BatchSource.PLUGIN_TYPE), ImmutableSet.of(BatchSink.PLUGIN_TYPE),
                                 TimePartitionedFileSet.class,
                                 FileSetProperties.builder()
                                   .setInputFormat(AvroKeyInputFormat.class)

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/TransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/TransformExecutorFactory.java
@@ -59,7 +59,6 @@ public abstract class TransformExecutorFactory<T> {
    * @throws Exception if there was an error initializing a plugin
    */
   public TransformExecutor<T> create(PipelinePhase pipeline) throws Exception {
-
     Map<String, TransformDetail> transformations = new HashMap<>();
     for (String pluginType : pipeline.getPluginTypes()) {
       for (StageInfo stageInfo : pipeline.getStagesOfType(pluginType)) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/BasicSparkPluginContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/BasicSparkPluginContext.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.spark;
+
+import co.cask.cdap.api.data.stream.StreamBatchReadable;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.spark.SparkContext;
+import co.cask.cdap.api.stream.StreamEventDecoder;
+import co.cask.cdap.etl.api.LookupProvider;
+import co.cask.cdap.etl.api.batch.SparkPluginContext;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.spark.api.java.JavaPairRDD;
+
+import java.util.Map;
+
+/**
+ * Implementation of SparkPluginContext that delegates to a SparkContext.
+ */
+public class BasicSparkPluginContext extends AbstractSparkBatchContext implements SparkPluginContext {
+
+  private final SparkContext sparkContext;
+
+  public BasicSparkPluginContext(SparkContext sparkContext, LookupProvider lookupProvider, String stageId) {
+    super(sparkContext, lookupProvider, stageId);
+    this.sparkContext = sparkContext;
+  }
+
+  @Override
+  public <V> JavaPairRDD<LongWritable, V> readFromStream(StreamBatchReadable stream, Class<? extends V> vClass) {
+    return sparkContext.readFromStream(stream, vClass);
+  }
+
+  @Override
+  public <V> JavaPairRDD<LongWritable, V> readFromStream(String streamName, Class<? extends V> vClass,
+                                                         long startTime, long endTime,
+                                                         Class<? extends StreamEventDecoder> decoderType) {
+    return sparkContext.readFromStream(streamName, vClass, startTime, endTime, decoderType);
+  }
+
+  @Override
+  public <K, V> JavaPairRDD<K, V> readFromStream(String streamName, Class<? extends V> vClass,
+                                                 long startTime, long endTime) {
+    return sparkContext.readFromStream(streamName, vClass, startTime, endTime);
+  }
+
+  @Override
+  public <V> JavaPairRDD<LongWritable, V> readFromStream(String streamName, Class<? extends V> vClass) {
+    return sparkContext.readFromStream(streamName, vClass);
+  }
+
+  @Override
+  public <K, V> void writeToDataset(JavaPairRDD<K, V> rdd, String datasetName,
+                                    Class<? extends K> kClass, Class<? extends V> vClass,
+                                    Map<String, String> datasetArgs) {
+    sparkContext.writeToDataset(rdd, datasetName, kClass, vClass, datasetArgs);
+  }
+
+  @Override
+  public <K, V> void writeToDataset(JavaPairRDD<K, V> rdd, String datasetName,
+                                    Class<? extends K> kClass, Class<? extends V> vClass) {
+    sparkContext.writeToDataset(rdd, datasetName, kClass, vClass);
+  }
+
+  @Override
+  public <K, V> JavaPairRDD<K, V> readFromDataset(String datasetName,
+                                                  Class<? extends K> kClass, Class<? extends V> vClass,
+                                                  Map<String, String> datasetArgs) {
+    return sparkContext.readFromDataset(datasetName, kClass, vClass, datasetArgs);
+  }
+
+  @Override
+  public <K, V> JavaPairRDD<K, V> readFromDataset(String datasetName,
+                                                  Class<? extends K> kClass, Class<? extends V> vClass) {
+    return sparkContext.readFromDataset(datasetName, kClass, vClass);
+  }
+
+  @Override
+  public <T> T getOriginalSparkContext() {
+    return sparkContext.getOriginalSparkContext();
+  }
+
+  @Override
+  public PluginContext getPluginContext() {
+    return sparkContext.getPluginContext();
+  }
+
+  @Override
+  public <T> void setSparkConf(T sparkConf) {
+    sparkContext.setSparkConf(sparkConf);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLBatchTestBase.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLBatchTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -61,9 +61,9 @@ public class ETLBatchTestBase extends TestBase {
 
     // add the artifact for etl batch app
     addAppArtifact(APP_ARTIFACT_ID, ETLBatchApplication.class,
-      BatchSource.class.getPackage().getName(),
-      PipelineConfigurable.class.getPackage().getName(),
-      "org.apache.avro.mapred", "org.apache.avro", "org.apache.avro.generic", "org.apache.avro.io");
+                   BatchSource.class.getPackage().getName(),
+                   PipelineConfigurable.class.getPackage().getName(),
+                   "org.apache.avro.mapred", "org.apache.avro", "org.apache.avro.generic", "org.apache.avro.io");
 
     // add some test plugins
     addPluginArtifact(Id.Artifact.from(Id.Namespace.DEFAULT, "test-plugins", "1.0.0"), APP_ARTIFACT_ID,

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformExecutor.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformExecutor.java
@@ -69,12 +69,13 @@ public class TransformExecutor<IN> implements Destroyable {
   }
 
   private <T> void executeTransformation(final String stageName, Collection<T> input) throws Exception {
-    TransformDetail transformDetail = transformDetailMap.get(stageName);
-    Transformation<T, Object> transformation = transformDetail.getTransformation();
-
     if (input == null) {
       return;
     }
+
+    TransformDetail transformDetail = transformDetailMap.get(stageName);
+    Transformation<T, Object> transformation = transformDetail.getTransformation();
+
 
     // clear old data for this stageName if its not a terminal node
     if (!transformDetail.getNextStages().isEmpty()) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -47,17 +47,17 @@ public class PipelineSpecGenerator {
   private final PluginConfigurer configurer;
   private final Class<? extends Dataset> errorDatasetClass;
   private final DatasetProperties errorDatasetProperties;
-  private final String sourcePluginType;
-  private final String sinkPluginType;
+  private final Set<String> sourcePluginTypes;
+  private final Set<String> sinkPluginTypes;
 
   public PipelineSpecGenerator(PluginConfigurer configurer,
-                               String sourcePluginType,
-                               String sinkPluginType,
+                               Set<String> sourcePluginTypes,
+                               Set<String> sinkPluginTypes,
                                Class<? extends Dataset> errorDatasetClass,
                                DatasetProperties errorDatasetProperties) {
     this.configurer = configurer;
-    this.sourcePluginType = sourcePluginType;
-    this.sinkPluginType = sinkPluginType;
+    this.sourcePluginTypes = sourcePluginTypes;
+    this.sinkPluginTypes = sinkPluginTypes;
     this.errorDatasetClass = errorDatasetClass;
     this.errorDatasetProperties = errorDatasetProperties;
   }
@@ -218,13 +218,13 @@ public class PipelineSpecGenerator {
       Set<String> stageInputs = dag.getNodeInputs(stageName);
       Set<String> stageOutputs = dag.getNodeOutputs(stageName);
 
-      if (sourcePluginType.equals(stage.getPlugin().getType())) {
+      if (isSource(stage.getPlugin().getType())) {
         if (!stageInputs.isEmpty()) {
           throw new IllegalArgumentException(
             String.format("Source %s has incoming connections from %s. Sources cannot have any incoming connections.",
                           stageName, Joiner.on(',').join(stageInputs)));
         }
-      } else if (sinkPluginType.equals(stage.getPlugin().getType())) {
+      } else if (isSink(stage.getPlugin().getType())) {
         if (!stageOutputs.isEmpty()) {
           throw new IllegalArgumentException(
             String.format("Sink %s has outgoing connections to %s. Sinks cannot have any outgoing connections.",
@@ -249,5 +249,13 @@ public class PipelineSpecGenerator {
     }
 
     return traversalOrder;
+  }
+
+  private boolean isSource(String pluginType) {
+    return sourcePluginTypes.contains(pluginType);
+  }
+
+  private boolean isSink(String pluginType) {
+    return sinkPluginTypes.contains(pluginType);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -69,7 +69,9 @@ public class PipelineSpecGeneratorTest {
     pluginConfigurer.addMockPlugin(Transform.PLUGIN_TYPE, "mockB", new MockPlugin(SCHEMA_B), artifactIds);
     pluginConfigurer.addMockPlugin(BatchSink.PLUGIN_TYPE, "mocksink", new MockPlugin(), artifactIds);
 
-    specGenerator = new PipelineSpecGenerator(pluginConfigurer, BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE,
+    specGenerator = new PipelineSpecGenerator(pluginConfigurer,
+                                              ImmutableSet.of(BatchSource.PLUGIN_TYPE),
+                                              ImmutableSet.of(BatchSink.PLUGIN_TYPE),
                                               FileSet.class, DatasetProperties.EMPTY);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/pom.xml
@@ -41,6 +41,22 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-api-spark</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-mllib_2.10</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-streaming_2.10</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/DataPipelineApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/DataPipelineApp.java
@@ -24,6 +24,7 @@ import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.common.Constants;
 import co.cask.cdap.etl.planner.PipelinePlan;
 import co.cask.cdap.etl.planner.PipelinePlanner;
@@ -44,7 +45,7 @@ public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
   public static final String DEFAULT_DESCRIPTION = "Data Pipeline Application";
   private static final Set<String> supportedPluginTypes = ImmutableSet.of(
     BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE, Transform.PLUGIN_TYPE,
-    Constants.CONNECTOR_TYPE, BatchAggregator.PLUGIN_TYPE);
+    Constants.CONNECTOR_TYPE, BatchAggregator.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE);
 
   @Override
   public void configure() {
@@ -52,7 +53,8 @@ public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
     setDescription(DEFAULT_DESCRIPTION);
 
     PipelineSpecGenerator specGenerator =
-      new PipelineSpecGenerator(getConfigurer(), BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE,
+      new PipelineSpecGenerator(getConfigurer(), ImmutableSet.of(BatchSource.PLUGIN_TYPE),
+                                ImmutableSet.of(BatchSink.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE),
                                 TimePartitionedFileSet.class,
                                 FileSetProperties.builder()
                                   .setInputFormat(AvroKeyInputFormat.class)

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/mock/SpamMessage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/mock/SpamMessage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.datapipeline.mock;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+
+/**
+ * Represents a string and whether that is spam or not.
+ */
+public class SpamMessage {
+  static final String IS_SPAM_FIELD = "isSpam";
+  static final String TEXT_FIELD = "text";
+  static final Schema SCHEMA = Schema.recordOf(
+    "simpleMessage",
+    Schema.Field.of(IS_SPAM_FIELD, Schema.of(Schema.Type.BOOLEAN)),
+    Schema.Field.of(TEXT_FIELD, Schema.of(Schema.Type.STRING))
+  );
+
+  private final boolean isSpam;
+  private final String text;
+
+  public SpamMessage(boolean isSpam, String text) {
+    this.isSpam = isSpam;
+    this.text = text;
+  }
+
+  public StructuredRecord toStructuredRecord() {
+    return StructuredRecord.builder(SCHEMA).set(IS_SPAM_FIELD, isSpam).set(TEXT_FIELD, text).build();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/mock/SpamOrHam.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/test/java/co/cask/cdap/etl/datapipeline/mock/SpamOrHam.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.datapipeline.mock;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.SparkPluginContext;
+import co.cask.cdap.etl.api.batch.SparkSink;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.PairFunction;
+import org.apache.spark.mllib.classification.NaiveBayes;
+import org.apache.spark.mllib.classification.NaiveBayesModel;
+import org.apache.spark.mllib.feature.HashingTF;
+import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.mllib.regression.LabeledPoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+
+/**
+ * Spark Sink plugin that trains a model based upon whether messages are spam or not, and then classifies messages.
+ * Also persists the trained model to a file in a FileSet.
+ */
+@Plugin(type = SparkSink.PLUGIN_TYPE)
+@Name("SpamOrHam")
+@Description("Trains a model based upon whether messages are spam or not.")
+public final class SpamOrHam extends SparkSink<StructuredRecord> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SpamOrHam.class);
+
+  private static final String OUTPUT_FILESET = "modelFileSet";
+
+  public static final String TEXTS_TO_CLASSIFY = "textsToClassify";
+  public static final String CLASSIFIED_TEXTS = "classifiedTexts";
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    pipelineConfigurer.addStream(TEXTS_TO_CLASSIFY);
+    pipelineConfigurer.createDataset(CLASSIFIED_TEXTS, KeyValueTable.class);
+    pipelineConfigurer.createDataset(OUTPUT_FILESET, FileSet.class, FileSetProperties.builder()
+      .setInputFormat(TextInputFormat.class)
+      .setOutputFormat(TextOutputFormat.class)
+      .setOutputProperty(TextOutputFormat.SEPERATOR, ":").build());
+  }
+
+  @Override
+  public void prepareRun(SparkPluginContext context) throws Exception {
+    // no-op; no need to do anything
+  }
+
+  @Override
+  public void run(SparkPluginContext sparkContext, JavaRDD<StructuredRecord> input) throws Exception {
+    Preconditions.checkArgument(input.count() != 0, "Input RDD is empty.");
+    final JavaRDD<StructuredRecord> spam = input.filter(new Function<StructuredRecord, Boolean>() {
+      @Override
+      public Boolean call(StructuredRecord record) throws Exception {
+        return record.get(SpamMessage.IS_SPAM_FIELD);
+      }
+    });
+
+    JavaRDD<StructuredRecord> ham = input.filter(new Function<StructuredRecord, Boolean>() {
+      @Override
+      public Boolean call(StructuredRecord record) throws Exception {
+        return !(Boolean) record.get(SpamMessage.IS_SPAM_FIELD);
+      }
+    });
+
+    final HashingTF tf = new HashingTF(100);
+    JavaRDD<Vector> spamFeatures = spam.map(new Function<StructuredRecord, Vector>() {
+      @Override
+      public Vector call(StructuredRecord structuredRecord) throws Exception {
+        String text = structuredRecord.get(SpamMessage.TEXT_FIELD);
+        return tf.transform(Lists.newArrayList(text.split(" ")));
+      }
+    });
+
+    JavaRDD<Vector> hamFeatures = ham.map(new Function<StructuredRecord, Vector>() {
+      @Override
+      public Vector call(StructuredRecord structuredRecord) throws Exception {
+        String text = structuredRecord.get(SpamMessage.TEXT_FIELD);
+        return tf.transform(Lists.newArrayList(text.split(" ")));
+      }
+    });
+
+
+    JavaRDD<LabeledPoint> positiveExamples = spamFeatures.map(new Function<Vector, LabeledPoint>() {
+      @Override
+      public LabeledPoint call(Vector vector) throws Exception {
+        return new LabeledPoint(1, vector);
+      }
+    });
+
+    JavaRDD<LabeledPoint> negativeExamples = hamFeatures.map(new Function<Vector, LabeledPoint>() {
+      @Override
+      public LabeledPoint call(Vector vector) throws Exception {
+        return new LabeledPoint(0, vector);
+      }
+    });
+
+    JavaRDD<LabeledPoint> trainingData = positiveExamples.union(negativeExamples);
+    trainingData.cache();
+
+    final NaiveBayesModel model = NaiveBayes.train(trainingData.rdd(), 1.0);
+
+    // save the model to a file in the output FileSet
+    JavaSparkContext javaSparkContext = sparkContext.getOriginalSparkContext();
+    FileSet outputFS = sparkContext.getDataset(OUTPUT_FILESET);
+    model.save(JavaSparkContext.toSparkContext(javaSparkContext),
+               outputFS.getBaseLocation().append("output").toURI().getPath());
+
+    JavaPairRDD<LongWritable, Text> textsToClassify = sparkContext.readFromStream("textsToClassify", Text.class);
+    JavaRDD<Vector> featuresToClassify = textsToClassify.map(new Function<Tuple2<LongWritable, Text>, Vector>() {
+      @Override
+      public Vector call(Tuple2<LongWritable, Text> longWritableTextTuple2) throws Exception {
+        String text = longWritableTextTuple2._2().toString();
+        return tf.transform(Lists.newArrayList(text.split(" ")));
+      }
+    });
+
+    JavaRDD<Double> predict = model.predict(featuresToClassify);
+    LOG.info("Predictions: {}", predict.collect());
+
+    // key the predictions with the message
+    JavaPairRDD<Text, Double> keyedPredictions = textsToClassify.values().zip(predict);
+
+    // convert to byte[],byte[] to write to data
+    JavaPairRDD<byte[], byte[]> bytesRDD =
+      keyedPredictions.mapToPair(new PairFunction<Tuple2<Text, Double>, byte[], byte[]>() {
+        @Override
+        public Tuple2<byte[], byte[]> call(Tuple2<Text, Double> tuple) throws Exception {
+          return new Tuple2<>(Bytes.toBytes(tuple._1().toString()), Bytes.toBytes(tuple._2()));
+        }
+      });
+
+    sparkContext.writeToDataset(bytesRDD, CLASSIFIED_TEXTS, byte[].class, byte[].class);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/ETLWorker.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/ETLWorker.java
@@ -138,8 +138,8 @@ public class ETLWorker extends AbstractWorker {
 
     PipelineSpecGenerator specGenerator =
       new PipelineSpecGenerator(getConfigurer(),
-                                RealtimeSource.PLUGIN_TYPE,
-                                RealtimeSink.PLUGIN_TYPE,
+                                ImmutableSet.of(RealtimeSource.PLUGIN_TYPE),
+                                ImmutableSet.of(RealtimeSink.PLUGIN_TYPE),
                                 Table.class,
                                 DatasetProperties.builder()
                                   .add(Table.PROPERTY_SCHEMA, ERROR_SCHEMA.toString())

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -31,6 +31,7 @@
 
   <modules>
     <module>cdap-etl-api</module>
+    <module>cdap-etl-api-spark</module>
     <module>cdap-etl-archetypes</module>
     <module>cdap-etl-batch</module>
     <module>cdap-etl-core</module>

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -237,6 +237,14 @@
                         <include>cdap-etl-realtime-${project.version}.jar</include>
                       </includes>
                     </resource>
+                    <resource>
+                      <directory>
+                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/target
+                      </directory>
+                      <includes>
+                        <include>cdap-etl-data-pipeline-${project.version}.jar</include>
+                      </includes>
+                    </resource>
                   </resources>
                 </configuration>
               </execution>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -408,6 +408,14 @@
                         <include>cdap-etl-realtime-${project.version}.jar</include>
                       </includes>
                     </resource>
+                    <resource>
+                      <directory>
+                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/target
+                      </directory>
+                      <includes>
+                        <include>cdap-etl-data-pipeline-${project.version}.jar</include>
+                      </includes>
+                    </resource>
                   </resources>
                 </configuration>
               </execution>


### PR DESCRIPTION
Users can write plugins that get the data from previous stages of an ETL pipeline and can run arbitrary spark code (for instance, MLLib functions) against it.

The Spark MLLib plugin is not a `BatchSink`, but it is treated as the final node of a pipeline.
Other stages can not come after it.

https://issues.cask.co/browse/CDAP-5362
http://builds.cask.co/browse/CDAP-DUT3792