### PR TITLE
(CDAP-5382) Added authorization enforcement for artifacts

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -49,6 +49,9 @@ import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.artifact.InvalidArtifactRangeException;
 import co.cask.cdap.proto.artifact.PluginInfo;
 import co.cask.cdap.proto.artifact.PluginSummary;
+import co.cask.cdap.proto.id.Ids;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HttpResponder;
@@ -156,10 +159,10 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
 
     try {
       if (scope == null) {
-        Id.Namespace namespace = validateAndGetNamespace(namespaceId);
+        NamespaceId namespace = validateAndGetNamespace(namespaceId);
         responder.sendJson(HttpResponseStatus.OK, artifactRepository.getArtifacts(namespace, true));
       } else {
-        Id.Namespace namespace = validateAndGetScopedNamespace(Id.Namespace.from(namespaceId), scope);
+        NamespaceId namespace = validateAndGetScopedNamespace(Ids.namespace(namespaceId), scope);
         responder.sendJson(HttpResponseStatus.OK, artifactRepository.getArtifacts(namespace, false));
       }
     } catch (IOException e) {
@@ -176,7 +179,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                                   @QueryParam("scope") @DefaultValue("user") String scope)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetScopedNamespace(Id.Namespace.from(namespaceId), scope);
+    NamespaceId namespace = validateAndGetScopedNamespace(Ids.namespace(namespaceId), scope);
 
     try {
       responder.sendJson(HttpResponseStatus.OK, artifactRepository.getArtifacts(namespace, artifactName));
@@ -197,7 +200,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                               @QueryParam("scope") @DefaultValue("user") String scope)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetScopedNamespace(Id.Namespace.from(namespaceId), scope);
+    NamespaceId namespace = validateAndGetScopedNamespace(Ids.namespace(namespaceId), scope);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {
@@ -225,7 +228,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                             @QueryParam("keys") @Nullable String keys)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetScopedNamespace(Id.Namespace.from(namespaceId), scope);
+    NamespaceId namespace = validateAndGetScopedNamespace(Ids.namespace(namespaceId), scope);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {
@@ -256,11 +259,9 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   public void writeProperties(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId,
                               @PathParam("artifact-name") String artifactName,
-                              @PathParam("artifact-version") String artifactVersion)
-    throws NamespaceNotFoundException, BadRequestException {
-
-    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
-      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
+                              @PathParam("artifact-version") String artifactVersion) throws Exception {
+    NamespaceId namespace = NamespaceId.SYSTEM.getNamespace().equalsIgnoreCase(namespaceId) ?
+      NamespaceId.SYSTEM : validateAndGetNamespace(namespaceId);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     Map<String, String> properties;
@@ -290,11 +291,9 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                             @PathParam("namespace-id") String namespaceId,
                             @PathParam("artifact-name") String artifactName,
                             @PathParam("artifact-version") String artifactVersion,
-                            @PathParam("property") String key)
-    throws NamespaceNotFoundException, BadRequestException {
-
-    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
-      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
+                            @PathParam("property") String key) throws Exception {
+    NamespaceId namespace = NamespaceId.SYSTEM.getNamespace().equalsIgnoreCase(namespaceId) ?
+      NamespaceId.SYSTEM : validateAndGetNamespace(namespaceId);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     String value = request.getContent().toString(Charsets.UTF_8);
@@ -323,8 +322,8 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                           @PathParam("property") String key)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
-      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
+    NamespaceId namespace = NamespaceId.SYSTEM.getNamespace().equalsIgnoreCase(namespaceId) ?
+      NamespaceId.SYSTEM : validateAndGetNamespace(namespaceId);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {
@@ -343,11 +342,10 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   public void deleteProperties(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
                                @PathParam("artifact-name") String artifactName,
-                               @PathParam("artifact-version") String artifactVersion)
-    throws NamespaceNotFoundException, BadRequestException {
+                               @PathParam("artifact-version") String artifactVersion) throws Exception {
 
-    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
-      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
+    NamespaceId namespace = NamespaceId.SYSTEM.getNamespace().equalsIgnoreCase(namespaceId) ?
+      NamespaceId.SYSTEM : validateAndGetNamespace(namespaceId);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {
@@ -367,11 +365,10 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                              @PathParam("namespace-id") String namespaceId,
                              @PathParam("artifact-name") String artifactName,
                              @PathParam("artifact-version") String artifactVersion,
-                             @PathParam("property") String key)
-    throws NamespaceNotFoundException, BadRequestException {
+                             @PathParam("property") String key) throws Exception {
 
-    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
-      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
+    NamespaceId namespace = NamespaceId.SYSTEM.getNamespace().equalsIgnoreCase(namespaceId) ?
+      NamespaceId.SYSTEM : validateAndGetNamespace(namespaceId);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {
@@ -394,8 +391,8 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                                      @QueryParam("scope") @DefaultValue("user") String scope)
     throws NamespaceNotFoundException, BadRequestException, ArtifactNotFoundException {
 
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    Id.Namespace artifactNamespace = validateAndGetScopedNamespace(namespace, scope);
+    NamespaceId namespace = Ids.namespace(namespaceId);
+    NamespaceId artifactNamespace = validateAndGetScopedNamespace(namespace, scope);
     Id.Artifact artifactId = validateAndGetArtifactId(artifactNamespace, artifactName, artifactVersion);
 
     try {
@@ -424,8 +421,8 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                                  @QueryParam("scope") @DefaultValue("user") String scope)
     throws NamespaceNotFoundException, BadRequestException, ArtifactNotFoundException {
 
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    Id.Namespace artifactNamespace = validateAndGetScopedNamespace(namespace, scope);
+    NamespaceId namespace = Ids.namespace(namespaceId);
+    NamespaceId artifactNamespace = validateAndGetScopedNamespace(namespace, scope);
     Id.Artifact artifactId = validateAndGetArtifactId(artifactNamespace, artifactName, artifactVersion);
 
     try {
@@ -466,8 +463,8 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     throws NotFoundException, BadRequestException, IOException, ClassNotFoundException, IllegalAccessException {
 
     String requestBody = request.getContent().toString(Charsets.UTF_8);
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    Id.Namespace artifactNamespace = validateAndGetScopedNamespace(namespace, scope);
+    NamespaceId namespace = Ids.namespace(namespaceId);
+    NamespaceId artifactNamespace = validateAndGetScopedNamespace(namespace, scope);
     Id.Artifact artifactId = validateAndGetArtifactId(artifactNamespace, artifactName, artifactVersion);
 
     if (requestBody.isEmpty()) {
@@ -507,8 +504,8 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                                 @QueryParam("scope") @DefaultValue("user") String scope)
     throws NamespaceNotFoundException, BadRequestException, ArtifactNotFoundException {
 
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    Id.Namespace artifactNamespace = validateAndGetScopedNamespace(namespace, scope);
+    NamespaceId namespace = Ids.namespace(namespaceId);
+    NamespaceId artifactNamespace = validateAndGetScopedNamespace(namespace, scope);
     Id.Artifact artifactId = validateAndGetArtifactId(artifactNamespace, artifactName, artifactVersion);
 
     try {
@@ -545,11 +542,11 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
 
     try {
       if (scope == null) {
-        Id.Namespace namespace = validateAndGetNamespace(namespaceId);
+        NamespaceId namespace = validateAndGetNamespace(namespaceId);
         responder.sendJson(HttpResponseStatus.OK, artifactRepository.getApplicationClasses(namespace, true),
                            APPCLASS_SUMMARIES_TYPE, GSON);
       } else {
-        Id.Namespace namespace = validateAndGetScopedNamespace(Id.Namespace.from(namespaceId), scope);
+        NamespaceId namespace = validateAndGetScopedNamespace(Ids.namespace(namespaceId), scope);
         responder.sendJson(HttpResponseStatus.OK, artifactRepository.getApplicationClasses(namespace, false),
                            APPCLASS_SUMMARIES_TYPE, GSON);
       }
@@ -568,7 +565,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                                     @QueryParam("scope") @DefaultValue("user") String scope)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetScopedNamespace(Id.Namespace.from(namespaceId), scope);
+    NamespaceId namespace = validateAndGetScopedNamespace(Ids.namespace(namespaceId), scope);
 
     try {
       responder.sendJson(HttpResponseStatus.OK, artifactRepository.getApplicationClasses(namespace, className),
@@ -583,14 +580,14 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   @POST
   @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}")
   public BodyConsumer addArtifact(HttpRequest request, HttpResponder responder,
-                                  @PathParam("namespace-id") String namespaceId,
+                                  @PathParam("namespace-id") final String namespaceId,
                                   @PathParam("artifact-name") final String artifactName,
                                   @HeaderParam(VERSION_HEADER) final String artifactVersion,
                                   @HeaderParam(EXTENDS_HEADER) final String parentArtifactsStr,
                                   @HeaderParam(PLUGINS_HEADER) String pluginClasses)
     throws NamespaceNotFoundException, BadRequestException {
 
-    final Id.Namespace namespace = validateAndGetNamespace(namespaceId);
+    final NamespaceId namespace = validateAndGetNamespace(namespaceId);
 
     // if version is explicitly given, validate the id now. otherwise version will be derived from the manifest
     // and validated there
@@ -637,11 +634,17 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
             responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                  "Conflict while writing artifact, please try again.");
           } catch (IOException e) {
-            LOG.error("Exception while trying to write artifact {}-{}.", artifactName, artifactVersion, e);
+            LOG.error("Exception while trying to write artifact {}-{}-{}.",
+                      namespaceId, artifactName, artifactVersion, e);
             responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                  "Error performing IO while writing artifact.");
           } catch (BadRequestException e) {
             responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
+          } catch (UnauthorizedException e) {
+            responder.sendString(HttpResponseStatus.FORBIDDEN, e.getMessage());
+          } catch (Exception e) {
+            LOG.error("Error while writing artifact {}-{}-{}", namespaceId, artifactName, artifactVersion, e);
+            responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error while adding artifact.");
           }
         }
 
@@ -679,11 +682,9 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   public void deleteArtifact(HttpRequest request, HttpResponder responder,
                              @PathParam("namespace-id") String namespaceId,
                              @PathParam("artifact-name") String artifactName,
-                             @PathParam("artifact-version") String artifactVersion)
-    throws NamespaceNotFoundException, BadRequestException {
-
-    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
-      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
+                             @PathParam("artifact-version") String artifactVersion) throws Exception {
+    NamespaceId namespace = NamespaceId.SYSTEM.getNamespace().equalsIgnoreCase(namespaceId) ?
+      NamespaceId.SYSTEM : validateAndGetNamespace(namespaceId);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {
@@ -704,11 +705,11 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     }
   }
 
-  private Id.Namespace validateAndGetNamespace(String namespaceId) throws NamespaceNotFoundException {
-    return validateAndGetScopedNamespace(Id.Namespace.from(namespaceId), ArtifactScope.USER);
+  private NamespaceId validateAndGetNamespace(String namespaceId) throws NamespaceNotFoundException {
+    return validateAndGetScopedNamespace(Ids.namespace(namespaceId), ArtifactScope.USER);
   }
 
-  private Id.Namespace validateAndGetScopedNamespace(Id.Namespace namespace, String scope)
+  private NamespaceId validateAndGetScopedNamespace(NamespaceId namespace, String scope)
     throws NamespaceNotFoundException, BadRequestException {
     if (scope != null) {
       return validateAndGetScopedNamespace(namespace, validateScope(scope));
@@ -718,11 +719,11 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
 
   // check that the namespace exists, and check if the request is only supposed to include system artifacts,
   // and returning the system namespace if so.
-  private Id.Namespace validateAndGetScopedNamespace(Id.Namespace namespace, ArtifactScope scope)
+  private NamespaceId validateAndGetScopedNamespace(NamespaceId namespace, ArtifactScope scope)
     throws NamespaceNotFoundException {
 
     try {
-      namespaceAdmin.get(namespace);
+      namespaceAdmin.get(namespace.toId());
     } catch (NamespaceNotFoundException e) {
       throw e;
     } catch (Exception e) {
@@ -732,13 +733,13 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
       throw Throwables.propagate(e);
     }
 
-    return ArtifactScope.SYSTEM.equals(scope) ? Id.Namespace.SYSTEM : namespace;
+    return ArtifactScope.SYSTEM.equals(scope) ? NamespaceId.SYSTEM : namespace;
   }
 
-  private Id.Artifact validateAndGetArtifactId(Id.Namespace namespace, String name,
+  private Id.Artifact validateAndGetArtifactId(NamespaceId namespace, String name,
                                                String version) throws BadRequestException {
     try {
-      return Id.Artifact.from(namespace, name, version);
+      return Id.Artifact.from(namespace.toId(), name, version);
     } catch (Exception e) {
       throw new BadRequestException(e.getMessage());
     }
@@ -747,7 +748,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   // find out if this artifact extends other artifacts. If so, there will be a header like
   // 'Artifact-Extends: <name>[<lowerversion>,<upperversion>]/<name>[<lowerversion>,<upperversion>]:
   // for example: 'Artifact-Extends: etl-batch[1.0.0,2.0.0]/etl-realtime[1.0.0:3.0.0]
-  private Set<ArtifactRange> parseExtendsHeader(Id.Namespace namespace, String extendsHeader)
+  private Set<ArtifactRange> parseExtendsHeader(NamespaceId namespace, String extendsHeader)
     throws BadRequestException {
 
     Set<ArtifactRange> parentArtifacts = Sets.newHashSet();
@@ -761,14 +762,14 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
           range = ArtifactRange.parse(parent);
           // only support extending an artifact that is in the same namespace, or system namespace
           if (!range.getNamespace().equals(Id.Namespace.SYSTEM) &&
-            !range.getNamespace().equals(namespace)) {
+            !range.getNamespace().equals(namespace.toId())) {
             throw new BadRequestException(
               String.format("Parent artifact %s must be in the same namespace or a system artifact.", parent));
           }
         } catch (InvalidArtifactRangeException e) {
           // if this failed, try parsing as a non-namespaced range like etl-batch[1.0.0,2.0.0)
           try {
-            range = ArtifactRange.parse(namespace, parent);
+            range = ArtifactRange.parse(namespace.toId(), parent);
           } catch (InvalidArtifactRangeException e1) {
             throw new BadRequestException(String.format("Invalid artifact range %s: %s", parent, e1.getMessage()));
           }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/FindPluginHelper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/FindPluginHelper.java
@@ -65,8 +65,7 @@ public final class FindPluginHelper {
     Preconditions.checkArgument(properties != null, "Plugin properties cannot be null");
     Map.Entry<ArtifactDescriptor, PluginClass> pluginEntry;
     try {
-      pluginEntry = artifactRepository.findPlugin(namespace.toId(),
-                                                  parentArtifactId, pluginType, pluginName, selector);
+      pluginEntry = artifactRepository.findPlugin(namespace, parentArtifactId, pluginType, pluginName, selector);
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }
@@ -74,8 +73,7 @@ public final class FindPluginHelper {
     // Just verify if all required properties are provided.
     // No type checking is done for now.
     for (PluginPropertyField field : pluginEntry.getValue().getProperties().values()) {
-      Preconditions.checkArgument(!field.isRequired() ||
-                                    (properties != null && properties.getProperties().containsKey(field.getName())),
+      Preconditions.checkArgument(!field.isRequired() || (properties.getProperties().containsKey(field.getName())),
                                   "Required property '%s' missing for plugin of type %s, name %s.",
                                   field.getName(), pluginType, pluginName);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginService.java
@@ -29,6 +29,7 @@ import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.artifact.CloseableClassLoader;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.io.Closeables;
 
 import java.io.Closeable;
@@ -72,7 +73,7 @@ public class PluginService implements Closeable {
    * @throws NotFoundException
    * @throws ClassNotFoundException
    */
-  public PluginEndpoint getPluginEndpoint(Id.Namespace namespace,
+  public PluginEndpoint getPluginEndpoint(NamespaceId namespace,
                                           Id.Artifact artifactId, String pluginType,
                                           String pluginName, String methodName)
     throws IOException, NotFoundException, ClassNotFoundException {
@@ -104,12 +105,12 @@ public class PluginService implements Closeable {
     return artifactDetails.get(0).getDescriptor();
   }
 
-  private PluginEndpoint getPluginEndpoint(Id.Namespace namespace, ArtifactDetail artifactDetail, String pluginType,
+  private PluginEndpoint getPluginEndpoint(NamespaceId namespace, ArtifactDetail artifactDetail, String pluginType,
                                            String pluginName, ArtifactDescriptor parentArtifactDescriptor,
                                            String methodName)
     throws NotFoundException, IOException, ClassNotFoundException {
 
-    Id.Artifact artifactId = Id.Artifact.from(namespace, artifactDetail.getDescriptor().getArtifactId());
+    Id.Artifact artifactId = Id.Artifact.from(namespace.toId(), artifactDetail.getDescriptor().getArtifactId());
     Set<PluginClass> pluginClasses = artifactDetail.getMeta().getClasses().getPlugins();
     PluginClass pluginClass = null;
 
@@ -140,8 +141,8 @@ public class PluginService implements Closeable {
     // we pass the parent artifact to endpoint plugin context,
     // as plugin method will use this context to load other plugins.
     DefaultEndpointPluginContext defaultEndpointPluginContext =
-      new DefaultEndpointPluginContext(namespace.toEntityId(), artifactRepository, pluginInstantiator,
-                                       Id.Artifact.from(namespace, parentArtifactDescriptor.getArtifactId()));
+      new DefaultEndpointPluginContext(namespace, artifactRepository, pluginInstantiator,
+                                       Id.Artifact.from(namespace.toId(), parentArtifactDescriptor.getArtifactId()));
 
     return getPluginEndpoint(pluginInstantiator, artifactId,
                              pluginClass, methodName, defaultEndpointPluginContext);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -398,7 +398,9 @@ public class AppFabricClient {
                                                                appId.getNamespaceId(), appId.getId());
     Preconditions.checkNotNull(bodyConsumer, "BodyConsumer from deploy call should not be null");
 
-    bodyConsumer.chunk(ChannelBuffers.wrappedBuffer(Bytes.toBytes(GSON.toJson(appRequest))), mockResponder);
+    byte[] contents = Bytes.toBytes(GSON.toJson(appRequest));
+    Preconditions.checkNotNull(contents);
+    bodyConsumer.chunk(ChannelBuffers.wrappedBuffer(contents), mockResponder);
     bodyConsumer.finished(mockResponder);
     verifyResponse(HttpResponseStatus.OK, mockResponder.getStatus(), "Failed to deploy app");
   }
@@ -409,7 +411,9 @@ public class AppFabricClient {
         String.format("/v3/namespaces/%s/apps/%s/update", appId.getNamespace(), appId.getApplication())
     );
     request.setHeader(Constants.Gateway.API_KEY, "api-key-example");
-    request.setContent(ChannelBuffers.wrappedBuffer(Bytes.toBytes(GSON.toJson(appRequest))));
+    byte[] contents = Bytes.toBytes(GSON.toJson(appRequest));
+    Preconditions.checkNotNull(contents);
+    request.setContent(ChannelBuffers.wrappedBuffer(contents));
     MockResponder mockResponder = new MockResponder();
     appLifecycleHttpHandler.updateApp(request, mockResponder, appId.getNamespace(), appId.getApplication());
     verifyResponse(HttpResponseStatus.OK, mockResponder.getStatus(), "Updating app failed");

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -48,6 +48,8 @@ import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.internal.test.PluginJarHelper;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.Ids;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import com.google.common.base.Charsets;
@@ -115,7 +117,7 @@ public class ArtifactRepositoryTest {
 
   @Before
   public void setupData() throws Exception {
-    artifactRepository.clear(Id.Namespace.DEFAULT);
+    artifactRepository.clear(NamespaceId.DEFAULT);
     File appArtifactFile = createAppJar(PluginTestApp.class, new File(tmpDir, "PluginTest-1.0.0.jar"),
       createManifest(ManifestFields.EXPORT_PACKAGE, PluginTestRunnable.class.getPackage().getName()));
     artifactRepository.addArtifact(APP_ARTIFACT_ID, appArtifactFile, null);
@@ -206,15 +208,15 @@ public class ArtifactRepositoryTest {
     }
 
     artifactRepository.addSystemArtifacts();
-    systemAppJar.delete();
-    pluginJar1.delete();
-    pluginJar2.delete();
+    Assert.assertTrue(systemAppJar.delete());
+    Assert.assertTrue(pluginJar1.delete());
+    Assert.assertTrue(pluginJar2.delete());
 
     try {
       // check app artifact added correctly
       ArtifactDetail appArtifactDetail = artifactRepository.getArtifact(systemAppArtifactId);
       Map<ArtifactDescriptor, List<PluginClass>> plugins =
-        artifactRepository.getPlugins(Id.Namespace.DEFAULT, systemAppArtifactId);
+        artifactRepository.getPlugins(NamespaceId.DEFAULT, systemAppArtifactId);
       Assert.assertEquals(2, plugins.size());
       List<PluginClass> pluginClasses = plugins.values().iterator().next();
 
@@ -247,7 +249,7 @@ public class ArtifactRepositoryTest {
       // check properties are there
       Assert.assertEquals(pluginConfig2.getProperties(), pluginArtifactDetail.getMeta().getProperties());
     } finally {
-      artifactRepository.clear(Id.Namespace.SYSTEM);
+      artifactRepository.clear(NamespaceId.SYSTEM);
     }
   }
 
@@ -277,7 +279,7 @@ public class ArtifactRepositoryTest {
 
     // check the parent can see the plugins
     SortedMap<ArtifactDescriptor, List<PluginClass>> plugins =
-      artifactRepository.getPlugins(Id.Namespace.DEFAULT, APP_ARTIFACT_ID);
+      artifactRepository.getPlugins(NamespaceId.DEFAULT, APP_ARTIFACT_ID);
     Assert.assertEquals(1, plugins.size());
     Assert.assertEquals(2, plugins.get(plugins.firstKey()).size());
 
@@ -302,7 +304,7 @@ public class ArtifactRepositoryTest {
   public void testPluginSelector() throws Exception {
     // No plugin yet
     try {
-      artifactRepository.findPlugin(Id.Namespace.DEFAULT, APP_ARTIFACT_ID,
+      artifactRepository.findPlugin(NamespaceId.DEFAULT, APP_ARTIFACT_ID,
                                     "plugin", "TestPlugin2", new PluginSelector());
       Assert.fail();
     } catch (PluginNotExistsException e) {
@@ -324,7 +326,7 @@ public class ArtifactRepositoryTest {
 
     // Should get the only version.
     Map.Entry<ArtifactDescriptor, PluginClass> plugin =
-      artifactRepository.findPlugin(Id.Namespace.DEFAULT, APP_ARTIFACT_ID,
+      artifactRepository.findPlugin(NamespaceId.DEFAULT, APP_ARTIFACT_ID,
                                     "plugin", "TestPlugin2", new PluginSelector());
     Assert.assertNotNull(plugin);
     Assert.assertEquals(new ArtifactVersion("1.0"), plugin.getKey().getArtifactId().getVersion());
@@ -338,7 +340,7 @@ public class ArtifactRepositoryTest {
     artifactRepository.addArtifact(artifact2Id, jarFile, parents);
 
     // Should select the latest version
-    plugin = artifactRepository.findPlugin(Id.Namespace.DEFAULT, APP_ARTIFACT_ID,
+    plugin = artifactRepository.findPlugin(NamespaceId.DEFAULT, APP_ARTIFACT_ID,
                                            "plugin", "TestPlugin2", new PluginSelector());
     Assert.assertNotNull(plugin);
     Assert.assertEquals(new ArtifactVersion("2.0"), plugin.getKey().getArtifactId().getVersion());
@@ -352,7 +354,7 @@ public class ArtifactRepositoryTest {
       Class<?> pluginClass = pluginClassLoader.loadClass(TestPlugin2.class.getName());
 
       // Use a custom plugin selector to select with smallest version
-      plugin = artifactRepository.findPlugin(Id.Namespace.DEFAULT, APP_ARTIFACT_ID,
+      plugin = artifactRepository.findPlugin(NamespaceId.DEFAULT, APP_ARTIFACT_ID,
                                              "plugin", "TestPlugin2", new PluginSelector() {
         @Override
         public Map.Entry<ArtifactId, PluginClass> select(SortedMap<ArtifactId, PluginClass> plugins) {
@@ -451,16 +453,16 @@ public class ArtifactRepositoryTest {
     File jar = createAppJar(PluginTestApp.class, new File(systemArtifactsDir1, "PluginTest-1.0.0.jar"),
                  createManifest(ManifestFields.EXPORT_PACKAGE, PluginTestRunnable.class.getPackage().getName()));
     artifactRepository.addSystemArtifacts();
-    jar.delete();
+    Assert.assertTrue(jar.delete());
 
     Set<ArtifactRange> parents = ImmutableSet.of(
       new ArtifactRange(systemAppArtifactId.getNamespace(), systemAppArtifactId.getName(),
                         new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0")));
-    Id.Namespace namespace1 = Id.Namespace.from("ns1");
-    Id.Namespace namespace2 = Id.Namespace.from("ns2");
+    NamespaceId namespace1 = Ids.namespace("ns1");
+    NamespaceId namespace2 = Ids.namespace("ns2");
 
-    Id.Artifact pluginArtifactId1 = Id.Artifact.from(namespace1, "myPlugin", "1.0");
-    Id.Artifact pluginArtifactId2 = Id.Artifact.from(namespace2, "myPlugin", "1.0");
+    Id.Artifact pluginArtifactId1 = Id.Artifact.from(namespace1.toId(), "myPlugin", "1.0");
+    Id.Artifact pluginArtifactId2 = Id.Artifact.from(namespace2.toId(), "myPlugin", "1.0");
 
     try {
       // create plugin artifact in namespace1 that extends the system artifact
@@ -482,7 +484,7 @@ public class ArtifactRepositoryTest {
       Assert.assertEquals(1, extensions.keySet().size());
       Assert.assertEquals(2, extensions.values().iterator().next().size());
     } finally {
-      artifactRepository.clear(Id.Namespace.SYSTEM);
+      artifactRepository.clear(NamespaceId.SYSTEM);
       artifactRepository.clear(namespace1);
       artifactRepository.clear(namespace2);
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
@@ -32,6 +32,8 @@ import co.cask.cdap.internal.app.runtime.plugin.PluginNotExistsException;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.Ids;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
@@ -76,18 +78,18 @@ public class ArtifactStoreTest {
 
   @After
   public void cleanup() throws IOException {
-    artifactStore.clear(Id.Namespace.DEFAULT);
+    artifactStore.clear(NamespaceId.DEFAULT);
   }
 
   @Test
   public void testGetNonexistantArtifact() throws IOException {
-    Id.Namespace namespace = Id.Namespace.from("ns1");
+    NamespaceId namespace = Ids.namespace("ns1");
 
     // no artifacts in a namespace should return an empty collection
     Assert.assertTrue(artifactStore.getArtifacts(namespace).isEmpty());
     // no artifacts in range should return an empty collection
     ArtifactRange range = new ArtifactRange(
-      namespace, "something", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0"));
+      namespace.toId(), "something", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0"));
     Assert.assertTrue(artifactStore.getArtifacts(range).isEmpty());
 
     // no artifact by namespace and artifact name should throw an exception
@@ -100,7 +102,7 @@ public class ArtifactStoreTest {
 
     // no artifact by namespace, artifact name, and version should throw an exception
     try {
-      artifactStore.getArtifact(Id.Artifact.from(namespace, "something", "1.0.0"));
+      artifactStore.getArtifact(Id.Artifact.from(namespace.toId(), "something", "1.0.0"));
       Assert.fail();
     } catch (ArtifactNotFoundException e) {
       // expected
@@ -113,21 +115,21 @@ public class ArtifactStoreTest {
 
     // if parent doesn't exist, we expect it to throw ArtifactNotFound
     try {
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifact);
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifact);
       Assert.fail();
     } catch (ArtifactNotFoundException e) {
       // expected
     }
 
     try {
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifact, "sometype");
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifact, "sometype");
       Assert.fail();
     } catch (ArtifactNotFoundException e) {
       // expected
     }
 
     try {
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifact, "sometype", "somename");
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifact, "sometype", "somename");
       Assert.fail();
     } catch (ArtifactNotFoundException e) {
       // expected
@@ -138,14 +140,14 @@ public class ArtifactStoreTest {
     writeArtifact(parentArtifact, meta, "jar contents");
 
     // no plugins in a namespace should return an empty collection
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifact).isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifact).isEmpty());
 
     // no plugins in namespace of a given type should return an empty map
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifact, "sometype").isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifact, "sometype").isEmpty());
 
     // no plugins in namespace of a given type and name should throw an exception about no plugins
     try {
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifact, "sometype", "somename");
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifact, "sometype", "somename");
       Assert.fail();
     } catch (PluginNotExistsException e) {
       // expected
@@ -175,7 +177,7 @@ public class ArtifactStoreTest {
 
     // test that plugins in the artifact show up when getting plugins for that artifact
     Map<ArtifactDescriptor, List<PluginClass>> pluginsMap =
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, artifactId);
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, artifactId);
     Assert.assertEquals(1, pluginsMap.size());
     Assert.assertTrue(pluginsMap.containsKey(artifactDetail.getDescriptor()));
     Set<PluginClass> expected = ImmutableSet.copyOf(plugins);
@@ -183,7 +185,7 @@ public class ArtifactStoreTest {
     Assert.assertEquals(expected, actual);
 
     // test plugins for the specific type
-    pluginsMap = artifactStore.getPluginClasses(Id.Namespace.DEFAULT, artifactId, "atype");
+    pluginsMap = artifactStore.getPluginClasses(NamespaceId.DEFAULT, artifactId, "atype");
     Assert.assertEquals(1, pluginsMap.size());
     Assert.assertTrue(pluginsMap.containsKey(artifactDetail.getDescriptor()));
     expected = ImmutableSet.copyOf(plugins);
@@ -192,7 +194,7 @@ public class ArtifactStoreTest {
 
     // test plugins for specific type and name
     Map<ArtifactDescriptor, PluginClass> pluginClasses =
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, artifactId, "atype", "plugin2");
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, artifactId, "atype", "plugin2");
     Assert.assertEquals(1, pluginClasses.size());
     Assert.assertTrue(pluginClasses.containsKey(artifactDetail.getDescriptor()));
     Assert.assertEquals(plugin2, pluginClasses.get(artifactDetail.getDescriptor()));
@@ -221,7 +223,7 @@ public class ArtifactStoreTest {
     writeArtifact(childId, artifactMeta, "child contents");
 
     // check parent has plugins from the child
-    Assert.assertFalse(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).isEmpty());
+    Assert.assertFalse(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).isEmpty());
 
     // delete the child artifact
     artifactStore.delete(childId);
@@ -235,18 +237,18 @@ public class ArtifactStoreTest {
     }
 
     // shouldn't see it in the list
-    List<ArtifactDetail> artifactList = artifactStore.getArtifacts(parentId.getNamespace());
+    List<ArtifactDetail> artifactList = artifactStore.getArtifacts(parentId.getNamespace().toEntityId());
     Assert.assertEquals(1, artifactList.size());
     Assert.assertEquals(parentId.getName(), artifactList.get(0).getDescriptor().getArtifactId().getName());
     // shouldn't see any more plugins for parent
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).isEmpty());
 
     // delete parent
     artifactStore.delete(parentId);
     // nothing should be in the list
-    Assert.assertTrue(artifactStore.getArtifacts(parentId.getNamespace()).isEmpty());
+    Assert.assertTrue(artifactStore.getArtifacts(parentId.getNamespace().toEntityId()).isEmpty());
     // shouldn't be able to see app class either
-    Assert.assertTrue(artifactStore.getApplicationClasses(Id.Namespace.DEFAULT, appClass.getClassName()).isEmpty());
+    Assert.assertTrue(artifactStore.getApplicationClasses(NamespaceId.DEFAULT, appClass.getClassName()).isEmpty());
   }
 
   @Test(expected = ArtifactAlreadyExistsException.class)
@@ -295,9 +297,9 @@ public class ArtifactStoreTest {
 
     // check that plugin1 was deleted and plugin2 remains
     Assert.assertEquals(ImmutableMap.of(detail.getDescriptor(), plugin2),
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifactId, plugin2.getType(), plugin2.getName()));
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifactId, plugin2.getType(), plugin2.getName()));
     try {
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifactId, plugin1.getType(), plugin1.getName());
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifactId, plugin1.getType(), plugin1.getName());
       Assert.fail();
     } catch (PluginNotExistsException e) {
       // expected
@@ -329,15 +331,15 @@ public class ArtifactStoreTest {
       assertEqual(artifact1, meta1, contents1, info1);
       assertEqual(artifact2, meta2, contents2, info2);
 
-      List<ArtifactDetail> namespace1Artifacts = artifactStore.getArtifacts(namespace1);
-      List<ArtifactDetail> namespace2Artifacts = artifactStore.getArtifacts(namespace2);
+      List<ArtifactDetail> namespace1Artifacts = artifactStore.getArtifacts(namespace1.toEntityId());
+      List<ArtifactDetail> namespace2Artifacts = artifactStore.getArtifacts(namespace2.toEntityId());
       Assert.assertEquals(1, namespace1Artifacts.size());
       assertEqual(artifact1, meta1, contents1, namespace1Artifacts.get(0));
       Assert.assertEquals(1, namespace2Artifacts.size());
       assertEqual(artifact2, meta2, contents2, namespace2Artifacts.get(0));
     } finally {
-      artifactStore.clear(namespace1);
-      artifactStore.clear(namespace2);
+      artifactStore.clear(namespace1.toEntityId());
+      artifactStore.clear(namespace2.toEntityId());
     }
   }
 
@@ -355,15 +357,15 @@ public class ArtifactStoreTest {
     PluginClass plugin =
       new PluginClass("atype", "plugin1", "", "c.c.c.plugin1", "cfg", ImmutableMap.<String, PluginPropertyField>of());
     // write a plugins artifact in namespace1
-    Id.Namespace namespace1 = Id.Namespace.from("ns1");
-    Id.Artifact artifact1 = Id.Artifact.from(namespace1, "plugins1", "1.0.0");
+    NamespaceId namespace1 = Ids.namespace("ns1");
+    Id.Artifact artifact1 = Id.Artifact.from(namespace1.toId(), "plugins1", "1.0.0");
     ArtifactMeta meta1 = new ArtifactMeta(ArtifactClasses.builder().addPlugin(plugin).build(), usableBy);
     String contents1 = "plugin1 contents";
     writeArtifact(artifact1, meta1, contents1);
 
     // write a plugins artifact in namespace2
-    Id.Namespace namespace2 = Id.Namespace.from("ns2");
-    Id.Artifact artifact2 = Id.Artifact.from(namespace2, "plugins2", "1.0.0");
+    NamespaceId namespace2 = Ids.namespace("ns2");
+    Id.Artifact artifact2 = Id.Artifact.from(namespace2.toId(), "plugins2", "1.0.0");
     ArtifactMeta meta2 = new ArtifactMeta(ArtifactClasses.builder().addPlugin(plugin).build(), usableBy);
     String contents2 = "plugin2 contents";
     writeArtifact(artifact2, meta2, contents2);
@@ -386,7 +388,7 @@ public class ArtifactStoreTest {
     } finally {
       artifactStore.clear(namespace1);
       artifactStore.clear(namespace2);
-      artifactStore.clear(Id.Namespace.SYSTEM);
+      artifactStore.clear(NamespaceId.SYSTEM);
     }
   }
 
@@ -416,18 +418,18 @@ public class ArtifactStoreTest {
 
     // test we get 1 version of artifact1 and 2 versions of artifact2
     List<ArtifactDetail> artifact1Versions =
-      artifactStore.getArtifacts(artifact1V1.getNamespace(), artifact1V1.getName());
+      artifactStore.getArtifacts(artifact1V1.getNamespace().toEntityId(), artifact1V1.getName());
     Assert.assertEquals(1, artifact1Versions.size());
     assertEqual(artifact1V1, meta1V1, contents1V1, artifact1Versions.get(0));
 
     List<ArtifactDetail> artifact2Versions =
-      artifactStore.getArtifacts(artifact2V1.getNamespace(), artifact2V1.getName());
+      artifactStore.getArtifacts(artifact2V1.getNamespace().toEntityId(), artifact2V1.getName());
     Assert.assertEquals(2, artifact2Versions.size());
     assertEqual(artifact2V1, meta2V1, contents2V1, artifact2Versions.get(0));
     assertEqual(artifact2V2, meta2V2, contents2V2, artifact2Versions.get(1));
 
     // test we get all 3 in the getArtifacts() call for the namespace
-    List<ArtifactDetail> artifactVersions = artifactStore.getArtifacts(Id.Namespace.DEFAULT);
+    List<ArtifactDetail> artifactVersions = artifactStore.getArtifacts(NamespaceId.DEFAULT);
     Assert.assertEquals(3, artifactVersions.size());
     assertEqual(artifact1V1, meta1V1, contents1V1, artifactVersions.get(0));
     assertEqual(artifact2V1, meta2V1, contents2V1, artifactVersions.get(1));
@@ -492,7 +494,7 @@ public class ArtifactStoreTest {
 
     // test getting all app classes in the namespace
     Map<ArtifactDescriptor, List<ApplicationClass>> appClasses =
-      artifactStore.getApplicationClasses(Id.Namespace.DEFAULT);
+      artifactStore.getApplicationClasses(NamespaceId.DEFAULT);
     Map<ArtifactDescriptor, List<ApplicationClass>> expected =
       ImmutableMap.<ArtifactDescriptor, List<ApplicationClass>>of(
         app1v1Detail.getDescriptor(), ImmutableList.of(inspectionClass1),
@@ -504,7 +506,7 @@ public class ArtifactStoreTest {
 
     // test getting all app classes by class name
     Map<ArtifactDescriptor, ApplicationClass> appArtifacts =
-      artifactStore.getApplicationClasses(Id.Namespace.DEFAULT, InspectionApp.class.getName());
+      artifactStore.getApplicationClasses(NamespaceId.DEFAULT, InspectionApp.class.getName());
     Map<ArtifactDescriptor, ApplicationClass> expectedAppArtifacts = ImmutableMap.of(
       app1v1Detail.getDescriptor(), inspectionClass1,
       app1v2Detail.getDescriptor(), inspectionClass2,
@@ -512,11 +514,11 @@ public class ArtifactStoreTest {
     );
     Assert.assertEquals(expectedAppArtifacts, appArtifacts);
 
-    appArtifacts = artifactStore.getApplicationClasses(Id.Namespace.DEFAULT, WordCountApp.class.getName());
+    appArtifacts = artifactStore.getApplicationClasses(NamespaceId.DEFAULT, WordCountApp.class.getName());
     expectedAppArtifacts = ImmutableMap.of(app3v1Detail.getDescriptor(), wordCountClass1);
     Assert.assertEquals(expectedAppArtifacts, appArtifacts);
 
-    Assert.assertTrue(artifactStore.getApplicationClasses(Id.Namespace.from("ghost")).isEmpty());
+    Assert.assertTrue(artifactStore.getApplicationClasses(Ids.namespace("ghost")).isEmpty());
   }
 
   @Test
@@ -621,7 +623,7 @@ public class ArtifactStoreTest {
     expected.put(artifactZv100Info, ImmutableList.of(pluginA1, pluginB1));
     expected.put(artifactZv200Info, ImmutableList.of(pluginA1, pluginA2, pluginB1, pluginB2));
     Map<ArtifactDescriptor, List<PluginClass>> actual =
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifactId);
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifactId);
     Assert.assertEquals(expected, actual);
 
     // test getting all plugins by namespace and type
@@ -632,7 +634,7 @@ public class ArtifactStoreTest {
     expected.put(artifactXv200Info, ImmutableList.of(pluginA1, pluginA2));
     expected.put(artifactZv100Info, ImmutableList.of(pluginA1));
     expected.put(artifactZv200Info, ImmutableList.of(pluginA1, pluginA2));
-    actual = artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifactId, "A");
+    actual = artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifactId, "A");
     Assert.assertEquals(expected, actual);
     // get all of type B
     expected = Maps.newHashMap();
@@ -640,7 +642,7 @@ public class ArtifactStoreTest {
     expected.put(artifactYv200Info, ImmutableList.of(pluginB2));
     expected.put(artifactZv100Info, ImmutableList.of(pluginB1));
     expected.put(artifactZv200Info, ImmutableList.of(pluginB1, pluginB2));
-    actual = artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifactId, "B");
+    actual = artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifactId, "B");
     Assert.assertEquals(expected, actual);
 
     // test getting plugins by namespace, type, and name
@@ -652,26 +654,26 @@ public class ArtifactStoreTest {
     expectedMap.put(artifactZv100Info, pluginA1);
     expectedMap.put(artifactZv200Info, pluginA1);
     Map<ArtifactDescriptor, PluginClass> actualMap =
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifactId, "A", "p1");
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifactId, "A", "p1");
     Assert.assertEquals(expectedMap, actualMap);
     // get all of type A and name p2
     expectedMap = Maps.newHashMap();
     expectedMap.put(artifactXv200Info, pluginA2);
     expectedMap.put(artifactZv200Info, pluginA2);
-    actualMap = artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifactId, "A", "p2");
+    actualMap = artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifactId, "A", "p2");
     Assert.assertEquals(expectedMap, actualMap);
     // get all of type B and name p1
     expectedMap = Maps.newHashMap();
     expectedMap.put(artifactYv100Info, pluginB1);
     expectedMap.put(artifactZv100Info, pluginB1);
     expectedMap.put(artifactZv200Info, pluginB1);
-    actualMap = artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifactId, "B", "p1");
+    actualMap = artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifactId, "B", "p1");
     Assert.assertEquals(expectedMap, actualMap);
     // get all of type B and name p2
     expectedMap = Maps.newHashMap();
     expectedMap.put(artifactYv200Info, pluginB2);
     expectedMap.put(artifactZv200Info, pluginB2);
-    actualMap = artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifactId, "B", "p2");
+    actualMap = artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifactId, "B", "p2");
     Assert.assertEquals(expectedMap, actualMap);
   }
 
@@ -703,7 +705,7 @@ public class ArtifactStoreTest {
     expected.put(artifact1Info, plugins);
     expected.put(artifact2Info, plugins);
     Map<ArtifactDescriptor, List<PluginClass>> actual =
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifactId);
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifactId);
     Assert.assertEquals(expected, actual);
   }
 
@@ -754,54 +756,54 @@ public class ArtifactStoreTest {
     // check parent-1.0.0 has plugin1 but parent-0.0.9 does not and 1.0.1 does not
     Id.Artifact parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "0.0.9");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).isEmpty());
 
     parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "1.0.1");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).isEmpty());
 
     parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "1.0.0");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertEquals(1, artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).size());
+    Assert.assertEquals(1, artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).size());
 
     // check parent-2.0.0 has plugin2 but parent-1.9.9 does not and 2.0.1 does not
     parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "1.9.9");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).isEmpty());
 
     parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "2.0.1");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).isEmpty());
 
     parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "2.0.0");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertEquals(1, artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).size());
+    Assert.assertEquals(1, artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).size());
 
     // check parent-3.0.1 has plugin3 but parent-3.0.0 does not and 3.0.2 does not
     parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "3.0.0");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).isEmpty());
 
     parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "3.0.2");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).isEmpty());
 
     parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "3.0.1");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertEquals(1, artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).size());
