### PR TITLE
CDAP-5482 Add Kerberos note to Cloudera installation

### DIFF
--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -493,12 +493,12 @@ Enabling Kerberos
 -----------------
 For Kerberos-enabled Hadoop clusters:
 
-- The ``'cdap'`` user needs to be granted HBase permissions to create tables.
+- The ``cdap`` user needs to be granted HBase permissions to create tables.
   As the ``hbase`` user, issue the command::
  
     $ echo "grant 'cdap', 'RWCA'" | hbase shell
 
-- The ``'cdap'`` user must be able to launch YARN containers, either by adding it to the YARN
+- The ``cdap`` user must be able to launch YARN containers, either by adding it to the YARN
   ``allowed.system.users`` or by adjusting the YARN ``min.user.id`` to include the ``cdap`` user.
   (Search for the YARN configuration ``allowed.system.users`` in Cloudera Manager, and then add
   the ``cdap`` user to the whitelist.)
@@ -508,11 +508,11 @@ For Kerberos-enabled Hadoop clusters:
   default settings will run CDAP containers as the user ``yarn``. A Kerberos cluster will
   run them as the user ``cdap``. When converting, the usercache directory that Yarn
   creates will already exist and be owned by a different user. On all datanodes, run this
-  command, substituting for ``<yarn.nodemanager.local-dirs>``::
+  command, substituting in the correct value of the YARN parameter ``yarn.nodemanager.local-dirs``::
     
-    rm -rf <yarn.nodemanager.local-dirs>/usercache/cdap
+    rm -rf <YARN.NODEMANAGER.LOCAL-DIRS>/usercache/cdap
     
-  On Cloudera, the default setting for ``<yarn.nodemanager.local-dirs>`` is ``/yarn/nm``, resulting in::
+  On Cloudera, the default setting for ``yarn.nodemanager.local-dirs`` is ``/yarn/nm``, resulting in::
   
     rm -rf /yarn/nm/usercache/cdap
 

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -502,3 +502,18 @@ For Kerberos-enabled Hadoop clusters:
   ``allowed.system.users`` or by adjusting the YARN ``min.user.id`` to include the ``cdap`` user.
   (Search for the YARN configuration ``allowed.system.users`` in Cloudera Manager, and then add
   the ``cdap`` user to the whitelist.)
+  
+- If you are converting an existing CDAP cluster to being Kerberos-enabled, then you may
+  run into Yarn usercache directory permission problems. A non-Kerberos cluster with
+  default settings will run CDAP containers as the user ``yarn``. A Kerberos cluster will
+  run them as the user ``cdap``. When converting, the usercache directory that Yarn
+  creates will already exist and be owned by a different user. On all datanodes, run this
+  command, substituting for ``<yarn.nodemanager.local-dirs>``::
+    
+    rm -rf <yarn.nodemanager.local-dirs>/usercache/cdap
+    
+  On Cloudera, the default setting for ``<yarn.nodemanager.local-dirs>`` is ``/yarn/nm``, resulting in::
+  
+    rm -rf /yarn/nm/usercache/cdap
+
+  Restart CDAP after removing the usercache.


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/CDAP-5482.

Passes [Quick Build 2](http://builds.cask.co/browse/CDAP-DOB160-2)

[Enabling Kerberos](http://builds.cask.co/artifact/CDAP-DOB160/shared/build-2/Docs-HTML/3.4.0-SNAPSHOT/en/admin-manual/installation/cloudera.html#advanced-topics)