### PR TITLE
[CDAP-5463] fix setInstances for workers and services

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -888,7 +888,9 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
         ProgramRuntimeService.RuntimeInfo runtimeInfo = findRuntimeInfo(programId, runtimeService);
         if (runtimeInfo != null) {
           runtimeInfo.getController().command(ProgramOptionConstants.INSTANCES,
-                                              ImmutableMap.of(programId.getId(), String.valueOf(instances))).get();
+                                              ImmutableMap.of("runnable", programId.getId(),
+                                                              "oldInstances", String.valueOf(oldInstances),
+                                                              "newInstances", String.valueOf(instances))).get();
         }
       }
       responder.sendStatus(HttpResponseStatus.OK);
@@ -1089,7 +1091,9 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
         ProgramRuntimeService.RuntimeInfo runtimeInfo = findRuntimeInfo(programId, runtimeService);
         if (runtimeInfo != null) {
           runtimeInfo.getController().command(ProgramOptionConstants.INSTANCES,
-                                              ImmutableMap.of(serviceId, String.valueOf(instances))).get();
+                                              ImmutableMap.of("runnable", programId.getId(),
+                                                              "oldInstances", String.valueOf(oldInstances),
+                                                              "newInstances", String.valueOf(instances))).get();
         }
       }
       responder.sendStatus(HttpResponseStatus.OK);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/AbstractInMemoryProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/AbstractInMemoryProgramRunner.java
@@ -189,11 +189,12 @@ public abstract class AbstractInMemoryProgramRunner implements ProgramRunner {
       Map<String, String> command = (Map<String, String>) value;
       lock.lock();
       try {
-        for (Map.Entry<String, String> entry : command.entrySet()) {
-          changeInstances(entry.getKey(), Integer.valueOf(entry.getValue()));
-        }
+        changeInstances(command.get("runnable"),
+                        Integer.valueOf(command.get("newInstances")),
+                        Integer.valueOf(command.get("oldInstances")));
       } catch (Throwable t) {
         LOG.error(String.format("Fail to change instances: %s", command), t);
+        throw t;
       } finally {
         lock.unlock();
       }
@@ -203,10 +204,13 @@ public abstract class AbstractInMemoryProgramRunner implements ProgramRunner {
      * Change the number of instances of the running runnable.
      * @param runnableName Name of the runnable
      * @param newCount New instance count
+     * @param oldCount New instance count
      * @throws java.util.concurrent.ExecutionException
      * @throws InterruptedException
      */
-    private void changeInstances(String runnableName, final int newCount) throws Exception {
+    private void changeInstances(String runnableName, final int newCount,
+                                 // unused but makes the in-memory controller expect the same command as twill
+                                 @SuppressWarnings("unused") final int oldCount) throws Exception {
       Map<Integer, ProgramController> liveRunnables = components.row(runnableName);
       int liveCount = liveRunnables.size();
       if (liveCount == newCount) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/FlowTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/FlowTwillProgramController.java
@@ -63,6 +63,7 @@ final class FlowTwillProgramController extends AbstractTwillProgramController {
     } catch (Throwable t) {
       LOG.error("Fail to change instances. Terminating flow: {}", command, t);
       stop();
+      throw t;
     } finally {
       lock.unlock();
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillProgramController.java
@@ -59,6 +59,7 @@ final class ServiceTwillProgramController extends AbstractTwillProgramController
                       Integer.valueOf(command.get("oldInstances")));
     } catch (Throwable t) {
       LOG.error(String.format("Failed to change instances: %s", command), t);
+      throw t;
     } finally {
       lock.unlock();
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkerTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkerTwillProgramController.java
@@ -55,6 +55,7 @@ public class WorkerTwillProgramController extends AbstractTwillProgramController
       }
     } catch (Throwable t) {
       LOG.error("Failed to change worker instances : {}", command, t);
+      throw t;
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowProgramRunner.java
@@ -251,6 +251,8 @@ public final class FlowProgramRunner implements ProgramRunner {
         changeInstances(command.get("flowlet"), Integer.valueOf(command.get("newInstances")));
       } catch (Throwable t) {
         LOG.error(String.format("Fail to change instances: %s", command), t);
+        stop();
+        throw t;
       } finally {
         lock.unlock();
       }


### PR DESCRIPTION
- make in-memory service/worker controller behave like Twill (expect runnable, oldInstances, newInstances)
- throw exceptions in program controllers if setInstances fails (used to be logged an ignored)
- no change to tests: existing unit test succeeded despite failure, because of the second bullet. 