### PR TITLE
Fix broken links in Javadocs.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Batch.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Batch.java
@@ -70,7 +70,7 @@ import java.lang.annotation.Target;
  * </p>
  * 
  * <p>
- * See the <i><a href="http://cask.co/docs/cdap/current/en/">Cask DAP Developer Guides</a></i>
+ * See the <i><a href="http://cask.co/docs/cdap/current/en/developers-manual/index.html">CDAP Developers' Manual</a></i>
  * for more information.
  * </p>
  *

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Batch.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Batch.java
@@ -70,7 +70,7 @@ import java.lang.annotation.Target;
  * </p>
  * 
  * <p>
- * See the <i><a href="http://cask.co/docs/cdap/current/en/developers-manual/index.html">CDAP Developers' Manual</a></i>
+ * See the <i><a href="http://docs.cask.co/cdap/current/en/developers-manual/index.html">CDAP Developers' Manual</a></i>
  * for more information.
  * </p>
  *

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/ProcessInput.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/ProcessInput.java
@@ -40,8 +40,9 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * <p>
- * See the <i><a href="http://cask.co/docs/cdap/current/en/">Cask DAP Developer Guides</a></i>
- * and the CDAP example applications for more information.
+ * See the <i><a href="http://cask.co/docs/cdap/current/en/developers-manual/index.html">CDAP Developers' Manual</a></i>
+ * and the <i><a href="http://cask.co/docs/cdap/current/en/examples-manual/index.html">CDAP examples</a></i>
+ * for more information.
  * </p>
  *
  * @see co.cask.cdap.api.flow.flowlet.Flowlet

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/ProcessInput.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/ProcessInput.java
@@ -40,8 +40,8 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * <p>
- * See the <i><a href="http://cask.co/docs/cdap/current/en/developers-manual/index.html">CDAP Developers' Manual</a></i>
- * and the <i><a href="http://cask.co/docs/cdap/current/en/examples-manual/index.html">CDAP examples</a></i>
+ * See the <i><a href="http://docs.cask.co/cdap/current/en/developers-manual/index.html">CDAP Developers' Manual</a></i>
+ * and the <i><a href="http://docs.cask.co/cdap/current/en/examples-manual/index.html">CDAP examples</a></i>
  * for more information.
  * </p>
  *


### PR DESCRIPTION
Passed [Docs Develop Build 2](http://builds.cask.co/browse/CDAP-DDB35-2) which builds the Javadocs...