### PR TITLE
CDAP-5512 plugin support in workflows

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.Predicate;
 import co.cask.cdap.api.ProgramLifecycle;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.internal.api.AbstractPluginConfigurable;
 
 import java.util.Map;
 
@@ -42,7 +43,8 @@ import java.util.Map;
  *
  * See the Purchase example application.
  */
-public abstract class AbstractWorkflow implements Workflow, ProgramLifecycle<WorkflowContext> {
+public abstract class AbstractWorkflow extends AbstractPluginConfigurable<WorkflowConfigurer>
+  implements Workflow, ProgramLifecycle<WorkflowContext> {
 
   private WorkflowConfigurer configurer;
   private WorkflowContext context;

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
@@ -21,11 +21,12 @@ import co.cask.cdap.api.ProgramConfigurer;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.plugin.PluginConfigurer;
 
 /**
  * Configurer for configuring the {@link Workflow}.
  */
-public interface WorkflowConfigurer extends ProgramConfigurer {
+public interface WorkflowConfigurer extends ProgramConfigurer, PluginConfigurer {
 
   /**
    * Adds a MapReduce program as a next sequential step in the {@link Workflow}. MapReduce program must be

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.plugin.PluginContext;
 
 import java.util.Map;
 
@@ -27,7 +28,7 @@ import java.util.Map;
  * Represents the runtime context of a {@link Workflow}. This context is also
  * available to {@link WorkflowAction}.
  */
-public interface WorkflowContext extends RuntimeContext, ServiceDiscoverer, DatasetContext {
+public interface WorkflowContext extends RuntimeContext, ServiceDiscoverer, DatasetContext, PluginContext {
 
   WorkflowSpecification getWorkflowSpecification();
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
@@ -37,6 +37,7 @@ import co.cask.cdap.api.worker.WorkerSpecification;
 import co.cask.cdap.api.workflow.ScheduleProgramInfo;
 import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.internal.api.DefaultDatasetConfigurer;
 import co.cask.cdap.internal.app.DefaultApplicationSpecification;
 import co.cask.cdap.internal.app.DefaultPluginConfigurer;
 import co.cask.cdap.internal.app.mapreduce.DefaultMapReduceConfigurer;
@@ -108,9 +109,7 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
     DefaultFlowConfigurer configurer = new DefaultFlowConfigurer(flow);
     flow.configure(configurer);
     FlowSpecification spec = configurer.createSpecification();
-    addStreams(configurer.getStreams());
-    addDatasetModules(configurer.getDatasetModules());
-    addDatasetSpecs(configurer.getDatasetSpecs());
+    addDatasets(configurer);
     flows.put(spec.getName(), spec);
   }
 
@@ -121,11 +120,7 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
                                                                            artifactRepository,
                                                                            pluginInstantiator);
     mapReduce.configure(configurer);
-
-    addStreams(configurer.getStreams());
-    addDatasetModules(configurer.getDatasetModules());
-    addDatasetSpecs(configurer.getDatasetSpecs());
-    addPlugins(configurer.getPlugins());
+    addDatasetsAndPlugins(configurer);
     MapReduceSpecification spec = configurer.createSpecification();
     mapReduces.put(spec.getName(), spec);
   }
@@ -137,11 +132,7 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
                                                                    artifactRepository,
                                                                    pluginInstantiator);
     spark.configure(configurer);
-
-    addStreams(configurer.getStreams());
-    addDatasetModules(configurer.getDatasetModules());
-    addDatasetSpecs(configurer.getDatasetSpecs());
-    addPlugins(configurer.getPlugins());
+    addDatasetsAndPlugins(configurer);
     SparkSpecification spec = configurer.createSpecification();
     sparks.put(spec.getName(), spec);
   }
@@ -149,9 +140,12 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
   @Override
   public void addWorkflow(Workflow workflow) {
     Preconditions.checkArgument(workflow != null, "Workflow cannot be null.");
-    DefaultWorkflowConfigurer configurer = new DefaultWorkflowConfigurer(workflow, this);
+    DefaultWorkflowConfigurer configurer = new DefaultWorkflowConfigurer(workflow, this,
+                                                                         deployNamespace, artifactId,
+                                                                         artifactRepository, pluginInstantiator);
     workflow.configure(configurer);
     WorkflowSpecification spec = configurer.createSpecification();
+    addDatasetsAndPlugins(configurer);
     workflows.put(spec.getName(), spec);
   }
 
@@ -162,10 +156,7 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
     service.configure(configurer);
 
     ServiceSpecification spec = configurer.createSpecification();
-    addStreams(configurer.getStreams());
-    addDatasetModules(configurer.getDatasetModules());
-    addDatasetSpecs(configurer.getDatasetSpecs());
-    addPlugins(configurer.getPlugins());
+    addDatasetsAndPlugins(configurer);
     services.put(spec.getName(), spec);
   }
 
