### PR TITLE
Remove the rule of having only source while creating DAG from UI

### DIFF
--- a/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
@@ -508,7 +508,6 @@ class HydratorPlusPlusConfigStore {
     let name = this.getName();
     let errorFactory = this.NonStorePipelineErrorFactory;
     let daglevelvalidation = [
-      errorFactory.hasOnlyOneSource,
       errorFactory.hasAtLeastOneSink
     ];
     let nodes = this.state.__ui__.nodes;

--- a/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
@@ -508,6 +508,7 @@ class HydratorPlusPlusConfigStore {
     let name = this.getName();
     let errorFactory = this.NonStorePipelineErrorFactory;
     let daglevelvalidation = [
+      errorFactory.hasAtleastOneSource,
       errorFactory.hasAtLeastOneSink
     ];
     let nodes = this.state.__ui__.nodes;

--- a/cdap-ui/app/features/hydratorplusplus/services/non-store-pipeline-error-factory.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/non-store-pipeline-error-factory.js
@@ -88,7 +88,24 @@ let isUniqueNodeNames = (myHelpers, nodes, cb) => {
   });
   return isRuleValid;
 };
-
+let hasAtleastOneSource = (myHelpers, GLOBALS, nodes, cb) => {
+  let error;
+  let countSource = 0;
+  if (!myHelpers.objectQuery(nodes, 'length')) {
+    cb(false);
+  }
+  nodes.forEach( node => {
+    if (GLOBALS.pluginConvert[node.type] === 'source') {
+      countSource++;
+    }
+  });
+  if (countSource === 0) {
+    error = 'NO-SOURCE-FOUND';
+    cb(error);
+    return;
+   }
+   cb(false);
+ };
 let isNodeNameUnique = (myHelpers, nodeName, nodes, cb) => {
   if (!myHelpers.objectQuery(nodes, 'length') || !nodeName.length) {
     cb(false);
@@ -238,6 +255,7 @@ let NonStorePipelineErrorFactory = (GLOBALS, myHelpers) => {
     isRequiredFieldsFilled: isRequiredFieldsFilled.bind(null, myHelpers),
     countUnFilledRequiredFields: countUnFilledRequiredFields,
     hasValidName: hasValidName,
+    hasAtleastOneSource: hasAtleastOneSource.bind(null, myHelpers, GLOBALS),
     hasAtLeastOneSink: hasAtLeastOneSink.bind(null, myHelpers, GLOBALS),
     isNodeNameUnique: isNodeNameUnique.bind(null, myHelpers),
     allNodesConnected: allNodesConnected.bind(null, GLOBALS),

--- a/cdap-ui/app/features/hydratorplusplus/services/non-store-pipeline-error-factory.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/non-store-pipeline-error-factory.js
@@ -123,30 +123,6 @@ let hasValidName = (name, cb) => {
   cb(false);
 };
 
-let hasOnlyOneSource = (myHelpers, GLOBALS, nodes, cb) => {
-  let error;
-  let countSource = 0;
-  if (!myHelpers.objectQuery(nodes, 'length')) {
-    cb(false);
-  }
-  nodes.forEach( node => {
-    if (GLOBALS.pluginConvert[node.type] === 'source') {
-      countSource++;
-    }
-  });
-  if (countSource === 0) {
-    error = 'NO-SOURCE-FOUND';
-    cb(error);
-    return;
-  }
-  if (countSource > 1) {
-    error = 'MORE-THAN-ONE-SOURCE-FOUND';
-    cb(error);
-    return;
-  }
-  cb(false);
-};
-
 let hasAtLeastOneSink = (myHelpers, GLOBALS, nodes, cb) => {
   let error;
   let countSink = 0;
@@ -262,7 +238,6 @@ let NonStorePipelineErrorFactory = (GLOBALS, myHelpers) => {
     isRequiredFieldsFilled: isRequiredFieldsFilled.bind(null, myHelpers),
     countUnFilledRequiredFields: countUnFilledRequiredFields,
     hasValidName: hasValidName,
-    hasOnlyOneSource: hasOnlyOneSource.bind(null, myHelpers, GLOBALS),
     hasAtLeastOneSink: hasAtLeastOneSink.bind(null, myHelpers, GLOBALS),
     isNodeNameUnique: isNodeNameUnique.bind(null, myHelpers),
     allNodesConnected: allNodesConnected.bind(null, GLOBALS),

--- a/cdap-ui/app/services/constants.js
+++ b/cdap-ui/app/services/constants.js
@@ -73,7 +73,7 @@ angular.module(PKG.name + '.services')
             'NAME-ALREADY-EXISTS': 'A pipeline with this name already exists. Please choose a different name.',
             'DUPLICATE-NODE-NAMES': 'Every node should have a unique name to be exported/published.',
             'DUPLICATE-NAME': 'Node with the same name already exists.',
-            'MISSING-CONNECTION': ' is missing connection',
+            'MISSING-CONNECTION': 'is missing connection',
             'IMPORT-JSON': {
               'INVALID-ARTIFACT': 'Pipeline configuration should have a valild artifact specification.',
               'INVALID-CONFIG': 'Missing \'config\' property in pipeline specification.',

--- a/cdap-ui/app/services/constants.js
+++ b/cdap-ui/app/services/constants.js
@@ -66,7 +66,6 @@ angular.module(PKG.name + '.services')
             'SEMANTIC-CONFIG-JSON': 'Semantic error in the configuration JSON for the plugin.',
             'GENERIC-MISSING-REQUIRED-FIELDS': 'Please provide required information.',
             'MISSING-REQUIRED-FIELDS': 'is missing required fields',
-            'MORE-THAN-ONE-SOURCE-FOUND': 'Pipelines can only have one source. Please remove any additional sources.',
             'NO-SOURCE-FOUND': 'Please add a source to your pipeline',
             'MISSING-NAME': 'Pipeline name is missing.',
             'INVALID-NAME': 'Pipeline names can only contain alphanumeric (\'a-z A-Z 0-9\') and underscore ( \'_\') characters. Please remove any other characters.',


### PR DESCRIPTION
Until now UI check if the DAG has exactly one source. This PR removes the validation rule while validating/publishing pipeline from UI.