### PR TITLE
(CDAP-5382) Enforced authorization for setting instances and runtime …

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -32,14 +32,12 @@ import co.cask.cdap.common.ConflictException;
 import co.cask.cdap.common.MethodNotAllowedException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.NotImplementedException;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
 import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
-import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
@@ -81,7 +79,6 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.apache.twill.api.RunId;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -97,9 +94,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -472,22 +467,15 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                      @PathParam("namespace-id") String namespaceId,
                                      @PathParam("app-id") String appId,
                                      @PathParam("program-type") String programType,
-                                     @PathParam("program-id") String programId)
-    throws BadRequestException, NotImplementedException, NotFoundException {
+                                     @PathParam("program-id") String programId) throws Exception {
     ProgramType type = getProgramType(programType);
     if (type == null || type == ProgramType.WEBAPP) {
       throw new NotFoundException(String.format("Saving program runtime arguments is not supported for program " +
                                                   "type '%s'.", programType));
     }
 
-    Id.Program id = Id.Program.from(namespaceId, appId, type, programId);
-
-    if (!store.programExists(id)) {
-      throw new NotFoundException(id);
-    }
-
-    Map<String, String> args = decodeArguments(request);
-    preferencesStore.setProperties(namespaceId, appId, programType, programId, args);
+    lifecycleService.saveRuntimeArgs(Ids.namespace(namespaceId).app(appId).program(type, programId),
+                                     decodeArguments(request));
     responder.sendStatus(HttpResponseStatus.OK);
   }
 
@@ -553,9 +541,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
         ProgramStatus programStatus = lifecycleService.getProgramStatus(programId);
         statuses.add(new BatchProgramStatus(
           program, HttpResponseStatus.OK.getCode(), null, programStatus.name()));
-      } catch (BadRequestException e) {
-        statuses.add(new BatchProgramStatus(
-          program, HttpResponseStatus.BAD_REQUEST.getCode(), e.getMessage(), null));
       } catch (NotFoundException e) {
         statuses.add(new BatchProgramStatus(
           program, HttpResponseStatus.NOT_FOUND.getCode(), e.getMessage(), null));
@@ -858,39 +843,10 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void setWorkerInstances(HttpRequest request, HttpResponder responder,
                                  @PathParam("namespace-id") String namespaceId,
                                  @PathParam("app-id") String appId,
-                                 @PathParam("worker-id") String workerId)
-    throws ExecutionException, InterruptedException {
-    int instances;
+                                 @PathParam("worker-id") String workerId) throws Exception {
+    int instances = getInstances(request);
     try {
-      try {
-        instances = getInstances(request);
-      } catch (IllegalArgumentException e) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid instance value in request");
-        return;
-      } catch (JsonSyntaxException e) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid JSON in request");
-        return;
-      }
-      if (instances < 1) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Instance count should be greater than 0");
-        return;
-      }
-    } catch (Throwable th) {
-      responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid instance count.");
-      return;
-    }
-
-    try {
-      Id.Program programId = Id.Program.from(namespaceId, appId, ProgramType.WORKER, workerId);
-      int oldInstances = store.getWorkerInstances(programId);
-      if (oldInstances != instances) {
-        store.setWorkerInstances(programId, instances);
-        ProgramRuntimeService.RuntimeInfo runtimeInfo = findRuntimeInfo(programId, runtimeService);
-        if (runtimeInfo != null) {
-          runtimeInfo.getController().command(ProgramOptionConstants.INSTANCES,
-                                              ImmutableMap.of(programId.getId(), String.valueOf(instances))).get();
-        }
-      }
+      lifecycleService.setInstances(Ids.namespace(namespaceId).app(appId).worker(workerId), instances);
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
@@ -933,42 +889,10 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public synchronized void setFlowletInstances(HttpRequest request, HttpResponder responder,
                                                @PathParam("namespace-id") String namespaceId,
                                                @PathParam("app-id") String appId, @PathParam("flow-id") String flowId,
-                                               @PathParam("flowlet-id") String flowletId)
-    throws ExecutionException, InterruptedException {
-    int instances;
+                                               @PathParam("flowlet-id") String flowletId) throws Exception {
+    int instances = getInstances(request);
     try {
-      try {
-        instances = getInstances(request);
-      } catch (IllegalArgumentException e) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid instance value in request");
-        return;
-      } catch (JsonSyntaxException e) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid JSON in request");
-        return;
-      }
-      if (instances < 1) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Instance count should be greater than 0");
-        return;
-      }
-    } catch (Throwable th) {
-      responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid instance count.");
-      return;
-    }
-
-    try {
-      Id.Program programId = Id.Program.from(namespaceId, appId, ProgramType.FLOW, flowId);
-      int oldInstances = store.getFlowletInstances(programId, flowletId);
-      if (oldInstances != instances) {
-        FlowSpecification flowSpec = store.setFlowletInstances(programId, flowletId, instances);
-        ProgramRuntimeService.RuntimeInfo runtimeInfo = findRuntimeInfo(programId, runtimeService);
-        if (runtimeInfo != null) {
-          runtimeInfo.getController()
-            .command(ProgramOptionConstants.INSTANCES,
-                     ImmutableMap.of("flowlet", flowletId,
-                                     "newInstances", String.valueOf(instances),
-                                     "oldFlowSpec", GSON.toJson(flowSpec, FlowSpecification.class))).get();
-        }
-      }
+      lifecycleService.setInstances(Ids.namespace(namespaceId).app(appId).flow(flowId), instances, flowletId);
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
@@ -1060,38 +984,16 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("app-id") String appId,
                                   @PathParam("service-id") String serviceId)
