### PR TITLE
Log HBase version upon Master startup.

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ClientVersions.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ClientVersions.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data.runtime.main;
 
+import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.util.hbase.HBaseVersion;
 import org.apache.hadoop.util.VersionInfo;
 import org.apache.kafka.clients.KafkaClient;
@@ -29,6 +30,21 @@ import java.util.regex.Pattern;
  * Provides client versions of infrastructure components.
  */
 public class ClientVersions {
+
+  public static String getCdapVersion() {
+    return ProjectInfo.getVersion().toString();
+  }
+
+  public static String getCdapHBaseCompatVersion() {
+    // cdap hbase compat module
+    return HBaseVersion.get().toString();
+  }
+
+  public static String getTephraHBaseCompatVersion() {
+    // tephra hbase compat module
+    return co.cask.tephra.util.HBaseVersion.get().toString();
+  }
+
 
   public static String getHadoopVersion() {
     return VersionInfo.getVersion();
@@ -60,6 +76,10 @@ public class ClientVersions {
     System.out.println("HBase version: " + ClientVersions.getHBaseVersion());
     System.out.println("ZooKeeper version: " + ClientVersions.getZooKeeperVersion());
     System.out.println("Kafka version: " + ClientVersions.getKafkaVersion());
+
+    System.out.println("CDAP version: " + ClientVersions.getCdapVersion());
+    System.out.println("CDAP HBase compat version: " + ClientVersions.getCdapHBaseCompatVersion());
+    System.out.println("Tephra HBase compat version: " + ClientVersions.getTephraHBaseCompatVersion());
   }
 
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ClientVersions.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ClientVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,8 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.data.runtime.main;
 
+import co.cask.cdap.data2.util.hbase.HBaseVersion;
 import org.apache.hadoop.util.VersionInfo;
 import org.apache.kafka.clients.KafkaClient;
 import org.apache.zookeeper.version.Info;
@@ -24,12 +26,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Provides client versions of infrasturcture components.
+ * Provides client versions of infrastructure components.
  */
 public class ClientVersions {
 
   public static String getHadoopVersion() {
     return VersionInfo.getVersion();
+  }
+
+  public static String getHBaseVersion() {
+    return HBaseVersion.getVersionString();
   }
 
   public static String getZooKeeperVersion() {
@@ -51,6 +57,7 @@ public class ClientVersions {
 
   public static void main(String[] args) {
     System.out.println("Hadoop version: " + ClientVersions.getHadoopVersion());
+    System.out.println("HBase version: " + ClientVersions.getHBaseVersion());
     System.out.println("ZooKeeper version: " + ClientVersions.getZooKeeperVersion());
     System.out.println("Kafka version: " + ClientVersions.getKafkaVersion());
   }

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/MasterStartupTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/MasterStartupTool.java
@@ -63,6 +63,9 @@ public class MasterStartupTool {
     if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       LOG.info("  Hive version: {}", ExploreServiceUtils.getHiveVersion());
     }
+    LOG.info("CDAP version: {}", ClientVersions.getCdapVersion());
+    LOG.info("CDAP HBase compat version: {}", ClientVersions.getCdapHBaseCompatVersion());
+    LOG.info("Tephra HBase compat version: {}", ClientVersions.getTephraHBaseCompatVersion());
 
     if (!cConf.getBoolean(Constants.Startup.CHECKS_ENABLED)) {
       return;

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/MasterStartupTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/MasterStartupTool.java
@@ -57,6 +57,7 @@ public class MasterStartupTool {
     ConfigurationLogger.logImportantConfig(cConf);
     LOG.info("Hadoop subsystem versions:");
     LOG.info("  Hadoop version: {}", ClientVersions.getHadoopVersion());
+    LOG.info("  HBase version: {}", ClientVersions.getHBaseVersion());
     LOG.info("  ZooKeeper version: {}", ClientVersions.getZooKeeperVersion());
     LOG.info("  Kafka version: {}", ClientVersions.getKafkaVersion());
     if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {


### PR DESCRIPTION
We log the version of several other components, so also logging hbase version.

http://builds.cask.co/browse/CDAP-DUT3867-1