### PR TITLE
(CDAP-5382) Enforced authorization for program lifecycle

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
@@ -42,6 +42,7 @@ import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.pipeline.Pipeline;
 import co.cask.cdap.pipeline.PipelineFactory;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
@@ -71,6 +72,7 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
   private final UsageRegistry usageRegistry;
   private final ArtifactRepository artifactRepository;
   private final MetadataStore metadataStore;
+  private final AuthorizerInstantiatorService authorizerInstantiatorService;
 
   @Inject
   LocalApplicationManager(CConfiguration configuration, PipelineFactory pipelineFactory,
@@ -81,7 +83,7 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
                           StreamAdmin streamAdmin, Scheduler scheduler,
                           @Assisted ProgramTerminator programTerminator, MetricStore metricStore,
                           UsageRegistry usageRegistry, ArtifactRepository artifactRepository,
-                          MetadataStore metadataStore) {
+                          MetadataStore metadataStore, AuthorizerInstantiatorService authorizerInstantiatorService) {
     this.configuration = configuration;
     this.namespacedLocationFactory = namespacedLocationFactory;
     this.pipelineFactory = pipelineFactory;
@@ -97,6 +99,7 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
     this.usageRegistry = usageRegistry;
     this.artifactRepository = artifactRepository;
     this.metadataStore = metadataStore;
+    this.authorizerInstantiatorService = authorizerInstantiatorService;
   }
 
   @Override
@@ -109,8 +112,10 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
     pipeline.addLast(new CreateDatasetInstancesStage(configuration, datasetFramework, namespace));
     pipeline.addLast(new CreateStreamsStage(namespace, streamAdmin));
     pipeline.addLast(new DeletedProgramHandlerStage(store, programTerminator, streamConsumerFactory,
-                                                    queueAdmin, metricStore, metadataStore));
-    pipeline.addLast(new ProgramGenerationStage(configuration, namespacedLocationFactory));
+                                                    queueAdmin, metricStore, metadataStore,
+                                                    authorizerInstantiatorService.get()));
+    pipeline.addLast(new ProgramGenerationStage(configuration, namespacedLocationFactory,
+                                                authorizerInstantiatorService.get()));
     pipeline.addLast(new ApplicationRegistrationStage(store, usageRegistry));
     pipeline.addLast(new CreateSchedulesStage(scheduler));
     pipeline.addLast(new SystemMetadataWriterStage(metadataStore));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowApp.java
@@ -60,10 +60,10 @@ public class WorkflowApp extends AbstractApplication {
    *
    */
   public static class FunWorkflow extends AbstractWorkflow {
-
+    public static final String NAME = "FunWorkflow";
     @Override
     public void configure() {
-      setName("FunWorkflow");
+      setName(NAME);
       setDescription("FunWorkflow description");
       addMapReduce("ClassicWordCount");
       addAction(new CustomAction("verify"));
@@ -75,10 +75,10 @@ public class WorkflowApp extends AbstractApplication {
    *
    */
   public static final class WordCountMapReduce extends AbstractMapReduce {
-
+    public static final String NAME = "ClassicWordCount";
     @Override
     public void configure() {
-      setName("ClassicWordCount");
+      setName(NAME);
       setDescription("WordCount job from Hadoop examples");
     }
 
@@ -97,9 +97,10 @@ public class WorkflowApp extends AbstractApplication {
   }
 
   public static class SparkWorkflowTestApp extends AbstractSpark {
+    public static final String NAME = "SparkWorkflowTest";
     @Override
     public void configure() {
-      setName("SparkWorkflowTest");
+      setName(NAME);
       setDescription("Test Spark with Workflow");
       setMainClass(SparkWorkflowTestProgram.class);
     }


### PR DESCRIPTION
- When an app is successfully deployed, the user gets ALL privileges on all programs in the app.
- To start/stop a program, a user needs EXECUTE privileges on the program.
- When an app is deleted, all privileges on all programs are revoked

Jira: [CDAP-5382](https://issues.cask.co/browse/CDAP-5382)
Build: http://builds.cask.co/browse/CDAP-DUT3807

Discovered a couple of issues in the authorization implementation during this PR: 
[CDAP-5427](https://issues.cask.co/browse/CDAP-5427) and [CDAP-5428](https://issues.cask.co/browse/CDAP-5428), which will be implemented in subsequent PRs and will remove some of the hacks in this PR.