### PR TITLE
(CDAP-5454) Temporary fix for loading system artifacts, to not have a…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -125,8 +125,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   private final CConfiguration cConf;
 
   @Inject
-  public ArtifactHttpHandler(CConfiguration cConf,
-                             ArtifactRepository artifactRepository, NamespaceAdmin namespaceAdmin) {
+  ArtifactHttpHandler(CConfiguration cConf, ArtifactRepository artifactRepository, NamespaceAdmin namespaceAdmin) {
     this.namespaceAdmin = namespaceAdmin;
     this.artifactRepository = artifactRepository;
     this.tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
@@ -136,7 +135,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
 
   @POST
   @Path("/namespaces/system/artifacts")
-  public void refreshSystemArtifacts(HttpRequest request, HttpResponder responder) {
+  public void refreshSystemArtifacts(HttpRequest request, HttpResponder responder) throws Exception {
     try {
       artifactRepository.addSystemArtifacts();
       responder.sendStatus(HttpResponseStatus.OK);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -576,7 +576,7 @@ public class ArtifactRepository {
    * @throws WriteConflictException if there was a write conflicting adding the system artifact. This shouldn't happen,
    *                                but if it does, it should be ok to retry the operation.
    */
-  public void addSystemArtifacts() throws IOException, WriteConflictException {
+  public void addSystemArtifacts() throws Exception {
 
     // scan the directory for artifact .jar files and config files for those artifacts
     List<SystemArtifactInfo> systemArtifacts = new ArrayList<>();
@@ -645,8 +645,8 @@ public class ArtifactRepository {
     }
   }
 
-  // TODO: Re-think authorization here
-  private void addSystemArtifact(SystemArtifactInfo systemArtifactInfo) throws IOException, WriteConflictException {
+  // TODO: CDAP-5455 Re-think authorization here. This can be called with a missing username in SecurityRequestContext
+  private void addSystemArtifact(SystemArtifactInfo systemArtifactInfo) throws Exception {
     String fileName = systemArtifactInfo.getArtifactFile().getName();
     try {
       Id.Artifact artifactId = systemArtifactInfo.getArtifactId();
@@ -671,13 +671,11 @@ public class ArtifactRepository {
     } catch (ArtifactAlreadyExistsException e) {
       // shouldn't happen... but if it does for some reason it's fine, it means it was added some other way already.
     } catch (ArtifactRangeNotFoundException e) {
-      LOG.warn(String.format("Could not add system artifact '%s' because it extends artifacts that do not exist.",
-                             fileName), e);
+      LOG.warn("Could not add system artifact '{}' because it extends artifacts that do not exist.", fileName, e);
     } catch (InvalidArtifactException e) {
-      LOG.warn(String.format("Could not add system artifact '%s' because it is invalid.", fileName), e);
-    } catch (Exception e) {
-      LOG.warn(String.format("Could not add system artifact '%s' because the user is not authorized to add artifacts",
-                             fileName), e);
+      LOG.warn("Could not add system artifact '{}' because it is invalid.", fileName, e);
+    } catch (UnauthorizedException e) {
+      LOG.warn("Could not add system artifact '{}' because of an authorization error.", fileName, e);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactLoader.java
@@ -23,7 +23,6 @@ import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.Inject;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -45,10 +44,7 @@ public final class SystemArtifactLoader extends AbstractService {
               artifactRepository.addSystemArtifacts();
               // if there is no exception, all good, continue on
               notifyStarted();
-            } catch (WriteConflictException e) {
-              // transient error, fail it and retry
-              notifyFailed(e);
-            } catch (IOException e) {
+            } catch (Exception e) {
               // transient error, fail it and retry
               notifyFailed(e);
             }


### PR DESCRIPTION
… catch all and instead propagate exceptions all the way. This way, the retry mechanism is not bypassed for unknown exceptions.

Temporary because this will still not work when authorization is enabled, because of [CDAP-5455](https://issues.cask.co/browse/CDAP-5455)

Jira: [CDAP-5454](https://issues.cask.co/browse/CDAP-5454)
Build: http://builds.cask.co/browse/CDAP-DUT3827