+    Assert.assertEquals(1, artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).size());
 
     // check parent-4.0.1 has plugin4 but parent-4.0.0 does not and 4.0.2 does not
     parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "4.0.0");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).isEmpty());
 
     parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "4.0.2");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).isEmpty());
 
     parentId = Id.Artifact.from(Id.Namespace.DEFAULT, "parent", "4.0.1");
     writeArtifact(parentId, parentMeta, "content");
-    Assert.assertEquals(1, artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentId).size());
+    Assert.assertEquals(1, artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentId).size());
   }
 
   // this test tests that when an artifact specifies a range of artifact versions it extends,
@@ -833,10 +835,10 @@ public class ArtifactStoreTest {
       // we're testing range filtering, not the absence of the parent artifact
       writeArtifact(badId, emptyMeta, "content");
 
-      Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, badId).isEmpty());
-      Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.DEFAULT, badId, "atype").isEmpty());
+      Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, badId).isEmpty());
+      Assert.assertTrue(artifactStore.getPluginClasses(NamespaceId.DEFAULT, badId, "atype").isEmpty());
       try {
-        artifactStore.getPluginClasses(Id.Namespace.DEFAULT, badId, "atype", "plugin1");
+        artifactStore.getPluginClasses(NamespaceId.DEFAULT, badId, "atype", "plugin1");
         Assert.fail();
       } catch (PluginNotExistsException e) {
         // expected
@@ -858,11 +860,11 @@ public class ArtifactStoreTest {
       // make sure parent actually exists
       writeArtifact(goodId, emptyMeta, "content");
 
-      Assert.assertEquals(expectedPluginsMapList, artifactStore.getPluginClasses(Id.Namespace.DEFAULT, goodId));
+      Assert.assertEquals(expectedPluginsMapList, artifactStore.getPluginClasses(NamespaceId.DEFAULT, goodId));
       Assert.assertEquals(expectedPluginsMapList,
-                          artifactStore.getPluginClasses(Id.Namespace.DEFAULT, goodId, "atype"));
+                          artifactStore.getPluginClasses(NamespaceId.DEFAULT, goodId, "atype"));
       Assert.assertEquals(expectedPluginsMap,
-                          artifactStore.getPluginClasses(Id.Namespace.DEFAULT, goodId, "atype", "plugin1"));
+                          artifactStore.getPluginClasses(NamespaceId.DEFAULT, goodId, "atype", "plugin1"));
     }
   }
 
