### PR TITLE
CDAP-5146 implement aggregators in spark program

### DIFF
--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.schema.Schema;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -28,9 +29,11 @@ import java.util.Objects;
  * Instance of a record structured by a {@link Schema}. Fields are accessible by name.
  */
 @Beta
-public class StructuredRecord {
+public class StructuredRecord implements Serializable {
   private final Schema schema;
   private final Map<String, Object> fields;
+
+  private static final long serialVersionUID = -4648752378975451591L;
 
   private StructuredRecord(Schema schema, Map<String, Object> fields) {
     this.schema = schema;

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/Schema.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/Schema.java
@@ -23,6 +23,7 @@ import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,8 +41,9 @@ import java.util.Set;
  * This class represents schema of data types.
  */
 @Beta
-public final class Schema {
+public final class Schema implements Serializable {
   private static final SchemaTypeAdapter SCHEMA_TYPE_ADAPTER = new SchemaTypeAdapter();
+  private static final long serialVersionUID = -1891891892562027345L;
 
   /**
    * Types known to Schema.
@@ -80,7 +82,8 @@ public final class Schema {
   /**
    * Represents a field inside a {@link Type#RECORD} schema.
    */
-  public static final class Field {
+  public static final class Field implements Serializable {
+    private static final long serialVersionUID = 5423721270457378454L;
     private final String name;
     private final Schema schema;
 

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/SchemaHash.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/SchemaHash.java
@@ -18,6 +18,7 @@ package co.cask.cdap.api.data.schema;
 
 import co.cask.cdap.api.annotation.Beta;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
@@ -31,9 +32,10 @@ import java.util.Set;
  * A MD5 hash of a {@link Schema}.
  */
 @Beta
-public final class SchemaHash {
+public final class SchemaHash implements Serializable {
 
   private static final Charset UTF_8 = Charset.forName("UTF-8");
+  private static final long serialVersionUID = 3640799184470835328L;
 
   private final byte[] hash;
   private String hashStr;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
@@ -26,6 +26,7 @@ import co.cask.cdap.app.deploy.Configurator;
 import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
@@ -43,6 +44,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import org.apache.twill.filesystem.Location;
 import org.slf4j.Logger;
@@ -62,6 +64,9 @@ import javax.annotation.Nullable;
  */
 public final class InMemoryConfigurator implements Configurator {
   private static final Logger LOG = LoggerFactory.getLogger(InMemoryConfigurator.class);
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
+    .create();
 
   /**
    * JAR file path.
@@ -171,7 +176,7 @@ public final class InMemoryConfigurator implements Configurator {
         appConfig = ((Class<? extends Config>) configType).newInstance();
       } else {
         try {
-          appConfig = new Gson().fromJson(configString, configType);
+          appConfig = GSON.fromJson(configString, configType);
         } catch (JsonSyntaxException e) {
           throw new IllegalArgumentException("Invalid JSON configuration was provided. Please check the syntax.", e);
         }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchAggregator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchAggregator.java
@@ -30,11 +30,12 @@ import java.util.Iterator;
  * As it is used in batch programs, a BatchAggregator must be parameterized
  * with supported group key and value classes. Group keys and values can be a
  * byte[], Boolean, Integer, Long, Float, Double, String, or StructuredRecord.
- * If the group key is not one of those types,
+ * If the group key is not one of those types and is being used in mapreduce,
  * it must implement Hadoop's org.apache.hadoop.io.WritableComparable interface.
- * If the group value is not one of those types,
+ * If the group value is not one of those types and is being used in mapreduce,
  * it must implement Hadoop's org.apache.hadoop.io.Writable interface.
- *
+ * If the aggregator is being used in spark, both the group key and value must implement the
+ * {@link java.io.Serializable} interface.
  *
  * @param <GROUP_KEY> group key type. Must be a supported type
  * @param <GROUP_VALUE> group value type. Must be a supported type

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSparkProgram.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSparkProgram.java
@@ -21,15 +21,18 @@ import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.spark.JavaSparkProgram;
 import co.cask.cdap.api.spark.SparkContext;
+import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.batch.BatchPhaseSpec;
 import co.cask.cdap.etl.batch.PipelinePluginInstantiator;
 import co.cask.cdap.etl.batch.TransformExecutorFactory;
 import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.PipelinePhase;
 import co.cask.cdap.etl.common.SetMultimapCodec;
 import co.cask.cdap.etl.common.TransformExecutor;
 import co.cask.cdap.etl.common.TransformResponse;
 import co.cask.cdap.etl.planner.StageInfo;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -41,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Tuple2;
 
+import java.io.DataInputStream;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -49,6 +53,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Spark program to run an ETL pipeline.
@@ -63,18 +68,33 @@ public class ETLSparkProgram implements JavaSparkProgram {
 
   @Override
   public void run(SparkContext context) throws Exception {
+    BatchPhaseSpec phaseSpec = GSON.fromJson(context.getSpecification().getProperty(Constants.PIPELINEID),
+                                             BatchPhaseSpec.class);
+    Set<StageInfo> aggregators = phaseSpec.getPhase().getStagesOfType(BatchAggregator.PLUGIN_TYPE);
+    String aggregatorName = null;
+    if (!aggregators.isEmpty()) {
+      aggregatorName = aggregators.iterator().next().getName();
+    }
+
     SparkBatchSourceFactory sourceFactory;
     SparkBatchSinkFactory sinkFactory;
+    Integer numPartitions;
     try (InputStream is = new FileInputStream(context.getTaskLocalizationContext().getLocalFile("ETLSpark.config"))) {
       sourceFactory = SparkBatchSourceFactory.deserialize(is);
       sinkFactory = SparkBatchSinkFactory.deserialize(is);
+      numPartitions = new DataInputStream(is).readInt();
     }
 
     JavaPairRDD<Object, Object> rdd = sourceFactory.createRDD(context, Object.class, Object.class);
-    JavaPairRDD<String, Object> resultRDD = rdd.flatMapToPair(new MapFunction(context)).cache();
-
-    BatchPhaseSpec phaseSpec = GSON.fromJson(context.getSpecification().getProperty(Constants.PIPELINEID),
-                                             BatchPhaseSpec.class);
+    JavaPairRDD<String, Object> resultRDD;
+    if (aggregatorName != null) {
+      JavaPairRDD<Object, Object> preGroupRDD = rdd.flatMapToPair(new PreGroupFunction(context, aggregatorName));
+      JavaPairRDD<Object, Iterable<Object>> groupedRDD =
+        numPartitions < 0 ? preGroupRDD.groupByKey() : preGroupRDD.groupByKey(numPartitions);
+      resultRDD = groupedRDD.flatMapToPair(new MapFunction<Iterable<Object>>(context, aggregatorName)).cache();
+    } else {
+      resultRDD = rdd.flatMapToPair(new MapFunction<>(context, null)).cache();
+    }
 
     Set<StageInfo> stagesOfTypeMLLib = phaseSpec.getPhase().getStagesOfType(SparkSink.PLUGIN_TYPE);
     Set<String> namesOfTypeMLLib = new HashSet<>();
@@ -120,57 +140,130 @@ public class ETLSparkProgram implements JavaSparkProgram {
     }
   }
 
+
   /**
-   * Performs all transforms, and returns tuples where the first item is the sink to write to, and the second item
-   * is the KeyValue to write.
+   * Base function that knows how to set up a transform executor and run it.
+   * Subclasses are responsible for massaging the output of the transform executor into the expected output,
+   * and for configuring the transform executor with the right part of the pipeline.
    */
-  public static final class MapFunction
-    implements PairFlatMapFunction<Tuple2<Object, Object>, String, Object> {
+  public abstract static class TransformExecutorFunction<KEY_IN, VAL_IN, KEY_OUT, VAL_OUT>
+    implements PairFlatMapFunction<Tuple2<KEY_IN, VAL_IN>, KEY_OUT, VAL_OUT> {
 
-    private final PluginContext pluginContext;
-    private final Metrics metrics;
-    private final long logicalStartTime;
-    private final String pipelineStr;
-    private final Map<String, String> runtimeArgs;
-    private transient TransformExecutor<KeyValue<Object, Object>> transformExecutor;
+    protected final PluginContext pluginContext;
+    protected final Metrics metrics;
+    protected final long logicalStartTime;
+    protected final Map<String, String> runtimeArgs;
+    protected final String pipelineStr;
+    private transient TransformExecutor<KeyValue<KEY_IN, VAL_IN>> transformExecutor;
 
-    public MapFunction(SparkContext sparkContext) {
+    public TransformExecutorFunction(SparkContext sparkContext) {
       this.pluginContext = sparkContext.getPluginContext();
       this.metrics = sparkContext.getMetrics();
       this.logicalStartTime = sparkContext.getLogicalStartTime();
-      this.pipelineStr = sparkContext.getSpecification().getProperty(Constants.PIPELINEID);
       this.runtimeArgs = sparkContext.getRuntimeArguments();
+      this.pipelineStr = sparkContext.getSpecification().getProperty(Constants.PIPELINEID);
     }
 
     @Override
-    public Iterable<Tuple2<String, Object>> call(Tuple2<Object, Object> tuple) throws Exception {
+    public Iterable<Tuple2<KEY_OUT, VAL_OUT>> call(Tuple2<KEY_IN, VAL_IN> tuple) throws Exception {
       if (transformExecutor == null) {
         // TODO: There is no way to call destroy() method on Transform
         // In fact, we can structure transform in a way that it doesn't need destroy
         // All current usage of destroy() in transform is actually for Source/Sink, which is actually
         // better do it in prepareRun and onRunFinish, which happen outside of the Job execution (true for both
         // Spark and MapReduce).
-        transformExecutor = initialize();
+        BatchPhaseSpec phaseSpec = GSON.fromJson(pipelineStr, BatchPhaseSpec.class);
+        PipelinePluginInstantiator pluginInstantiator = new PipelinePluginInstantiator(pluginContext, phaseSpec);
+        transformExecutor = initialize(phaseSpec, pluginInstantiator);
       }
       TransformResponse response = transformExecutor.runOneIteration(new KeyValue<>(tuple._1(), tuple._2()));
+      Iterable<Tuple2<KEY_OUT, VAL_OUT>> output = getOutput(response);
+      transformExecutor.resetEmitter();
+      return output;
+    }
 
+    protected abstract Iterable<Tuple2<KEY_OUT, VAL_OUT>> getOutput(TransformResponse transformResponse);
+
+    protected abstract TransformExecutor<KeyValue<KEY_IN, VAL_IN>> initialize(
+      BatchPhaseSpec phaseSpec, PipelinePluginInstantiator pluginInstantiator) throws Exception;
+  }
+
+  /**
+   * Performs all transforms before an aggregator plugin. Outputs tuples whose keys are the group key and values
+   * are the group values that result by calling the aggregator's groupBy method.
+   */
+  public static final class PreGroupFunction extends TransformExecutorFunction<Object, Object, Object, Object> {
+    private final String aggregatorName;
+
+    public PreGroupFunction(SparkContext sparkContext, @Nullable String aggregatorName) {
+      super(sparkContext);
+      this.aggregatorName = aggregatorName;
+    }
+
+    @Override
+    protected Iterable<Tuple2<Object, Object>> getOutput(TransformResponse transformResponse) {
+      List<Tuple2<Object, Object>> result = new ArrayList<>();
+      for (Map.Entry<String, Collection<Object>> transformedEntry : transformResponse.getSinksResults().entrySet()) {
+        for (Object output : transformedEntry.getValue()) {
+          result.add((Tuple2<Object, Object>) output);
+        }
+      }
+      return result;
+    }
+
+    @Override
+    protected TransformExecutor<KeyValue<Object, Object>> initialize(BatchPhaseSpec phaseSpec,
+                                                                     PipelinePluginInstantiator pluginInstantiator)
+      throws Exception {
+
+      TransformExecutorFactory<KeyValue<Object, Object>> transformExecutorFactory =
+        new SparkTransformExecutorFactory<>(pluginContext, pluginInstantiator, metrics,
+                                            logicalStartTime, runtimeArgs, true);
+      PipelinePhase pipelinePhase = phaseSpec.getPhase().subsetTo(ImmutableSet.of(aggregatorName));
+      return transformExecutorFactory.create(pipelinePhase);
+    }
+  }
+
+  /**
+   * Performs all transforms that happen after an aggregator, or if there is no aggregator at all.
+   * Outputs tuples whose first item is the name of the sink that is being written to, and second item is
+   * the key-value that should be written to that sink
+   */
+  public static final class MapFunction<T> extends TransformExecutorFunction<Object, T, String, Object> {
+    @Nullable
+    private final String aggregatorName;
+
+    public MapFunction(SparkContext sparkContext, @Nullable String aggregatorName) {
+      super(sparkContext);
+      this.aggregatorName = aggregatorName;
+    }
+
+    @Override
+    protected Iterable<Tuple2<String, Object>> getOutput(TransformResponse transformResponse) {
       List<Tuple2<String, Object>> result = new ArrayList<>();
-      for (Map.Entry<String, Collection<Object>> transformedEntry : response.getSinksResults().entrySet()) {
+      for (Map.Entry<String, Collection<Object>> transformedEntry : transformResponse.getSinksResults().entrySet()) {
         String sinkName = transformedEntry.getKey();
         for (Object outputRecord : transformedEntry.getValue()) {
           result.add(new Tuple2<>(sinkName, outputRecord));
         }
       }
-      transformExecutor.resetEmitter();
       return result;
     }
 
-    private TransformExecutor<KeyValue<Object, Object>> initialize() throws Exception {
-      BatchPhaseSpec phaseSpec = GSON.fromJson(pipelineStr, BatchPhaseSpec.class);
-      PipelinePluginInstantiator pluginInstantiator = new PipelinePluginInstantiator(pluginContext, phaseSpec);
-      TransformExecutorFactory<KeyValue<Object, Object>> transformExecutorFactory =
-        new SparkTransformExecutorFactory<>(pluginContext, pluginInstantiator, metrics, logicalStartTime, runtimeArgs);
-      return transformExecutorFactory.create(phaseSpec.getPhase());
+    @Override
+    protected TransformExecutor<KeyValue<Object, T>> initialize(BatchPhaseSpec phaseSpec,
+                                                                PipelinePluginInstantiator pluginInstantiator)
+      throws Exception {
+      TransformExecutorFactory<KeyValue<Object, T>> transformExecutorFactory =
+        new SparkTransformExecutorFactory<>(pluginContext, pluginInstantiator, metrics,
+                                            logicalStartTime, runtimeArgs, false);
+
+      PipelinePhase pipelinePhase = phaseSpec.getPhase();
+      if (aggregatorName != null) {
+        pipelinePhase = pipelinePhase.subsetFrom(ImmutableSet.of(aggregatorName));
+      }
+
+      return transformExecutorFactory.create(pipelinePhase);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkAggregatorContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkAggregatorContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,30 +18,20 @@ package co.cask.cdap.etl.batch.spark;
 
 import co.cask.cdap.api.spark.SparkContext;
 import co.cask.cdap.etl.api.LookupProvider;
-import co.cask.cdap.etl.api.batch.BatchContext;
-import co.cask.cdap.etl.batch.AbstractBatchContext;
+import co.cask.cdap.etl.batch.AbstractAggregatorContext;
 
 /**
- * Abstract implementation of {@link BatchContext} using {@link SparkContext}.
+ * Spark Aggregator Context.
  */
-public abstract class AbstractSparkBatchContext extends AbstractBatchContext implements BatchContext {
+public class SparkAggregatorContext extends AbstractAggregatorContext {
 
-  private final SparkContext sparkContext;
-
-  public AbstractSparkBatchContext(SparkContext sparkContext, LookupProvider lookupProvider, String stageId) {
-    super(sparkContext.getPluginContext(), sparkContext, sparkContext.getMetrics(), lookupProvider, stageId,
-          sparkContext.getLogicalStartTime(), sparkContext.getRuntimeArguments());
-    this.sparkContext = sparkContext;
-  }
-
-  @Override
-  public long getLogicalStartTime() {
-    return sparkContext.getLogicalStartTime();
+  public SparkAggregatorContext(SparkContext context, LookupProvider lookup, String stageName) {
+    super(context.getPluginContext(), context, context.getMetrics(),
+          lookup, stageName, context.getLogicalStartTime(), context.getRuntimeArguments());
   }
 
   @Override
   public <T> T getHadoopJob() {
     throw new UnsupportedOperationException("Hadoop Job is not available in Spark");
   }
-
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkTransformExecutorFactory.java
@@ -16,14 +16,21 @@
 
 package co.cask.cdap.etl.batch.spark;
 
+import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.etl.api.Aggregator;
 import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.api.Transformation;
+import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.batch.PipelinePluginInstantiator;
 import co.cask.cdap.etl.batch.TransformExecutorFactory;
+import co.cask.cdap.etl.common.DefaultEmitter;
+import co.cask.cdap.etl.common.DefaultStageMetrics;
+import scala.Tuple2;
 
 import java.util.Map;
 
@@ -43,15 +50,18 @@ public class SparkTransformExecutorFactory<T> extends TransformExecutorFactory<T
   private final PluginContext pluginContext;
   private final long logicalStartTime;
   private final Map<String, String> runtimeArgs;
+  private final boolean isPreGroup;
 
   public SparkTransformExecutorFactory(PluginContext pluginContext,
                                        PipelinePluginInstantiator pluginInstantiator,
                                        Metrics metrics, long logicalStartTime,
-                                       Map<String, String> runtimeArgs) {
+                                       Map<String, String> runtimeArgs,
+                                       boolean isPreGroup) {
     super(pluginInstantiator, metrics);
     this.pluginContext = pluginContext;
     this.logicalStartTime = logicalStartTime;
     this.runtimeArgs = runtimeArgs;
+    this.isPreGroup = isPreGroup;
   }
 
   @Override
@@ -59,12 +69,73 @@ public class SparkTransformExecutorFactory<T> extends TransformExecutorFactory<T
     return new SparkBatchRuntimeContext(pluginContext, metrics, logicalStartTime, runtimeArgs, stageName);
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   protected Transformation getTransformation(String pluginType, String stageName) throws Exception {
     if (SparkSink.PLUGIN_TYPE.equals(pluginType)) {
       // if this plugin type is not a transformation, substitute in an IDENTITY_TRANSFORMATION
       return IDENTITY_TRANSFORMATION;
+    } else if (BatchAggregator.PLUGIN_TYPE.equals(pluginType)) {
+      BatchAggregator<?, ?, ?> batchAggregator = pluginInstantiator.newPluginInstance(stageName);
+      BatchRuntimeContext runtimeContext = createRuntimeContext(stageName);
+      batchAggregator.initialize(runtimeContext);
+      if (isPreGroup) {
+        return new PreGroupAggregatorTransformation(batchAggregator, new DefaultStageMetrics(metrics, stageName));
+      } else {
+        return new PostGroupAggregatorTransformation(batchAggregator);
+      }
     }
     return super.getTransformation(pluginType, stageName);
   }
+
+  /**
+   * A Transformation that uses an aggregator's groupBy method to transform input records into
+   * zero or more tuples where the first item is the group key and second item is the input record.
+   *
+   * @param <GROUP_KEY> type of group key output by the aggregator
+   * @param <GROUP_VAL> type of group value used by the aggregator
+   */
+  private static class PreGroupAggregatorTransformation<GROUP_KEY, GROUP_VAL>
+    implements Transformation<GROUP_VAL, Tuple2<GROUP_KEY, GROUP_VAL>> {
+    private final Aggregator<GROUP_KEY, GROUP_VAL, ?> aggregator;
+    private final DefaultEmitter<GROUP_KEY> groupKeyEmitter;
+
+    public PreGroupAggregatorTransformation(Aggregator<GROUP_KEY, GROUP_VAL, ?> aggregator,
+                                            StageMetrics stageMetrics) {
+      this.aggregator = aggregator;
+      this.groupKeyEmitter = new DefaultEmitter<>(stageMetrics);
+    }
+
+    @Override
+    public void transform(GROUP_VAL input, Emitter<Tuple2<GROUP_KEY, GROUP_VAL>> emitter) throws Exception {
+      groupKeyEmitter.reset();
+      aggregator.groupBy(input, groupKeyEmitter);
+      for (GROUP_KEY groupKey : groupKeyEmitter.getEntries()) {
+        emitter.emit(new Tuple2<>(groupKey, input));
+      }
+    }
+  }
+
+  /**
+   * A Transformation that uses an aggregator's aggregate method. Takes as input a key-value representing a group,
+   * where the key is the group key, and the value is an iterable of group values. Transforms each group into
+   * zero or more output records.
+   *
+   * @param <GROUP_KEY> type of group key output by the aggregator
+   * @param <GROUP_VAL> type of group value used by the aggregator
+   */
+  private static class PostGroupAggregatorTransformation<GROUP_KEY, GROUP_VAL, OUT>
+    implements Transformation<KeyValue<GROUP_KEY, Iterable<GROUP_VAL>>, OUT> {
+    private final Aggregator<GROUP_KEY, GROUP_VAL, OUT> aggregator;
+
+    public PostGroupAggregatorTransformation(Aggregator<GROUP_KEY, GROUP_VAL, OUT> aggregator) {
+      this.aggregator = aggregator;
+    }
+
+    @Override
+    public void transform(KeyValue<GROUP_KEY, Iterable<GROUP_VAL>> input, Emitter<OUT> emitter) throws Exception {
+      aggregator.aggregate(input.getKey(), input.getValue().iterator(), emitter);
+    }
+  }
+
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractAggregatorContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractAggregatorContext.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.etl.api.LookupProvider;
+import co.cask.cdap.etl.api.batch.BatchAggregator;
+import co.cask.cdap.etl.api.batch.BatchAggregatorContext;
+
+import java.util.Map;
+
+/**
+ * Base Aggregator Context.
+ */
+public abstract class AbstractAggregatorContext extends AbstractBatchContext implements BatchAggregatorContext {
+  private Integer numPartitions;
+  private Class<?> groupKeyClass;
+  private Class<?> groupValueClass;
+
+  protected AbstractAggregatorContext(PluginContext pluginContext,
+                                      DatasetContext datasetContext,
+                                      Metrics metrics,
+                                      LookupProvider lookup,
+                                      String stageName,
+                                      long logicalStartTime,
+                                      Map<String, String> runtimeArgs) {
+    super(pluginContext, datasetContext, metrics, lookup, stageName, logicalStartTime, runtimeArgs);
+  }
+
+  @Override
+  public void setNumPartitions(int numPartitions) {
+    if (numPartitions < 1) {
+      throw new IllegalArgumentException(String.format(
+        "Invalid value for numPartitions %d. It must be a positive integer.", numPartitions));
+    }
+    this.numPartitions = numPartitions;
+  }
+
+  @Override
+  public void setGroupKeyClass(Class<?> groupKeyClass) {
+    this.groupKeyClass = groupKeyClass;
+  }
+
+  @Override
+  public void setGroupValueClass(Class<?> groupValueClass) {
+    this.groupValueClass = groupValueClass;
+  }
+
+  public Integer getNumPartitions() {
+    return numPartitions;
+  }
+
+  public Class<?> getGroupKeyClass() {
+    return groupKeyClass;
+  }
+
+  public Class<?> getGroupValueClass() {
+    return groupValueClass;
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractBatchContext.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.etl.api.LookupProvider;
+import co.cask.cdap.etl.api.batch.BatchContext;
+import co.cask.cdap.etl.common.AbstractTransformContext;
+import co.cask.cdap.etl.log.LogContext;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * MapReduce Aggregator Context.
+ */
+public abstract class AbstractBatchContext extends AbstractTransformContext implements BatchContext {
+  private final DatasetContext datasetContext;
+  private final long logicalStartTime;
+  private final Map<String, String> runtimeArgs;
+
+  protected AbstractBatchContext(PluginContext pluginContext,
+                                 DatasetContext datasetContext,
+                                 Metrics metrics,
+                                 LookupProvider lookup,
+                                 String stageName,
+                                 long logicalStartTime,
+                                 Map<String, String> runtimeArgs) {
+    super(pluginContext, metrics, lookup, stageName);
+    this.datasetContext = datasetContext;
+    this.logicalStartTime = logicalStartTime;
+    this.runtimeArgs = runtimeArgs;
+  }
+
+  protected <T extends PluginContext & DatasetContext> AbstractBatchContext(T context,
+                                                                            Metrics metrics,
+                                                                            LookupProvider lookup,
+                                                                            String stageName,
+                                                                            long logicalStartTime,
+                                                                            Map<String, String> runtimeArgs) {
+    super(context, metrics, lookup, stageName);
+    this.datasetContext = context;
+    this.logicalStartTime = logicalStartTime;
+    this.runtimeArgs = runtimeArgs;
+  }
+
+
+  @Override
+  public long getLogicalStartTime() {
+    return logicalStartTime;
+  }
+
+  @Override
+  public Map<String, String> getRuntimeArguments() {
+    return Collections.unmodifiableMap(runtimeArgs);
+  }
+
+  @Override
+  public void setRuntimeArgument(String key, String value, boolean overwrite) {
+    if (overwrite || !runtimeArgs.containsKey(key)) {
+      runtimeArgs.put(key, value);
+    }
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(final String name) throws DatasetInstantiationException {
+    return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
+      @Override
+      public T call() throws Exception {
+        return datasetContext.getDataset(name);
+      }
+    });
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(final String name,
+                                          final Map<String, String> arguments) throws DatasetInstantiationException {
+    return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
+      @Override
+      public T call() throws Exception {
+        return datasetContext.getDataset(name, arguments);
+      }
+    });
+  }
+
+  @Override
+  public void releaseDataset(final Dataset dataset) {
+    LogContext.runWithoutLoggingUnchecked(new Callable<Void>() {
+      @Override
+      public Void call() {
+        datasetContext.releaseDataset(dataset);
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public void discardDataset(final Dataset dataset) {
+    LogContext.runWithoutLoggingUnchecked(new Callable<Void>() {
+      @Override
+      public Void call() {
+        datasetContext.discardDataset(dataset);
+        return null;
+      }
+    });
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceAggregatorContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceAggregatorContext.java
@@ -19,48 +19,25 @@ package co.cask.cdap.etl.batch.mapreduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.etl.api.LookupProvider;
-import co.cask.cdap.etl.api.batch.BatchAggregatorContext;
+import co.cask.cdap.etl.batch.AbstractAggregatorContext;
 
 import java.util.Map;
 
 /**
  * MapReduce Aggregator Context.
  */
-public class MapReduceAggregatorContext extends MapReduceBatchContext implements BatchAggregatorContext {
-  private Integer numPartitions;
-  private Class<?> groupKeyClass;
-  private Class<?> groupValueClass;
+public class MapReduceAggregatorContext extends AbstractAggregatorContext {
+  private final MapReduceContext mrContext;
 
   public MapReduceAggregatorContext(MapReduceContext context, Metrics metrics, LookupProvider lookup,
                                     String stageName,
                                     Map<String, String> runtimeArgs) {
-    super(context, metrics, lookup, stageName, runtimeArgs);
+    super(context, context, metrics, lookup, stageName, context.getLogicalStartTime(), runtimeArgs);
+    this.mrContext = context;
   }
 
   @Override
-  public void setNumPartitions(int numPartitions) {
-    this.numPartitions = numPartitions;
-  }
-
-  @Override
-  public void setGroupKeyClass(Class<?> groupKeyClass) {
-    this.groupKeyClass = groupKeyClass;
-  }
-
-  @Override
-  public void setGroupValueClass(Class<?> groupValueClass) {
-    this.groupValueClass = groupValueClass;
-  }
-
-  public Integer getNumPartitions() {
-    return numPartitions;
-  }
-
-  public Class<?> getGroupKeyClass() {
-    return groupKeyClass;
-  }
-
-  public Class<?> getGroupValueClass() {
-    return groupValueClass;
+  public <T> T getHadoopJob() {
+    return mrContext.getHadoopJob();
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceBatchContext.java
@@ -16,45 +16,26 @@
 
 package co.cask.cdap.etl.batch.mapreduce;
 
-import co.cask.cdap.api.data.DatasetInstantiationException;
-import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.batch.BatchContext;
-import co.cask.cdap.etl.common.AbstractTransformContext;
+import co.cask.cdap.etl.batch.AbstractBatchContext;
 import co.cask.cdap.etl.log.LogContext;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
 /**
  * Abstract implementation of {@link BatchContext} using {@link MapReduceContext}.
  */
-public abstract class MapReduceBatchContext extends AbstractTransformContext implements BatchContext {
-
+public class MapReduceBatchContext extends AbstractBatchContext {
   protected final MapReduceContext mrContext;
-  protected final LookupProvider lookup;
-  private final Map<String, String> runtimeArguments;
 
   public MapReduceBatchContext(MapReduceContext context, Metrics metrics,
                                LookupProvider lookup, String stageName, Map<String, String> runtimeArguments) {
-    super(context, metrics, lookup, stageName);
+    super(context, metrics, lookup, stageName, context.getLogicalStartTime(), runtimeArguments);
     this.mrContext = context;
-    this.lookup = lookup;
-    this.runtimeArguments = new HashMap<>(runtimeArguments);
-  }
-
-  @Override
-  public long getLogicalStartTime() {
-    return LogContext.runWithoutLoggingUnchecked(new Callable<Long>() {
-      @Override
-      public Long call() throws Exception {
-        return mrContext.getLogicalStartTime();
-      }
-    });
   }
 
   @Override
@@ -65,60 +46,5 @@ public abstract class MapReduceBatchContext extends AbstractTransformContext imp
         return mrContext.getHadoopJob();
       }
     });
-  }
-
-  @Override
-  public <T extends Dataset> T getDataset(final String name) throws DatasetInstantiationException {
-    return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
-      @Override
-      public T call() throws Exception {
-        return mrContext.getDataset(name);
-      }
-    });
-  }
-
-  @Override
-  public <T extends Dataset> T getDataset(final String name, final Map<String, String> arguments)
-    throws DatasetInstantiationException {
-    return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
-      @Override
-      public T call() throws Exception {
-        return mrContext.getDataset(name, arguments);
-      }
-    });
-  }
-
-  @Override
-  public void releaseDataset(final Dataset dataset) {
-    LogContext.runWithoutLoggingUnchecked(new Callable<Void>() {
-      @Override
-      public Void call() {
-        mrContext.releaseDataset(dataset);
-        return null;
-      }
-    });
-  }
-
-  @Override
-  public void discardDataset(final Dataset dataset) {
-    LogContext.runWithoutLoggingUnchecked(new Callable<Void>() {
-      @Override
-      public Void call() {
-        mrContext.discardDataset(dataset);
-        return null;
-      }
-    });
-  }
-
-  @Override
-  public Map<String, String> getRuntimeArguments() {
-    return Collections.unmodifiableMap(runtimeArguments);
-  }
-
-  @Override
-  public void setRuntimeArgument(String key, String value, boolean overwrite) {
-    if (overwrite || !runtimeArguments.containsKey(key)) {
-      runtimeArguments.put(key, value);
-    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/DataPipelineApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-data-pipeline/src/main/java/co/cask/cdap/etl/datapipeline/DataPipelineApp.java
@@ -72,7 +72,7 @@ public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
                                                   ImmutableSet.<String>of());
     PipelinePlan plan = planner.plan(spec);
 
-    addWorkflow(new SmartWorkflow(spec, plan, getConfigurer()));
+    addWorkflow(new SmartWorkflow(spec, plan, getConfigurer(), config.getEngine()));
     scheduleWorkflow(Schedules.builder(SCHEDULE_NAME)
                        .setDescription("Data pipeline schedule")
                        .createTimeSchedule(config.getSchedule()),


### PR DESCRIPTION
Added an implementation for aggregators in spark. Implementation
is not ideal for a few reasons. The first is that we can't run
multiple spark programs at the same time in a workflow, so we
are forced to squash a parallel jobs into sequential jobs.
The second is that we should be able to compute the entire pipeline
in a single spark job rather than splitting it across multiple.

As part of this change, had to make StructuredRecord an Schema
implement the Serializable interface in order for them to be
usable in Spark.

Also made a small fix so that enums in application configs dont
have to be given as all caps.