### PR TITLE
(CDAP-4329) Enforced authorization in grant/revoke APIs.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AuthorizationHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AuthorizationHandler.java
@@ -87,6 +87,9 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
     verifyAuthRequest(request);
 
     Set<Action> actions = request.getActions() == null ? EnumSet.allOf(Action.class) : request.getActions();
+    // enforce that the user granting access has admin privileges on the entity
+    authorizerInstantiatorService.get().enforce(request.getEntity(), SecurityRequestContext.toPrincipal(),
+                                                Action.ADMIN);
     authorizerInstantiatorService.get().grant(request.getEntity(), request.getPrincipal(), actions);
 
     httpResponder.sendStatus(HttpResponseStatus.OK);
@@ -101,6 +104,9 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
     RevokeRequest request = parseBody(httpRequest, RevokeRequest.class);
     verifyAuthRequest(request);
 
+    // enforce that the user revoking access has admin privileges on the entity
+    authorizerInstantiatorService.get().enforce(request.getEntity(), SecurityRequestContext.toPrincipal(),
+                                                Action.ADMIN);
     if (request.getPrincipal() == null && request.getActions() == null) {
       authorizerInstantiatorService.get().revoke(request.getEntity());
     } else {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
@@ -24,6 +24,7 @@ import co.cask.cdap.client.config.ConnectionConfig;
 import co.cask.cdap.common.FeatureDisabledException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.AuthenticationChannelHandler;
 import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.Ids;
@@ -41,17 +42,23 @@ import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
 import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.http.NettyHttpService;
 import co.cask.tephra.TransactionFailureException;
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelHandler;
+import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.UnknownHostException;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Properties;
@@ -62,8 +69,7 @@ import java.util.Set;
  */
 public class AuthorizationHandlerTest {
 
-  private NettyHttpService service;
-  private AuthorizationClient client;
+  private static final String USERNAME_PROPERTY = "cdap.username";
   private static final AuthorizationContextFactory factory = new AuthorizationContextFactory() {
     @Override
     public AuthorizationContext create(Properties extensionProperties) {
@@ -76,13 +82,20 @@ public class AuthorizationHandlerTest {
       return new DefaultAuthorizationContext(extensionProperties, new NoOpDatasetContext(), new NoOpAdmin(), txnl);
     }
   };
+  private final Principal admin = new Principal("admin", Principal.PrincipalType.USER);
+  private final Properties properties = new Properties();
+
+  private NettyHttpService service;
+  private AuthorizationClient client;
 
   @Before
-  public void setUp() throws UnknownHostException {
+  public void setUp() throws Exception {
     CConfiguration conf = CConfiguration.create();
     conf.setBoolean(Constants.Security.Authorization.ENABLED, true);
-
+    conf.setBoolean(Constants.Security.ENABLED, true);
+    properties.setProperty("superusers", admin.getName());
     final InMemoryAuthorizer auth = new InMemoryAuthorizer();
+    auth.initialize(factory.create(properties));
     service = new CommonNettyHttpServiceBuilder(conf)
       .addHttpHandlers(ImmutableList.of(new AuthorizationHandler(
         new AuthorizerInstantiatorService(conf, factory) {
@@ -91,6 +104,14 @@ public class AuthorizationHandlerTest {
             return auth;
           }
         }, conf)))
+      .modifyChannelPipeline(new Function<ChannelPipeline, ChannelPipeline>() {
+        @Override
+        public ChannelPipeline apply(ChannelPipeline input) {
+          input.addBefore("dispatcher", "usernamesetter", new TestUserNameSetter());
+          input.addAfter("usernamesetter", "authenticator", new AuthenticationChannelHandler());
+          return input;
+        }
+      })
       .build();
     service.startAndWait();
 
@@ -103,6 +124,7 @@ public class AuthorizationHandlerTest {
             .setSSLEnabled(false)
             .build())
         .build());
+    System.setProperty(USERNAME_PROPERTY, admin.getName());
   }
 
   @After
@@ -125,90 +147,92 @@ public class AuthorizationHandlerTest {
         }, conf)))
       .build();
     service.startAndWait();
