### PR TITLE
Fix flaky test case

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -44,6 +44,7 @@ import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionFailureException;
+import co.cask.tephra.TxConstants;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -53,8 +54,10 @@ import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExternalResource;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -77,6 +80,16 @@ import javax.annotation.Nullable;
  */
 @Category(XSlowTests.class)
 public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
+  @ClassRule
+  public static final ExternalResource RESOURCE = new ExternalResource() {
+    @Override
+    protected void before() throws Throwable {
+      // Set the tx timeout to a ridiculously low value that will test that the long-running transactions
+      // actually bypass that timeout.
+      System.setProperty(TxConstants.Manager.CFG_TX_TIMEOUT, "1");
+      System.setProperty(TxConstants.Manager.CFG_TX_CLEANUP_INTERVAL, "2");
+    }
+  };
 
   /**
    * Tests that beforeSubmit() and getSplits() are called in the same transaction,

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
@@ -112,11 +112,16 @@ public class MapReduceRunnerTestBase {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    // Set the tx timeout to a ridiculously low value that will test that the long-running transactions
-    // actually bypass that timeout.
     CConfiguration conf = CConfiguration.create();
-    conf.setInt(TxConstants.Manager.CFG_TX_TIMEOUT, 1);
-    conf.setInt(TxConstants.Manager.CFG_TX_CLEANUP_INTERVAL, 2);
+    // allow subclasses to override the following two parameters
+    Integer txTimeout = Integer.getInteger(TxConstants.Manager.CFG_TX_TIMEOUT);
+    if (txTimeout != null) {
+      conf.setInt(TxConstants.Manager.CFG_TX_TIMEOUT, txTimeout);
+    }
+    Integer txCleanupInterval = Integer.getInteger(TxConstants.Manager.CFG_TX_CLEANUP_INTERVAL);
+    if (txCleanupInterval != null) {
+      conf.setInt(TxConstants.Manager.CFG_TX_CLEANUP_INTERVAL, txCleanupInterval);
+    }
     injector = AppFabricTestHelper.getInjector(conf, new AbstractModule() {
       @Override
       protected void configure() {


### PR DESCRIPTION
Set a low tx timeout value for only one of the test classes, instead of everything that extends MapReduceRunnerTestBase.

The `MapReduceWithMultipleInputsTest` test runs a MapReduce job with more mappers than usual, so it makes more simultaneous calls to the dataset service. Because of this, the reads that the dataset service does may take more than the 1 second tx timeout and then time out the transaction.

https://issues.cask.co/browse/CDAP-5439
http://builds.cask.co/browse/CDAP-DUT3854-3