### PR TITLE
Deprecated a couple of old artifact methods in TestBase that were mis…

### DIFF
--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -527,8 +527,9 @@ public class TestBase {
    * @param appClass the application class to build the artifact from
    * @param exportPackages the packages to export and place in the manifest of the jar to build. This should include
    *                       packages that contain classes that plugins for the application will implement.
-   * @throws Exception
+   * @deprecated since 3.4.0. Use {@link #addAppArtifact(NamespacedArtifactId, Class, String...)}
    */
+  @Deprecated
   protected static void addAppArtifact(Id.Artifact artifactId, Class<?> appClass,
                                        String... exportPackages) throws Exception {
     getTestManager().addAppArtifact(artifactId, appClass, exportPackages);
@@ -539,11 +540,39 @@ public class TestBase {
    *
    * @param artifactId the id of the artifact to add
    * @param appClass the application class to build the artifact from
-   * @param manifest the manifest to use when building the jar
-   * @throws Exception
+   * @param exportPackages the packages to export and place in the manifest of the jar to build. This should include
+   *                       packages that contain classes that plugins for the application will implement.
+   * @return an {@link ArtifactManager} to manage the added artifact
    */
+  protected static ArtifactManager addAppArtifact(NamespacedArtifactId artifactId, Class<?> appClass,
+                                                  String... exportPackages) throws Exception {
+    return getTestManager().addAppArtifact(artifactId, appClass, exportPackages);
+  }
+
+  /**
+   * Build an application artifact from the specified class and then add it.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param appClass the application class to build the artifact from
+   * @param manifest the manifest to use when building the jar
+   * @deprecated since 3.4.0. Use {@link #addAppArtifact(NamespacedArtifactId, Class, Manifest)}
+   */
+  @Deprecated
   protected static void addAppArtifact(Id.Artifact artifactId, Class<?> appClass, Manifest manifest) throws Exception {
     getTestManager().addAppArtifact(artifactId, appClass, manifest);
+  }
+
+  /**
+   * Build an application artifact from the specified class and then add it.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param appClass the application class to build the artifact from
+   * @param manifest the manifest to use when building the jar
+   * @return an {@link ArtifactManager} to manage the added artifact
+   */
+  protected static ArtifactManager addAppArtifact(NamespacedArtifactId artifactId, Class<?> appClass,
+                                                  Manifest manifest) throws Exception {
+    return getTestManager().addAppArtifact(artifactId, appClass, manifest);
   }
 
   /**


### PR DESCRIPTION
…sed in a recent refactor. Added equivalent methods that return an ``ArtifactManager``. The corresponding methods for these APIs in ``TestManager have already been deprecated.

I had missed deprecating these APIs during https://github.com/caskdata/cdap/pull/5399.

Build: http://builds.cask.co/browse/CDAP-DUT3878-1