### PR TITLE
CDAP-4357 Missed the case where the pending events metric for source flowlet to fwd-one flowet can be 8

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/FlowTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/FlowTest.java
@@ -294,15 +294,15 @@ public class FlowTest {
       // source emits 4, then forward-one reads 1, hence 3 should be pending
       waitForPending(tagsForSourceToOne, 3, 5000); // wait a little longer as flow needs to start
       waitForPending(tagsForAllToOne, 3, 100); // wait a little longer as flow needs to start
-      // forward-two receives each of the 4 as a string and an int, but could have read 1 per each queue
-      // so there should be either 3 + 4 = 7 pending or 3 + 3 = 6 pending,
-      // but we don't know whether the queue pending count will be 4, 3 or 3, 4 or 3, 3
+      // forward-two receives each of the 4 as a string and an int, but could have read 1 at most per each queue
+      // so there should be either 3 + 4 = 7 pending or 3 + 3 = 6 pending, or 4 + 4 = 8 pending
+      // but we don't know whether the queue pending count will be 4, 3 or 3, 4 or 3, 3 or 4, 4
       long intPending = waitForPending(tagsForSourceToTwoInts, 3, 4L, 1000);
       long stringPending = waitForPending(tagsForSourceToTwoStrings, 3, 4L, 1000);
       long totalPending = intPending + stringPending;
-      Assert.assertTrue(String.format("Expected the pending events count to be 6 or 7. But it was %d", totalPending),
-                        totalPending == 6 || totalPending == 7);
-      waitForPending(tagsForSourceToTwo, 7, 6L, 100);
+      Assert.assertTrue(String.format("Expected the pending events count to be 6, 7 or 8. But it was %d", totalPending),
+                        totalPending == 6 || totalPending == 7 || totalPending == 8);
+      waitForPending(tagsForSourceToTwo, 7, 6L, 500);
       waitForPending(tagsForAllToTwo, 7, 6L, 100);
       // neither one nor two have emitted, so the total pending should be = 12 - 1 (forward-one) - 1 or 2 (forward-two)
       // => 10 or 9 events


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-4357

Take-2 at fixing this flaky test. Missed the case where the pending events metrics will be 8. This was observed in this build failure : https://builds.cask.co/download/CDAP-BUT842-JOB1/build_logs/CDAP-BUT842-JOB1-37.log

Build : http://builds.cask.co/browse/CDAP-DUT3934