### PR TITLE
Fix a bug in InMemoryTable implementation that it cannot read it’s own writes after flushing.

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -222,12 +222,14 @@ public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
     final long[] values = { 15L, 17L, 7L, 3L };
     final FileSet input = datasetCache.getDataset(inputDatasetName, inputArgs);
     long sum = 0L, count = 1;
+    long inputRecords = 0;
     for (Location inputLocation : input.getInputLocations()) {
       final PrintWriter writer = new PrintWriter(inputLocation.getOutputStream());
       for (long value : values) {
         value *= count;
         writer.println(value);
         sum += value;
+        inputRecords++;
       }
       writer.close();
       count++;
@@ -261,11 +263,13 @@ public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
     Assert.assertEquals(sum, Long.parseLong(fields[1]));
 
     if (counterTableName != null) {
+      final long totalInputRecords = inputRecords;
       Transactions.execute(datasetCache.newTransactionContext(), "countersVerify", new Runnable() {
         @Override
         public void run() {
           KeyValueTable counters = datasetCache.getDataset(counterTableName);
-          Assert.assertEquals(4L, counters.incrementAndGet(AppWithMapReduceUsingRuntimeDatasets.INPUT_RECORDS, 0L));
+          Assert.assertEquals(totalInputRecords,
+                              counters.incrementAndGet(AppWithMapReduceUsingRuntimeDatasets.INPUT_RECORDS, 0L));
           Assert.assertEquals(1L, counters.incrementAndGet(AppWithMapReduceUsingRuntimeDatasets.REDUCE_KEYS, 0L));
         }
       });

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
@@ -26,6 +26,7 @@ import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data.runtime.LocationStreamFileWriterFactory;
 import co.cask.cdap.data.stream.StreamFileWriterFactory;
@@ -43,6 +44,7 @@ import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.tephra.TransactionExecutorFactory;
@@ -109,7 +111,7 @@ public class MapReduceRunnerTestBase {
   };
 
   @BeforeClass
-  public static void beforeClass() {
+  public static void beforeClass() throws Exception {
     // Set the tx timeout to a ridiculously low value that will test that the long-running transactions
     // actually bypass that timeout.
     CConfiguration conf = CConfiguration.create();
@@ -132,6 +134,9 @@ public class MapReduceRunnerTestBase {
     metricStore = injector.getInstance(MetricStore.class);
     txService.startAndWait();
     streamHandler = injector.getInstance(StreamHandler.class);
+
+    // Always create the default namespace
+    injector.getInstance(NamespaceAdmin.class).create(NamespaceMeta.DEFAULT);
   }
 
   @AfterClass

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTable.java
@@ -127,7 +127,7 @@ public class InMemoryTable extends BufferingTable {
     byte[] stopRow = scan.getStopRow();
     NavigableMap<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>> rowRange =
       InMemoryTableService.getRowRange(getTableName(), startRow, stopRow,
-          tx == null ? null : tx.getReadPointer());
+          tx == null ? null : tx);
     NavigableMap<byte[], NavigableMap<byte[], byte[]>> visibleRowRange = getLatestNotExcludedRows(rowRange, tx);
     NavigableMap<byte[], NavigableMap<byte[], byte[]>> rows = unwrapDeletesForRows(visibleRowRange);
 
@@ -162,13 +162,13 @@ public class InMemoryTable extends BufferingTable {
     // no tx logic needed
     if (tx == null) {
       NavigableMap<byte[], NavigableMap<Long, byte[]>> rowMap =
-        InMemoryTableService.get(getTableName(), row, NO_TX_VERSION);
+        InMemoryTableService.get(getTableName(), row, tx);
 
       return unwrapDeletes(filterByColumns(getLatest(rowMap), columns));
     }
 
     NavigableMap<byte[], NavigableMap<Long, byte[]>> rowMap =
-      InMemoryTableService.get(getTableName(), row, tx.getReadPointer());
+      InMemoryTableService.get(getTableName(), row, tx);
 
     if (rowMap == null) {
       return EMPTY_ROW_MAP;

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableServiceTest.java
@@ -19,6 +19,8 @@ package co.cask.cdap.data2.dataset2.lib.table.inmemory;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.data2.dataset2.lib.table.PutValue;
 import co.cask.cdap.data2.dataset2.lib.table.Update;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.util.TxUtils;
 import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
@@ -59,7 +61,7 @@ public class InMemoryTableServiceTest {
 
     // verify changing returned data from get doesn't affect the stored data
     NavigableMap<byte[], NavigableMap<Long, byte[]>> rowFromGet =
-      InMemoryTableService.get("table", new byte[]{1}, 1L);
+      InMemoryTableService.get("table", new byte[]{1}, new Transaction(1L, 2L, new long[0], new long[0], 1L));
     Assert.assertEquals(1, rowFromGet.size());
     byte[] columnFromGet = rowFromGet.firstEntry().getKey();
     Assert.assertArrayEquals(new byte[] {2}, columnFromGet);
@@ -75,7 +77,7 @@ public class InMemoryTableServiceTest {
 
     // verify changing returned data doesn't affect the stored data
     NavigableMap<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>> fromGetRange = 
-      InMemoryTableService.getRowRange("table", null, null, 1L);
+      InMemoryTableService.getRowRange("table", null, null, new Transaction(1L, 2L, new long[0], new long[0], 1L));
     Assert.assertEquals(1, fromGetRange.size());
     byte[] keyFromGetRange = fromGetRange.firstEntry().getKey();
     Assert.assertArrayEquals(new byte[] {1}, keyFromGetRange);
@@ -98,7 +100,7 @@ public class InMemoryTableServiceTest {
 
   private void verify123() {
     NavigableMap<byte[], NavigableMap<Long, byte[]>> rowFromGet =
-      InMemoryTableService.get("table", new byte[]{1}, 1L);
+      InMemoryTableService.get("table", new byte[]{1}, new Transaction(1L, 2L, new long[0], new long[0], 1L));
     Assert.assertEquals(1, rowFromGet.size());
     Assert.assertArrayEquals(new byte[] {2}, rowFromGet.firstEntry().getKey());
     Assert.assertArrayEquals(new byte[] {3}, rowFromGet.firstEntry().getValue().get(1L));


### PR DESCRIPTION
- Use Transaction.isVisible instead of just the read point to filter versions