### PR TITLE
(CDAP-5530) (CDAP-5547) Fix Spark ClassLoader and memory leakage

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
@@ -296,8 +297,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
     File tempFile = File.createTempFile(clz.getName(), ".jar", tempDir);
     try {
       // Create a bundle jar in a temp location
-      ClassLoader remembered = Thread.currentThread().getContextClassLoader();
-      Thread.currentThread().setContextClassLoader(clz.getClassLoader());
+      ClassLoader remembered = ClassLoaders.setContextClassLoader(clz.getClassLoader());
       try {
         ApplicationBundler bundler = new ApplicationBundler(ImmutableList.of("co.cask.cdap.api",
                                                                              "org.apache.hadoop",
@@ -305,7 +305,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
                                                                              "org.apache.hive"));
         bundler.createBundle(Locations.toLocation(tempFile), clz);
       } finally {
-        Thread.currentThread().setContextClassLoader(remembered);
+        ClassLoaders.setContextClassLoader(remembered);
       }
 
       // Create the program jar for deployment. It removes the "classes/" prefix as that's the convention taken

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
@@ -27,9 +27,14 @@ import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.io.Closeables;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.ProvisionException;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Type;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -79,7 +84,7 @@ public class SparkProgramRuntimeProvider implements ProgramRuntimeProvider {
           // Closing of the SparkRunnerClassLoader is done by the SparkProgramRunner when the program execution finished
           // The current CDAP call run right after it get a ProgramRunner and never reuse a ProgramRunner.
           // TODO: CDAP-5506 to refactor the program runtime architecture to remove the need of this assumption
-          return (ProgramRunner) injector.getInstance(classLoader.loadClass(SPARK_PROGRAM_RUNNER_CLASS_NAME));
+          return createInstance(injector, classLoader.loadClass(SPARK_PROGRAM_RUNNER_CLASS_NAME), classLoader);
         } finally {
           ClassLoaders.setContextClassLoader(oldClassLoader);
         }
@@ -90,6 +95,66 @@ public class SparkProgramRuntimeProvider implements ProgramRuntimeProvider {
       }
     } catch (Throwable t) {
       throw Throwables.propagate(t);
+    }
+  }
+
+  /**
+   * Create a new instance of the given {@link Type} from the given {@link Injector}. This method
+   * is doing Guice injection manually through the @Inject constructor to avoid ClassLoader leakage
+   * due to the just-in-time binding map inside the Guice Injector that holds a strong reference to the type,
+   * hence the ClassLoader of that type
+   *
+   * @param injector The Guice Injector for acquiring CDAP system instances
+   * @param type the {@link Class} of the instance to create
+   * @return a new instance of the given {@link Type}
+   */
+  private <T> T createInstance(Injector injector, Type type, ClassLoader sparkClassLoader) throws Exception {
+    Key<?> typeKey = Key.get(type);
+    @SuppressWarnings("unchecked")
+    Class<T> rawType = (Class<T>) typeKey.getTypeLiteral().getRawType();
+
+    Constructor<T> constructor = findInjectableConstructor(rawType);
+    constructor.setAccessible(true);
+
+    // Acquire the instances for each parameter for the constructor
+    Type[] paramTypes = constructor.getGenericParameterTypes();
+    Object[] args = new Object[paramTypes.length];
+    int i = 0;
+    for (Type paramType : paramTypes) {
+      Key<?> paramTypeKey = Key.get(paramType);
+
+      // If the classloader of the parameter is the same as the Spark ClassLoader, we need to create the
+      // instance manually instead of getting through the Guice Injector to avoid ClassLoader leakage
+      if (paramTypeKey.getTypeLiteral().getRawType().getClassLoader() == sparkClassLoader) {
+        args[i++] = createInstance(injector, paramType, sparkClassLoader);
+      } else {
+        args[i++] = injector.getInstance(paramTypeKey);
+      }
+    }
+    return constructor.newInstance(args);
+  }
+
+  /**
+   * Finds the constructor of the given type that is suitable for Guice injection. If the given type has
+   * a constructor annotated with {@link Inject}, then it will be returned. Otherwise, the default constructor
+   * will be returned.
+   *
+   * @throws ProvisionException if failed to locate a constructor for the injection
+   */
+  @SuppressWarnings("unchecked")
+  private <T> Constructor<T> findInjectableConstructor(Class<T> type) throws ProvisionException {
+    for (Constructor<?> constructor : type.getDeclaredConstructors()) {
+      // Find the @Inject constructor
+      if (constructor.isAnnotationPresent(Inject.class)) {
+        return (Constructor<T>) constructor;
+      }
+    }
+
+    // If no @Inject constructor, use the default constructor
+    try {
+      return type.getDeclaredConstructor();
+    } catch (NoSuchMethodException e) {
+      throw new ProvisionException("No constructor is annotated with @Inject and there is no default constructor", e);
     }
   }
 

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoader.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoader.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.common.internal.guava.ClassPath;
 import co.cask.cdap.common.lang.ClassPathResources;
 import com.google.common.collect.Iterables;
