### PR TITLE
Fixes the logic to match metric with a node name in hydrator++

### DIFF
--- a/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-metrics-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-metrics-store.js
@@ -54,9 +54,9 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
           };
         }
 
-        if (split[split.length - 1] === 'in') {
+        if (metric.metricName.indexOf(split[1] + '.records.in') !== -1) {
           metricObj[key].recordsIn = metric.data[0].value;
-        } else if (split[split.length - 1] === 'out') {
+        } else if (metric.metricName.indexOf(split[1] + '.records.out') !== -1) {
           metricObj[key].recordsOut = metric.data[0].value;
         }
 


### PR DESCRIPTION
Previously we used to check for just `in` & `out` in metric names. It is possible that the UI gets more than one metric with the node name. Changing it to make it explict (`'user.' + <node-name> + '.records.in/out'`)