### PR TITLE
Fix Broken Documentation Build

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -260,19 +260,19 @@
   </property>
 
   <property>
-    <name>app.program.runtime.extensions.dir</name>
-    <value>/opt/cdap/master/ext/runtimes</value>
-    <description>
-      Semicolon-separated list of local directories scanned for program runtime extension.
-    </description>
-  </property>
-
-  <property>
     <name>app.program.runid.corrector.interval</name>
     <value>180</value>
     <description>
       The interval of how often the run id corrector thread will run in
       seconds; this value should be greater than 0
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.runtime.extensions.dir</name>
+    <value>/opt/cdap/master/ext/runtimes</value>
+    <description>
+      Semicolon-separated list of local directories that are scanned for program runtime extensions
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="acb8e1410495b1af417298c43eeb2177"
+DEFAULT_XML_MD5_HASH="a3e18e97b847f2f643ed038f651e968b"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -86,7 +86,7 @@ function download_includes() {
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
   test_an_include 7f83b852a8e7b4594094d4e88d80a0b4 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
   test_an_include b5aa09ede42a877e15df5e482607e256 ../../cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/TopNMapReduce.java
-  test_an_include 62144353b40314640d74d4b675432620 ../../cdap-examples/WikipediaPipeline/src/main/scala/co/cask/cdap/examples/wikipedia/ClusteringUtils.scala
+  test_an_include 8c24858e8d168c0909fd554e96a2aba9 ../../cdap-examples/WikipediaPipeline/src/main/scala/co/cask/cdap/examples/wikipedia/ClusteringUtils.scala
 }
 
 function test_includes () {

--- a/cdap-docs/developers-manual/source/building-blocks/workflows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/workflows.rst
@@ -308,6 +308,7 @@ the :ref:`Wikipedia Pipeline <examples-wikipedia-data-pipeline>` example's ``Clu
 .. literalinclude:: /../../../cdap-examples/WikipediaPipeline/src/main/scala/co/cask/cdap/examples/wikipedia/ClusteringUtils.scala
    :language: scala
    :lines: 121-126
+   :dedent: 4
 
 Persisting the WorkflowToken
 ----------------------------

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -152,14 +152,14 @@ function download_includes() {
   
   test_an_include c2374d482454dc57c5944e557b544dba ../../cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java
 
-  test_an_include a9a7fd53c199defff09e6e3c73e4e71f ../../cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
+  test_an_include 56bad93a55876df47302c7955d0b0742 ../../cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
   
   test_an_include 6e91764bbf75e2c4efd5547ab1a3e4e6 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
   test_an_include 0bcc5fe3914acbb793c993e72834bbde ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
   test_an_include 80216a08a2b3d480e4a081722408222f ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
 
-  test_an_include 950241d0199883f3bcb23d6f7da0551f ../../cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java
+  test_an_include cac0cfb9977d233fe97ba1ab9b0cf1c9 ../../cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java
   
   test_an_include 7f83b852a8e7b4594094d4e88d80a0b4 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 

--- a/cdap-docs/examples-manual/source/examples/log-analysis.rst
+++ b/cdap-docs/examples-manual/source/examples/log-analysis.rst
@@ -57,6 +57,7 @@ of the application are tied together by the class ``LogAnalysisApp``:
 .. literalinclude:: /../../../cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
    :language: java
    :lines: 60-94
+   :append: . . .
 
 The *hitCount* and *responseCount* KeyValueTables and *reqCount* TimePartitionedFileSet
 ---------------------------------------------------------------------------------------

--- a/cdap-docs/examples-manual/source/examples/spark-k-means.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-k-means.rst
@@ -36,6 +36,7 @@ of the application are tied together by the class ``SparkKMeansApp``:
 .. literalinclude:: /../../../cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java
    :language: java
    :lines: 51-82
+   :append: . . .
 
 The *points* and *centers* ObjectStore Data Storage
 ---------------------------------------------------


### PR DESCRIPTION
Fix build MD55 hashes.
Edited cdap-default.xml to place new properties in correct order and adjust text of descriptions.
Adjusted the display of certain code samples to be flush left and include ellipsis (...) if they are fragments.

Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DOB165-1).