-import com.google.common.io.ByteStreams;
 import org.apache.spark.SparkContext;
 import org.apache.spark.streaming.StreamingContext;
 import org.objectweb.asm.ClassReader;
@@ -33,6 +32,8 @@ import org.objectweb.asm.commons.AdviceAdapter;
 import org.objectweb.asm.commons.Method;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.ExecutionContextExecutor;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,6 +42,7 @@ import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 /**
@@ -54,6 +56,10 @@ final class SparkRunnerClassLoader extends URLClassLoader {
   private static final Type SPARK_CONTEXT_TYPE = Type.getType(SparkContext.class);
   private static final Type SPARK_STREAMING_CONTEXT_TYPE = Type.getType(StreamingContext.class);
   private static final Type SPARK_CONTEXT_CACHE_TYPE = Type.getType(SparkContextCache.class);
+
+  // Don't refer akka Remoting with the ".class" because in future Spark version, akka dependency is removed and
+  // we don't want to force a dependency on akka.
+  private static final Type AKKA_REMOTING_TYPE = Type.getObjectType("akka/remote/Remoting");
 
   // Set of resources that are in cdap-api. They should be loaded by the parent ClassLoader
   private static final Set<String> API_CLASSES;
@@ -89,7 +95,7 @@ final class SparkRunnerClassLoader extends URLClassLoader {
     // Any class that is not from Spark
     if (API_CLASSES.contains(name) || (!name.startsWith("co.cask.cdap.api.spark.")
         && !name.startsWith("co.cask.cdap.app.runtime.spark.")
-        && !name.startsWith("org.apache.spark."))) {
+        && !name.startsWith("org.apache.spark.") && !name.startsWith("akka."))) {
       return super.loadClass(name, resolve);
     }
 
@@ -111,10 +117,12 @@ final class SparkRunnerClassLoader extends URLClassLoader {
       } else if (name.equals(SPARK_STREAMING_CONTEXT_TYPE.getClassName())) {
         // Define the StreamingContext class by rewriting the constructor
         cls = defineContext(SPARK_STREAMING_CONTEXT_TYPE, name, is);
+      } else if (name.equals(AKKA_REMOTING_TYPE.getClassName())) {
+        // Define the akka.remote.Remoting class to avoid thread leakage
+        cls = defineAkkaRemoting(name, is);
       } else {
         // Otherwise, just define it with this ClassLoader
-        byte[] byteCode = ByteStreams.toByteArray(is);
-        cls = defineClass(name, byteCode, 0, byteCode.length);
+        cls = findClass(name);
       }
 
       if (resolve) {
@@ -180,5 +188,112 @@ final class SparkRunnerClassLoader extends URLClassLoader {
 
     byte[] byteCode = cw.toByteArray();
     return defineClass(name, byteCode, 0, byteCode.length);
+  }
+
+  /**
+   * Define the akka.remote.Remoting by rewriting usages of scala.concurrent.ExecutionContext.Implicits.global
+   * to Remoting.system().dispatcher() in the shutdown() method for fixing the Akka thread/permgen leak bug in
+   * https://github.com/akka/akka/issues/17729
+   */
+  private Class<?> defineAkkaRemoting(String name,
+                                      InputStream byteCodeStream) throws IOException, ClassNotFoundException {
+    final Type dispatcherReturnType = determineAkkaDispatcherReturnType();
+    if (dispatcherReturnType == null) {
+      LOG.warn("Failed to determine ActorSystem.dispatcher() return type. " +
+                 "No rewriting of akka.remote.Remoting class. ClassLoader leakage might happen in SDK.");
+      return findClass(name);
+    }
+
+    ClassReader cr = new ClassReader(byteCodeStream);
+    ClassWriter cw = new ClassWriter(0);
+
+    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
+      @Override
+      public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        // Call super so that the method signature is registered with the ClassWriter (parent)
+        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+
+        // Only rewrite the shutdown() method
+        if (!"shutdown".equals(name)) {
+          return mv;
+        }
+
+        return new MethodVisitor(Opcodes.ASM5, mv) {
+          @Override
+          public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+            // Detect if it is making call "import scala.concurrent.ExecutionContext.Implicits.global",
+            // which translate to Java code as
+            // scala.concurrent.ExecutionContext$Implicits$.MODULE$.global()
+            // hence as bytecode
+            // GETSTATIC scala/concurrent/ExecutionContext$Implicits$.MODULE$ :
+            //           Lscala/concurrent/ExecutionContext$Implicits$;
+            // INVOKEVIRTUAL scala/concurrent/ExecutionContext$Implicits$.global
+            //           ()Lscala/concurrent/ExecutionContextExecutor;
+            Type executionContextExecutorType = Type.getType(ExecutionContextExecutor.class);
+            if (opcode == Opcodes.INVOKEVIRTUAL
+                && "global".equals(name)
+                && "scala/concurrent/ExecutionContext$Implicits$".equals(owner)
+                && Type.getMethodDescriptor(executionContextExecutorType).equals(desc)) {
+              // Discard the GETSTATIC result from the stack by popping it
+              super.visitInsn(Opcodes.POP);
+              // Make the call "import system.dispatch", which translate to Java code as
+              // this.system().dispatcher()
+              // hence as bytecode
+              // ALOAD 0 (load this)
+              // INVOKEVIRTUAL akka/remote/Remoting.system ()Lakka/actor/ExtendedActorSystem;
+              // INVOKEVIRTUAL akka/actor/ExtendedActorSystem.dispatcher ()Lscala/concurrent/ExecutionContextExecutor;
+              Type extendedActorSystemType = Type.getObjectType("akka/actor/ExtendedActorSystem");
+              super.visitVarInsn(Opcodes.ALOAD, 0);
+              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "akka/remote/Remoting", "system",
+                                    Type.getMethodDescriptor(extendedActorSystemType), false);
+              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, extendedActorSystemType.getInternalName(), "dispatcher",
+                                    Type.getMethodDescriptor(dispatcherReturnType), false);
+            } else {
+              // For other instructions, just call parent to deal with it
+              super.visitMethodInsn(opcode, owner, name, desc, itf);
+            }
+          }
+        };
+      }
+    }, ClassReader.EXPAND_FRAMES);
+
+    byte[] byteCode = cw.toByteArray();
+    return defineClass(name, byteCode, 0, byteCode.length);
+  }
+
+  /**
+   * Find the return type of the ActorSystem.dispatcher() method. It is {@link ExecutionContextExecutor} in
+   * Akka 2.3 (Spark 1.2+) and {@link ExecutionContext} in Akka 2.2 (Spark < 1.2, which CDAP doesn't support,
+   * however the Spark 1.5 in CDH 5.6. still has Akka 2.2, instead of 2.3).
+   *
+   * @return the return type of the ActorSystem.dispatcher() method or {@code null} if no such method
+   */
+  @Nullable
+  private Type determineAkkaDispatcherReturnType() {
+    try (InputStream is = getResourceAsStream("akka/actor/ActorSystem.class")) {
+      final AtomicReference<Type> result = new AtomicReference<>();
+      ClassReader cr = new ClassReader(is);
+      cr.accept(new ClassVisitor(Opcodes.ASM5) {
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+          if (name.equals("dispatcher") && Type.getArgumentTypes(desc).length == 0) {
+            // Expected to be either ExecutionContext (akka 2.2, only in CDH spark)
+            // or ExecutionContextExecutor (akka 2.3, for open source, HDP spark).
+            Type returnType = Type.getReturnType(desc);
+            if (returnType.equals(Type.getType(ExecutionContext.class))
+              || returnType.equals(Type.getType(ExecutionContextExecutor.class))) {
+              result.set(returnType);
+            } else {
+              LOG.warn("Unsupported return type of ActorSystem.dispatcher(): {}", returnType.getClassName());
+            }
+          }
+          return super.visitMethod(access, name, desc, signature, exceptions);
+        }
+      }, ClassReader.SKIP_DEBUG | ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
+      return result.get();
+    } catch (IOException e) {
+      LOG.warn("Failed to determine ActorSystem dispatcher() return type.", e);
+      return null;
+    }
   }
 }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -34,10 +34,12 @@ import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.internal.app.runtime.LocalizationUtils;
 import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
