### PR TITLE
(CDAP-5397) Make dependencies of cdap-api available via the authorize…

### DIFF
--- a/cdap-security-spi/pom.xml
+++ b/cdap-security-spi/pom.xml
@@ -32,6 +32,11 @@
   <dependencies>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-proto</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerClassLoader.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerClassLoader.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.security.authorization;
 
+import co.cask.cdap.api.app.Application;
 import co.cask.cdap.common.lang.ClassPathResources;
 import co.cask.cdap.common.lang.DirectoryClassLoader;
 import co.cask.cdap.common.lang.FilterClassLoader;
@@ -23,6 +24,7 @@ import co.cask.cdap.security.spi.authorization.Authorizer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,15 +42,29 @@ public class AuthorizerClassLoader extends DirectoryClassLoader {
   @VisibleForTesting
   static ClassLoader createParent() {
     ClassLoader baseClassLoader = AuthorizerClassLoader.class.getClassLoader();
+    // Trace dependencies for Authorizer class. This will make classes from cdap-security-spi as well as  cdap-proto
+    // and other dependencies of cdap-security-spi available to the authorizer extension.
     Set<String> authorizerResources;
     try {
       authorizerResources = ClassPathResources.getResourcesWithDependencies(baseClassLoader, Authorizer.class);
     } catch (IOException e) {
-      LOG.error("Failed to determine resources for authorizer class loader.", e);
+      LOG.error("Failed to determine resources for authorizer class loader while tracing dependencies of " +
+                  "Authorizer.", e);
       authorizerResources = ImmutableSet.of();
     }
 
-    final Set<String> finalAuthorizerResources = authorizerResources;
+    // Trace dependencies of cdap-api and include them as well. This will make classes like slf4j Logger implementation
+    // as well as classes from twill-api and other dependencies required for cdap-api available to the authorizer
+    // extension.
+    Set<String> apiResources;
+    try {
+      apiResources = ClassPathResources.getResourcesWithDependencies(baseClassLoader, Application.class);
+    } catch (IOException e) {
+      LOG.error("Failed to determine resources for authorizer class loader while tracing dependencies of " +
+                  "cdap-api.", e);
+      apiResources = ImmutableSet.of();
+    }
+    final Set<String> finalAuthorizerResources = Sets.union(authorizerResources, apiResources);
     return new FilterClassLoader(baseClassLoader, new FilterClassLoader.Filter() {
       @Override
       public boolean acceptResource(String resource) {

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerClassLoaderTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerClassLoaderTest.java
@@ -49,6 +49,10 @@ public class AuthorizerClassLoaderTest {
     parent.loadClass(Gson.class.getName());
     // classes from cdap-api should be available
     parent.loadClass(Application.class.getName());
+    // classes from twill-api should be available as dependencies of cdap-api
+    parent.loadClass(LocationFactory.class.getName());
+    // classes from slf4j-api should be available as dependencies of cdap-api
+    parent.loadClass(Logger.class.getName());
     // classes from cdap-proto should be available
     parent.loadClass(Principal.class.getName());
     // classes from cdap-security-spi should be available
@@ -66,10 +70,6 @@ public class AuthorizerClassLoaderTest {
     assertClassUnavailable(HTable.class);
     // classes from spark should not be available
     assertClassUnavailable("org.apache.spark.SparkConf");
-    // classes from twill should not be available
-    assertClassUnavailable(LocationFactory.class);
-    // classes from logback should not be available
-    assertClassUnavailable(Logger.class);
     // classes from cdap-common should not be available
     assertClassUnavailable(ClassPathResources.class);
     // classes from cdap-security should not be available


### PR DESCRIPTION
…r classloader parent, so an implementation of Logger (and other classes required by cdap-api like classes from twill-api) is available to all extensions. Also made the cdap-api dependency in cdap-security-spi explicit.

Jira: [CDAP-5397](https://issues.cask.co/browse/CDAP-5397)
Build: http://builds.cask.co/browse/CDAP-DUT3924