@@ -176,11 +167,7 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
                                                                      artifactRepository,
                                                                      pluginInstantiator);
     worker.configure(configurer);
-
-    addStreams(configurer.getStreams());
-    addDatasetModules(configurer.getDatasetModules());
-    addDatasetSpecs(configurer.getDatasetSpecs());
-    addPlugins(configurer.getPlugins());
+    addDatasetsAndPlugins(configurer);
     WorkerSpecification spec = configurer.createSpecification();
     workers.put(spec.getName(), spec);
   }
@@ -215,5 +202,16 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
                                                getDatasetModules(), getDatasetSpecs(),
                                                flows, mapReduces, sparks, workflows, services,
                                                schedules, workers, getPlugins());
+  }
+
+  private void addDatasetsAndPlugins(DefaultPluginConfigurer configurer) {
+    addDatasets(configurer);
+    addPlugins(configurer.getPlugins());
+  }
+
+  private void addDatasets(DefaultDatasetConfigurer configurer) {
+    addStreams(configurer.getStreams());
+    addDatasetModules(configurer.getDatasetModules());
+    addDatasetSpecs(configurer.getDatasetSpecs());
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
@@ -16,11 +16,6 @@
 
 package co.cask.cdap.internal.app;
 
-import co.cask.cdap.api.DatasetConfigurer;
-import co.cask.cdap.api.data.stream.Stream;
-import co.cask.cdap.api.dataset.Dataset;
-import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.api.plugin.PluginConfigurer;
 import co.cask.cdap.api.plugin.PluginProperties;
@@ -31,7 +26,6 @@ import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.plugin.FindPluginHelper;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.plugin.PluginNotExistsException;
-import co.cask.cdap.internal.test.PluginJarHelper;
 import co.cask.cdap.proto.Id;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
@@ -29,6 +29,7 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
@@ -59,11 +60,12 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
                        Arguments arguments, WorkflowToken token, Program program, RunId runId,
                        MetricsCollectionService metricsCollectionService,
                        DatasetFramework datasetFramework, TransactionSystemClient txClient,
-                       DiscoveryServiceClient discoveryServiceClient, Map<String, WorkflowNodeState> nodeStates) {
+                       DiscoveryServiceClient discoveryServiceClient, Map<String, WorkflowNodeState> nodeStates,
+                       @Nullable PluginInstantiator pluginInstantiator) {
     super(program, runId, arguments,
           (spec == null) ? new HashSet<String>() : spec.getDatasets(),
           getMetricCollector(program, runId.getId(), metricsCollectionService),
-          datasetFramework, txClient, discoveryServiceClient, false);
+          datasetFramework, txClient, discoveryServiceClient, false, pluginInstantiator);
     this.workflowSpec = workflowSpec;
     this.specification = spec;
     this.programWorkflowRunner = programWorkflowRunner;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -51,6 +51,7 @@ import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.workflow.DefaultWorkflowActionConfigurer;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.workflow.ProgramWorkflowAction;