+import co.cask.cdap.internal.lang.Fields;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionFailureException;
 import com.google.common.base.Charsets;
 import com.google.common.base.Objects;
+import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -47,6 +49,7 @@ import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.spark.SparkConf;
 import org.apache.spark.deploy.SparkSubmit;
 import org.apache.twill.api.ClassAcceptor;
@@ -62,10 +65,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -343,6 +349,11 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
                                                   String metricsConfPath, @Nullable String logbackJarName) {
     Map<String, String> configs = new HashMap<>();
 
+    // Make Spark UI runs on random port. By default, Spark UI runs on port 4040 and it will do a sequential search
+    // of the next port if 4040 is already occupied. However, during the process, it unnecessarily logs big stacktrace
+    // as WARN, which pollute the logs a lot if there are concurrent Spark job running (e.g. a fork in Workflow).
+    configs.put("spark.ui.port", "0");
+
     // Add user specified configs first. CDAP specifics config will override them later if there are duplicates.
     SparkConf sparkConf = context.getSparkConf();
     if (sparkConf != null) {
@@ -504,6 +515,9 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
 
       @Override
       public void run() {
+        cleanupShutdownHooks();
+        invalidateBeanIntrospectorCache();
+
         // Cleanup all system properties setup by SparkSubmit
         Iterable<String> sparkKeys = Iterables.filter(System.getProperties().stringPropertyNames(),
                                                       Predicates.containsPattern("^spark\\."));
@@ -525,6 +539,88 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
         }
       }
     };