@@ -1012,7 +1014,7 @@ public class ArtifactStoreTest {
 
     // check only 1 plugin remains and that its the correct one
     Map<ArtifactDescriptor, List<PluginClass>> pluginMap =
-      artifactStore.getPluginClasses(Id.Namespace.DEFAULT, parentArtifactId, "plugin-type");
+      artifactStore.getPluginClasses(NamespaceId.DEFAULT, parentArtifactId, "plugin-type");
     Map<ArtifactDescriptor, List<PluginClass>> expected = Maps.newHashMap();
     expected.put(detail.getDescriptor(), Lists.newArrayList(
       new PluginClass("plugin-type", "plugin" + winnerWriter, "", "classname", "cfg",

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTest.java
@@ -53,6 +53,7 @@ import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.artifact.PluginInfo;
 import co.cask.cdap.proto.artifact.PluginSummary;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.common.http.HttpRequest;
@@ -128,9 +129,9 @@ public class ArtifactHttpHandlerTest extends AppFabricTestBase {
   }
 
   @After
-  public void wipeData() throws IOException {
-    artifactRepository.clear(Id.Namespace.DEFAULT);
-    artifactRepository.clear(Id.Namespace.SYSTEM);
+  public void wipeData() throws Exception {
+    artifactRepository.clear(NamespaceId.DEFAULT);
+    artifactRepository.clear(NamespaceId.SYSTEM);
   }
 
   // test deploying an application artifact that has a non-application as its main class

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionCommand.java
@@ -50,7 +50,7 @@ public abstract class RevokeActionCommand extends AbstractAuthCommand {
     String principalName = arguments.getOptional("principal-name", null);
     String type = arguments.getOptional("principal-type", null);
     Principal.PrincipalType principalType =
-      type != null ? Principal.PrincipalType.valueOf(arguments.get("principal-type")) : null;
+      type != null ? Principal.PrincipalType.valueOf(type.toUpperCase()) : null;
     Principal principal = type != null ? new Principal(principalName, principalType) : null;
     String actionsString = arguments.getOptional("actions", null);
     Set<Action> actions = actionsString == null ? null : ACTIONS_STRING_TO_SET.apply(actionsString);

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -37,6 +37,7 @@ import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.artifact.PluginInfo;
 import co.cask.cdap.proto.artifact.PluginSummary;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteArtifactManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteArtifactManager.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.remote;
+
+import co.cask.cdap.client.ArtifactClient;
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.util.RESTClient;
+import co.cask.cdap.proto.id.NamespacedArtifactId;
+import co.cask.cdap.test.ArtifactManager;
+
+import java.util.Map;
+
+/**
+ * {@link ArtifactManager} for use in integration tests.
+ */
+public class RemoteArtifactManager implements ArtifactManager {
+  private final ArtifactClient artifactClient;
+  private final NamespacedArtifactId artifactId;
+
+  public RemoteArtifactManager(ClientConfig clientConfig, RESTClient restClient, NamespacedArtifactId artifactId) {
+    this.artifactClient = new ArtifactClient(clientConfig, restClient);
+    this.artifactId = artifactId;
+  }
+
+  @Override
+  public void writeProperties(Map<String, String> properties) throws Exception {
+    artifactClient.writeProperties(artifactId.toId(), properties);
+  }
+
+  @Override
+  public void removeProperties() throws Exception {
+    artifactClient.deleteProperties(artifactId.toId());
+  }
+
+  @Override
+  public void delete() throws Exception {
+    artifactClient.delete(artifactId.toId());
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/ExistingEntitySystemMetadataWriter.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/ExistingEntitySystemMetadataWriter.java
@@ -94,7 +94,7 @@ public class ExistingEntitySystemMetadataWriter {
   }
 
   private void writeSystemMetadataForArtifacts(Id.Namespace namespace) throws IOException {
-    for (ArtifactDetail artifactDetail : artifactStore.getArtifacts(namespace)) {
+    for (ArtifactDetail artifactDetail : artifactStore.getArtifacts(namespace.toEntityId())) {
       ArtifactInfo artifactInfo = new ArtifactInfo(artifactDetail.getDescriptor().getArtifactId(),
                                                    artifactDetail.getMeta().getClasses(),
                                                    artifactDetail.getMeta().getProperties());

--- a/cdap-test/src/main/java/co/cask/cdap/test/ArtifactManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ArtifactManager.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test;
+
+import co.cask.cdap.proto.id.NamespacedArtifactId;
+
+import java.util.Map;
+
+/**
+ * An interface to manage interactions with an {@link NamespacedArtifactId artifact} in tests.
+ */
+public interface ArtifactManager {
+  /**
+   * Write properties to the artifact.
+   *
+   * @param properties the properties to write
+   */
+  void writeProperties(Map<String, String> properties) throws Exception;
+
+  /**
+   * Remove properties from the artifact.
+   */
+  void removeProperties() throws Exception;
+
+  /**
+   * Delete the artifact
+   */
+  void delete() throws Exception;
+}

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedArtifactId;
 
 import java.io.File;
 import java.sql.Connection;
@@ -89,18 +90,38 @@ public interface TestManager {
    *
    * @param artifactId the id of the artifact to add
    * @param artifactFile the contents of the artifact. Must be a valid jar file containing apps or plugins
-   * @throws Exception
+   * @deprecated since 3.4.0 use {@link #addArtifact(NamespacedArtifactId, File)}
    */
+  @Deprecated
   void addArtifact(Id.Artifact artifactId, File artifactFile) throws Exception;
+
+  /**
+   * Add the specified artifact.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param artifactFile the contents of the artifact. Must be a valid jar file containing apps or plugins
+   * @return an {@link ArtifactManager} to manage the added artifact
+   */
+  ArtifactManager addArtifact(NamespacedArtifactId artifactId, File artifactFile) throws Exception;
 
   /**
    * Build an application artifact from the specified class and then add it.
    *
    * @param artifactId the id of the artifact to add
    * @param appClass the application class to build the artifact from
-   * @throws Exception
+   * @deprecated since 3.4.0. Use {@link #addAppArtifact(NamespacedArtifactId, Class)}
    */
+  @Deprecated
   void addAppArtifact(Id.Artifact artifactId, Class<?> appClass) throws Exception;
+
+  /**
+   * Build an application artifact from the specified class and then add it.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param appClass the application class to build the artifact from
+   * @return an {@link ArtifactManager} for managing the added app artifact
+   */
+  ArtifactManager addAppArtifact(NamespacedArtifactId artifactId, Class<?> appClass) throws Exception;
 
   /**
    * Build an application artifact from the specified class and then add it.
@@ -109,8 +130,9 @@ public interface TestManager {
    * @param appClass the application class to build the artifact from
    * @param exportPackages the packages to export and place in the manifest of the jar to build. This should include
    *                       packages that contain classes that plugins for the application will implement.
-   * @throws Exception
+   * @deprecated since 3.4.0. Use {@link #addAppArtifact(NamespacedArtifactId, Class, String...)} instead
    */
+  @Deprecated
   void addAppArtifact(Id.Artifact artifactId, Class<?> appClass, String... exportPackages) throws Exception;
 
   /**
@@ -118,12 +140,36 @@ public interface TestManager {
    *
    * @param artifactId the id of the artifact to add
    * @param appClass the application class to build the artifact from
-   * @param manifest the manifest to use when building the jar
-   * @throws Exception
+   * @param exportPackages the packages to export and place in the manifest of the jar to build. This should include
+   *                       packages that contain classes that plugins for the application will implement.
+   * @return an {@link ArtifactManager} to manage the added app artifact
    */
+  ArtifactManager addAppArtifact(NamespacedArtifactId artifactId, Class<?> appClass,
+                                 String... exportPackages) throws Exception;
+
+  /**
+   * Build an application artifact from the specified class and then add it.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param appClass the application class to build the artifact from
+   * @param manifest the manifest to use when building the jar
+   * @deprecated since 3.4.0. Use {@link #addAppArtifact(NamespacedArtifactId, Class, Manifest)} instead
+   */
+  @Deprecated
   void addAppArtifact(Id.Artifact artifactId, Class<?> appClass, Manifest manifest) throws Exception;
 
   /**
+   * Build an application artifact from the specified class and then add it.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param appClass the application class to build the artifact from
+   * @param manifest the manifest to use when building the jar
+   * @return an {@link ArtifactManager} to manage the added app artifact
+   */
+  ArtifactManager addAppArtifact(NamespacedArtifactId artifactId, Class<?> appClass,
+                                 Manifest manifest) throws Exception;
+
+  /**
    * Build an artifact from the specified plugin classes and then add it. The
    * jar created will include all classes in the same package as the give classes, plus any dependencies of the
    * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
@@ -138,9 +184,50 @@ public interface TestManager {
    * @param parent the parent artifact it extends
    * @param pluginClass the plugin class to build the jar from
    * @param pluginClasses any additional plugin classes that should be included in the jar
-   * @throws Exception
+   * @deprecated since 3.4.0. Use {@link #addPluginArtifact(NamespacedArtifactId, NamespacedArtifactId, Class, Class[])}
    */
+  @Deprecated
   void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
+                         Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
+
+  /**
+   * Build an artifact from the specified plugin classes and then add it. The
+   * jar created will include all classes in the same package as the give classes, plus any dependencies of the
+   * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
+   * classes, you must include both plugins. For example, suppose you have two plugins,
+   * com.company.myapp.functions.functionX and com.company.myapp.function.functionY, with functionX having
+   * one set of dependencies and functionY having another set of dependencies. If you only add functionX, functionY
+   * will also be included in the created jar since it is in the same package. However, only functionX's dependencies
+   * will be traced and added to the jar, so you will run into issues when the platform tries to register functionY.
+   * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param parent the parent artifact it extends
+   * @param pluginClass the plugin class to build the jar from
+   * @param pluginClasses any additional plugin classes that should be included in the jar
+   * @return an {@link ArtifactManager} for managing the added artifact
+   */
+  ArtifactManager addPluginArtifact(NamespacedArtifactId artifactId, NamespacedArtifactId parent,
+                                    Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
+
+  /**
+   * Build an artifact from the specified plugin classes and then add it. The
+   * jar created will include all classes in the same package as the give classes, plus any dependencies of the
+   * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
+   * classes, you must include both plugins. For example, suppose you have two plugins,
+   * com.company.myapp.functions.functionX and com.company.myapp.function.functionY, with functionX having
+   * one set of dependencies and functionY having another set of dependencies. If you only add functionX, functionY
+   * will also be included in the created jar since it is in the same package. However, only functionX's dependencies
+   * will be traced and added to the jar, so you will run into issues when the platform tries to register functionY.
+   * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param parents the parent artifacts it extends
+   * @param pluginClass the plugin class to build the jar from
+   * @param pluginClasses any additional plugin classes that should be included in the jar
+   * @deprecated since 3.4.0. Use {@link #addPluginArtifact(NamespacedArtifactId, Set, Class, Class[])}
+   */
+  void addPluginArtifact(Id.Artifact artifactId, Set<ArtifactRange> parents,
                          Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
 
   /**
@@ -158,10 +245,10 @@ public interface TestManager {
    * @param parents the parent artifacts it extends
    * @param pluginClass the plugin class to build the jar from
    * @param pluginClasses any additional plugin classes that should be included in the jar
-   * @throws Exception
+   * @return an {@link ArtifactManager} to manage the added plugin artifact
    */
-  void addPluginArtifact(Id.Artifact artifactId, Set<ArtifactRange> parents,
-                         Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
+  ArtifactManager addPluginArtifact(NamespacedArtifactId artifactId, Set<ArtifactRange> parents,
+                                    Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
 
 
   /**
@@ -181,9 +268,58 @@ public interface TestManager {
    *                          by inspecting the jar. This is true for 3rd party plugins, such as jdbc drivers
    * @param pluginClass the plugin class to build the jar from
    * @param pluginClasses any additional plugin classes that should be included in the jar
-   * @throws Exception
+   * @deprecated since 3.4.0.
+   * Use {@link #addPluginArtifact(NamespacedArtifactId, NamespacedArtifactId, Set, Class, Class[])}
    */
+  @Deprecated
   void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
+                         @Nullable Set<PluginClass> additionalPlugins,
+                         Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
+
+  /**
+   * Build an artifact from the specified plugin classes and then add it. The
+   * jar created will include all classes in the same package as the give classes, plus any dependencies of the
+   * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
+   * classes, you must include both plugins. For example, suppose you have two plugins,
+   * com.company.myapp.functions.functionX and com.company.myapp.function.functionY, with functionX having
+   * one set of dependencies and functionY having another set of dependencies. If you only add functionX, functionY
+   * will also be included in the created jar since it is in the same package. However, only functionX's dependencies
+   * will be traced and added to the jar, so you will run into issues when the platform tries to register functionY.
+   * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param parent the parent artifact it extends
+   * @param additionalPlugins any plugin classes that need to be explicitly declared because they cannot be found
+   *                          by inspecting the jar. This is true for 3rd party plugins, such as jdbc drivers
+   * @param pluginClass the plugin class to build the jar from
+   * @param pluginClasses any additional plugin classes that should be included in the jar
+   * @return an {@link ArtifactManager} to manage this artifact
+   */
+  ArtifactManager addPluginArtifact(NamespacedArtifactId artifactId, NamespacedArtifactId parent,
+                                    @Nullable Set<PluginClass> additionalPlugins,
+                                    Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
+
+  /**
+   * Build an artifact from the specified plugin classes and then add it. The
+   * jar created will include all classes in the same package as the give classes, plus any dependencies of the
+   * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
+   * classes, you must include both plugins. For example, suppose you have two plugins,
+   * com.company.myapp.functions.functionX and com.company.myapp.function.functionY, with functionX having
+   * one set of dependencies and functionY having another set of dependencies. If you only add functionX, functionY
+   * will also be included in the created jar since it is in the same package. However, only functionX's dependencies
+   * will be traced and added to the jar, so you will run into issues when the platform tries to register functionY.
+   * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param parents the parent artifacts it extends
+   * @param additionalPlugins any plugin classes that need to be explicitly declared because they cannot be found
+   *                          by inspecting the jar. This is true for 3rd party plugins, such as jdbc drivers
+   * @param pluginClass the plugin class to build the jar from
+   * @param pluginClasses any additional plugin classes that should be included in the jar
+   * @deprecated since 3.4.0
+   * Use {@link #addPluginArtifact(NamespacedArtifactId, Set, Set, Class, Class[])}
+   */
+  void addPluginArtifact(Id.Artifact artifactId, Set<ArtifactRange> parents,
                          @Nullable Set<PluginClass> additionalPlugins,
                          Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
 
@@ -204,17 +340,19 @@ public interface TestManager {
    *                          by inspecting the jar. This is true for 3rd party plugins, such as jdbc drivers
    * @param pluginClass the plugin class to build the jar from
    * @param pluginClasses any additional plugin classes that should be included in the jar
-   * @throws Exception
+   * @return {@link ArtifactManager} to manage the added plugin artifact
    */
-  void addPluginArtifact(Id.Artifact artifactId, Set<ArtifactRange> parents,
-                         @Nullable Set<PluginClass> additionalPlugins,
-                         Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
+  ArtifactManager addPluginArtifact(NamespacedArtifactId artifactId, Set<ArtifactRange> parents,
+                                    @Nullable Set<PluginClass> additionalPlugins,
+                                    Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
 
   /**
    * Delete the specified artifact.
    *
    * @param artifactId the id of the artifact to delete
+   * @deprecated since 3.4.0. Use {@link ArtifactManager#delete()} instead
    */
+  @Deprecated
   void deleteArtifact(Id.Artifact artifactId) throws Exception;
 
   /**
@@ -305,7 +443,7 @@ public interface TestManager {
   /**
    * Removes all apps in the specified namespace.
    *
-   * @param namespaceId the specified namespace from which to remove all apps
+   * @param namespaceId the namespace from which to remove all apps
    */
   void deleteAllApplications(NamespaceId namespaceId) throws Exception;
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -82,6 +82,7 @@ import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedArtifactId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
@@ -90,7 +91,9 @@ import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.cdap.test.internal.ApplicationManagerFactory;
+import co.cask.cdap.test.internal.ArtifactManagerFactory;
 import co.cask.cdap.test.internal.DefaultApplicationManager;
+import co.cask.cdap.test.internal.DefaultArtifactManager;
 import co.cask.cdap.test.internal.DefaultStreamManager;
 import co.cask.cdap.test.internal.LocalStreamWriter;
 import co.cask.cdap.test.internal.StreamManagerFactory;
@@ -239,6 +242,8 @@ public class TestBase {
         protected void configure() {
           install(new FactoryModuleBuilder().implement(ApplicationManager.class, DefaultApplicationManager.class)
                     .build(ApplicationManagerFactory.class));
+          install(new FactoryModuleBuilder().implement(ArtifactManager.class, DefaultArtifactManager.class)
+                    .build(ArtifactManagerFactory.class));
           install(new FactoryModuleBuilder().implement(StreamManager.class, DefaultStreamManager.class)
                     .build(StreamManagerFactory.class));
           bind(TemporaryFolder.class).toInstance(TMP_FOLDER);
@@ -474,10 +479,22 @@ public class TestBase {
    *
    * @param artifactId the id of the artifact to add
    * @param artifactFile the contents of the artifact. Must be a valid jar file containing apps or plugins
+   * @deprecated since 3.4.0. Use {@link #addArtifact(NamespacedArtifactId, File)}
+   */
+  @Deprecated
+  protected static void addArtifact(Id.Artifact artifactId, File artifactFile) throws Exception {
+    addArtifact(artifactId.toEntityId(), artifactFile);
+  }
+
+  /**
+   * Add the specified artifact.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param artifactFile the contents of the artifact. Must be a valid jar file containing apps or plugins
    * @throws Exception
    */
-  protected static void addArtifact(Id.Artifact artifactId, File artifactFile) throws Exception {
-    getTestManager().addArtifact(artifactId, artifactFile);
+  protected static ArtifactManager addArtifact(NamespacedArtifactId artifactId, File artifactFile) throws Exception {
+    return getTestManager().addArtifact(artifactId, artifactFile);
   }
 
   /**
@@ -485,10 +502,22 @@ public class TestBase {
    *
    * @param artifactId the id of the artifact to add
    * @param appClass the application class to build the artifact from
-   * @throws Exception
+   * @deprecated since 3.4.0. Use {@link #addArtifact(NamespacedArtifactId, File)}.
    */
+  @Deprecated
   protected static void addAppArtifact(Id.Artifact artifactId, Class<?> appClass) throws Exception {
     getTestManager().addAppArtifact(artifactId, appClass);
+  }
+
+  /**
+   * Build an application artifact from the specified class and then add it.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param appClass the application class to build the artifact from
+   * @return an {@link ArtifactManager} to manage the added artifact
+   */
+  protected static ArtifactManager addAppArtifact(NamespacedArtifactId artifactId, Class<?> appClass) throws Exception {
+    return getTestManager().addAppArtifact(artifactId, appClass);
   }
 
   /**
@@ -532,11 +561,35 @@ public class TestBase {
    * @param parent the parent artifact it extends
    * @param pluginClass the plugin class to build the jar from
    * @param pluginClasses any additional plugin classes that should be included in the jar
-   * @throws Exception
+   * @deprecated since 3.4.0. Use {@link #addPluginArtifact(NamespacedArtifactId, NamespacedArtifactId, Class, Class[])}
    */
+  @Deprecated
   protected static void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
                                           Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
     getTestManager().addPluginArtifact(artifactId, parent, pluginClass, pluginClasses);
+  }
+
+  /**
+   * Build an artifact from the specified plugin classes and then add it. The
+   * jar created will include all classes in the same package as the give classes, plus any dependencies of the
+   * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
+   * classes, you must include both plugins. For example, suppose you have two plugins,
+   * com.company.myapp.functions.functionX and com.company.myapp.function.functionY, with functionX having
+   * one set of dependencies and functionY having another set of dependencies. If you only add functionX, functionY
+   * will also be included in the created jar since it is in the same package. However, only functionX's dependencies
+   * will be traced and added to the jar, so you will run into issues when the platform tries to register functionY.
+   * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param parent the parent artifact it extends
+   * @param pluginClass the plugin class to build the jar from
+   * @param pluginClasses any additional plugin classes that should be included in the jar
+   * @return {@link ArtifactManager} to manage the added plugin artifact
+   */
+  protected static ArtifactManager addPluginArtifact(NamespacedArtifactId artifactId, NamespacedArtifactId parent,
+                                                     Class<?> pluginClass,
+                                                     Class<?>... pluginClasses) throws Exception {
+    return getTestManager().addPluginArtifact(artifactId, parent, pluginClass, pluginClasses);
   }
 
   /**
@@ -556,8 +609,10 @@ public class TestBase {
    *                          by inspecting the jar. This is true for 3rd party plugins, such as jdbc drivers
    * @param pluginClass the plugin class to build the jar from
    * @param pluginClasses any additional plugin classes that should be included in the jar
-   * @throws Exception
+   * @deprecated since 3.4.0. Use
+   * {@link #addPluginArtifact(NamespacedArtifactId, NamespacedArtifactId, Set, Class, Class[])}
    */
+  @Deprecated
   protected static void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
                                           Set<PluginClass> additionalPlugins,
                                           Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
@@ -576,14 +631,63 @@ public class TestBase {
    * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
    *
    * @param artifactId the id of the artifact to add
+   * @param parent the parent artifact it extends
+   * @param additionalPlugins any plugin classes that need to be explicitly declared because they cannot be found
+   *                          by inspecting the jar. This is true for 3rd party plugins, such as jdbc drivers
+   * @param pluginClass the plugin class to build the jar from
+   * @param pluginClasses any additional plugin classes that should be included in the jar
+   * @return an {@link ArtifactManager} to manage the added plugin artifact
+   */
+  protected static ArtifactManager addPluginArtifact(NamespacedArtifactId artifactId, NamespacedArtifactId parent,
+                                                     Set<PluginClass> additionalPlugins,
+                                                     Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
+    return getTestManager().addPluginArtifact(artifactId, parent, additionalPlugins, pluginClass, pluginClasses);
+  }
+
+  /**
+   * Build an artifact from the specified plugin classes and then add it. The
+   * jar created will include all classes in the same package as the give classes, plus any dependencies of the
+   * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
+   * classes, you must include both plugins. For example, suppose you have two plugins,
+   * com.company.myapp.functions.functionX and com.company.myapp.function.functionY, with functionX having
+   * one set of dependencies and functionY having another set of dependencies. If you only add functionX, functionY
+   * will also be included in the created jar since it is in the same package. However, only functionX's dependencies
+   * will be traced and added to the jar, so you will run into issues when the platform tries to register functionY.
+   * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
+   *
+   * @param artifactId the id of the artifact to add
    * @param parentArtifacts the parent artifacts it extends
    * @param pluginClass the plugin class to build the jar from
    * @param pluginClasses any additional plugin classes that should be included in the jar
-   * @throws Exception
+   * @deprecated since 3.4.0. Use {@link #addPluginArtifact(NamespacedArtifactId, Set, Class, Class[])}
    */
+  @Deprecated
   protected static void addPluginArtifact(Id.Artifact artifactId, Set<ArtifactRange> parentArtifacts,
                                           Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
     getTestManager().addPluginArtifact(artifactId, parentArtifacts, pluginClass, pluginClasses);
+  }
+
+  /**
+   * Build an artifact from the specified plugin classes and then add it. The
+   * jar created will include all classes in the same package as the give classes, plus any dependencies of the
+   * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
+   * classes, you must include both plugins. For example, suppose you have two plugins,
+   * com.company.myapp.functions.functionX and com.company.myapp.function.functionY, with functionX having
+   * one set of dependencies and functionY having another set of dependencies. If you only add functionX, functionY
+   * will also be included in the created jar since it is in the same package. However, only functionX's dependencies
+   * will be traced and added to the jar, so you will run into issues when the platform tries to register functionY.
+   * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param parentArtifacts the parent artifacts it extends
+   * @param pluginClass the plugin class to build the jar from
+   * @param pluginClasses any additional plugin classes that should be included in the jar
+   * @return an {@link ArtifactManager} to manage the added plugin artifact
+   */
+  protected static ArtifactManager addPluginArtifact(NamespacedArtifactId artifactId,
+                                                     Set<ArtifactRange> parentArtifacts, Class<?> pluginClass,
+                                                     Class<?>... pluginClasses) throws Exception {
+    return getTestManager().addPluginArtifact(artifactId, parentArtifacts, pluginClass, pluginClasses);
   }
 
   /**

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -19,6 +19,7 @@ package co.cask.cdap.test;
 import co.cask.cdap.api.Config;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.app.Application;
+import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
@@ -41,8 +42,11 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedArtifactId;
 import co.cask.cdap.test.internal.ApplicationManagerFactory;
+import co.cask.cdap.test.internal.ArtifactManagerFactory;
 import co.cask.cdap.test.internal.StreamManagerFactory;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionContext;
@@ -88,6 +92,7 @@ public class UnitTestManager implements TestManager {
   private final StreamManagerFactory streamManagerFactory;
   private final LocationFactory locationFactory;
   private final ArtifactRepository artifactRepository;
+  private final ArtifactManagerFactory artifactManagerFactory;
   private final MetricsManager metricsManager;
   private final File tmpDir;
 
@@ -102,6 +107,7 @@ public class UnitTestManager implements TestManager {
                          LocationFactory locationFactory,
                          MetricsManager metricsManager,
                          ArtifactRepository artifactRepository,
+                         ArtifactManagerFactory artifactManagerFactory,
                          CConfiguration cConf) {
     this.appFabricClient = appFabricClient;
     this.datasetFramework = datasetFramework;
@@ -114,6 +120,7 @@ public class UnitTestManager implements TestManager {
     this.artifactRepository = artifactRepository;
     // this should have been set to a temp dir during injector setup
     this.metricsManager = metricsManager;
+    this.artifactManagerFactory = artifactManagerFactory;
     this.tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
       cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
   }
@@ -177,60 +184,118 @@ public class UnitTestManager implements TestManager {
   }
 
   @Override
+  public ArtifactManager addArtifact(NamespacedArtifactId artifactId, File artifactFile) throws Exception {
+    artifactRepository.addArtifact(artifactId.toId(), artifactFile);
+    return artifactManagerFactory.create(artifactId);
+  }
+
+  @Override
   public void addAppArtifact(Id.Artifact artifactId, Class<?> appClass) throws Exception {
+    addAppArtifact(artifactId.toEntityId(), appClass);
+  }
+
+  @Override
+  public ArtifactManager addAppArtifact(NamespacedArtifactId artifactId, Class<?> appClass) throws Exception {
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, appClass, new Manifest());
     addArtifact(artifactId, appJar);
+    return artifactManagerFactory.create(artifactId);
   }
 
   @Override
   public void addAppArtifact(Id.Artifact artifactId, Class<?> appClass, String... exportPackages) throws Exception {
+    addAppArtifact(artifactId.toEntityId(), appClass, exportPackages);
+  }
+
+  @Override
+  public ArtifactManager addAppArtifact(NamespacedArtifactId artifactId, Class<?> appClass,
+                                        String... exportPackages) throws Exception {
     Manifest manifest = new Manifest();
     manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, Joiner.on(',').join(exportPackages));
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, appClass, manifest);
     addArtifact(artifactId, appJar);
+    return artifactManagerFactory.create(artifactId);
   }
 
   @Override
   public void addAppArtifact(Id.Artifact artifactId, Class<?> appClass, Manifest manifest) throws Exception {
+    addAppArtifact(artifactId.toEntityId(), appClass, manifest);
+  }
+
+  @Override
+  public ArtifactManager addAppArtifact(NamespacedArtifactId artifactId, Class<?> appClass,
+                                        Manifest manifest) throws Exception {
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, appClass, manifest);
     addArtifact(artifactId, appJar);
+    return artifactManagerFactory.create(artifactId);
   }
 
   @Override
   public void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
                                 Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
+    addPluginArtifact(artifactId.toEntityId(), parent.toEntityId(), pluginClass, pluginClasses);
+  }
+
+  @Override
+  public ArtifactManager addPluginArtifact(NamespacedArtifactId artifactId, NamespacedArtifactId parent,
+                                           Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
     Set<ArtifactRange> parents = new HashSet<>();
     parents.add(new ArtifactRange(
-      parent.getNamespace(), parent.getName(), parent.getVersion(), true, parent.getVersion(), true));
+      Ids.namespace(parent.getNamespace()).toId(), parent.getArtifact(), new ArtifactVersion(parent.getVersion()),
+      true, new ArtifactVersion(parent.getVersion()), true));
     addPluginArtifact(artifactId, parents, pluginClass, pluginClasses);
+    return artifactManagerFactory.create(artifactId);
   }
 
   @Override
   public void addPluginArtifact(Id.Artifact artifactId, Set<ArtifactRange> parents,
                                 Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
+    addPluginArtifact(artifactId.toEntityId(), parents, pluginClass, pluginClasses);
+  }
+
+  @Override
+  public ArtifactManager addPluginArtifact(NamespacedArtifactId artifactId, Set<ArtifactRange> parents,
+                                           Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
     File pluginJar = createPluginJar(artifactId, pluginClass, pluginClasses);
-    artifactRepository.addArtifact(artifactId, pluginJar, parents);
-    pluginJar.delete();
+    artifactRepository.addArtifact(artifactId.toId(), pluginJar, parents);
+    Preconditions.checkState(pluginJar.delete());
+    return artifactManagerFactory.create(artifactId);
   }
 
   @Override
   public void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
                                 @Nullable Set<PluginClass> additionalPlugins,
                                 Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
+    addPluginArtifact(artifactId.toEntityId(), parent.toEntityId(), additionalPlugins, pluginClass, pluginClasses);
+  }
+
+  @Override
+  public ArtifactManager addPluginArtifact(NamespacedArtifactId artifactId, NamespacedArtifactId parent,
+                                           @Nullable Set<PluginClass> additionalPlugins, Class<?> pluginClass,
+                                           Class<?>... pluginClasses) throws Exception {
     Set<ArtifactRange> parents = new HashSet<>();
     parents.add(new ArtifactRange(
-      parent.getNamespace(), parent.getName(), parent.getVersion(), true, parent.getVersion(), true));
+      Ids.namespace(parent.getNamespace()).toId(), parent.getArtifact(), new ArtifactVersion(parent.getVersion()),
+      true, new ArtifactVersion(parent.getVersion()), true));
     addPluginArtifact(artifactId, parents, additionalPlugins, pluginClass, pluginClasses);
+    return artifactManagerFactory.create(artifactId);
   }
 
   @Override
   public void addPluginArtifact(Id.Artifact artifactId, Set<ArtifactRange> parents,
                                 @Nullable Set<PluginClass> additionalPlugins,
                                 Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
+
+  }
+
+  @Override
+  public ArtifactManager addPluginArtifact(NamespacedArtifactId artifactId, Set<ArtifactRange> parents,
+                                           @Nullable Set<PluginClass> additionalPlugins, Class<?> pluginClass,
+                                           Class<?>... pluginClasses) throws Exception {
     File pluginJar = createPluginJar(artifactId, pluginClass, pluginClasses);
-    artifactRepository.addArtifact(artifactId, pluginJar, parents,
+    artifactRepository.addArtifact(artifactId.toId(), pluginJar, parents,
                                    additionalPlugins, Collections.<String, String>emptyMap());
-    pluginJar.delete();
+    Preconditions.checkState(pluginJar.delete());
+    return artifactManagerFactory.create(artifactId);
   }
 
   @Override
@@ -378,24 +443,24 @@ public class UnitTestManager implements TestManager {
     return manifest;
   }
 
-  private File createPluginJar(Id.Artifact artifactId, Class<?> pluginClass,
+  private File createPluginJar(NamespacedArtifactId artifactId, Class<?> pluginClass,
                                Class<?>... pluginClasses) throws IOException {
     Manifest manifest = createManifest(pluginClass, pluginClasses);
     Location appJar = PluginJarHelper.createPluginJar(locationFactory, manifest, pluginClass, pluginClasses);
     File destination =
-      new File(tmpDir, String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
+      new File(tmpDir, String.format("%s-%s.jar", artifactId.getArtifact(), artifactId.getVersion()));
     Files.copy(Locations.newInputSupplier(appJar), destination);
     appJar.delete();
     return destination;
   }
 
-  private void addArtifact(Id.Artifact artifactId, Location jar) throws Exception {
+  private void addArtifact(NamespacedArtifactId artifactId, Location jar) throws Exception {
     File destination =
-      new File(tmpDir, String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
+      new File(tmpDir, String.format("%s-%s.jar", artifactId.getArtifact(), artifactId.getVersion()));
     Files.copy(Locations.newInputSupplier(jar), destination);
     jar.delete();
 
-    artifactRepository.addArtifact(artifactId, destination);
-    destination.delete();
+    artifactRepository.addArtifact(artifactId.toId(), destination);
+    Preconditions.checkState(destination.delete());
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/ArtifactManagerFactory.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/ArtifactManagerFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.internal;
+
+import co.cask.cdap.proto.id.NamespacedArtifactId;
+import co.cask.cdap.test.ArtifactManager;
+import com.google.inject.Guice;
+import com.google.inject.assistedinject.Assisted;
+
+/**
+ * A {@link Guice} factory to create {@link ArtifactManager}.
+ */
+public interface ArtifactManagerFactory {
+  /**
+   * Creates a {@link ArtifactManager} for the specified {@link NamespacedArtifactId artifact}.
+   */
+  ArtifactManager create(@Assisted("artifactId") NamespacedArtifactId artifactId);
+}

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultArtifactManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultArtifactManager.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.internal;
+
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.proto.id.NamespacedArtifactId;
+import co.cask.cdap.test.ArtifactManager;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+import java.util.Map;
+
+/**
+ * {@link ArtifactManager} for use in unit tests
+ */
+public class DefaultArtifactManager implements ArtifactManager {
+  private final ArtifactRepository artifactRepository;
+  private final NamespacedArtifactId artifactId;
+
+  @Inject
+  DefaultArtifactManager(ArtifactRepository artifactRepository,
+                         @Assisted("artifactId") NamespacedArtifactId artifactId) {
+    this.artifactRepository = artifactRepository;
+    this.artifactId = artifactId;
+  }
+
+  @Override
+  public void writeProperties(Map<String, String> properties) throws Exception {
+    artifactRepository.writeArtifactProperties(artifactId.toId(), properties);
+  }
+
+  @Override
+  public void removeProperties() throws Exception {
+    artifactRepository.deleteArtifactProperties(artifactId.toId());
+  }
+
+  @Override
+  public void delete() throws Exception {
+    artifactRepository.deleteArtifact(artifactId.toId());
+  }
+}


### PR DESCRIPTION
- Added authorization checks in ArtifactRepository
- To deploy an artifact, a user needs WRITE permission on the namespace
- Once deployment is successful, the user gets ALL privileges on the artifact
- To write/remove properties of an artifact, or to delete an artifact a user needs ADMIN privileges on the artifact

- Replaced usages of Id.Namespace with NamespaceId where easily possible

(CDAP-4925) Improved support for artifacts in TestBase using an ArtifactManager. Deprecated old methods.

Jira: 
[CDAP-5382](https://issues.cask.co/browse/CDAP-5382)
[CDAP-4925](https://issues.cask.co/browse/CDAP-4925)

Build: http://builds.cask.co/browse/CDAP-DUT3796