### PR TITLE
Revert changes to PurchaseApp, which brought in an 'oldPurchases' dat…

### DIFF
--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2014-2015 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -81,7 +81,7 @@ function download_includes() {
   download_readme_file_and_test ${includes_dir} ${ingest_url} 5fc88ec3a658062775403f5be30afbe9 cdap-stream-clients/ruby
 
   echo_red_bold "Check included example files for changes"
-  test_an_include 26e904a0a4524ab5dd97c4b3072d26fc ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+  test_an_include 0bcc5fe3914acbb793c993e72834bbde ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
   test_an_include 80216a08a2b3d480e4a081722408222f ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
   test_an_include 7f83b852a8e7b4594094d4e88d80a0b4 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java

--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
@@ -341,8 +341,6 @@ are set:
    :lines: 47-57
    :append: ...
 
-..   :lines: 44-54
-
 The Resources API, if called with two arguments, sets both the memory used in megabytes
 and the number of virtual cores used.
 

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2014-2015 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -154,9 +154,9 @@ function download_includes() {
 
   test_an_include a9a7fd53c199defff09e6e3c73e4e71f ../../cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
   
-  test_an_include ad0d0b46225a2e4e0564d8755fbb99b0 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
+  test_an_include 6e91764bbf75e2c4efd5547ab1a3e4e6 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
-  test_an_include 26e904a0a4524ab5dd97c4b3072d26fc ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+  test_an_include 0bcc5fe3914acbb793c993e72834bbde ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
   test_an_include 80216a08a2b3d480e4a081722408222f ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
 
   test_an_include 950241d0199883f3bcb23d6f7da0551f ../../cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java

--- a/cdap-docs/examples-manual/source/examples/purchase.rst
+++ b/cdap-docs/examples-manual/source/examples/purchase.rst
@@ -97,7 +97,7 @@ default values used in configuration and as runtime arguments:
 
 .. literalinclude:: /../../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
    :language: java
-   :lines: 47-78
+   :lines: 47-77
 
 ``PurchaseHistoryService`` Service
 ----------------------------------

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
@@ -91,8 +91,5 @@ public class PurchaseApp extends AbstractApplication {
       // because PurchaseHistory and Purchase are actual classes.
       throw new RuntimeException(e);
     }
-    // create an 'oldPurchases' KeyValueTable, which stores Purchase events, but in JSON format in one column, instead
-    // of in an ObjectMappedTable
-    createDataset("oldPurchases", KeyValueTable.class);
   }
 }

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
@@ -62,7 +62,6 @@ public class PurchaseHistoryBuilder extends AbstractMapReduce {
     job.setReducerClass(PerUserReducer.class);
 
     context.addInput(Input.ofDataset("purchases"), PurchaseMapper.class);
-    context.addInput(Input.ofDataset("oldPurchases"), OldPurchaseMapper.class);
     context.addOutput("history");
 
     // override default memory usage if the corresponding runtime arguments are set.
@@ -86,27 +85,6 @@ public class PurchaseHistoryBuilder extends AbstractMapReduce {
 
     @Override
     public void map(byte[] key, Purchase purchase, Context context) throws IOException, InterruptedException {
-      String user = purchase.getCustomer();
-      if (purchase.getPrice() > 100000) {
-        mapMetrics.count("purchases.large", 1);
-      }
-      context.write(new Text(user), purchase);
-    }
-  }
-
-  /**
-   * Mapper class to emit user and corresponding purchase information. The input value to this mapper is byte[],
-   * instead of a Purchase object, and so it first must deserialize the byte[] before acting on it.
-   */
-  public static class OldPurchaseMapper extends Mapper<byte[], byte[], Text, Purchase> {
-
-    private static final Gson GSON = new Gson();
-    private Metrics mapMetrics;
-
-    @Override
-    public void map(byte[] key, byte[] purchaseBytes, Context context)
-      throws IOException, InterruptedException {
-      Purchase purchase = GSON.fromJson(Bytes.toString(purchaseBytes), Purchase.class);
       String user = purchase.getCustomer();
       if (purchase.getPrice() > 100000) {
         mapMetrics.count("purchases.large", 1);

--- a/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
+++ b/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
@@ -16,11 +16,8 @@
 
 package co.cask.cdap.examples.purchase;
 
-import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.test.ApplicationManager;
-import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.ServiceManager;
@@ -28,7 +25,6 @@ import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import co.cask.cdap.test.TestConfiguration;
 import com.google.common.base.Charsets;
-import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
 import org.junit.Assert;
@@ -37,7 +33,6 @@ import org.junit.Test;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -73,21 +68,6 @@ public class PurchaseAppTest extends TestBase {
     } finally {
       flowManager.stop();
     }
-
-    // write a few purchase records into the 'oldPurchases' dataset, which stores it in a different format
-    DataSetManager<KeyValueTable> oldPurchasesManager = getDataset("oldPurchases");
-    KeyValueTable oldPurchases = oldPurchasesManager.get();
-    long now = System.currentTimeMillis();
-    List<Purchase> purchases = ImmutableList.of(new Purchase("bob", "pineapples", 1, 4, now),
-                                                new Purchase("bob", "drupes", 16, 30, now + 1),
-                                                new Purchase("joe", "bananas", 4, 5, now + 2),
-                                                new Purchase("joe", "oranges", 5, 3, now + 3),
-                                                new Purchase("joe", "pomegranates", 1, 10, now + 4));
-    for (Purchase purchase : purchases) {
-      oldPurchases.write(Bytes.toBytes(purchase.getPurchaseTime()), Bytes.toBytes(GSON.toJson(purchase)));
-    }
-    oldPurchasesManager.flush();
-
 
     ServiceManager userProfileServiceManager = getUserProfileServiceManager(appManager);
 
@@ -146,7 +126,7 @@ public class PurchaseAppTest extends TestBase {
     }
     PurchaseHistory history = GSON.fromJson(historyJson, PurchaseHistory.class);
     Assert.assertEquals("joe", history.getCustomer());
-    Assert.assertEquals(5, history.getPurchases().size());
+    Assert.assertEquals(2, history.getPurchases().size());
 
     UserProfile profileFromPurchaseHistory = history.getUserProfile();
     Assert.assertEquals(profileFromPurchaseHistory.getFirstName(), "joe");


### PR DESCRIPTION
Revert changes to PurchaseApp, which brought in an 'oldPurchases' dataset.

https://issues.cask.co/browse/CDAP-5383
http://builds.cask.co/browse/CDAP-DUT3806-1

Passed [Doc Quick Build 1](http://builds.cask.co/browse/CDAP-DOB158-1)
[Purchase Example](http://builds.cask.co/artifact/CDAP-DOB158/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/examples-manual/examples/purchase.html)