### PR TITLE
Make DatasetInstanceConfiguration backward-compatible again

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetInstanceConfiguration.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetInstanceConfiguration.java
@@ -28,6 +28,10 @@ public final class DatasetInstanceConfiguration {
   private final Map<String, String> properties;
   private final String description;
 
+  public DatasetInstanceConfiguration(String typeName, Map<String, String> properties) {
+    this(typeName, properties, null);
+  }
+  
   public DatasetInstanceConfiguration(String typeName, Map<String, String> properties, @Nullable String description) {
     this.typeName = typeName;
     this.properties = properties;


### PR DESCRIPTION
The incompatibility was introduced in #5374 causing build failures in external repos.
