### PR TITLE
add scala version in deploy-pom.xml

### DIFF
--- a/cdap-examples/deploy_pom.xml
+++ b/cdap-examples/deploy_pom.xml
@@ -61,6 +61,7 @@
     <slf4j.version>@slf4j.version@</slf4j.version>
     <junit.version>@junit.version@</junit.version>
     <spark.version>@spark.version@</spark.version>
+    <scala.version>@scala.version@</scala.version>
     <cask.common.version>@cask.common.version@</cask.common.version>
   </properties>
 


### PR DESCRIPTION
The scala version should be in deploy pom. This was causing failure in VM builds. 

scala was added in example pom here: https://github.com/caskdata/cdap/pull/5501