### PR TITLE
Fix IntegrationTestBase to check if default namespace exists instead of checking default is the only namespace that exists

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -96,7 +96,7 @@ public abstract class IntegrationTestBase {
           return false;
         }
         // Check that the dataset service is up, and also that the default namespace exists
-        // Using list and checking that the only namespace to exist is default, as opposed to using get()
+        // Using list and checking if default namespace exists, as opposed to using get()
         // so we don't have to unnecessarily add a try-catch for NamespaceNotFoundException, since that exception is
         // not handled in checkServicesWithRetry.
         List<NamespaceMeta> namespaces = getNamespaceClient().list();
@@ -104,10 +104,11 @@ public abstract class IntegrationTestBase {
         if (namespaces.size() == 0) {
           return false;
         }
-        if (namespaces.size() == 1 && NamespaceMeta.DEFAULT.equals(namespaces.get(0))) {
+        if (namespaces.contains(NamespaceMeta.DEFAULT)) {
           return true;
         }
-        throw new IllegalStateException("Unexpected namespaces: " + namespaces);
+        throw new IllegalStateException("Default namespace not found. Instead found unexpected namespaces: "
+                                          + namespaces);
       }
     };
 


### PR DESCRIPTION
Fix IntegrationTestBase to check if default namespace exists instead of checking default is the only namespace that exists.

Build: http://builds.cask.co/browse/CDAP-DUT3881-2