+  }
+
+  /**
+   * Cleanup all shutdown hooks added by Spark and execute them directly.
+   * This is needed so that for CDAP standalone, it won't leak memory through shutdown hooks.
+   */
+  private void cleanupShutdownHooks() {
+    // With Hadoop 2, Spark uses the Hadoop ShutdownHookManager
+    ShutdownHookManager manager = ShutdownHookManager.get();
+    try {
+      // Use reflection to get the shutdown hooks
+      Method getShutdownHooksInOrder = manager.getClass().getDeclaredMethod("getShutdownHooksInOrder");
+      if (!Collection.class.isAssignableFrom(getShutdownHooksInOrder.getReturnType())) {
+        LOG.warn("Unsupported method {}. Spark shutdown hooks cleanup skipped.", getShutdownHooksInOrder);
+        return;
+      }
+      getShutdownHooksInOrder.setAccessible(true);
+
+      // Filter out hooks that are defined in the same SparkRunnerClassLoader as this SparkProgramRunner class
+      // This is for the case when there are concurrent Spark job running in the same VM
+      List<Runnable> hooks = ImmutableList.copyOf(
+        Iterables.filter(
+          Iterables.filter((Collection<?>) getShutdownHooksInOrder.invoke(manager), Runnable.class),
+          new Predicate<Runnable>() {
+            @Override
+            public boolean apply(Runnable runnable) {
+              return runnable.getClass().getClassLoader() == SparkRuntimeService.this.getClass().getClassLoader();
+            }
+          }
+        )
+      );
+
+      for (Runnable hook : hooks) {
+        LOG.debug("Running Spark shutdown hook {}", hook);
+        hook.run();
+        manager.removeShutdownHook(hook);
+      }
+
+    } catch (Exception e) {
+      LOG.warn("Failed to cleanup Spark shutdown hooks.", e);
+    }
+  }
+
+  /**
+   * Clear the constructor cache in the BeanIntrospector to avoid leaking ClassLoader.
+   */
+  private void invalidateBeanIntrospectorCache() {
+    try {
+      // Get the class through reflection since some Spark version doesn't depend on the fasterxml scala module.
+      // This is to avoid class not found issue
+      Class<?> cls = Class.forName("com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$");
+      Field field = Fields.findField(cls, "ctorParamNamesCache");
+
+      // See if it is a LoadingCache. Need to check with class name since in distributed mode assembly jar, the
+      // guava classes are shaded and renamed.
+      switch (field.getType().getName()) {
+        // Get the cache field and invalid it.
+        // The BeanIntrospector is a scala object and scala generates a static MODULE$ field to the singleton object
+        // We need to make both two different class name because in the Spark assembly jar, the guava classes
+        // get renamed. In unit-test, however, the class won't get renamed because they are pulled from dependency
+        case "com.google.common.cache.LoadingCache":
+        case "org.spark-project.guava.cache.LoadingCache":
+          field.setAccessible(true);
+          Object cache = field.get(Fields.findField(cls, "MODULE$").get(null));
+          // Try to call the invalidateAll method of the cache
+          Method invalidateAll = cache.getClass().getMethod("invalidateAll");
+          invalidateAll.setAccessible(true);
+          invalidateAll.invoke(cache);
+          LOG.debug("BeanIntrospector.ctorParamNamesCache has been invalidated.");
+        break;
+
+        default:
+          // Unexpected, maybe due to version change in the BeanIntrospector, hence log a WARN.
+          LOG.warn("BeanIntrospector.ctorParamNamesCache is not a LoadingCache, may lead to memory leak in SDK." +
+                     "Field type is {}", field.getType());
+      }
+    } catch (ClassNotFoundException e) {
+      // Catch the case when there is no BeanIntrospector class. It is ok since some Spark version may not be using it.
+      LOG.debug("No BeanIntrospector class found. The current Spark version is not using BeanIntrospector.");
+    } catch (Exception e) {
+      LOG.warn("Failed to cleanup BeanIntrospector cache, may lead to memory leak in SDK.", e);
+    }
   }
 
   /**

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
@@ -170,7 +170,9 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
         LOG.warn("Failed to registry usage of {} -> {}", streamId, owners, e)
     }
 
-    rdd.values.map(new SerializableStreamEvent(_)).map(decoder)
+    // Wrap the StreamEvent with a SerializableStreamEvent
+    // Don't use rdd.values() as it brings in implicit object from SparkContext, which is not available in Spark 1.2
+    rdd.map(t => new SerializableStreamEvent(t._2)).map(decoder)
   }
 
   override def saveAsDataset[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)], datasetName: String,

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SparkMainWrapper.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SparkMainWrapper.scala
@@ -53,7 +53,8 @@ object SparkMainWrapper {
           getMainMethod(cls).fold(
             throw new IllegalArgumentException(userSparkClass.getName
               + " is not a supported Spark program. It should implements either "
-              + classOf[SparkMain].getName + " or " + classOf[JavaSparkMain].getName)
+              + classOf[SparkMain].getName + " or " + classOf[JavaSparkMain].getName
+              + " or has a main method defined")
           )(
             _.invoke(null, RuntimeArguments.toPosixArray(runtimeContext.getRuntimeArguments))
           )

--- a/pom.xml
+++ b/pom.xml
@@ -1302,10 +1302,6 @@
             <artifactId>curator-recipes</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.tachyonproject</groupId>
-            <artifactId>tachyon-client</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
           </exclusion>
@@ -1449,7 +1445,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.14.1</version>
           <configuration>
-            <argLine>-Xmx5000m -Djava.awt.headless=true -XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC -XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError -Djava.net.preferIPv4Stack=true</argLine>
+            <argLine>-Xmx5000m -Djava.awt.headless=true -XX:MaxPermSize=256m -XX:+UseConcMarkSweepGC -XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError -Djava.net.preferIPv4Stack=true</argLine>
             <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
             <reuseForks>false</reuseForks>
             <reportFormat>plain</reportFormat>


### PR DESCRIPTION
- Spark is not designed for running multiple times inside the same VM, hence it's not doing proper cleanup.
  Extra cleanup steps are added
  - Shutdown the jetty server that Spark uses as file server (SPARK-14513)
  - Stop the QueuedThreadPool(s) used by the jetty server that Spark uses as file server and WebUI (SPARK-14513)
  - Remove the shutdown hook from ShutdownHookManager
  - Invalid the LoadingCache of class constructor in BeanIntrospector
  - Patch the akka.remote.Remoting code for fixing akka thread leak bug https://github.com/akka/akka/issues/17729
    - Done through simple bytecode replacement

- Also there are CDAP spark-core fixes related to ClassLoader leakage
  - Clear the SparkListener list when Spark job finished
  - Don't use guice Injector to instantiate SparkProgramRunner directly, as guice will cache the class

- Fixed CDAP-5547 by defining the class using parent method so that package is also defined

- Also an improvement to the AbstractSparkSubmitter to make sure the Spark job is finished before returning control back to SparkRuntimeService