### PR TITLE
CDAP-5417 Purchase Example fails under Windows

### DIFF
--- a/cdap-cli/bin/cdap-cli.bat
+++ b/cdap-cli/bin/cdap-cli.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright (c) 2014 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/bin/tx-debugger.bat
+++ b/cdap-data-fabric/bin/tx-debugger.bat
@@ -1,7 +1,7 @@
 @echo OFF
 
 REM #################################################################################
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright (c) 2014 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014-2015 Cask Data, Inc.
+REM ## Copyright (c) 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of
@@ -22,6 +22,7 @@ SET ORIGPATH=%cd%
 SET CDAP_HOME=%~dp0
 SET CDAP_HOME=%CDAP_HOME:~0,-5%
 SET JAVACMD=%JAVA_HOME%\bin\java.exe
+SET DEFAULT_JVM_OPTS=-Xmx2048m -XX:MaxPermSize=128m
 
 REM %CDAP_HOME%
 SET CLASSPATH=%CDAP_HOME%\lib\*;%CDAP_HOME%\conf\
@@ -188,7 +189,7 @@ IF "%2" == "--enable-debug" (
   set DEBUG_OPTIONS="-agentlib:jdwp=transport=dt_socket,address=localhost:!port!,server=y,suspend=n"
 )
 
-start /B %JAVACMD% !DEBUG_OPTIONS! -Dhadoop.security.group.mapping=org.apache.hadoop.security.JniBasedUnixGroupsMappingWithFallback -Dhadoop.home.dir=%CDAP_HOME%\libexec -classpath %CLASSPATH% co.cask.cdap.StandaloneMain >> %CDAP_HOME%\logs\cdap-process.log 2>&1 < NUL
+start /B %JAVACMD% %DEFAULT_JVM_OPTS% !DEBUG_OPTIONS! -Dhadoop.security.group.mapping=org.apache.hadoop.security.JniBasedUnixGroupsMappingWithFallback -Dhadoop.home.dir=%CDAP_HOME%\libexec -classpath %CLASSPATH% co.cask.cdap.StandaloneMain >> %CDAP_HOME%\logs\cdap-process.log 2>&1 < NUL
 echo Starting Standalone CDAP...
 
 for /F "TOKENS=1,2,*" %%a in ('tasklist /FI "IMAGENAME eq java.exe"') DO SET MyPID=%%b

--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -121,8 +121,6 @@ NODE_VERSION_MINOR=`echo $NODE_VERSION | awk -F'[\\\.v]*' ' { print $3 } '`
 NODE_VERSION_PATCH=`echo $NODE_VERSION | awk -F'[\\\.v]*' ' { print $4 } '`
 if [ "$NODE_VERSION_MAJOR" -lt 1 ] && [ "$NODE_VERSION_MINOR" -lt 11 ] && [ "$NODE_VERSION_PATCH" -lt 36 ]; then
   die "ERROR: Node.js $NODE_VERSION is not supported. The minimum version supported is $NODE_VERSION_MINIMUM."
-else
-  echo "Node.js version: $NODE_VERSION"
 fi
 
 # Split up the JVM_OPTS And CDAP_OPTS values into an array, following the shell quoting and substitution rules


### PR DESCRIPTION
This PR:

- Changes (in all our `.bat` files) the copyright to remove the © symbol, so that the file encoding on Windows won't cause a problem if the files are edited in an editor such as `Notepad`.

- Adds to the Windows SDK start-script the same JVM options as our shell script (`-Xmx2048m -XX:MaxPermSize=128m`). This fixes running the Purchase app under Windows. Tested on two different Windows installations.

- Removes two lines from of *NIX start script that were printing the `Node.js` version unnecessarily.

Fixes https://issues.cask.co/browse/CDAP-5417.

Running a Develop RAT and Checkstyle at: http://builds.cask.co/browse/CDAP-DRC3558-1