-    throws ExecutionException, InterruptedException {
+    throws Exception {
     try {
-      Id.Program programId = Id.Program.from(namespaceId, appId, ProgramType.SERVICE, serviceId);
-      if (!store.programExists(programId)) {
+      ProgramId programId = Ids.namespace(namespaceId).app(appId).service(serviceId);
+      if (!store.programExists(programId.toId())) {
         responder.sendString(HttpResponseStatus.NOT_FOUND, "Service not found");
         return;
       }
 
-      int instances;
-      try {
-        instances = getInstances(request);
-      } catch (IllegalArgumentException e) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid instance value in request");
-        return;
-      } catch (JsonSyntaxException e) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid JSON in request");
-        return;
-      }
-      if (instances < 1) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Instance count should be greater than 0");
-        return;
-      }
-
-      int oldInstances = store.getServiceInstances(programId);
-      if (oldInstances != instances) {
-        store.setServiceInstances(programId, instances);
-        ProgramRuntimeService.RuntimeInfo runtimeInfo = findRuntimeInfo(programId, runtimeService);
-        if (runtimeInfo != null) {
-          runtimeInfo.getController().command(ProgramOptionConstants.INSTANCES,
-                                              ImmutableMap.of(serviceId, String.valueOf(instances))).get();
-        }
-      }
+      int instances = getInstances(request);
+      lifecycleService.setInstances(programId, instances);
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
@@ -1191,22 +1093,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     int provisioned = getInstanceCount(programId.toEntityId(), runnableId);
     // use the pretty name of program types to be consistent
     return new BatchRunnableInstances(runnable, HttpResponseStatus.OK.getCode(), provisioned, requested);
-  }
-
-  @Nullable
-  private ProgramRuntimeService.RuntimeInfo findRuntimeInfo(Id.Program identifier, @Nullable String runId) {
-    Map<RunId, ProgramRuntimeService.RuntimeInfo> runtimeInfos = runtimeService.list(identifier.getType());
-
-    if (runId != null) {
-      return runtimeInfos.get(RunIds.fromString(runId));
-    }
-
-    for (ProgramRuntimeService.RuntimeInfo info : runtimeInfos.values()) {
-      if (identifier.equals(info.getProgramId())) {
-        return info;
-      }
-    }
-    return null;
   }
 
   private void getRuns(HttpResponder responder, Id.Program programId, String status,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.internal.UserErrors;
 import co.cask.cdap.internal.UserMessages;
 import co.cask.cdap.proto.Id;
@@ -80,10 +81,15 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
 
   public static final String APP_CONFIG_HEADER = "X-App-Config";
 
-  protected int getInstances(HttpRequest request) throws IllegalArgumentException, JsonSyntaxException {
-    Instances instances = parseBody(request, Instances.class);
+  protected int getInstances(HttpRequest request) throws BadRequestException {
+    Instances instances;
+      try {
+        instances = parseBody(request, Instances.class);
+      } catch (JsonSyntaxException e) {
+        throw new BadRequestException("Invalid JSON in request: " + e.getMessage());
+      }
     if (instances == null) {
-      throw new IllegalArgumentException("Could not read instances from request body");
+      throw new BadRequestException("Invalid instance value in request");
     }
     return instances.getInstances();
   }

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.test.AbstractApplicationManager;
 import co.cask.cdap.test.DefaultMapReduceManager;
 import co.cask.cdap.test.DefaultSparkManager;
@@ -164,5 +165,10 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
   @Override
   public ApplicationDetail getInfo() throws Exception {
     return applicationClient.get(application);
+  }
+
+  @Override
+  public void setRuntimeArgs(ProgramId programId, Map<String, String> args) throws Exception {
+    programClient.setRuntimeArgs(programId.toId(), args);
   }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
@@ -116,4 +116,9 @@ public abstract class AbstractProgramManager<T extends ProgramManager> implement
   public List<RunRecord> getHistory(ProgramRunStatus status) {
     return applicationManager.getHistory(programId, status);
   }
+
+  @Override
+  public void setRuntimeArgs(Map<String, String> args) throws Exception {
+    applicationManager.setRuntimeArgs(programId.toEntityId(), args);
+  }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
@@ -21,6 +21,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ProgramId;
 
 import java.util.List;
 import java.util.Map;
@@ -124,4 +125,12 @@ public interface ApplicationManager {
    * Returns the application's details.
    */
   ApplicationDetail getInfo() throws Exception;
+
+  /**
+   * Save runtime arguments for the specified program for all runs.
+   *
+   * @param programId the {@link ProgramId program} to save runtime arguments for
+   * @param args the arguments to save
+   */
+  void setRuntimeArgs(ProgramId programId, Map<String, String> args) throws Exception;
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
@@ -91,4 +91,11 @@ public interface ProgramManager<T extends ProgramManager> {
    * @return list of {@link RunRecord} history
    */
   List<RunRecord> getHistory(ProgramRunStatus status);
+
+  /**
+   * Save runtime arguments for the program for all runs.
+   *
+   * @param args the runtime arguments to save
+   */
+  void setRuntimeArgs(Map<String, String> args) throws Exception;
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -23,6 +23,7 @@ import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.test.AbstractApplicationManager;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DefaultMapReduceManager;
@@ -183,5 +184,10 @@ public class DefaultApplicationManager extends AbstractApplicationManager {
   @Override
   public ApplicationDetail getInfo() throws Exception {
     return appFabricClient.getInfo(application.toEntityId());
+  }
+
+  @Override
+  public void setRuntimeArgs(ProgramId programId, Map<String, String> args) throws Exception {
+    appFabricClient.setRuntimeArgs(programId, args);
   }
 }


### PR DESCRIPTION
…arguments for programs

- Refactored setting instances and saving runtime arguments logic in ``ProgramLifecycleHttpHandler`` to move most code to ``ProgramLifecycleService``
- Setting instances for a program requires ADMIN privileges on the program
- Saving runtime arguments also requires ADMIN privileges on the program
- Added support for saving runtime arguments for a program in Test Framework

Jira: [CDAP-5382](https://issues.cask.co/browse/CDAP-5382)
Build: http://builds.cask.co/browse/CDAP-DUT3819