### PR TITLE
Program descriptions for ETLSpark and ETLMapReduce weren't accurate.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/BatchPhaseSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/BatchPhaseSpec.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.batch;
 
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.etl.common.PipelinePhase;
+import com.google.common.base.Joiner;
 
 import java.util.Map;
 
@@ -30,14 +31,16 @@ public class BatchPhaseSpec {
   private final Resources resources;
   private final boolean isStageLoggingEnabled;
   private final Map<String, String> connectorDatasets;
+  private final String description;
 
-  public BatchPhaseSpec(String phaseName, PipelinePhase phase, Resources resources, boolean
-    isStageLoggingEnabled, Map<String, String> connectorDatasets) {
+  public BatchPhaseSpec(String phaseName, PipelinePhase phase, Resources resources, boolean isStageLoggingEnabled,
+                        Map<String, String> connectorDatasets) {
     this.phaseName = phaseName;
     this.phase = phase;
     this.resources = resources;
     this.isStageLoggingEnabled = isStageLoggingEnabled;
     this.connectorDatasets = connectorDatasets;
+    this.description = createDescription();
   }
 
   public String getPhaseName() {
@@ -58,5 +61,19 @@ public class BatchPhaseSpec {
 
   public Map<String, String> getConnectorDatasets() {
     return connectorDatasets;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  private String createDescription() {
+    StringBuilder description = new StringBuilder("Sources '");
+    Joiner.on("', '").appendTo(description, phase.getSources());
+    description.append("' to sinks '");
+
+    Joiner.on("', '").appendTo(description, phase.getSinks());
+    description.append("'.");
+    return description.toString();
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -98,18 +98,7 @@ public class ETLMapReduce extends AbstractMapReduce {
   @Override
   public void configure() {
     setName(phaseSpec.getPhaseName());
-
-    StringBuilder description = new StringBuilder("DataFlow MapReduce phase executor. Sources");
-
-    for (String sourceName : phaseSpec.getPhase().getSources()) {
-      description.append(" '").append(sourceName).append("'");
-    }
-    description.append(" to sinks");
-
-    for (StageInfo sinkInfo : phaseSpec.getPhase().getStagesOfType(BatchSink.PLUGIN_TYPE)) {
-      description.append(" '").append(sinkInfo.getName()).append("'");
-    }
-    setDescription(description.toString());
+    setDescription("MapReduce phase executor. " + phaseSpec.getDescription());
 
     setMapperResources(phaseSpec.getResources());
     setDriverResources(phaseSpec.getResources());

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -69,7 +69,8 @@ public class ETLSpark extends AbstractSpark {
   @Override
   protected void configure() {
     setName(phaseSpec.getPhaseName());
-    setDescription("Spark Driver for ETL Batch Applications");
+    setDescription("Spark phase executor. " + phaseSpec.getDescription());
+
     setMainClass(ETLSparkProgram.class);
 
     setExecutorResources(phaseSpec.getResources());

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/BatchPhaseSpecTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/BatchPhaseSpecTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.PipelinePhase;
+import co.cask.cdap.etl.planner.StageInfo;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+/**
+ * Tests description of BatchPhaseSpec.
+ */
+public class BatchPhaseSpecTest {
+
+  @Test
+  public void testDescription() throws Exception {
+    PipelinePhase.Builder builder =
+      PipelinePhase.builder(ImmutableSet.of(BatchSource.PLUGIN_TYPE, Constants.CONNECTOR_TYPE));
+    /*
+     * source1 --|
+     *           |--> sink.connector
+     * source2 --|
+     */
+    builder.addStages(BatchSource.PLUGIN_TYPE, ImmutableList.of(new StageInfo("source1"), new StageInfo("source2")));
+    builder.addStage(Constants.CONNECTOR_TYPE, new StageInfo("sink.connector"));
+
+    builder.addConnection("source1", "sink.connector");
+    builder.addConnection("source2", "sink.connector");
+
+
+    BatchPhaseSpec phaseSpec =
+      new BatchPhaseSpec("phase-1", builder.build(), new Resources(), false, Collections.<String, String>emptyMap());
+    Assert.assertEquals("Sources 'source2', 'source1' to sinks 'sink.connector'.", phaseSpec.getDescription());
+  }
+}


### PR DESCRIPTION
The description was being built using plugins of type `BatchSink`, but this is inaccurate now, since plugins of Type `Connector` might also be the terminating nodes of the nodes that the program is handling.

This also gives ETLSpark's description more information than it previously had.

http://builds.cask.co/browse/CDAP-DUT3850-2