### PR TITLE
CDAP-4842 explicitly list all mock plugins

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -40,6 +40,8 @@ import co.cask.cdap.etl.proto.v2.ETLStage;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedArtifactId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.StreamManager;
@@ -65,8 +67,9 @@ import java.util.concurrent.TimeUnit;
  */
 public class DataPipelineTest extends HydratorTestBase {
 
-  protected static final Id.Artifact APP_ARTIFACT_ID = Id.Artifact.from(Id.Namespace.DEFAULT, "app", "1.0.0");
-  protected static final ArtifactSummary APP_ARTIFACT = ArtifactSummary.from(APP_ARTIFACT_ID);
+  protected static final NamespacedArtifactId APP_ARTIFACT_ID =
+    new NamespacedArtifactId(NamespaceId.DEFAULT.getNamespace(), "app", "1.0.0");
+  protected static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
   private static int startCount = 0;
   @ClassRule
   public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
@@ -79,7 +82,8 @@ public class DataPipelineTest extends HydratorTestBase {
     setupBatchArtifacts(APP_ARTIFACT_ID, DataPipelineApp.class);
 
     // add some test plugins
-    addPluginArtifact(Id.Artifact.from(Id.Namespace.DEFAULT, "spark-plugins", "1.0.0"), APP_ARTIFACT_ID,
+    addPluginArtifact(new NamespacedArtifactId(NamespaceId.DEFAULT.getNamespace(), "spark-plugins", "1.0.0"),
+                      APP_ARTIFACT_ID,
                       NaiveBayesTrainer.class, NaiveBayesClassifier.class);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLBatchTestBase.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLBatchTestBase.java
@@ -19,8 +19,9 @@ package co.cask.cdap.etl.batch;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.etl.mock.test.HydratorTestBase;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedArtifactId;
 import co.cask.cdap.test.TestConfiguration;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -39,8 +40,9 @@ import java.util.List;
  * Base test class that sets up plugins and the batch template.
  */
 public class ETLBatchTestBase extends HydratorTestBase {
-  protected static final Id.Artifact APP_ARTIFACT_ID = Id.Artifact.from(Id.Namespace.DEFAULT, "app", "1.0.0");
-  protected static final ArtifactSummary APP_ARTIFACT = ArtifactSummary.from(APP_ARTIFACT_ID);
+  protected static final NamespacedArtifactId APP_ARTIFACT_ID =
+    new NamespacedArtifactId(NamespaceId.DEFAULT.getNamespace(), "app", "1.0.0");
+  protected static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
   private static int startCount = 0;
 
   @ClassRule

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/ETLWorkerTest.java
@@ -32,6 +32,8 @@ import co.cask.cdap.etl.proto.v2.ETLStage;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedArtifactId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.SlowTests;
@@ -58,8 +60,9 @@ import java.util.concurrent.TimeUnit;
  */
 public class ETLWorkerTest extends HydratorTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(ETLWorkerTest.class);
-  protected static final Id.Artifact APP_ARTIFACT_ID = Id.Artifact.from(Id.Namespace.DEFAULT, "app", "1.0.0");
-  protected static final ArtifactSummary APP_ARTIFACT = ArtifactSummary.from(APP_ARTIFACT_ID);
+  protected static final NamespacedArtifactId APP_ARTIFACT_ID =
+    new NamespacedArtifactId(NamespaceId.DEFAULT.getNamespace(), "app", "1.0.0");
+  protected static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
   private static int startCount = 0;
 
   @ClassRule

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockSink.java
@@ -26,7 +26,9 @@ import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
@@ -48,6 +50,7 @@ import java.util.UUID;
 @Plugin(type = BatchSink.PLUGIN_TYPE)
 @Name("Mock")
 public class MockSink extends BatchSink<StructuredRecord, byte[], Put> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
   private static final byte[] SCHEMA_COL = Bytes.toBytes("s");
   private static final byte[] RECORD_COL = Bytes.toBytes("r");
   private final Config config;
@@ -115,5 +118,11 @@ public class MockSink extends BatchSink<StructuredRecord, byte[], Put> {
     } finally {
       scanner.close();
     }
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("tableName", new PluginPropertyField("tableName", "", "string", true));
+    return new PluginClass(BatchSink.PLUGIN_TYPE, "Mock", "", MockSink.class.getName(), "config", properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockSource.java
@@ -24,10 +24,13 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -45,6 +48,7 @@ import java.util.UUID;
 @Plugin(type = BatchSource.PLUGIN_TYPE)
 @Name("Mock")
 public class MockSource extends BatchSource<byte[], Row, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
   private static final byte[] SCHEMA_COL = Bytes.toBytes("s");
   private static final byte[] RECORD_COL = Bytes.toBytes("r");
   private final Config config;
@@ -107,5 +111,11 @@ public class MockSource extends BatchSource<byte[], Row, StructuredRecord> {
       table.put(row, RECORD_COL, Bytes.toBytes(StructuredRecordStringConverter.toJsonString(record)));
     }
     tableManager.flush();
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("tableName", new PluginPropertyField("tableName", "", "string", true));
+    return new PluginClass(BatchSource.PLUGIN_TYPE, "Mock", "", MockSource.class.getName(), "config", properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/FieldCountAggregator.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/FieldCountAggregator.java
@@ -20,13 +20,16 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchAggregatorContext;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 
 import java.util.HashMap;
@@ -41,6 +44,7 @@ import java.util.Map;
 @Plugin(type = BatchAggregator.PLUGIN_TYPE)
 @Name("FieldCount")
 public class FieldCountAggregator extends BatchAggregator<Object, StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
   private final Config config;
   private Schema schema;
 
@@ -128,5 +132,13 @@ public class FieldCountAggregator extends BatchAggregator<Object, StructuredReco
     properties.put("fieldName", fieldName);
     properties.put("fieldType", fieldType);
     return new ETLPlugin("FieldCount", BatchAggregator.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("fieldName", new PluginPropertyField("fieldName", "", "string", true));
+    properties.put("fieldType", new PluginPropertyField("fieldType", "", "string", true));
+    return new PluginClass(BatchAggregator.PLUGIN_TYPE, "FieldCount", "", FieldCountAggregator.class.getName(),
+                           "config", properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/IdentityAggregator.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/IdentityAggregator.java
@@ -19,6 +19,8 @@ package co.cask.cdap.etl.mock.batch.aggregator;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
@@ -35,6 +37,7 @@ import java.util.Map;
 @Plugin(type = BatchAggregator.PLUGIN_TYPE)
 @Name("Identity")
 public class IdentityAggregator extends BatchAggregator<StructuredRecord, StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
@@ -58,5 +61,11 @@ public class IdentityAggregator extends BatchAggregator<StructuredRecord, Struct
   public static ETLPlugin getPlugin() {
     Map<String, String> properties = new HashMap<>();
     return new ETLPlugin("Identity", BatchAggregator.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    return new PluginClass(BatchAggregator.PLUGIN_TYPE, "Identity", "", IdentityAggregator.class.getName(),
+                           null, properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/realtime/LookupSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/realtime/LookupSource.java
@@ -20,9 +20,12 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.Lookup;
+import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.realtime.RealtimeContext;
 import co.cask.cdap.etl.api.realtime.RealtimeSource;
 import co.cask.cdap.etl.api.realtime.SourceState;
@@ -45,6 +48,7 @@ import javax.annotation.Nullable;
 @Plugin(type = RealtimeSource.PLUGIN_TYPE)
 @Name("Lookup")
 public class LookupSource extends RealtimeSource<StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
   private final Config config;
   private Set<String> fields;
   private Schema schema;
@@ -94,5 +98,13 @@ public class LookupSource extends RealtimeSource<StructuredRecord> {
     properties.put("fields", Joiner.on(',').join(fields));
     properties.put("lookupName", lookupName);
     return new ETLPlugin("Lookup", RealtimeSource.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("fields", new PluginPropertyField("fields", "", "string", true));
+    properties.put("lookupName", new PluginPropertyField("lookupName", "", "string", true));
+    return new PluginClass(RealtimeSource.PLUGIN_TYPE, "Lookup", "", LookupSource.class.getName(),
+                           "config", properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/realtime/MockSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/realtime/MockSink.java
@@ -19,7 +19,9 @@ package co.cask.cdap.etl.mock.realtime;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.etl.api.realtime.DataWriter;
 import co.cask.cdap.etl.api.realtime.RealtimeContext;
@@ -50,6 +52,7 @@ import javax.annotation.Nullable;
 @Plugin(type = RealtimeSink.PLUGIN_TYPE)
 @Name("Mock")
 public class MockSink extends RealtimeSink<StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(StructuredRecord.class, new StructuredRecordCodec())
     .create();
@@ -139,5 +142,11 @@ public class MockSink extends RealtimeSink<StructuredRecord> {
     File recordsFile = new File(dir, String.valueOf(writeNum));
     String contents = new String(Files.readAllBytes(recordsFile.toPath()), StandardCharsets.UTF_8);
     return GSON.fromJson(contents, LIST_TYPE);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("dir", new PluginPropertyField("dir", "", "string", false));
+    return new PluginClass(RealtimeSink.PLUGIN_TYPE, "Mock", "", MockSink.class.getName(), "config", properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/realtime/MockSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/realtime/MockSource.java
@@ -19,9 +19,12 @@ package co.cask.cdap.etl.mock.realtime;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.realtime.RealtimeContext;
+import co.cask.cdap.etl.api.realtime.RealtimeSink;
 import co.cask.cdap.etl.api.realtime.RealtimeSource;
 import co.cask.cdap.etl.api.realtime.SourceState;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -41,6 +44,7 @@ import javax.annotation.Nullable;
 @Plugin(type = RealtimeSource.PLUGIN_TYPE)
 @Name("Mock")
 public class MockSource extends RealtimeSource<StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(StructuredRecord.class, new StructuredRecordCodec())
     .create();
@@ -92,5 +96,12 @@ public class MockSource extends RealtimeSource<StructuredRecord> {
       properties.put("records", GSON.toJson(records));
     }
     return new ETLPlugin("Mock", RealtimeSource.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("records", new PluginPropertyField("records", "", "string", false));
+    return new PluginClass(RealtimeSource.PLUGIN_TYPE, "Mock", "", MockSource.class.getName(),
+                           "config", properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/DoubleTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/DoubleTransform.java
@@ -19,11 +19,15 @@ package co.cask.cdap.etl.mock.transform;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.realtime.RealtimeSink;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Transform that doubles every record it receives.
@@ -31,6 +35,7 @@ import java.util.HashMap;
 @Plugin(type = Transform.PLUGIN_TYPE)
 @Name("Double")
 public class DoubleTransform extends Transform<StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
 
   @Override
   public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
@@ -40,5 +45,10 @@ public class DoubleTransform extends Transform<StructuredRecord, StructuredRecor
 
   public static ETLPlugin getPlugin() {
     return new ETLPlugin("Double", Transform.PLUGIN_TYPE, new HashMap<String, String>(), null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    return new PluginClass(Transform.PLUGIN_TYPE, "Double", "", DoubleTransform.class.getName(), null, properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/ErrorTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/ErrorTransform.java
@@ -19,12 +19,15 @@ package co.cask.cdap.etl.mock.transform;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Transform used to test writing to error datasets. Writes all its input as errors.
@@ -32,6 +35,7 @@ import java.util.HashMap;
 @Plugin(type = Transform.PLUGIN_TYPE)
 @Name("Error")
 public class ErrorTransform extends Transform<StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
 
   @Override
   public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
@@ -40,5 +44,10 @@ public class ErrorTransform extends Transform<StructuredRecord, StructuredRecord
 
   public static ETLPlugin getPlugin() {
     return new ETLPlugin("Error", Transform.PLUGIN_TYPE, new HashMap<String, String>(), null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    return new PluginClass(Transform.PLUGIN_TYPE, "Error", "", ErrorTransform.class.getName(), null, properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/IdentityTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/IdentityTransform.java
@@ -19,6 +19,8 @@ package co.cask.cdap.etl.mock.transform;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
@@ -34,6 +36,7 @@ import java.util.Map;
 @Plugin(type = Transform.PLUGIN_TYPE)
 @Name("Identity")
 public class IdentityTransform extends Transform<StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
@@ -49,5 +52,11 @@ public class IdentityTransform extends Transform<StructuredRecord, StructuredRec
   public static ETLPlugin getPlugin() {
     Map<String, String> properties = new HashMap<>();
     return new ETLPlugin("Identity", Transform.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    return new PluginClass(Transform.PLUGIN_TYPE, "Identity", "", IdentityTransform.class.getName(),
+                           null, properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/IntValueFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/IntValueFilterTransform.java
@@ -19,7 +19,9 @@ package co.cask.cdap.etl.mock.transform;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -34,6 +36,7 @@ import java.util.Map;
 @Plugin(type = Transform.PLUGIN_TYPE)
 @Name("IntValueFilter")
 public class IntValueFilterTransform extends Transform<StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
   private final Config config;
 
   public IntValueFilterTransform(Config config) {
@@ -61,5 +64,13 @@ public class IntValueFilterTransform extends Transform<StructuredRecord, Structu
     properties.put("field", field);
     properties.put("value", String.valueOf(value));
     return new ETLPlugin("IntValueFilter", Transform.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("field", new PluginPropertyField("field", "", "string", true));
+    properties.put("value", new PluginPropertyField("value", "", "int", true));
+    return new PluginClass(Transform.PLUGIN_TYPE, "IntValueFilter", "", IntValueFilterTransform.class.getName(),
+                           "config", properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/StringValueFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/StringValueFilterTransform.java
@@ -19,7 +19,9 @@ package co.cask.cdap.etl.mock.transform;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -34,6 +36,7 @@ import java.util.Map;
 @Plugin(type = Transform.PLUGIN_TYPE)
 @Name("StringValueFilter")
 public class StringValueFilterTransform extends Transform<StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
   private final Config config;
 
   public StringValueFilterTransform(Config config) {
@@ -61,5 +64,13 @@ public class StringValueFilterTransform extends Transform<StructuredRecord, Stru
     properties.put("field", field);
     properties.put("value", value);
     return new ETLPlugin("StringValueFilter", Transform.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("field", new PluginPropertyField("field", "", "string", true));
+    properties.put("value", new PluginPropertyField("value", "", "string", true));
+    return new PluginClass(Transform.PLUGIN_TYPE, "StringValueFilter", "", StringValueFilterTransform.class.getName(),
+                           "config", properties);
   }
 }


### PR DESCRIPTION
This is to workaround the fact that when a project adds
hydrator-test as a dependency, the jar that gets created adds
hydrator-test as a lib jar, which does not get inspected for
plugins.