### PR TITLE
Implementation of returning node states from WorkflowContext and through REST endpoint.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/NodeStatus.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/NodeStatus.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api.workflow;
+
+/**
+ * Represents the runtime status of the node in {@link Workflow}.
+ */
+public enum NodeStatus {
+  RUNNING,
+  COMPLETED,
+  FAILED,
+  KILLED
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
@@ -54,4 +54,9 @@ public interface WorkflowContext extends RuntimeContext, ServiceDiscoverer, Data
    * @return a {@link WorkflowToken}
    */
   WorkflowToken getToken();
+
+  /**
+   * Return the {@link Map} of node ids to {@link WorkflowNodeState}.
+   */
+  Map<String, WorkflowNodeState> getNodeStates();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowNodeState.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowNodeState.java
@@ -21,17 +21,7 @@ import javax.annotation.Nullable;
 /**
  * Class to represent the state of the node in the {@link Workflow}.
  */
-public final class WorkflowNodeState {
-
-  /**
-   * Status of the node running inside the Workflow.
-   */
-  public enum NodeStatus {
-    RUNNING,
-    COMPLETED,
-    FAILED,
-    KILLED
-  }
+public class WorkflowNodeState {
 
   private final String nodeId;
   private final NodeStatus nodeStatus;

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowNodeState.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowNodeState.java
@@ -16,11 +16,14 @@
 
 package co.cask.cdap.api.workflow;
 
+import co.cask.cdap.api.annotation.Beta;
+
 import javax.annotation.Nullable;
 
 /**
  * Class to represent the state of the node in the {@link Workflow}.
  */
+@Beta
 public class WorkflowNodeState {
 
   private final String nodeId;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.worker.Worker;
+import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.common.ApplicationNotFoundException;
@@ -30,6 +31,7 @@ import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.internal.app.store.WorkflowDataset;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.WorkflowNodeStateDetail;
 import co.cask.cdap.proto.WorkflowStatistics;
 import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.annotations.VisibleForTesting;
@@ -368,6 +370,13 @@ public interface Store {
    * @return the {@link WorkflowToken} for the specified workflow run
    */
   WorkflowToken getWorkflowToken(Id.Workflow workflowId, String workflowRunId);
+
+  /**
+   * Get the node states for {@link Workflow} run.
+   * @param workflowRunId run of the Workflow.
+   * @return {@link Map} of node id to the {@link WorkflowNodeStateDetail}
+   */
+  Map<String, WorkflowNodeStateDetail> getWorkflowNodeStates(ProgramRunId workflowRunId);
 
   /**
    * Used by {@link co.cask.cdap.gateway.handlers.WorkflowStatsSLAHttpHandler} to get the statistics of all completed

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -380,11 +380,12 @@ public interface Store {
   void addWorkflowNodeState(ProgramRunId workflowRunId, WorkflowNodeStateDetail nodeStateDetail);
 
   /**
-   * Get the node states for {@link Workflow} run.
+   * Get the node states for a given {@link Workflow} run.
+   *
    * @param workflowRunId run of the Workflow.
-   * @return {@link Map} of node id to the {@link WorkflowNodeStateDetail}
+   * @return {@link List} of {@link WorkflowNodeStateDetail}
    */
-  Map<String, WorkflowNodeStateDetail> getWorkflowNodeStates(ProgramRunId workflowRunId);
+  List<WorkflowNodeStateDetail> getWorkflowNodeStates(ProgramRunId workflowRunId);
 
   /**
    * Used by {@link co.cask.cdap.gateway.handlers.WorkflowStatsSLAHttpHandler} to get the statistics of all completed

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -372,6 +372,14 @@ public interface Store {
   WorkflowToken getWorkflowToken(Id.Workflow workflowId, String workflowRunId);
 
   /**
+   * Add node state for the given {@link Workflow} run. This method is used to update the
+   * state of the custom actions started by Workflow.
+   * @param workflowRunId the Workflow run
+   * @param nodeStateDetail the node state to be added for the Workflow run
+   */
+  void addWorkflowNodeState(ProgramRunId workflowRunId, WorkflowNodeStateDetail nodeStateDetail);
+
+  /**
    * Get the node states for {@link Workflow} run.
    * @param workflowRunId run of the Workflow.
    * @return {@link Map} of node id to the {@link WorkflowNodeStateDetail}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
@@ -373,8 +373,13 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
       throw new NotFoundException(workflowRunId);
     }
 
-    responder.sendJson(HttpResponseStatus.OK, store.getWorkflowNodeStates(workflowRunId),
-                       STRING_TO_NODESTATEDETAIL_MAP_TYPE);
+    List<WorkflowNodeStateDetail> nodeStateDetails = store.getWorkflowNodeStates(workflowRunId);
+    Map<String, WorkflowNodeStateDetail> nodeStates = new HashMap<>();
+    for (WorkflowNodeStateDetail nodeStateDetail : nodeStateDetails) {
+      nodeStates.put(nodeStateDetail.getNodeId(), nodeStateDetail);
+    }
+
+    responder.sendJson(HttpResponseStatus.OK, nodeStates, STRING_TO_NODESTATEDETAIL_MAP_TYPE);
   }
 
   @GET

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -32,6 +32,8 @@ import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.internal.io.SchemaGenerator;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
+import co.cask.cdap.proto.DefaultThrowable;
+import co.cask.cdap.proto.codec.DefaultThrowableCodec;
 import co.cask.cdap.proto.codec.FlowSpecificationCodec;
 import co.cask.cdap.proto.codec.FlowletSpecificationCodec;
 import co.cask.cdap.proto.codec.MapReduceSpecificationCodec;
@@ -92,6 +94,7 @@ public final class ApplicationSpecificationAdapter {
       .registerTypeAdapter(ScheduleSpecification.class, new ScheduleSpecificationCodec())
       .registerTypeAdapter(ServiceSpecification.class, new ServiceSpecificationCodec())
       .registerTypeAdapter(WorkerSpecification.class, new WorkerSpecificationCodec())
+      .registerTypeAdapter(DefaultThrowable.class, new DefaultThrowableCodec())
       .registerTypeAdapterFactory(new AppSpecTypeAdapterFactory());
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
@@ -32,8 +32,7 @@ import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.internal.io.SchemaGenerator;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
-import co.cask.cdap.proto.DefaultThrowable;
-import co.cask.cdap.proto.codec.DefaultThrowableCodec;
+import co.cask.cdap.proto.WorkflowNodeThrowable;
 import co.cask.cdap.proto.codec.FlowSpecificationCodec;
 import co.cask.cdap.proto.codec.FlowletSpecificationCodec;
 import co.cask.cdap.proto.codec.MapReduceSpecificationCodec;
@@ -42,6 +41,7 @@ import co.cask.cdap.proto.codec.SparkSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkerSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkflowActionSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkflowNodeCodec;
+import co.cask.cdap.proto.codec.WorkflowNodeThrowableCodec;
 import co.cask.cdap.proto.codec.WorkflowSpecificationCodec;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -94,7 +94,7 @@ public final class ApplicationSpecificationAdapter {
       .registerTypeAdapter(ScheduleSpecification.class, new ScheduleSpecificationCodec())
       .registerTypeAdapter(ServiceSpecification.class, new ServiceSpecificationCodec())
       .registerTypeAdapter(WorkerSpecification.class, new WorkerSpecificationCodec())
-      .registerTypeAdapter(DefaultThrowable.class, new DefaultThrowableCodec())
+      .registerTypeAdapter(WorkflowNodeThrowable.class, new WorkflowNodeThrowableCodec())
       .registerTypeAdapterFactory(new AppSpecTypeAdapterFactory());
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/AbstractProgramWorkflowRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/AbstractProgramWorkflowRunner.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.runtime.workflow;
 import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.common.Scope;
+import co.cask.cdap.api.workflow.NodeStatus;
 import co.cask.cdap.api.workflow.WorkflowNodeState;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
@@ -146,22 +147,20 @@ public abstract class AbstractProgramWorkflowRunner implements ProgramWorkflowRu
     controller.addListener(new AbstractListener() {
       @Override
       public void completed() {
-        nodeStates.put(nodeId, new WorkflowNodeState(nodeId, WorkflowNodeState.NodeStatus.COMPLETED,
-                                                     controller.getRunId().getId(), null));
+        nodeStates.put(nodeId, new WorkflowNodeState(nodeId, NodeStatus.COMPLETED, controller.getRunId().getId(),
+                                                     null));
         completion.set(null);
       }
 
       @Override
       public void killed() {
-        nodeStates.put(nodeId, new WorkflowNodeState(nodeId, WorkflowNodeState.NodeStatus.KILLED,
-                                                     controller.getRunId().getId(), null));
+        nodeStates.put(nodeId, new WorkflowNodeState(nodeId, NodeStatus.KILLED, controller.getRunId().getId(), null));
         completion.set(null);
       }
 
       @Override
       public void error(Throwable cause) {
-        nodeStates.put(nodeId, new WorkflowNodeState(nodeId, WorkflowNodeState.NodeStatus.FAILED,
-                                                     controller.getRunId().getId(), cause));
+        nodeStates.put(nodeId, new WorkflowNodeState(nodeId, NodeStatus.FAILED, controller.getRunId().getId(), cause));
         completion.setException(cause);
       }
     }, Threads.SAME_THREAD_EXECUTOR);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,6 +21,7 @@ import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.api.workflow.WorkflowActionSpecification;
 import co.cask.cdap.api.workflow.WorkflowContext;
+import co.cask.cdap.api.workflow.WorkflowNodeState;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.metrics.ProgramUserMetrics;
@@ -49,13 +50,14 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
   private final Map<String, String> runtimeArgs;
   private final WorkflowToken token;
   private final Metrics userMetrics;
+  private final Map<String, WorkflowNodeState> nodeStates;
 
   BasicWorkflowContext(WorkflowSpecification workflowSpec, @Nullable WorkflowActionSpecification spec,
                        @Nullable ProgramWorkflowRunner programWorkflowRunner,
                        Arguments arguments, WorkflowToken token, Program program, RunId runId,
                        MetricsCollectionService metricsCollectionService,
                        DatasetFramework datasetFramework, TransactionSystemClient txClient,
-                       DiscoveryServiceClient discoveryServiceClient) {
+                       DiscoveryServiceClient discoveryServiceClient, Map<String, WorkflowNodeState> nodeStates) {
     super(program, runId, arguments,
           (spec == null) ? new HashSet<String>() : spec.getDatasets(),
           getMetricCollector(program, runId.getId(), metricsCollectionService),
@@ -70,6 +72,7 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
     } else {
       this.userMetrics = null;
     }
+    this.nodeStates = nodeStates;
   }
 
   @Nullable
@@ -122,5 +125,10 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
   @Override
   public WorkflowToken getToken() {
     return token;
+  }
+
+  @Override
+  public Map<String, WorkflowNodeState> getNodeStates() {
+    return ImmutableMap.copyOf(nodeStates);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/MapReduceProgramWorkflowRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/MapReduceProgramWorkflowRunner.java
@@ -17,12 +17,15 @@ package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.workflow.WorkflowNodeState;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
 import com.google.common.base.Preconditions;
+
+import java.util.Map;
 
 /**
  * A {@link ProgramWorkflowRunner} that creates {@link Runnable} for executing MapReduce job from Workflow.
@@ -31,8 +34,8 @@ final class MapReduceProgramWorkflowRunner extends AbstractProgramWorkflowRunner
 
   MapReduceProgramWorkflowRunner(WorkflowSpecification workflowSpec, ProgramRunnerFactory programRunnerFactory,
                                  Program workflowProgram, ProgramOptions workflowProgramOptions, WorkflowToken token,
-                                 String nodeId) {
-    super(workflowProgram, workflowProgramOptions, programRunnerFactory, workflowSpec, token, nodeId);
+                                 String nodeId, Map<String, WorkflowNodeState> nodeStates) {
+    super(workflowProgram, workflowProgramOptions, programRunnerFactory, workflowSpec, token, nodeId, nodeStates);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ProgramWorkflowRunnerFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ProgramWorkflowRunnerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,6 +20,7 @@ import co.cask.cdap.api.mapreduce.MapReduce;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.workflow.WorkflowActionSpecification;
+import co.cask.cdap.api.workflow.WorkflowNodeState;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.program.Program;
@@ -28,6 +29,8 @@ import co.cask.cdap.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.internal.workflow.ProgramWorkflowAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 
 /**
  * A Factory for {@link ProgramWorkflowRunner} which returns the appropriate {@link ProgramWorkflowRunner}
@@ -56,21 +59,22 @@ public class ProgramWorkflowRunnerFactory {
    * Gives the appropriate instance of {@link ProgramWorkflowRunner} depending upon the program type found in the
    * properties of the {@link WorkflowActionSpecification}.
    *
-   * @param actionSpec The {@link WorkflowActionSpecification}
-   * @param token      The {@link WorkflowToken}
+   * @param actionSpec the {@link WorkflowActionSpecification}
+   * @param token the {@link WorkflowToken}
+   * @param nodeStates the map of node ids to node states
    * @return the appropriate concrete implementation of {@link ProgramWorkflowRunner} for the program
    */
   public ProgramWorkflowRunner getProgramWorkflowRunner(WorkflowActionSpecification actionSpec, WorkflowToken token,
-                                                        String nodeId) {
+                                                        String nodeId, Map<String, WorkflowNodeState> nodeStates) {
 
     if (actionSpec.getProperties().containsKey(ProgramWorkflowAction.PROGRAM_TYPE)) {
       switch (SchedulableProgramType.valueOf(actionSpec.getProperties().get(ProgramWorkflowAction.PROGRAM_TYPE))) {
         case MAPREDUCE:
           return new MapReduceProgramWorkflowRunner(workflowSpec, programRunnerFactory, workflowProgram,
-                                                    workflowProgramOptions, token, nodeId);
+                                                    workflowProgramOptions, token, nodeId, nodeStates);
         case SPARK:
           return new SparkProgramWorkflowRunner(workflowSpec, programRunnerFactory, workflowProgram,
-                                                workflowProgramOptions, token, nodeId);
+                                                workflowProgramOptions, token, nodeId, nodeStates);
         default:
           LOG.debug("No workflow program runner found for this program");
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/SparkProgramWorkflowRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/SparkProgramWorkflowRunner.java
@@ -19,12 +19,15 @@ import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.api.workflow.Workflow;
+import co.cask.cdap.api.workflow.WorkflowNodeState;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
 import com.google.common.base.Preconditions;
+
+import java.util.Map;
 
 /**
  * Creates {@link Runnable} for executing {@link Spark} programs from {@link Workflow}.
@@ -33,8 +36,8 @@ final class SparkProgramWorkflowRunner extends AbstractProgramWorkflowRunner {
 
   SparkProgramWorkflowRunner(WorkflowSpecification workflowSpec, ProgramRunnerFactory programRunnerFactory,
                              Program workflowProgram, ProgramOptions workflowProgramOptions, WorkflowToken token,
-                             String nodeId) {
-    super(workflowProgram, workflowProgramOptions, programRunnerFactory, workflowSpec, token, nodeId);
+                             String nodeId, Map<String, WorkflowNodeState> nodeStates) {
+    super(workflowProgram, workflowProgramOptions, programRunnerFactory, workflowSpec, token, nodeId, nodeStates);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -392,8 +392,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     CustomActionExecutor customActionExecutor = new CustomActionExecutor(workflowRunId, context,
                                                                          instantiator, classLoader);
     status.put(node.getNodeId(), node);
-    store.addWorkflowNodeState(workflowRunId, new WorkflowNodeStateDetail(node.getNodeId(), NodeStatus.RUNNING, null,
-                                                                          null));
+    store.addWorkflowNodeState(workflowRunId, new WorkflowNodeStateDetail(node.getNodeId(), NodeStatus.RUNNING));
     Throwable failureCause = null;
     try {
       customActionExecutor.execute();
@@ -406,9 +405,9 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       store.updateWorkflowToken(workflowRunId, token);
       NodeStatus status = failureCause == null ? NodeStatus.COMPLETED : NodeStatus.FAILED;
       nodeStates.put(node.getNodeId(), new WorkflowNodeState(node.getNodeId(), status, null, failureCause));
+      DefaultThrowable defaultThrowable = failureCause == null ? null : new DefaultThrowable(failureCause);
       store.addWorkflowNodeState(workflowRunId, new WorkflowNodeStateDetail(node.getNodeId(), status, null,
-                                                                            failureCause == null ? null
-                                                                              : new DefaultThrowable(failureCause)));
+                                                                            defaultThrowable));
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -55,9 +55,9 @@ import co.cask.cdap.internal.app.workflow.DefaultWorkflowActionConfigurer;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.workflow.ProgramWorkflowAction;
 import co.cask.cdap.logging.context.WorkflowLoggingContext;
-import co.cask.cdap.proto.DefaultThrowable;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
+import co.cask.cdap.proto.WorkflowNodeThrowable;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.http.NettyHttpService;
@@ -405,7 +405,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       store.updateWorkflowToken(workflowRunId, token);
       NodeStatus status = failureCause == null ? NodeStatus.COMPLETED : NodeStatus.FAILED;
       nodeStates.put(node.getNodeId(), new WorkflowNodeState(node.getNodeId(), status, null, failureCause));
-      DefaultThrowable defaultThrowable = failureCause == null ? null : new DefaultThrowable(failureCause);
+      WorkflowNodeThrowable defaultThrowable = failureCause == null ? null : new WorkflowNodeThrowable(failureCause);
       store.addWorkflowNodeState(workflowRunId, new WorkflowNodeStateDetail(node.getNodeId(), status, null,
                                                                             defaultThrowable));
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -168,6 +168,15 @@ public class AppMetadataStore extends MetadataStoreDataset {
     return nodeStates;
   }
 
+  public void addWorkflowNodeState(ProgramRunId workflowRunId, WorkflowNodeStateDetail nodeStateDetail) {
+    // Node states will be stored with following key:
+    // workflowNodeState.namespace.app.WORKFLOW.workflowName.workflowRun.workflowNodeId
+    MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_NODE_STATE, workflowRunId.getParent().toId())
+      .add(workflowRunId.getRun()).add(nodeStateDetail.getNodeId()).build();
+
+    write(key, nodeStateDetail);
+  }
+
   private void addWorkflowNodeState(Id.Program program, String pid, Map<String, String> systemArgs,
                                     ProgramRunStatus status, @Nullable Throwable failureCause) {
     String workflowNodeId = systemArgs.get(ProgramOptionConstants.WORKFLOW_NODE_ID);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -54,6 +54,7 @@ import co.cask.cdap.internal.app.program.ProgramBundle;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.WorkflowNodeStateDetail;
 import co.cask.cdap.proto.WorkflowStatistics;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramRunId;
@@ -902,6 +903,17 @@ public class DefaultStore implements Store {
         @Override
         public WorkflowToken apply(AppMetadataStore mds) throws Exception {
           return mds.getWorkflowToken(workflowId, workflowRunId);
+        }
+      }, apps.get());
+  }
+
+  @Override
+  public Map<String, WorkflowNodeStateDetail> getWorkflowNodeStates(final ProgramRunId workflowRunId) {
+    return appsTx.get().executeUnchecked(
+      new TransactionExecutor.Function<AppMetadataStore, Map<String, WorkflowNodeStateDetail>>() {
+        @Override
+        public Map<String, WorkflowNodeStateDetail> apply(AppMetadataStore mds) throws Exception {
+          return mds.getWorkflowNodeStates(workflowRunId);
         }
       }, apps.get());
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -908,6 +908,18 @@ public class DefaultStore implements Store {
   }
 
   @Override
+  public void addWorkflowNodeState(final ProgramRunId workflowRunId, final WorkflowNodeStateDetail nodeStateDetail) {
+    appsTx.get().executeUnchecked(
+      new TransactionExecutor.Function<AppMetadataStore, Void>() {
+        @Override
+        public Void apply(AppMetadataStore mds) throws Exception {
+          mds.addWorkflowNodeState(workflowRunId, nodeStateDetail);
+          return null;
+        }
+      }, apps.get());
+  }
+
+  @Override
   public Map<String, WorkflowNodeStateDetail> getWorkflowNodeStates(final ProgramRunId workflowRunId) {
     return appsTx.get().executeUnchecked(
       new TransactionExecutor.Function<AppMetadataStore, Map<String, WorkflowNodeStateDetail>>() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -920,11 +920,11 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public Map<String, WorkflowNodeStateDetail> getWorkflowNodeStates(final ProgramRunId workflowRunId) {
+  public List<WorkflowNodeStateDetail> getWorkflowNodeStates(final ProgramRunId workflowRunId) {
     return appsTx.get().executeUnchecked(
-      new TransactionExecutor.Function<AppMetadataStore, Map<String, WorkflowNodeStateDetail>>() {
+      new TransactionExecutor.Function<AppMetadataStore, List<WorkflowNodeStateDetail>>() {
         @Override
-        public Map<String, WorkflowNodeStateDetail> apply(AppMetadataStore mds) throws Exception {
+        public List<WorkflowNodeStateDetail> apply(AppMetadataStore mds) throws Exception {
           return mds.getWorkflowNodeStates(workflowRunId);
         }
       }, apps.get());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.spark.JavaSparkProgram;
 import co.cask.cdap.api.spark.SparkContext;
 import co.cask.cdap.api.workflow.AbstractWorkflow;
 import co.cask.cdap.api.workflow.AbstractWorkflowAction;
+import co.cask.cdap.api.workflow.NodeStatus;
 import co.cask.cdap.api.workflow.WorkflowContext;
 import co.cask.cdap.api.workflow.WorkflowNodeState;
 import co.cask.cdap.internal.app.runtime.batch.WordCount;
@@ -140,7 +141,6 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
     }
   }
 
-
   /**
    *
    */
@@ -164,26 +164,30 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
     @Override
     public void destroy() {
       Map<String, WorkflowNodeState> nodeStates = getContext().getNodeStates();
-      Preconditions.checkArgument(4 == nodeStates.size());
+      Preconditions.checkArgument(5 == nodeStates.size());
       WorkflowNodeState nodeState = nodeStates.get("OneMR");
       Preconditions.checkArgument("OneMR".equals(nodeState.getNodeId()));
-      Preconditions.checkNotNull(nodeState.getRunId());
-      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
+      Preconditions.checkArgument(nodeState.getRunId() != null);
+      Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
 
       nodeState = nodeStates.get("OneSpark");
       Preconditions.checkArgument("OneSpark".equals(nodeState.getNodeId()));
-      Preconditions.checkNotNull(nodeState.getRunId());
-      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
+      Preconditions.checkArgument(nodeState.getRunId() != null);
+      Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
 
       nodeState = nodeStates.get("AnotherMR");
       Preconditions.checkArgument("AnotherMR".equals(nodeState.getNodeId()));
-      Preconditions.checkNotNull(nodeState.getRunId());
-      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
+      Preconditions.checkArgument(nodeState.getRunId() != null);
+      Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
 
       nodeState = nodeStates.get("AnotherSpark");
       Preconditions.checkArgument("AnotherSpark".equals(nodeState.getNodeId()));
-      Preconditions.checkNotNull(nodeState.getRunId());
-      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
+      Preconditions.checkArgument(nodeState.getRunId() != null);
+      Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
+
+      nodeState = nodeStates.get("OneAction");
+      Preconditions.checkArgument("OneAction".equals(nodeState.getNodeId()));
+      Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
     }
   }
 
@@ -195,13 +199,13 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
       Preconditions.checkArgument(2 == nodeStates.size());
       WorkflowNodeState nodeState = nodeStates.get("OneMR");
       Preconditions.checkArgument("OneMR".equals(nodeState.getNodeId()));
-      Preconditions.checkNotNull(nodeState.getRunId());
-      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
+      Preconditions.checkArgument(nodeState.getRunId() != null);
+      Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
 
       nodeState = nodeStates.get("OneSpark");
       Preconditions.checkArgument("OneSpark".equals(nodeState.getNodeId()));
-      Preconditions.checkNotNull(nodeState.getRunId());
-      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
+      Preconditions.checkArgument(nodeState.getRunId() != null);
+      Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
     }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
@@ -24,6 +24,9 @@ import co.cask.cdap.api.spark.AbstractSpark;
 import co.cask.cdap.api.spark.JavaSparkProgram;
 import co.cask.cdap.api.spark.SparkContext;
 import co.cask.cdap.api.workflow.AbstractWorkflow;
+import co.cask.cdap.api.workflow.AbstractWorkflowAction;
+import co.cask.cdap.api.workflow.WorkflowContext;
+import co.cask.cdap.api.workflow.WorkflowNodeState;
 import co.cask.cdap.internal.app.runtime.batch.WordCount;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.mapreduce.Job;
@@ -142,12 +145,63 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
    *
    */
   public static class OneWorkflow extends AbstractWorkflow {
+
+    @Override
+    public void initialize(WorkflowContext context) throws Exception {
+      super.initialize(context);
+      Preconditions.checkArgument(0 == context.getNodeStates().size());
+    }
+
     @Override
     public void configure() {
       addMapReduce("OneMR");
       addSpark("OneSpark");
+      addAction(new OneAction());
       addMapReduce("AnotherMR");
       addSpark("AnotherSpark");
+    }
+
+    @Override
+    public void destroy() {
+      Map<String, WorkflowNodeState> nodeStates = getContext().getNodeStates();
+      Preconditions.checkArgument(4 == nodeStates.size());
+      WorkflowNodeState nodeState = nodeStates.get("OneMR");
+      Preconditions.checkArgument("OneMR".equals(nodeState.getNodeId()));
+      Preconditions.checkNotNull(nodeState.getRunId());
+      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
+
+      nodeState = nodeStates.get("OneSpark");
+      Preconditions.checkArgument("OneSpark".equals(nodeState.getNodeId()));
+      Preconditions.checkNotNull(nodeState.getRunId());
+      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
+
+      nodeState = nodeStates.get("AnotherMR");
+      Preconditions.checkArgument("AnotherMR".equals(nodeState.getNodeId()));
+      Preconditions.checkNotNull(nodeState.getRunId());
+      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
+
+      nodeState = nodeStates.get("AnotherSpark");
+      Preconditions.checkArgument("AnotherSpark".equals(nodeState.getNodeId()));
+      Preconditions.checkNotNull(nodeState.getRunId());
+      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
+    }
+  }
+
+  public static class OneAction extends AbstractWorkflowAction {
+
+    @Override
+    public void run() {
+      Map<String, WorkflowNodeState> nodeStates = getContext().getNodeStates();
+      Preconditions.checkArgument(2 == nodeStates.size());
+      WorkflowNodeState nodeState = nodeStates.get("OneMR");
+      Preconditions.checkArgument("OneMR".equals(nodeState.getNodeId()));
+      Preconditions.checkNotNull(nodeState.getRunId());
+      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
+
+      nodeState = nodeStates.get("OneSpark");
+      Preconditions.checkArgument("OneSpark".equals(nodeState.getNodeId()));
+      Preconditions.checkNotNull(nodeState.getRunId());
+      Preconditions.checkArgument(WorkflowNodeState.NodeStatus.COMPLETED == nodeState.getNodeStatus());
     }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
@@ -42,9 +42,18 @@ import java.util.Map;
  *
  */
 public class WorkflowAppWithScopedParameters extends AbstractApplication {
+
+  public static final String APP_NAME = "WorkflowAppWithScopedParameters";
+  public static final String ONE_MR = "OneMR";
+  public static final String ANOTHER_MR = "AnotherMR";
+  public static final String ONE_SPARK = "OneSpark";
+  public static final String ANOTHER_SPARK = "AnotherSpark";
+  public static final String ONE_WORKFLOW = "OneWorkflow";
+  public static final String ONE_ACTION = "OneAction";
+
   @Override
   public void configure() {
-    setName("WorkflowAppWithScopedParameters");
+    setName(APP_NAME);
     setDescription("WorkflowApp which demonstrates the scoped runtime arguments.");
     addMapReduce(new OneMR());
     addMapReduce(new AnotherMR());
@@ -154,39 +163,39 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
 
     @Override
     public void configure() {
-      addMapReduce("OneMR");
-      addSpark("OneSpark");
+      addMapReduce(ONE_MR);
+      addSpark(ONE_SPARK);
       addAction(new OneAction());
-      addMapReduce("AnotherMR");
-      addSpark("AnotherSpark");
+      addMapReduce(ANOTHER_MR);
+      addSpark(ANOTHER_SPARK);
     }
 
     @Override
     public void destroy() {
       Map<String, WorkflowNodeState> nodeStates = getContext().getNodeStates();
       Preconditions.checkArgument(5 == nodeStates.size());
-      WorkflowNodeState nodeState = nodeStates.get("OneMR");
-      Preconditions.checkArgument("OneMR".equals(nodeState.getNodeId()));
+      WorkflowNodeState nodeState = nodeStates.get(ONE_MR);
+      Preconditions.checkArgument(ONE_MR.equals(nodeState.getNodeId()));
       Preconditions.checkArgument(nodeState.getRunId() != null);
       Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
 
-      nodeState = nodeStates.get("OneSpark");
-      Preconditions.checkArgument("OneSpark".equals(nodeState.getNodeId()));
+      nodeState = nodeStates.get(ONE_SPARK);
+      Preconditions.checkArgument(ONE_SPARK.equals(nodeState.getNodeId()));
       Preconditions.checkArgument(nodeState.getRunId() != null);
       Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
 
-      nodeState = nodeStates.get("AnotherMR");
-      Preconditions.checkArgument("AnotherMR".equals(nodeState.getNodeId()));
+      nodeState = nodeStates.get(ANOTHER_MR);
+      Preconditions.checkArgument(ANOTHER_MR.equals(nodeState.getNodeId()));
       Preconditions.checkArgument(nodeState.getRunId() != null);
       Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
 
-      nodeState = nodeStates.get("AnotherSpark");
-      Preconditions.checkArgument("AnotherSpark".equals(nodeState.getNodeId()));
+      nodeState = nodeStates.get(ANOTHER_SPARK);
+      Preconditions.checkArgument(ANOTHER_SPARK.equals(nodeState.getNodeId()));
       Preconditions.checkArgument(nodeState.getRunId() != null);
       Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
 
-      nodeState = nodeStates.get("OneAction");
-      Preconditions.checkArgument("OneAction".equals(nodeState.getNodeId()));
+      nodeState = nodeStates.get(ONE_ACTION);
+      Preconditions.checkArgument(ONE_ACTION.equals(nodeState.getNodeId()));
       Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
     }
   }
@@ -197,13 +206,13 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
     public void run() {
       Map<String, WorkflowNodeState> nodeStates = getContext().getNodeStates();
       Preconditions.checkArgument(2 == nodeStates.size());
-      WorkflowNodeState nodeState = nodeStates.get("OneMR");
-      Preconditions.checkArgument("OneMR".equals(nodeState.getNodeId()));
+      WorkflowNodeState nodeState = nodeStates.get(ONE_MR);
+      Preconditions.checkArgument(ONE_MR.equals(nodeState.getNodeId()));
       Preconditions.checkArgument(nodeState.getRunId() != null);
       Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
 
-      nodeState = nodeStates.get("OneSpark");
-      Preconditions.checkArgument("OneSpark".equals(nodeState.getNodeId()));
+      nodeState = nodeStates.get(ONE_SPARK);
+      Preconditions.checkArgument(ONE_SPARK.equals(nodeState.getNodeId()));
       Preconditions.checkArgument(nodeState.getRunId() != null);
       Preconditions.checkArgument(NodeStatus.COMPLETED == nodeState.getNodeStatus());
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -188,8 +188,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     String versionedUrl = getVersionedAPIPath(nextRunTimeUrl, Constants.Gateway.API_VERSION_3_TOKEN,
                                               program.getNamespaceId());
     HttpResponse response = doGet(versionedUrl);
-    return readResponse(response, new TypeToken<List<ScheduledRuntime>>() {
-    }.getType());
+    return readResponse(response, new TypeToken<List<ScheduledRuntime>>() { }.getType());
   }
 
   private String getLocalDatasetPath(ProgramId workflowId, String runId) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -53,7 +53,6 @@ import co.cask.cdap.proto.codec.WorkflowActionSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkflowTokenDetailCodec;
 import co.cask.cdap.proto.codec.WorkflowTokenNodeDetailCodec;
 import co.cask.cdap.proto.id.ProgramId;
-import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
@@ -188,7 +187,8 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     String versionedUrl = getVersionedAPIPath(nextRunTimeUrl, Constants.Gateway.API_VERSION_3_TOKEN,
                                               program.getNamespaceId());
     HttpResponse response = doGet(versionedUrl);
-    return readResponse(response, new TypeToken<List<ScheduledRuntime>>() { }.getType());
+    return readResponse(response, new TypeToken<List<ScheduledRuntime>>() {
+    }.getType());
   }
 
   private String getLocalDatasetPath(ProgramId workflowId, String runId) {
@@ -201,7 +201,8 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
   private Map<String, DatasetSpecificationSummary> getWorkflowLocalDatasets(ProgramId workflowId, String runId)
     throws Exception {
     HttpResponse response = doGet(getLocalDatasetPath(workflowId, runId));
-    return readResponse(response, new TypeToken<Map<String, DatasetSpecificationSummary>>() { }.getType());
+    return readResponse(response, new TypeToken<Map<String, DatasetSpecificationSummary>>() {
+    }.getType());
   }
 
   private void deleteWorkflowLocalDatasets(ProgramId workflowId, String runId) throws Exception {
@@ -645,13 +646,14 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
   private Map<String, WorkflowNodeStateDetail> getWorkflowNodeStates(ProgramId workflowId, String runId)
     throws Exception {
-    String path = String.format("apps/%s/workflows/%s/runs/%s/nodestates", workflowId.getApplication(),
+    String path = String.format("apps/%s/workflows/%s/runs/%s/nodes/state", workflowId.getApplication(),
                                 workflowId.getProgram(), runId);
 
     path = getVersionedAPIPath(path, Constants.Gateway.API_VERSION_3_TOKEN, workflowId.getNamespace());
 
     HttpResponse response = doGet(path);
-    return readResponse(response, new TypeToken<Map<String, WorkflowNodeStateDetail>>() { }.getType());
+    return readResponse(response, new TypeToken<Map<String, WorkflowNodeStateDetail>>() {
+    }.getType());
   }
 
   @Category(XSlowTests.class)
@@ -758,6 +760,12 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     Assert.assertNotNull(anotherSparkRunRecordProperties.get("workflowrunid"));
     Assert.assertEquals(workflowHistoryRuns.get(0).getPid(), anotherSparkRunRecordProperties.get("workflowrunid"));
+
+    Assert.assertEquals(workflowRunRecordProperties.get("OneMR"), oneMRHistoryRuns.get(0).getPid());
+    Assert.assertEquals(workflowRunRecordProperties.get("OneSpark"), oneSparkHistoryRuns.get(0).getPid());
+    Assert.assertEquals(workflowRunRecordProperties.get("AnotherMR"), anotherMRHistoryRuns.get(0).getPid());
+    Assert.assertEquals(workflowRunRecordProperties.get("AnotherSpark"), anotherSparkHistoryRuns.get(0).getPid());
+
 
     // Get Workflow node states
     Map<String, WorkflowNodeStateDetail> nodeStates = getWorkflowNodeStates(programId,

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -764,7 +764,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
                                                                             workflowHistoryRuns.get(0).getPid());
 
     Assert.assertNotNull(nodeStates);
-    Assert.assertEquals(4, nodeStates.size());
+    Assert.assertEquals(5, nodeStates.size());
     WorkflowNodeStateDetail mrNodeState = nodeStates.get("OneMR");
     Assert.assertNotNull(mrNodeState);
     Assert.assertEquals("OneMR", mrNodeState.getNodeId());
@@ -784,6 +784,10 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     Assert.assertNotNull(sparkNodeState);
     Assert.assertEquals("AnotherSpark", sparkNodeState.getNodeId());
     Assert.assertEquals(anotherSparkHistoryRuns.get(0).getPid(), sparkNodeState.getRunId());
+
+    WorkflowNodeStateDetail oneActionNodeState = nodeStates.get("OneAction");
+    Assert.assertNotNull(oneActionNodeState);
+    Assert.assertEquals("OneAction", oneActionNodeState.getNodeId());
   }
 
   @Ignore

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -652,8 +652,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     path = getVersionedAPIPath(path, Constants.Gateway.API_VERSION_3_TOKEN, workflowId.getNamespace());
 
     HttpResponse response = doGet(path);
-    return readResponse(response, new TypeToken<Map<String, WorkflowNodeStateDetail>>() {
-    }.getType());
+    return readResponse(response, new TypeToken<Map<String, WorkflowNodeStateDetail>>() { }.getType());
   }
 
   @Category(XSlowTests.class)

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -31,7 +31,6 @@ import co.cask.cdap.WorkflowTokenTestPutApp;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.workflow.WorkflowActionNode;
 import co.cask.cdap.api.workflow.WorkflowActionSpecification;
-import co.cask.cdap.api.workflow.WorkflowNodeState;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Tasks;
@@ -93,7 +92,12 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     .registerTypeAdapter(WorkflowTokenNodeDetail.class, new WorkflowTokenNodeDetailCodec())
     .create();
 
-  protected static final Type LIST_WORKFLOWACTIONNODE_TYPE = new TypeToken<List<WorkflowActionNode>>() { }.getType();
+  private static final Type LIST_WORKFLOWACTIONNODE_TYPE = new TypeToken<List<WorkflowActionNode>>() { }.getType();
+  private static final Type MAP_STRING_TO_WORKFLOWNODESTATEDETAIL_TYPE
+    = new TypeToken<Map<String, WorkflowNodeStateDetail>>() { }.getType();
+  private static final Type MAP_STRING_TO_DATASETSPECIFICATIONSUMMARY_TYPE
+    = new TypeToken<Map<String, DatasetSpecificationSummary>>() { }.getType();
+
 
   private void verifyRunningProgramCount(final Id.Program program, final String runId, final int expected)
     throws Exception {
@@ -201,8 +205,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
   private Map<String, DatasetSpecificationSummary> getWorkflowLocalDatasets(ProgramId workflowId, String runId)
     throws Exception {
     HttpResponse response = doGet(getLocalDatasetPath(workflowId, runId));
-    return readResponse(response, new TypeToken<Map<String, DatasetSpecificationSummary>>() {
-    }.getType());
+    return readResponse(response, MAP_STRING_TO_DATASETSPECIFICATIONSUMMARY_TYPE);
   }
 
   private void deleteWorkflowLocalDatasets(ProgramId workflowId, String runId) throws Exception {
@@ -652,7 +655,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     path = getVersionedAPIPath(path, Constants.Gateway.API_VERSION_3_TOKEN, workflowId.getNamespace());
 
     HttpResponse response = doGet(path);
-    return readResponse(response, new TypeToken<Map<String, WorkflowNodeStateDetail>>() { }.getType());
+    return readResponse(response, MAP_STRING_TO_WORKFLOWNODESTATEDETAIL_TYPE);
   }
 
   @Category(XSlowTests.class)

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -60,12 +60,13 @@ import co.cask.cdap.internal.DefaultId;
 import co.cask.cdap.internal.app.Specifications;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
-import co.cask.cdap.proto.DefaultThrowable;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
+import co.cask.cdap.proto.WorkflowNodeThrowable;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
@@ -192,13 +193,13 @@ public class DefaultStoreTest {
     String mapReduceName = "mapReduce1";
     String sparkName = "spark1";
 
-    ProgramId mapReduceProgram = Ids.namespace(namespaceName).app(appName).mr(mapReduceName);
-    ProgramId sparkProgram = Ids.namespace(namespaceName).app(appName).spark(sparkName);
+    ApplicationId appId = Ids.namespace(namespaceName).app(appName);
+    ProgramId mapReduceProgram = appId.mr(mapReduceName);
+    ProgramId sparkProgram = appId.spark(sparkName);
 
     long currentTime = System.currentTimeMillis();
     RunId workflowRunId = RunIds.generate(currentTime);
-    ProgramRunId workflowRun = Ids.namespace(namespaceName).app(appName)
-      .workflow(workflowName).run(workflowRunId.getId());
+    ProgramRunId workflowRun = appId.workflow(workflowName).run(workflowRunId.getId());
 
     // start Workflow
     store.setStart(workflowRun.getParent().toId(), workflowRun.getRun(), currentTime);
@@ -249,7 +250,7 @@ public class DefaultStoreTest {
     Assert.assertEquals(sparkName, nodeStateDetail.getNodeId());
     Assert.assertEquals(NodeStatus.FAILED, nodeStateDetail.getNodeStatus());
     Assert.assertEquals(sparkRunId.getId(), nodeStateDetail.getRunId());
-    DefaultThrowable failureCause = nodeStateDetail.getFailureCause();
+    WorkflowNodeThrowable failureCause = nodeStateDetail.getFailureCause();
     Assert.assertNotNull(failureCause);
     Assert.assertTrue("illegal argument".equals(failureCause.getMessage()));
     Assert.assertTrue("java.lang.IllegalArgumentException".equals(failureCause.getClassName()));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -46,6 +46,7 @@ import co.cask.cdap.api.schedule.Schedule;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.schedule.Schedules;
 import co.cask.cdap.api.service.ServiceSpecification;
+import co.cask.cdap.api.workflow.NodeStatus;
 import co.cask.cdap.api.workflow.ScheduleProgramInfo;
 import co.cask.cdap.app.DefaultAppConfigurer;
 import co.cask.cdap.app.DefaultApplicationContext;
@@ -231,13 +232,13 @@ public class DefaultStoreTest {
     Assert.assertEquals(2, workflowNodeStates.size());
     WorkflowNodeStateDetail nodeStateDetail = workflowNodeStates.get(mapReduceName);
     Assert.assertEquals(mapReduceName, nodeStateDetail.getNodeId());
-    Assert.assertEquals(WorkflowNodeStateDetail.NodeStatus.COMPLETED, nodeStateDetail.getNodeStatus());
+    Assert.assertEquals(NodeStatus.COMPLETED, nodeStateDetail.getNodeStatus());
     Assert.assertEquals(mapReduceRunId.getId(), nodeStateDetail.getRunId());
     Assert.assertNull(nodeStateDetail.getFailureCause());
 
     nodeStateDetail = workflowNodeStates.get(sparkName);
     Assert.assertEquals(sparkName, nodeStateDetail.getNodeId());
-    Assert.assertEquals(WorkflowNodeStateDetail.NodeStatus.FAILED, nodeStateDetail.getNodeStatus());
+    Assert.assertEquals(NodeStatus.FAILED, nodeStateDetail.getNodeStatus());
     Assert.assertEquals(sparkRunId.getId(), nodeStateDetail.getRunId());
     Assert.assertNull(nodeStateDetail.getFailureCause());
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DefaultThrowable.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DefaultThrowable.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto;
+
+import javax.annotation.Nullable;
+
+/**
+ * Carries {@link Throwable} information in {@link WorkflowNodeStateDetail}.
+ */
+public final class DefaultThrowable {
+  private final String className;
+  private final String message;
+  private final StackTraceElement[] stackTraces;
+  private final DefaultThrowable cause;
+
+  /**
+   * Creates serializable instance from {@link Throwable}.
+   */
+  public DefaultThrowable(Throwable throwable) {
+    this.className = throwable.getClass().getName();
+    this.message = throwable.getMessage();
+
+    StackTraceElement[] stackTraceElements = throwable.getStackTrace();
+    this.stackTraces = new StackTraceElement[stackTraceElements.length];
+    System.arraycopy(stackTraceElements, 0, stackTraces, 0, stackTraceElements.length);
+
+    cause = (throwable.getCause() == null) ? null : new DefaultThrowable(throwable.getCause());
+  }
+
+  /**
+   * Return the class name for the Throwable.
+   */
+  public String getClassName() {
+    return className;
+  }
+
+  /**
+   * Return the detail message associated with the Throwable.
+   */
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Return the stack traces.
+   */
+  public StackTraceElement[] getStackTraces() {
+    return stackTraces;
+  }
+
+  /**
+   * Return the cause of Throwable if it is available, otherwise {@code null}.
+   */
+  @Nullable
+  public DefaultThrowable getCause() {
+    return cause;
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DefaultThrowable.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DefaultThrowable.java
@@ -26,6 +26,13 @@ public final class DefaultThrowable {
   private final StackTraceElement[] stackTraces;
   private final DefaultThrowable cause;
 
+  public DefaultThrowable(String className, String message, StackTraceElement[] stackTraces, DefaultThrowable cause) {
+    this.className = className;
+    this.message = message;
+    this.stackTraces = stackTraces;
+    this.cause = cause;
+  }
+
   /**
    * Creates serializable instance from {@link Throwable}.
    */
@@ -37,11 +44,11 @@ public final class DefaultThrowable {
     this.stackTraces = new StackTraceElement[stackTraceElements.length];
     System.arraycopy(stackTraceElements, 0, stackTraces, 0, stackTraceElements.length);
 
-    cause = (throwable.getCause() == null) ? null : new DefaultThrowable(throwable.getCause());
+    this.cause = (throwable.getCause() == null) ? null : new DefaultThrowable(throwable.getCause());
   }
 
   /**
-   * Return the class name for the Throwable.
+   * Return the class name for the Throwablne.
    */
   public String getClassName() {
     return className;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,9 +15,6 @@
  */
 
 package co.cask.cdap.proto;
-
-
-import co.cask.cdap.api.workflow.WorkflowNodeState;
 
 /**
  * Program Status Types used to query program runs
@@ -35,16 +32,16 @@ public enum ProgramRunStatus {
    * @param status the program run status to be converted
    * @return the converted Workflow node status
    */
-  public static WorkflowNodeState.NodeStatus toNodeStatus(ProgramRunStatus status) {
+  public static WorkflowNodeStateDetail.NodeStatus toNodeStatus(ProgramRunStatus status) {
     switch(status) {
       case RUNNING:
-        return WorkflowNodeState.NodeStatus.RUNNING;
+        return WorkflowNodeStateDetail.NodeStatus.RUNNING;
       case COMPLETED:
-        return WorkflowNodeState.NodeStatus.COMPLETED;
+        return WorkflowNodeStateDetail.NodeStatus.COMPLETED;
       case FAILED:
-        return WorkflowNodeState.NodeStatus.FAILED;
+        return WorkflowNodeStateDetail.NodeStatus.FAILED;
       case KILLED:
-        return WorkflowNodeState.NodeStatus.KILLED;
+        return WorkflowNodeStateDetail.NodeStatus.KILLED;
       default:
         throw new IllegalArgumentException(String.format("No node status available corresponding to program status %s",
                                                          status.name()));

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.proto;
 
+import co.cask.cdap.api.workflow.NodeStatus;
+
 /**
  * Program Status Types used to query program runs
  */
@@ -32,16 +34,16 @@ public enum ProgramRunStatus {
    * @param status the program run status to be converted
    * @return the converted Workflow node status
    */
-  public static WorkflowNodeStateDetail.NodeStatus toNodeStatus(ProgramRunStatus status) {
+  public static NodeStatus toNodeStatus(ProgramRunStatus status) {
     switch(status) {
       case RUNNING:
-        return WorkflowNodeStateDetail.NodeStatus.RUNNING;
+        return NodeStatus.RUNNING;
       case COMPLETED:
-        return WorkflowNodeStateDetail.NodeStatus.COMPLETED;
+        return NodeStatus.COMPLETED;
       case FAILED:
-        return WorkflowNodeStateDetail.NodeStatus.FAILED;
+        return NodeStatus.FAILED;
       case KILLED:
-        return WorkflowNodeStateDetail.NodeStatus.KILLED;
+        return NodeStatus.KILLED;
       default:
         throw new IllegalArgumentException(String.format("No node status available corresponding to program status %s",
                                                          status.name()));

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeStateDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeStateDetail.java
@@ -28,7 +28,7 @@ public final class WorkflowNodeStateDetail {
   private final String nodeId;
   private final NodeStatus nodeStatus;
   private final String runId;
-  private final DefaultThrowable failureCause;
+  private final WorkflowNodeThrowable failureCause;
 
   /**
    * Create a new instance.
@@ -49,7 +49,7 @@ public final class WorkflowNodeStateDetail {
    * @param failureCause cause of failure, {code null} if execution of the node succeeded
    */
   public WorkflowNodeStateDetail(String nodeId, NodeStatus nodeStatus, @Nullable String runId,
-                                 @Nullable DefaultThrowable failureCause) {
+                                 @Nullable WorkflowNodeThrowable failureCause) {
     this.nodeId = nodeId;
     this.nodeStatus = nodeStatus;
     this.runId = runId;
@@ -83,7 +83,7 @@ public final class WorkflowNodeStateDetail {
    * Return the detail message string for failure if node execution failed, otherwise {@code null} is returned.
    */
   @Nullable
-  public DefaultThrowable getFailureCause() {
+  public WorkflowNodeThrowable getFailureCause() {
     return failureCause;
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeStateDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeStateDetail.java
@@ -13,15 +13,16 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+package co.cask.cdap.proto;
 
-package co.cask.cdap.api.workflow;
+import co.cask.cdap.api.workflow.Workflow;
 
 import javax.annotation.Nullable;
 
 /**
  * Class to represent the state of the node in the {@link Workflow}.
  */
-public final class WorkflowNodeState {
+public final class WorkflowNodeStateDetail {
 
   /**
    * Status of the node running inside the Workflow.
@@ -36,7 +37,7 @@ public final class WorkflowNodeState {
   private final String nodeId;
   private final NodeStatus nodeStatus;
   private final String runId;
-  private final Throwable failureCause;
+  private final DefaultThrowable failureCause;
 
   /**
    * Create a new instance.
@@ -45,8 +46,8 @@ public final class WorkflowNodeState {
    * @param runId run id assigned to the node, null if current node represents custom action or predicate
    * @param failureCause cause of failure, null if execution of the node succeeded
    */
-  public WorkflowNodeState(String nodeId, NodeStatus nodeStatus, @Nullable String runId,
-                           @Nullable Throwable failureCause) {
+  public WorkflowNodeStateDetail(String nodeId, NodeStatus nodeStatus, @Nullable String runId,
+                                 @Nullable DefaultThrowable failureCause) {
     this.nodeId = nodeId;
     this.nodeStatus = nodeStatus;
     this.runId = runId;
@@ -80,7 +81,7 @@ public final class WorkflowNodeState {
    * Return the detail message string for failure if node execution failed, otherwise {@code null} is returned.
    */
   @Nullable
-  public Throwable getFailureCause() {
+  public DefaultThrowable getFailureCause() {
     return failureCause;
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeStateDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeStateDetail.java
@@ -32,10 +32,21 @@ public final class WorkflowNodeStateDetail {
 
   /**
    * Create a new instance.
-   * @param nodeId id of the node inside the Workflow
+   *
+   * @param nodeId id of the node inside a Workflow
    * @param nodeStatus status of the node
-   * @param runId run id assigned to the node, null if current node represents custom action or predicate
-   * @param failureCause cause of failure, null if execution of the node succeeded
+   */
+  public WorkflowNodeStateDetail(String nodeId, NodeStatus nodeStatus) {
+    this(nodeId, nodeStatus, null, null);
+  }
+
+  /**
+   * Create a new instance.
+   *
+   * @param nodeId id of the node inside a Workflow
+   * @param nodeStatus status of the node
+   * @param runId run id assigned to the node, {code null} if current node represents custom action or predicate
+   * @param failureCause cause of failure, {code null} if execution of the node succeeded
    */
   public WorkflowNodeStateDetail(String nodeId, NodeStatus nodeStatus, @Nullable String runId,
                                  @Nullable DefaultThrowable failureCause) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeStateDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeStateDetail.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.proto;
 
+import co.cask.cdap.api.workflow.NodeStatus;
 import co.cask.cdap.api.workflow.Workflow;
 
 import javax.annotation.Nullable;
@@ -23,16 +24,6 @@ import javax.annotation.Nullable;
  * Class to represent the state of the node in the {@link Workflow}.
  */
 public final class WorkflowNodeStateDetail {
-
-  /**
-   * Status of the node running inside the Workflow.
-   */
-  public enum NodeStatus {
-    RUNNING,
-    COMPLETED,
-    FAILED,
-    KILLED
-  }
 
   private final String nodeId;
   private final NodeStatus nodeStatus;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeThrowable.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeThrowable.java
@@ -15,18 +15,29 @@
  */
 package co.cask.cdap.proto;
 
+import co.cask.cdap.proto.codec.WorkflowNodeThrowableCodec;
+
 import javax.annotation.Nullable;
 
 /**
  * Carries {@link Throwable} information in {@link WorkflowNodeStateDetail}.
  */
-public final class DefaultThrowable {
+public final class WorkflowNodeThrowable {
   private final String className;
   private final String message;
   private final StackTraceElement[] stackTraces;
-  private final DefaultThrowable cause;
+  private final WorkflowNodeThrowable cause;
 
-  public DefaultThrowable(String className, String message, StackTraceElement[] stackTraces, DefaultThrowable cause) {
+  /**
+   * This constructor is used by {@link WorkflowNodeThrowableCodec} during de-serialization.
+   *
+   * @param className the name of the Throwable
+   * @param message the message inside the Throwable
+   * @param stackTraces stack traces associated with the Throwable
+   * @param cause cause associated with the Throwable
+   */
+  public WorkflowNodeThrowable(String className, String message, StackTraceElement[] stackTraces,
+                               @Nullable WorkflowNodeThrowable cause) {
     this.className = className;
     this.message = message;
     this.stackTraces = stackTraces;
@@ -34,9 +45,11 @@ public final class DefaultThrowable {
   }
 
   /**
-   * Creates serializable instance from {@link Throwable}.
+   * This constructor is used to create serializable instance from {@link Throwable}.
+   *
+   * @param throwable the instance of Throwable to be serialize
    */
-  public DefaultThrowable(Throwable throwable) {
+  public WorkflowNodeThrowable(Throwable throwable) {
     this.className = throwable.getClass().getName();
     this.message = throwable.getMessage();
 
@@ -44,11 +57,11 @@ public final class DefaultThrowable {
     this.stackTraces = new StackTraceElement[stackTraceElements.length];
     System.arraycopy(stackTraceElements, 0, stackTraces, 0, stackTraceElements.length);
 
-    this.cause = (throwable.getCause() == null) ? null : new DefaultThrowable(throwable.getCause());
+    this.cause = (throwable.getCause() == null) ? null : new WorkflowNodeThrowable(throwable.getCause());
   }
 
   /**
-   * Return the class name for the Throwablne.
+   * Return the class name for the Throwable.
    */
   public String getClassName() {
     return className;
@@ -72,7 +85,7 @@ public final class DefaultThrowable {
    * Return the cause of Throwable if it is available, otherwise {@code null}.
    */
   @Nullable
-  public DefaultThrowable getCause() {
+  public WorkflowNodeThrowable getCause() {
     return cause;
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/DefaultThrowableCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/DefaultThrowableCodec.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.proto.DefaultThrowable;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+
+import java.lang.reflect.Type;
+
+/**
+ * Codec for {@link DefaultThrowable}.
+ */
+public final class DefaultThrowableCodec extends AbstractSpecificationCodec<DefaultThrowable> {
+
+  @Override
+  public JsonElement serialize(DefaultThrowable src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject json = new JsonObject();
+    json.addProperty("className", src.getClassName());
+    json.addProperty("message", src.getMessage());
+    json.add("stackTraces", context.serialize(src.getStackTraces(), StackTraceElement[].class));
+
+    DefaultThrowable cause = src.getCause();
+    if (cause != null) {
+      json.add("cause", context.serialize(cause, DefaultThrowable.class));
+    }
+
+    return json;
+  }
+
+  @Override
+  public DefaultThrowable deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+    throws JsonParseException {
+    return context.deserialize(json, DefaultThrowable.class);
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowNodeThrowableCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowNodeThrowableCodec.java
@@ -49,10 +49,10 @@ public final class WorkflowNodeThrowableCodec extends AbstractSpecificationCodec
     JsonArray stackTraces = jsonObj.get("stackTraces").getAsJsonArray();
     StackTraceElement[] stackTraceElements = context.deserialize(stackTraces, StackTraceElement[].class);
     JsonElement cause = jsonObj.get("cause");
-    if (cause == null) {
-      return new WorkflowNodeThrowable(className, message, stackTraceElements, null);
+    WorkflowNodeThrowable dfc = null;
+    if (cause != null) {
+      dfc = context.deserialize(cause, WorkflowNodeThrowable.class);
     }
-    WorkflowNodeThrowable dfc = context.deserialize(cause, WorkflowNodeThrowable.class);
     return new WorkflowNodeThrowable(className, message, stackTraceElements, dfc);
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowNodeThrowableCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowNodeThrowableCodec.java
@@ -15,7 +15,7 @@
  */
 package co.cask.cdap.proto.codec;
 
-import co.cask.cdap.proto.DefaultThrowable;
+import co.cask.cdap.proto.WorkflowNodeThrowable;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
@@ -23,38 +23,36 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;
-import java.util.Iterator;
 
 /**
- * Codec for {@link DefaultThrowable}.
+ * Codec for {@link WorkflowNodeThrowable}.
  */
-public final class DefaultThrowableCodec extends AbstractSpecificationCodec<DefaultThrowable> {
+public final class WorkflowNodeThrowableCodec extends AbstractSpecificationCodec<WorkflowNodeThrowable> {
 
   @Override
-  public JsonElement serialize(DefaultThrowable src, Type typeOfSrc, JsonSerializationContext context) {
+  public JsonElement serialize(WorkflowNodeThrowable src, Type typeOfSrc, JsonSerializationContext context) {
     JsonObject json = new JsonObject();
     json.addProperty("className", src.getClassName());
     json.addProperty("message", src.getMessage());
     json.add("stackTraces", context.serialize(src.getStackTraces(), StackTraceElement[].class));
-    json.add("cause", context.serialize(src.getCause(), DefaultThrowable.class));
+    json.add("cause", context.serialize(src.getCause(), WorkflowNodeThrowable.class));
     return json;
   }
 
   @Override
-  public DefaultThrowable deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+  public WorkflowNodeThrowable deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
     throws JsonParseException {
     JsonObject jsonObj = json.getAsJsonObject();
     String className = jsonObj.get("className").getAsString();
     String message = jsonObj.get("message").getAsString();
     JsonArray stackTraces = jsonObj.get("stackTraces").getAsJsonArray();
     StackTraceElement[] stackTraceElements = context.deserialize(stackTraces, StackTraceElement[].class);
-    final JsonElement cause = jsonObj.get("cause");
+    JsonElement cause = jsonObj.get("cause");
     if (cause == null) {
-      return new DefaultThrowable(className, message, stackTraceElements, null);
+      return new WorkflowNodeThrowable(className, message, stackTraceElements, null);
     }
-    DefaultThrowable dfc = context.deserialize(cause, DefaultThrowable.class);
-    return new DefaultThrowable(className, message, stackTraceElements, dfc);
+    WorkflowNodeThrowable dfc = context.deserialize(cause, WorkflowNodeThrowable.class);
+    return new WorkflowNodeThrowable(className, message, stackTraceElements, dfc);
   }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-4075
JIRA: https://issues.cask.co/browse/CDAP-5181

Following changes are done as a part of the PR:

1. In memory `Map<String, WorkflowNodeState>` is maintained in the `WorkflowDriver`.

2. `WorkflowContext` api has method `getNodeStates` which returns the above map.

3. `WorkflowNodeState` class now contains the failureCause of type `Throwable` instead of `String`, so as to give the programmatic access to the developer.

4. Added `WorkflowNodeStateDetail` class in the `cdap-proto` which has failureCause of type `DefaultThrowable` for storing it in MDS and serving through REST endpoint.

5. REST endpoint implementation for getting node states. The endpoint has path: `/apps/{app-id}/workflows/{workflow-id}/runs/{run-id}/nodestates`