+    try {
 
-    final AuthorizationClient client = new AuthorizationClient(
-      ClientConfig.builder()
-        .setConnectionConfig(
-          ConnectionConfig.builder()
-            .setHostname(service.getBindAddress().getHostName())
-            .setPort(service.getBindAddress().getPort())
-            .setSSLEnabled(false)
-            .build())
-        .build());
+      final AuthorizationClient client = new AuthorizationClient(
+        ClientConfig.builder()
+          .setConnectionConfig(
+            ConnectionConfig.builder()
+              .setHostname(service.getBindAddress().getHostName())
+              .setPort(service.getBindAddress().getPort())
+              .setSSLEnabled(false)
+              .build())
+          .build());
 
-    final NamespaceId ns1 = Ids.namespace("ns1");
-    final Principal admin = new Principal("admin", Principal.PrincipalType.USER);
-    final Role admins = new Role("admins");
+      final NamespaceId ns1 = Ids.namespace("ns1");
+      final Role admins = new Role("admins");
 
-    // Test that the right exception is thrown when any Authorization REST API is called when authorization is disabled
-    verifyFeatureDisabled(new DisabledFeatureCaller() {
-      @Override
-      public void call() throws Exception {
-        client.grant(ns1, admin, ImmutableSet.of(Action.READ));
-      }
-    });
+      // Test that the right exception is thrown when any Authorization REST API is called with authorization disabled
+      verifyFeatureDisabled(new DisabledFeatureCaller() {
+        @Override
+        public void call() throws Exception {
+          client.grant(ns1, admin, ImmutableSet.of(Action.READ));
+        }
+      });
 
-    verifyFeatureDisabled(new DisabledFeatureCaller() {
-      @Override
-      public void call() throws Exception {
-        client.revoke(ns1, admin, ImmutableSet.of(Action.READ));
-      }
-    });
+      verifyFeatureDisabled(new DisabledFeatureCaller() {
+        @Override
+        public void call() throws Exception {
+          client.revoke(ns1, admin, ImmutableSet.of(Action.READ));
+        }
+      });
 
-    verifyFeatureDisabled(new DisabledFeatureCaller() {
-      @Override
-      public void call() throws Exception {
-        client.revoke(ns1);
-      }
-    });
+      verifyFeatureDisabled(new DisabledFeatureCaller() {
+        @Override
+        public void call() throws Exception {
+          client.revoke(ns1);
+        }
+      });
 
-    verifyFeatureDisabled(new DisabledFeatureCaller() {
-      @Override
-      public void call() throws Exception {
-        client.listPrivileges(admin);
-      }
-    });
+      verifyFeatureDisabled(new DisabledFeatureCaller() {
+        @Override
+        public void call() throws Exception {
+          client.listPrivileges(admin);
+        }
+      });
 
-    verifyFeatureDisabled(new DisabledFeatureCaller() {
-      @Override
-      public void call() throws Exception {
-        client.addRoleToPrincipal(new Role("admins"), admin);
-      }
-    });
+      verifyFeatureDisabled(new DisabledFeatureCaller() {
+        @Override
+        public void call() throws Exception {
+          client.addRoleToPrincipal(admins, admin);
+        }
+      });
 
-    verifyFeatureDisabled(new DisabledFeatureCaller() {
-      @Override
-      public void call() throws Exception {
-        client.removeRoleFromPrincipal(admins, admin);
-      }
-    });
+      verifyFeatureDisabled(new DisabledFeatureCaller() {
+        @Override
+        public void call() throws Exception {
+          client.removeRoleFromPrincipal(admins, admin);
+        }
+      });
 
-    verifyFeatureDisabled(new DisabledFeatureCaller() {
-      @Override
-      public void call() throws Exception {
-        client.createRole(admins);
-      }
-    });
+      verifyFeatureDisabled(new DisabledFeatureCaller() {
+        @Override
+        public void call() throws Exception {
+          client.createRole(admins);
+        }
+      });
 
-    verifyFeatureDisabled(new DisabledFeatureCaller() {
-      @Override
-      public void call() throws Exception {
-        client.dropRole(admins);
-      }
-    });
+      verifyFeatureDisabled(new DisabledFeatureCaller() {
+        @Override
+        public void call() throws Exception {
+          client.dropRole(admins);
+        }
+      });
 
-    verifyFeatureDisabled(new DisabledFeatureCaller() {
-      @Override
-      public void call() throws Exception {
-        client.listAllRoles();
-      }
-    });
+      verifyFeatureDisabled(new DisabledFeatureCaller() {
+        @Override
+        public void call() throws Exception {
+          client.listAllRoles();
+        }
+      });
+    } finally {
+      service.stopAndWait();
+    }
   }
 
   @Test
   public void testRevokeEntityUserActions() throws Exception {
     NamespaceId ns1 = Ids.namespace("ns1");
-    Principal admin = new Principal("admin", Principal.PrincipalType.ROLE);
 
     // grant() and revoke(EntityId, String, Set<Action>)
     verifyAuthFailure(ns1, admin, Action.READ);
@@ -223,17 +247,17 @@ public class AuthorizationHandlerTest {
   @Test
   public void testRevokeEntityUser() throws Exception {
     NamespaceId ns1 = Ids.namespace("ns1");
-    Principal admin = new Principal("admin", Principal.PrincipalType.GROUP);
+    Principal adminGroup = new Principal("admin", Principal.PrincipalType.GROUP);
     Principal bob = new Principal("bob", Principal.PrincipalType.USER);
 
     // grant() and revoke(EntityId, String)
-    client.grant(ns1, admin, ImmutableSet.of(Action.READ));
+    client.grant(ns1, adminGroup, ImmutableSet.of(Action.READ));
     client.grant(ns1, bob, ImmutableSet.of(Action.READ));
-    verifyAuthSuccess(ns1, admin, Action.READ);
+    verifyAuthSuccess(ns1, adminGroup, Action.READ);
     verifyAuthSuccess(ns1, bob, Action.READ);
 
-    client.revoke(ns1, admin, EnumSet.allOf(Action.class));
-    verifyAuthFailure(ns1, admin, Action.READ);
+    client.revoke(ns1, adminGroup, EnumSet.allOf(Action.class));
+    verifyAuthFailure(ns1, adminGroup, Action.READ);
     verifyAuthSuccess(ns1, bob, Action.READ);
   }
 
@@ -241,21 +265,21 @@ public class AuthorizationHandlerTest {
   public void testRevokeEntity() throws Exception {
     NamespaceId ns1 = Ids.namespace("ns1");
     NamespaceId ns2 = Ids.namespace("ns2");
-    Principal admin = new Principal("admin", Principal.PrincipalType.GROUP);
+    Principal adminGroup = new Principal("admin", Principal.PrincipalType.GROUP);
     Principal bob = new Principal("bob", Principal.PrincipalType.USER);
 
     // grant() and revoke(EntityId)
-    client.grant(ns1, admin, ImmutableSet.of(Action.READ));
+    client.grant(ns1, adminGroup, ImmutableSet.of(Action.READ));
     client.grant(ns1, bob, ImmutableSet.of(Action.READ));
-    client.grant(ns2, admin, ImmutableSet.of(Action.READ));
-    verifyAuthSuccess(ns1, admin, Action.READ);
+    client.grant(ns2, adminGroup, ImmutableSet.of(Action.READ));
+    verifyAuthSuccess(ns1, adminGroup, Action.READ);
     verifyAuthSuccess(ns1, bob, Action.READ);
-    verifyAuthSuccess(ns2, admin, Action.READ);
+    verifyAuthSuccess(ns2, adminGroup, Action.READ);
 
     client.revoke(ns1);
-    verifyAuthFailure(ns1, admin, Action.READ);
+    verifyAuthFailure(ns1, adminGroup, Action.READ);
     verifyAuthFailure(ns1, bob, Action.READ);
-    verifyAuthSuccess(ns2, admin, Action.READ);
+    verifyAuthSuccess(ns2, adminGroup, Action.READ);
   }
 
   @Test
@@ -349,6 +373,51 @@ public class AuthorizationHandlerTest {
     }
   }
 
+  @Test
+  public void testAuthorizationForPrivileges() throws Exception {
+    NamespaceId ns = Ids.namespace("ns");
+    Principal bob = new Principal("bob", Principal.PrincipalType.USER);
+    Principal alice = new Principal("alice", Principal.PrincipalType.USER);
+    // olduser has been set as admin in the beginning of this test. admin has been configured as a superuser.
+    String oldUser = getCurrentUser();
+    setCurrentUser(alice.getName());
+    try {
+      try {
+        client.grant(ns, bob, ImmutableSet.of(Action.ALL));
+        Assert.fail(String.format("alice should not be able to grant privileges to bob on namespace %s because she " +
+                                    "does not have admin privileges on the namespace.", ns));
+      } catch (UnauthorizedException expected) {
+        // expected
+      }
+      setCurrentUser(oldUser);
+      // admin should be able to grant since he is a super user
+      client.grant(ns, alice, ImmutableSet.of(Action.ADMIN));
+      // now alice should be able to grant privileges on ns since she has ADMIN privileges
+      setCurrentUser(alice.getName());
+      client.grant(ns, bob, ImmutableSet.of(Action.ALL));
+      // revoke alice's permissions as admin
+      setCurrentUser(oldUser);
+      client.revoke(ns);
+      // revoking bob's privileges as alice should fail
+      setCurrentUser(alice.getName());
+      try {
+        client.revoke(ns, bob, ImmutableSet.of(Action.ALL));
+        Assert.fail(String.format("alice should not be able to revoke bob's privileges on namespace %s because she " +
+                                    "does not have admin privileges on the namespace.", ns));
+      } catch (UnauthorizedException expected) {
+        // expected
+      }
+      // grant alice privileges as admin again
+      setCurrentUser(oldUser);
+      client.grant(ns, alice, ImmutableSet.of(Action.ALL));
+      // Now alice should be able to revoke bob's privileges
+      setCurrentUser(alice.getName());
+      client.revoke(ns, bob, ImmutableSet.of(Action.ALL));
+    } finally {
+      setCurrentUser(oldUser);
+    }
+  }
+
   /**
    * Interface to centralize testing the exception thrown when Authorization is disabled.
    */
@@ -392,5 +461,32 @@ public class AuthorizationHandlerTest {
       ),
       privileges.contains(privilegeToCheck)
     );
+  }
+
+  private static void setCurrentUser(String username) {
+    System.setProperty(USERNAME_PROPERTY, username);
+  }
+
+  private static String getCurrentUser() {
+    return System.getProperty(USERNAME_PROPERTY);
+  }
+
+  /**
+   * Test {@link SimpleChannelHandler} to set the username as an HTTP Header
+   * {@link co.cask.cdap.common.conf.Constants.Security.Headers#USER_ID}. In production, this is done in the router by
+   * SecurityAuthenticationHandler
+   */
+  private static final class TestUserNameSetter extends SimpleChannelHandler {
+
+    @Override
+    public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+      Object msg = e.getMessage();
+      if (!(msg instanceof HttpRequest)) {
+        return;
+      }
+      HttpRequest request = (HttpRequest) msg;
+      request.setHeader(Constants.Security.Headers.USER_ID, System.getProperty(USERNAME_PROPERTY));
+      super.messageReceived(ctx, e);
+    }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/InMemoryAuthorizer.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/InMemoryAuthorizer.java
@@ -22,10 +22,12 @@ import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.Role;
 import co.cask.cdap.security.spi.authorization.AbstractAuthorizer;