@@ -99,6 +100,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import javax.annotation.Nullable;
 
 /**
  * Core of Workflow engine that drives the execution of Workflow.
@@ -128,6 +130,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   private Workflow workflow;
   private final BasicWorkflowContext basicWorkflowContext;
   private final Map<String, WorkflowNodeState> nodeStates = new ConcurrentHashMap<>();
+  @Nullable
+  private final PluginInstantiator pluginInstantiator;
 
   private final CConfiguration cConf;
 
@@ -135,7 +139,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                  WorkflowSpecification workflowSpec, ProgramRunnerFactory programRunnerFactory,
                  MetricsCollectionService metricsCollectionService,
                  DatasetFramework datasetFramework, DiscoveryServiceClient discoveryServiceClient,
-                 TransactionSystemClient txClient, Store store, CConfiguration cConf) {
+                 TransactionSystemClient txClient, Store store, CConfiguration cConf,
+                 @Nullable PluginInstantiator pluginInstantiator) {
     this.program = program;
     this.hostname = hostname;
     this.runtimeArgs = createRuntimeArgs(options.getUserArguments());
@@ -162,7 +167,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     this.basicWorkflowContext = new BasicWorkflowContext(workflowSpec, null, null, new BasicArguments(runtimeArgs),
                                                          null, program, RunIds.fromString(runId),
                                                          metricsCollectionService, datasetFramework, txClient,
-                                                         discoveryServiceClient, nodeStates);
+                                                         discoveryServiceClient, nodeStates, pluginInstantiator);
+    this.pluginInstantiator = pluginInstantiator;
   }
 
   @Override
@@ -257,6 +263,9 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     httpService.stopAndWait();
     deleteLocalDatasets();
     destroyWorkflow();
+    if (pluginInstantiator != null) {
+      pluginInstantiator.close();
+    }
   }
 
   @SuppressWarnings("unchecked")
@@ -446,7 +455,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                                                        new BasicArguments(runtimeArgs), token,
                                                        program, RunIds.fromString(workflowRunId.getRun()),
                                                        metricsCollectionService, datasetFramework, txClient,
-                                                       discoveryServiceClient, nodeStates);
+                                                       discoveryServiceClient, nodeStates, pluginInstantiator);
     Iterator<WorkflowNode> iterator;
     if (predicate.apply(context)) {
       // execute the if branch
@@ -543,7 +552,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                                                                                           nodeStates),
                                     new BasicArguments(runtimeArgs), token, program,
                                     RunIds.fromString(workflowRunId.getRun()), metricsCollectionService,
-                                    datasetFramework, txClient, discoveryServiceClient, nodeStates);
+                                    datasetFramework, txClient, discoveryServiceClient, nodeStates,
+                                    pluginInstantiator);
   }
 
   private Map<String, String> createRuntimeArgs(Arguments args) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
@@ -31,8 +31,11 @@ import co.cask.cdap.api.workflow.WorkflowForkConfigurer;
 import co.cask.cdap.api.workflow.WorkflowForkNode;
 import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
-import co.cask.cdap.app.DefaultAppConfigurer;
+import co.cask.cdap.internal.app.DefaultPluginConfigurer;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
+import co.cask.cdap.proto.Id;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
@@ -43,7 +46,8 @@ import java.util.Map;
 /**
  * Default implementation of {@link WorkflowConfigurer}.
  */
-public class DefaultWorkflowConfigurer implements WorkflowConfigurer, WorkflowForkJoiner, WorkflowConditionAdder {
+public class DefaultWorkflowConfigurer extends DefaultPluginConfigurer
+  implements WorkflowConfigurer, WorkflowForkJoiner, WorkflowConditionAdder {
 
   private final String className;
   private String name;
@@ -55,7 +59,10 @@ public class DefaultWorkflowConfigurer implements WorkflowConfigurer, WorkflowFo
 
   private final List<WorkflowNode> nodes = Lists.newArrayList();
 
-  public DefaultWorkflowConfigurer(Workflow workflow, DatasetConfigurer datasetConfigurer) {
+  public DefaultWorkflowConfigurer(Workflow workflow, DatasetConfigurer datasetConfigurer,
+                                   Id.Namespace deployNamespace, Id.Artifact artifactId,
+                                   ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
+    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
     this.className = workflow.getClass().getName();
     this.name = workflow.getClass().getSimpleName();
     this.description = "";

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -71,7 +71,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
@@ -291,11 +290,14 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
       }
     }, 5, TimeUnit.SECONDS, 10, TimeUnit.MILLISECONDS);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(AppWithPlugin.MAPREDUCE);
-    mrManager.start();
-    mrManager.waitForFinish(10, TimeUnit.MINUTES);
-    List<RunRecord> runRecords = mrManager.getHistory();
+    WorkflowManager workflowManager = appManager.getWorkflowManager(AppWithPlugin.WORKFLOW);
+    workflowManager.start();
+    workflowManager.waitForFinish(10, TimeUnit.MINUTES);
+    List<RunRecord> runRecords = workflowManager.getHistory();
     Assert.assertNotEquals(ProgramRunStatus.FAILED, runRecords.get(0).getStatus());
+    DataSetManager<KeyValueTable> workflowTableManager = getDataset(AppWithPlugin.WORKFLOW_TABLE);
+    String value = Bytes.toString(workflowTableManager.get().read("val"));
+    Assert.assertEquals(AppWithPlugin.TEST, value);
 
     // Testing Spark Plugins. First send some data to stream for the Spark program to process
     StreamManager streamManager = getStreamManager(AppWithPlugin.SPARK_STREAM);


### PR DESCRIPTION
Add plugin support in workflows. This amounts to extending the
WorkflowContext interface so that it also implements PluginContext,
and extending WorkflowConfigurer so that it also implements
PluginConfigurer, and extending AbstractWorkflow so that it extends
AbstractPluginConfigurable.

The rest is just re-using the plugin work already done for the
other program types to pass a PluginInstantiator into
BasicWorkflowContext.