### PR TITLE
CDAP-5086 Automatically determine SPARK_HOME

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -270,6 +270,22 @@ cdap_set_hive_classpath() {
   fi
 }
 
+# Get SPARK_HOME
+cdap_set_spark() {
+  # First, see if we're set to something sane
+  if [ -n "${SPARK_HOME}" -a -d "${SPARK_HOME}" ]; then
+    return 0 # SPARK_HOME is set, already
+  else
+    if [[ $(which spark-shell 2>/dev/null) ]]; then
+      SPARK_VAR_OUT=$(echo 'for ((key, value) <- sys.env) println (key + "=" + value); exit' | spark-shell --master local 2>/dev/null)
+      SPARK_HOME=$(echo -e "${SPARK_VAR_OUT}" | grep ^SPARK_HOME= | cut -d= -f2)
+      export SPARK_HOME
+      return 0
+    fi
+    return 1
+  fi
+}
+
 # Check that directory /var/tmp/cdap exists in the master node, or create it
 cdap_check_or_create_master_local_dir() {
   mkdir -p "${LOCAL_DIR}"

--- a/cdap-common/bin/service
+++ b/cdap-common/bin/service
@@ -210,7 +210,7 @@ run() {
   # Setup classpaths.
   cdap_set_classpath "${COMPONENT_HOME}" "${CDAP_CONF}"
   cdap_set_hive_classpath || exit 1
-  cdap_set_spark
+  cdap_set_spark || logecho "Could not determine SPARK_HOME! Spark support unavailable!"
   # Setup Java
   cdap_set_java || exit 1
   # Add proper HBase compatibility to CLASSPATH

--- a/cdap-common/bin/service
+++ b/cdap-common/bin/service
@@ -101,6 +101,8 @@ _start_java() {
     cdap_set_hive_classpath || exit 1
     # Add proper HBase compatibility to CLASSPATH
     cdap_set_hbase || exit 1
+    # Determine SPARK_HOME
+    cdap_set_spark || logecho "Could not determine SPARK_HOME! Spark support unavailable!"
     # Master requires this local directory
     cdap_check_or_create_master_local_dir || die "Could not create Master local directory"
     logecho "Running startup checks -- this may take a few minutes"
@@ -208,6 +210,7 @@ run() {
   # Setup classpaths.
   cdap_set_classpath "${COMPONENT_HOME}" "${CDAP_CONF}"
   cdap_set_hive_classpath || exit 1
+  cdap_set_spark
   # Setup Java
   cdap_set_java || exit 1
   # Add proper HBase compatibility to CLASSPATH


### PR DESCRIPTION
This uses `spark-shell` to determine `SPARK_HOME` in the start script. This way the user does not have to configure it in their environment. However, any configuration pointing to a valid directory will override detection.