+import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
 import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import com.google.common.base.Splitter;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
@@ -45,9 +47,27 @@ public class InMemoryAuthorizer extends AbstractAuthorizer {
 
   private final Table<EntityId, Principal, Set<Action>> table = HashBasedTable.create();
   private final Map<Role, Set<Principal>> roleToPrincipals = new HashMap<>();
+  private final Set<Principal> superUsers = new HashSet<>();
+  // Bypass enforcement for tests that want to simulate every user as a super user
+  private final Principal allSuperUsers = new Principal("*", Principal.PrincipalType.USER);
+
+  @Override
+  public void initialize(AuthorizationContext context) throws Exception {
+    Properties properties = context.getExtensionProperties();
+    if (properties.containsKey("superusers")) {
+      for (String superuser : Splitter.on(",").trimResults().omitEmptyStrings()
+        .split(properties.getProperty("superusers"))) {
+        superUsers.add(new Principal(superuser, Principal.PrincipalType.USER));
+      }
+    }
+  }
 
   @Override
   public void enforce(EntityId entity, Principal principal, Action action) throws UnauthorizedException {
+    // super users do not have any enforcement
+    if (superUsers.contains(principal) || superUsers.contains(allSuperUsers)) {
+      return;
+    }
     // actions allowed to this principal
     Set<Action> allowed = Sets.newHashSet(getActions(entity, principal));
     // actions allowed to any of the roles to which this principal belongs if its not a role

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
@@ -70,7 +70,6 @@ public class AuthorizationCLITest extends CLITestBase {
 
     /**
      * Return the base URI of Standalone for use in tests.
-     * @return
      */
     public URI getBaseURI() {
       return standaloneTester.getBaseURI();
@@ -81,7 +80,10 @@ public class AuthorizationCLITest extends CLITestBase {
       Location authExtensionJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);
       return new String[] {
         Constants.Security.Authorization.ENABLED, "true",
-        Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath()
+        Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath(),
+        // Bypass authorization enforcement for grant/revoke operations in this test. Authorization enforcement for
+        // grant/revoke is tested in AuthorizationHandlerTest
+        Constants.Security.Authorization.EXTENSION_CONFIG_PREFIX + "superusers", "*"
       };
     }
   }
@@ -99,7 +101,6 @@ public class AuthorizationCLITest extends CLITestBase {
     cli = cliMain.getCLI();
     testCommandOutputContains(cli, "connect " + AUTH_STANDALONE.getBaseURI(), "Successfully connected");
   }
-
 
   @Test
   public void testAuthorizationCLI() throws Exception {


### PR DESCRIPTION
- To grant/revoke privileges on an entity, a user must have ``ADMIN`` privileges on that entity.
- Added support for superusers in ``InMemoryAuthorizer`` and ``DatasetBasedAuthorizer``.

Jira: [CDAP-4329](https://issues.cask.co/browse/CDAP-4329)
Build: http://builds.cask.co/browse/CDAP-DUT3859