### PR TITLE
Fix to show node config for tranfrom-type plugins

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-factory.js
+++ b/cdap-ui/app/directives/widget-container/widget-factory.js
@@ -122,6 +122,13 @@ angular.module(PKG.name + '.commons')
           'is-dropdown': 'true'
         }
       },
+      'function-dropdown-with-alias': {
+        element: '<my-function-dropdown-with-alias></my-function-dropdown-with-alias>',
+        attributes: {
+          'ng-model': 'model',
+          'data-config': 'myconfig'
+        }
+      },
       'schedule': {
         element: '<my-schedule></my-schedule>',
         attributes: {

--- a/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.html
+++ b/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.html
@@ -1,0 +1,19 @@
+<div class="row" ng-repeat="fnalias in functionAliasList">
+  <div class="col-xs-7">
+    <input type="text" class="form-control" ng-model="fnalias.field"/>
+    <select ng-model="fnalias.functionName"
+            class="form-control"
+            ng-options="fn as fn for fn in dropdownOptions"></select>
+  </div>
+  <div class="col-xs-3">
+    <input class="form-control" type="text" ng-model="fnalias.alias"/>
+  </div>
+  <div class="col-xs-2">
+    <a class="btn btn-danger">
+      <span class="fa fa-fw fa-trash" ng-click="removeFunctionAlias($index)"></span>
+    </a>
+    <a class="btn btn-info btn-transparent" ng-click="addFunctionAlias()" ng-if="$last">
+      <span class="fa fa-fw fa-plus"></span>
+    </a>
+  </div>
+</div>

--- a/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.html
+++ b/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.html
@@ -1,3 +1,19 @@
+<!--
+  Copyright © 2016 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
 <div class="row" ng-repeat="fnalias in functionAliasList">
   <div class="col-xs-7">
     <input type="text" class="form-control" ng-model="fnalias.field"/>

--- a/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.js
+++ b/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ angular.module(PKG.name + '.commons')
+   .directive('myFunctionDropdownWithAlias', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        model: '=ngModel',
+        config: '=',
+      },
+      templateUrl: 'widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.html',
+      controller: function($scope, myHelpers) {
+        $scope.functionAliasList = [];
+        $scope.placeholders = myHelpers.objectQuery($scope.config, 'widget-attributes', 'placeholders');
+        $scope.dropdownOptions = myHelpers.objectQuery($scope.config, 'widget-attributes', 'dropdownOptions');
+        if (angular.isObject($scope.placeholders)) {
+          $scope.aliasPlaceholder = $scope.placeholders.alias || '';
+          $scope.fieldPlaceholder = $scope.placeholders.field || '';
+        }
+
+        $scope.addFunctionAlias = function() {
+          $scope.functionAliasList.push({
+            functionName: '',
+            field:'',
+            alias: ''
+          });
+        };
+        $scope.removeFunctionAlias = function(index) {
+          $scope.functionAliasList.splice(index, 1);
+          if (!$scope.functionAliasList.length) {
+            $scope.addFunctionAlias();
+          }
+        };
+        $scope.convertInternalToExternalModel = function() {
+          var externalModel = '';
+          $scope.functionAliasList.forEach( function(fnAlias) {
+            if ([fnAlias.functionName.length, fnAlias.field.length, fnAlias.alias.length].indexOf(0) !== -1) {
+              return;
+            }
+            if (externalModel.length) {
+              externalModel += ',';
+            }
+            externalModel += fnAlias.alias + ':' + fnAlias.functionName + '(' + fnAlias.field + ')';
+          });
+          return externalModel;
+        };
+        $scope.convertExternalToInternalModel = function() {
+          var functionsAliasList = $scope.model.split(',');
+          functionsAliasList.forEach( function (fnAlias) {
+            if (!fnAlias.length) {
+              return;
+            }
+            var aliasEndIndex = fnAlias.indexOf(':');
+            var fnEndIndex = fnAlias.indexOf('(');
+            var fieldEndIndex = fnAlias.indexOf(')');
+            if ([aliasEndIndex, fnEndIndex, fieldEndIndex].indexOf(-1) !== -1) {
+              return;
+            }
+            $scope.functionAliasList.push({
+              alias: fnAlias.substring(0, aliasEndIndex),
+              functionName: fnAlias.substring(aliasEndIndex+1, fnEndIndex),
+              field: fnAlias.substring(fnEndIndex+1, fieldEndIndex)
+            });
+          });
+        };
+
+        if ($scope.model && $scope.model.length) {
+          $scope.convertExternalToInternalModel();
+        } else {
+          $scope.addFunctionAlias();
+        }
+        $scope.$watch('functionAliasList', function() {
+          $scope.model = $scope.convertInternalToExternalModel();
+        }, true);
+      }
+    };
+  });

--- a/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.less
+++ b/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.less
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+my-function-dropdown-with-alias {
+  .row {
+    margin-bottom: 5px;
+    > div {
+      > input.form-control , select.form-control {
+        display: inline-block;
+        width: 46%;
+      }
+     > select.form-control {
+       margin-left: 5px;
+     }
+      > input.form-control {
+        &:only-child {
+           width: 100%;
+           display: inline-block;
+         }
+      }
+    }
+    [class*="col-xs-"] {
+      padding-left: 0;
+
+      &:first-child {
+        padding-right: 0;
+        padding-left: 15px;
+      }
+    }
+  }
+}

--- a/cdap-ui/app/features/hydrator/templates/list.html
+++ b/cdap-ui/app/features/hydrator/templates/list.html
@@ -78,7 +78,7 @@
               <a ui-sref="hydratorplusplus.detail({ pipelineId: pipeline.name })" ng-if="!pipeline.isDraft">
                 {{pipeline.name}}
               </a>
-              <a ui-sref="hydrator.create.studio({ draftId: pipeline.id, type:pipeline.artifact.name })" ng-if="pipeline.isDraft">
+              <a ui-sref="hydratorplusplus.create({ draftId: pipeline.id, type:pipeline.artifact.name })" ng-if="pipeline.isDraft">
                 {{pipeline.name}}
               </a>
             </td>

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/create-studio-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/create-studio-ctrl.js
@@ -37,7 +37,9 @@ class HydratorPlusPlusStudioCtrl {
     HydratorPlusPlusNodeConfigStore.init();
     let artifact = getValidArtifact();
     if (rConfig) {
-      rConfig.artifact = artifact;
+      if (!rConfig.artifact){
+        rConfig.artifact = artifact;
+      }
       HydratorPlusPlusConfigActions.initializeConfigStore(rConfig);
       let configJson = rConfig;
       if (!rConfig.__ui__) {

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-nodeconfig-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-nodeconfig-store.js
@@ -173,7 +173,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
       if (this.state.node.type === artifactTypeExtension.sink) {
         this.state.isSink = true;
       }
-      if (this.state.node.type === 'transform') {
+      if ([artifactTypeExtension.source, artifactTypeExtension.sink].indexOf(this.state.node.type) === -1) {
         this.state.isTransform = true;
       }
     }


### PR DESCRIPTION
Right now we have explicit layout for source,transform & sink plugins. We are adding batchaggregator as a type of plugin and we are treating it as a transform plugin. This fix allows a user to view/edit batchaggregator type plugin configuration as a transform plugin. 

TL;DR - View batchaggregator type plugins as a transform type plugin.