### PR TITLE
Fix a bug in deploying artifacts with Spark usage

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DefaultProgramRunnerFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DefaultProgramRunnerFactory.java
@@ -62,7 +62,9 @@ public final class DefaultProgramRunnerFactory implements ProgramRunnerFactory {
     }
 
     Provider<ProgramRunner> defaultProvider = defaultRunnerProviders.get(programType);
-    Preconditions.checkNotNull(defaultProvider, "Unsupported program type: " + programType);
+    if (defaultProvider == null) {
+      throw new IllegalArgumentException("Unsupported program type: " + programType);
+    }
     return defaultProvider.get();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnerModule.java
@@ -50,8 +50,10 @@ final class DistributedProgramRunnerModule extends PrivateModule {
 
     // ProgramRunnerFactory should be in distributed mode
     bind(ProgramRuntimeProvider.Mode.class).toInstance(ProgramRuntimeProvider.Mode.DISTRIBUTED);
-    // Bind ProgramRunnerFactory
+    // Bind and expose ProgramRunnerFactory. It is used in both program deployment and program execution.
+    // Should get refactory by CDAP-5506
     bind(ProgramRunnerFactory.class).to(DefaultProgramRunnerFactory.class).in(Scopes.SINGLETON);
+    expose(ProgramRunnerFactory.class);
 
     // Bind and expose ProgramRuntimeService
     bind(ProgramRuntimeService.class).to(DistributedProgramRuntimeService.class).in(Scopes.SINGLETON);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramRuntimeProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramRuntimeProvider.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.app.runtime;
 
-import co.cask.cdap.common.lang.FilterClassLoader;
-import co.cask.cdap.common.lang.ProgramClassLoader;
 import co.cask.cdap.proto.ProgramType;
 import com.google.inject.Injector;
 
@@ -59,12 +57,4 @@ public interface ProgramRuntimeProvider {
    * @param injector the CDAP app-fabric Guice {@link Injector} for acquiring system services to interact with CDAP
    */
   ProgramRunner createProgramRunner(ProgramType programType, Mode mode, Injector injector);
-
-  /**
-   * Creates a {@link FilterClassLoader.Filter} to be used for resources filtering on the parent ClassLoader for
-   * the {@link ProgramClassLoader} being created for the program execution.
-   *
-   * @param programType the {@link ProgramType} that the filtering would be applied on
-   */
-  FilterClassLoader.Filter createProgramClassLoaderFilter(ProgramType programType);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramRuntimeProviderLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramRuntimeProviderLoader.java
@@ -21,7 +21,6 @@ import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRuntimeProvider;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.annotations.VisibleForTesting;
@@ -71,12 +70,6 @@ public class ProgramRuntimeProviderLoader {
     public ProgramRunner createProgramRunner(ProgramType type, Mode mode, Injector injector) {
       throw new UnsupportedOperationException();
     }
-
-    @Override
-    public FilterClassLoader.Filter createProgramClassLoaderFilter(ProgramType programType) {
-      throw new UnsupportedOperationException();
-    }
-
   };
 
   private final LoadingCache<ProgramType, ProgramRuntimeProvider> programRunnerProviderCache;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactClassLoaderFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactClassLoaderFactory.java
@@ -16,15 +16,15 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
-import co.cask.cdap.app.runtime.ProgramRuntimeProvider;
+import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.ProgramClassLoader;
+import co.cask.cdap.common.lang.ProgramClassLoaderProvider;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.common.utils.DirUtils;
-import co.cask.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
-import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.io.Closeables;
 import org.apache.twill.filesystem.Location;
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.net.URLClassLoader;
 
 /**
  * Given an artifact, creates a {@link CloseableClassLoader} from it. Takes care of unpacking the artifact and
@@ -44,12 +43,12 @@ final class ArtifactClassLoaderFactory {
   private static final Logger LOG = LoggerFactory.getLogger(ArtifactClassLoaderFactory.class);
 
   private final CConfiguration cConf;
-  private final ProgramRuntimeProviderLoader runtimeProviderLoader;
+  private final ProgramRunnerFactory programRunnerFactory;
   private final File tmpDir;
 
-  ArtifactClassLoaderFactory(CConfiguration cConf, ProgramRuntimeProviderLoader runtimeProviderLoader) {
+  ArtifactClassLoaderFactory(CConfiguration cConf, ProgramRunnerFactory programRunnerFactory) {
     this.cConf = cConf;
-    this.runtimeProviderLoader = runtimeProviderLoader;
+    this.programRunnerFactory = programRunnerFactory;
     this.tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
   }
@@ -68,25 +67,28 @@ final class ArtifactClassLoaderFactory {
   CloseableClassLoader createClassLoader(Location artifactLocation) throws IOException {
     final File unpackDir = BundleJarUtil.unJar(artifactLocation, DirUtils.createTempDir(tmpDir));
 
-    ClassLoader parentClassLoader;
-
-    ProgramRuntimeProvider sparkRuntimeProvider = runtimeProviderLoader.get(ProgramType.SPARK);
-    if (sparkRuntimeProvider != null) {
-      // Always have spark classes visible for artifact class loading purpose since we don't know if
-      // any classes inside the artifact is a Spark program
-      parentClassLoader = new FilterClassLoader(sparkRuntimeProvider.getClass().getClassLoader(),
-                                                sparkRuntimeProvider.createProgramClassLoaderFilter(ProgramType.SPARK));
-    } else {
-      // If no Spark is available, just use the standard filter
-      parentClassLoader = new FilterClassLoader(getClass().getClassLoader(), FilterClassLoader.defaultFilter());
+    ProgramClassLoader programClassLoader = null;
+    try {
+      // Try to create a ProgramClassLoader from the Spark runtime system if it is available.
+      // It is needed because we don't know what program types that an artifact might have.
+      ProgramRunner programRunner = programRunnerFactory.create(ProgramType.SPARK);
+      if (programRunner instanceof ProgramClassLoaderProvider) {
+        programClassLoader = ((ProgramClassLoaderProvider) programRunner).createProgramClassLoader(cConf, unpackDir);
+      }
+    } catch (IllegalArgumentException e) {
+      // If Spark is not supported, exception is expected. We'll use the default filter.
+    }
+    if (programClassLoader == null) {
+      programClassLoader = new ProgramClassLoader(cConf, unpackDir,
+                                                  FilterClassLoader.create(getClass().getClassLoader()));
     }
 
-    final ProgramClassLoader programClassLoader = new ProgramClassLoader(cConf, unpackDir, parentClassLoader);
+    final ProgramClassLoader finalProgramClassLoader = programClassLoader;
     return new CloseableClassLoader(programClassLoader, new Closeable() {
       @Override
       public void close() {
         try {
-          Closeables.closeQuietly(programClassLoader);
+          Closeables.closeQuietly(finalProgramClassLoader);
           DirUtils.deleteDirectoryContents(unpackDir);
         } catch (IOException e) {
           LOG.warn("Failed to delete directory {}", unpackDir, e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginSelector;
+import co.cask.cdap.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.common.ArtifactAlreadyExistsException;
 import co.cask.cdap.common.ArtifactNotFoundException;
 import co.cask.cdap.common.ArtifactRangeNotFoundException;
@@ -34,7 +35,6 @@ import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.metadata.system.ArtifactSystemMetadataWriter;
-import co.cask.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import co.cask.cdap.internal.app.runtime.plugin.PluginNotExistsException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ApplicationClassInfo;
@@ -93,9 +93,9 @@ public class ArtifactRepository {
   @Inject
   public ArtifactRepository(CConfiguration cConf, ArtifactStore artifactStore, MetadataStore metadataStore,
                             AuthorizerInstantiatorService authorizerInstantiatorService,
-                            ProgramRuntimeProviderLoader programRuntimeProviderLoader) {
+                            ProgramRunnerFactory programRunnerFactory) {
     this.artifactStore = artifactStore;
-    this.artifactClassLoaderFactory = new ArtifactClassLoaderFactory(cConf, programRuntimeProviderLoader);
+    this.artifactClassLoaderFactory = new ArtifactClassLoaderFactory(cConf, programRunnerFactory);
     this.artifactInspector = new ArtifactInspector(cConf, artifactClassLoaderFactory);
     this.systemArtifactDirs = new ArrayList<>();
     for (String dir : cConf.get(Constants.AppFabric.SYSTEM_ARTIFACTS_DIR).split(";")) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/runtime/DummyProgramRunnerFactory.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/runtime/DummyProgramRunnerFactory.java
@@ -19,16 +19,12 @@ package co.cask.cdap.app.runtime;
 import co.cask.cdap.proto.ProgramType;
 
 /**
- * Factory for creating {@link ProgramRunner}.
+ * A dummy implementation of {@link ProgramRunnerFactory} that doesn't support any program type.
+ * It is purely for testing purpose.
  */
-public interface ProgramRunnerFactory {
-
-  /**
-   * Creates a {@link ProgramRunner} for the given {@link ProgramType}.
-   *
-   * @param programType type of program
-   * @return a {@link ProgramRunner} that can execute the given program type.
-   * @throws IllegalArgumentException if no {@link ProgramRunner} is found for the given program type
-   */
-  ProgramRunner create(ProgramType programType);
+public class DummyProgramRunnerFactory implements ProgramRunnerFactory {
+  @Override
+  public ProgramRunner create(ProgramType programType) {
+    throw new IllegalArgumentException("Program type not supported: " + programType);
+  }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -21,10 +21,10 @@ import co.cask.cdap.WordCountApp;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.app.deploy.ConfigResponse;
 import co.cask.cdap.app.deploy.Configurator;
+import co.cask.cdap.app.runtime.DummyProgramRunnerFactory;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
-import co.cask.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.internal.test.AppJarHelper;
@@ -68,8 +68,7 @@ public class ConfiguratorTest {
     LocationFactory locationFactory = new LocalLocationFactory(TMP_FOLDER.newFolder());
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, WordCountApp.class);
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, WordCountApp.class.getSimpleName(), "1.0.0");
-    ArtifactRepository artifactRepo = new ArtifactRepository(conf, null, null, null,
-                                                             new ProgramRuntimeProviderLoader(conf));
+    ArtifactRepository artifactRepo = new ArtifactRepository(conf, null, null, null, new DummyProgramRunnerFactory());
 
     // Create a configurator that is testable. Provide it a application.
     Configurator configurator = new InMemoryConfigurator(conf, Id.Namespace.DEFAULT, artifactId,
@@ -93,8 +92,7 @@ public class ConfiguratorTest {
     LocationFactory locationFactory = new LocalLocationFactory(TMP_FOLDER.newFolder());
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, ConfigTestApp.class);
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, ConfigTestApp.class.getSimpleName(), "1.0.0");
-    ArtifactRepository artifactRepo = new ArtifactRepository(conf, null, null, null,
-                                                             new ProgramRuntimeProviderLoader(conf));
+    ArtifactRepository artifactRepo = new ArtifactRepository(conf, null, null, null, new DummyProgramRunnerFactory());
 
     ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("myStream", "myTable");
     Configurator configuratorWithConfig =

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -21,12 +21,12 @@ import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.app.program.ManifestFields;
+import co.cask.cdap.app.runtime.DummyProgramRunnerFactory;
 import co.cask.cdap.common.InvalidArtifactException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.utils.DirUtils;
-import co.cask.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import co.cask.cdap.internal.app.runtime.artifact.app.InvalidConfigApp;
 import co.cask.cdap.internal.app.runtime.artifact.app.inspection.InspectionApp;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
@@ -62,7 +62,7 @@ public class ArtifactInspectorTest {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
 
-    classLoaderFactory = new ArtifactClassLoaderFactory(cConf, new ProgramRuntimeProviderLoader(cConf));
+    classLoaderFactory = new ArtifactClassLoaderFactory(cConf, new DummyProgramRunnerFactory());
     artifactInspector = new ArtifactInspector(cConf, classLoaderFactory);
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramClassLoaderProvider.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramClassLoaderProvider.java
@@ -14,14 +14,23 @@
  * the License.
  */
 
-package co.cask.cdap.app.runtime;
+package co.cask.cdap.common.lang;
 
-import co.cask.cdap.common.lang.FilterClassLoader;
+import co.cask.cdap.common.conf.CConfiguration;
+
+import java.io.File;
 
 /**
- * A provider for {@link FilterClassLoader.Filter} used for ClassLoading filtering.
+ * A provider for {@link ProgramClassLoader} used for program classloading.
  */
-public interface ProgramClassLoaderFilterProvider {
+public interface ProgramClassLoaderProvider {
 
-  FilterClassLoader.Filter getFilter();
+  /**
+   * Creates a {@link ProgramClassLoader}.
+   *
+   * @param cConf configuration for the classloader creation
+   * @param dir directory where the program artifact jar is unpacked to
+   * @return an instance of {@link ProgramClassLoader}
+   */
+  ProgramClassLoader createProgramClassLoader(CConfiguration cConf, File dir);
 }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -22,7 +22,6 @@ import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
-import co.cask.cdap.app.runtime.ProgramClassLoaderFilterProvider;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
@@ -33,8 +32,9 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.InstantiatorFactory;
+import co.cask.cdap.common.lang.ProgramClassLoader;
+import co.cask.cdap.common.lang.ProgramClassLoaderProvider;
 import co.cask.cdap.common.lang.PropertyFieldSetter;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
@@ -79,37 +79,9 @@ import javax.annotation.Nullable;
 /**
  * The {@link ProgramRunner} that executes Spark program.
  */
-final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin implements ProgramClassLoaderFilterProvider {
+final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin implements ProgramClassLoaderProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkProgramRunner.class);
-  static final FilterClassLoader.Filter SPARK_PROGRAM_CLASS_LOADER_FILTER = new FilterClassLoader.Filter() {
-
-    final FilterClassLoader.Filter defaultFilter = FilterClassLoader.defaultFilter();
-
-    @Override
-    public boolean acceptResource(String resource) {
-      return resource.startsWith("co/cask/cdap/api/spark/") || resource.startsWith("scala/")
-        || resource.startsWith("org/apache/spark/") || resource.startsWith("akka/")
-        || defaultFilter.acceptResource(resource);
-    }
-
-    @Override
-    public boolean acceptPackage(String packageName) {
-      if (packageName.equals("co.cask.cdap.api.spark") || packageName.startsWith("co.cask.cdap.api.spark.")) {
-        return true;
-      }
-      if (packageName.equals("scala") || packageName.startsWith("scala.")) {
-        return true;
-      }
-      if (packageName.equals("org.apache.spark") || packageName.startsWith("org.apache.spark.")) {
-        return true;
-      }
-      if (packageName.equals("akka") || packageName.startsWith("akka.")) {
-        return true;
-      }
-      return defaultFilter.acceptResource(packageName);
-    }
-  };
 
   private final CConfiguration cConf;
   private final Configuration hConf;
@@ -222,8 +194,8 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin implement
   }
 
   @Override
-  public FilterClassLoader.Filter getFilter() {
-    return SPARK_PROGRAM_CLASS_LOADER_FILTER;
+  public ProgramClassLoader createProgramClassLoader(CConfiguration cConf, File dir) {
+    return SparkRuntimeUtils.createProgramClassLoader(cConf, dir, getClass().getClassLoader());
   }
 
   /**

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
@@ -21,7 +21,6 @@ import co.cask.cdap.app.runtime.ProgramRuntimeProvider;
 import co.cask.cdap.app.runtime.spark.distributed.DistributedSparkProgramRunner;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.lang.ClassLoaders;
-import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
@@ -58,11 +57,6 @@ public class SparkProgramRuntimeProvider implements ProgramRuntimeProvider {
       default:
         throw new IllegalArgumentException("Unsupported Spark execution mode " + mode);
     }
-  }
-
-  @Override
-  public FilterClassLoader.Filter createProgramClassLoaderFilter(ProgramType programType) {
-    return SparkProgramRunner.SPARK_PROGRAM_CLASS_LOADER_FILTER;
   }
 
   /**

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -29,7 +29,6 @@ import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.lang.ClassLoaders;
-import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.ProgramClassLoader;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -215,9 +214,8 @@ public final class SparkRuntimeContextProvider {
                                        SparkRuntimeContextConfig contextConfig) throws IOException {
     File programJar = new File(PROGRAM_JAR_NAME);
     File programDir = new File(PROGRAM_JAR_EXPANDED_NAME);
-    ClassLoader parentClassLoader = new FilterClassLoader(SparkRuntimeContextProvider.class.getClassLoader(),
-                                                          SparkProgramRunner.SPARK_PROGRAM_CLASS_LOADER_FILTER);
-    ProgramClassLoader classLoader = new ProgramClassLoader(cConf, programDir, parentClassLoader);
+    ProgramClassLoader classLoader = SparkRuntimeUtils.createProgramClassLoader(
+      cConf, programDir, SparkRuntimeContextProvider.class.getClassLoader());
     final Id.Program programId = contextConfig.getProgramId().toId();
     return new ForwardingProgram(Programs.create(Locations.toLocation(programJar), classLoader)) {
       @Override

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.lang.FilterClassLoader;
+import co.cask.cdap.common.lang.ProgramClassLoader;
+
+import java.io.File;
+
+/**
+ * Util class for common functions needed for Spark implementation.
+ */
+public final class SparkRuntimeUtils {
+
+  // ClassLoader filter
+  private static final FilterClassLoader.Filter SPARK_PROGRAM_CLASS_LOADER_FILTER = new FilterClassLoader.Filter() {
+
+    final FilterClassLoader.Filter defaultFilter = FilterClassLoader.defaultFilter();
+
+    @Override
+    public boolean acceptResource(String resource) {
+      return resource.startsWith("co/cask/cdap/api/spark/") || resource.startsWith("scala/")
+        || resource.startsWith("org/apache/spark/") || resource.startsWith("akka/")
+        || defaultFilter.acceptResource(resource);
+    }
+
+    @Override
+    public boolean acceptPackage(String packageName) {
+      if (packageName.equals("co.cask.cdap.api.spark") || packageName.startsWith("co.cask.cdap.api.spark.")) {
+        return true;
+      }
+      if (packageName.equals("scala") || packageName.startsWith("scala.")) {
+        return true;
+      }
+      if (packageName.equals("org.apache.spark") || packageName.startsWith("org.apache.spark.")) {
+        return true;
+      }
+      if (packageName.equals("akka") || packageName.startsWith("akka.")) {
+        return true;
+      }
+      return defaultFilter.acceptResource(packageName);
+    }
+  };
+
+
+  public static ProgramClassLoader createProgramClassLoader(CConfiguration cConf, File dir,
+                                                            ClassLoader unfilteredClassLoader) {
+    ClassLoader parent = new FilterClassLoader(unfilteredClassLoader, SPARK_PROGRAM_CLASS_LOADER_FILTER);
+    return new ProgramClassLoader(cConf, dir, parent);
+  }
+
+
+  private SparkRuntimeUtils() {
+    // private
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -24,8 +24,11 @@ import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeContextConfig;
+import co.cask.cdap.app.runtime.spark.SparkRuntimeUtils;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.lang.ProgramClassLoader;
+import co.cask.cdap.common.lang.ProgramClassLoaderProvider;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.distributed.AbstractDistributedProgramRunner;
 import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
@@ -49,7 +52,8 @@ import java.util.Map;
  * a YARN application to act as the Spark client. A second YARN application will be launched
  * by Spark framework as the actual Spark program execution.
  */
-public final class DistributedSparkProgramRunner extends AbstractDistributedProgramRunner {
+public final class DistributedSparkProgramRunner extends AbstractDistributedProgramRunner
+                                                 implements ProgramClassLoaderProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(DistributedSparkProgramRunner.class);
 
@@ -91,5 +95,10 @@ public final class DistributedSparkProgramRunner extends AbstractDistributedProg
     YarnConfiguration configuration = new YarnConfiguration(hConf);
     configuration.setBoolean(SparkRuntimeContextConfig.HCONF_ATTR_CLUSTER_MODE, true);
     return configuration;
+  }
+
+  @Override
+  public ProgramClassLoader createProgramClassLoader(CConfiguration cConf, File dir) {
+    return SparkRuntimeUtils.createProgramClassLoader(cConf, dir, getClass().getClassLoader());
   }
 }


### PR DESCRIPTION
- When a class with Spark/Scala classes usage is being called in configure() method, the program class loader created for deployment needs to be able to load those classes.