### PR TITLE
Fix/cdh5.7onrelease

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -165,7 +165,10 @@ cdap_set_hbase() {
         hbasecompat="${CDAP_HOME}/hbase-compat-1.0/lib/*"
         ;;
       1.1*)
-        hbasecompat="$CDAP_HOME/hbase-compat-1.1/lib/*"
+        hbasecompat="${CDAP_HOME}/hbase-compat-1.1/lib/*"
+        ;;
+      1.2-cdh*)
+        hbasecompat="${CDAP_HOME}/hbase-compat-1.2-cdh5.7.0/lib/*"
         ;;
       *)
         echo "ERROR: Unknown/unsupported version of HBase found: ${HBASE_VERSION}"

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueUtilFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueUtilFactory.java
@@ -48,6 +48,11 @@ public class HBaseQueueUtilFactory extends HBaseVersionSpecificFactory<HBaseQueu
   }
 
   @Override
+  protected String getHBase12CHD570ClassName() {
+    return "co.cask.cdap.data2.transaction.queue.hbase.HBase12CDH570QueueUtil";
+  }
+
+  @Override
   protected String getHBase10CHD550ClassName() {
     return "co.cask.cdap.data2.transaction.queue.hbase.HBase10CDH550QueueUtil";
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
@@ -73,4 +73,9 @@ public class HBaseTableUtilFactory extends HBaseVersionSpecificFactory<HBaseTabl
   protected String getHBase10CHD550ClassName() {
     return "co.cask.cdap.data2.util.hbase.HBase10CDH550TableUtil";
   }
+
+  @Override
+  protected String getHBase12CHD570ClassName() {
+    return "co.cask.cdap.data2.util.hbase.HBase12CDH570TableUtil";
+  }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -34,8 +34,10 @@ public class HBaseVersion {
   private static final String HBASE_98_VERSION = "0.98";
   private static final String HBASE_10_VERSION = "1.0";
   private static final String HBASE_11_VERSION = "1.1";
+  private static final String HBASE_12_VERSION = "1.2";
   private static final String CDH55_CLASSIFIER = "cdh5.5";
   private static final String CDH56_CLASSIFIER = "cdh5.6";
+  private static final String CDH57_CLASSIFIER = "cdh5.7";
   private static final String CDH_CLASSIFIER = "cdh";
 
   private static final Logger LOG = LoggerFactory.getLogger(HBaseVersion.class);
@@ -52,6 +54,7 @@ public class HBaseVersion {
     HBASE_10_CDH55("1.0-cdh5.5"),
     HBASE_10_CDH56("1.0-cdh5.6"),
     HBASE_11("1.1"),
+    HBASE_12_CDH57("1.2-cdh5.7"),
     UNKNOWN("unknown");
 
     final String majorVersion;
@@ -91,6 +94,13 @@ public class HBaseVersion {
         }
       } else if (versionString.startsWith(HBASE_11_VERSION)) {
         currentVersion = Version.HBASE_11;
+      } else if (versionString.startsWith(HBASE_12_VERSION)) {
+        VersionNumber ver = VersionNumber.create(versionString);
+        if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH57_CLASSIFIER)) {
+          currentVersion = Version.HBASE_12_CDH57;
+        } else {
+          currentVersion = Version.UNKNOWN;
+        }
       } else {
         currentVersion = Version.UNKNOWN;
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
@@ -46,12 +46,15 @@ public abstract class HBaseVersionSpecificFactory<T> implements Provider<T> {
         case HBASE_10_CDH:
           instance = createInstance(getHBase10CDHClassname());
           break;
-        case HBASE_11:
-          instance = createInstance(getHBase11Classname());
-          break;
         case HBASE_10_CDH55:
         case HBASE_10_CDH56:
           instance = createInstance(getHBase10CHD550ClassName());
+          break;
+        case HBASE_11:
+          instance = createInstance(getHBase11Classname());
+          break;
+        case HBASE_12_CDH57:
+          instance = createInstance(getHBase12CHD570ClassName());
           break;
         case UNKNOWN:
           throw new ProvisionException("Unknown HBase version: " + HBaseVersion.getVersionString());
@@ -74,4 +77,5 @@ public abstract class HBaseVersionSpecificFactory<T> implements Provider<T> {
   protected abstract String getHBase10CDHClassname();
   protected abstract String getHBase11Classname();
   protected abstract String getHBase10CHD550ClassName();
+  protected abstract String getHBase12CHD570ClassName();
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverterFactory.java
@@ -49,4 +49,9 @@ public class HTableNameConverterFactory extends HBaseVersionSpecificFactory<HTab
   protected String getHBase10CHD550ClassName() {
     return "co.cask.cdap.data2.util.hbase.HTable10CDH550NameConverter";
   }
+
+  @Override
+  protected String getHBase12CHD570ClassName() {
+    return "co.cask.cdap.data2.util.hbase.HTable12CDH570NameConverter";
+  }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestFactory.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestFactory.java
@@ -52,4 +52,9 @@ public class HBaseTestFactory extends HBaseVersionSpecificFactory<HBaseTestBase>
   protected String getHBase10CHD550ClassName() {
     return "co.cask.cdap.data.hbase.HBase10CDH550Test";
   }
+
+  @Override
+  protected String getHBase12CHD570ClassName() {
+    return "co.cask.cdap.data.hbase.HBase12CDH570Test";
+  }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive14ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive14ExploreService.java
@@ -29,7 +29,6 @@ import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.store.NamespaceStore;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -44,6 +43,7 @@ import org.apache.hive.service.cli.RowSet;
 import org.apache.hive.service.cli.SessionHandle;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -88,6 +88,6 @@ public class Hive14ExploreService extends BaseHiveExploreService {
   @Override
   protected OperationHandle doExecute(SessionHandle sessionHandle, String statement)
     throws HiveSQLException, ExploreException {
-    return getCliService().executeStatementAsync(sessionHandle, statement, ImmutableMap.<String, String>of());
+    return getCliService().executeStatementAsync(sessionHandle, statement, new HashMap<String, String>());
   }
 }

--- a/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2016 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>cdap</artifactId>
+    <groupId>co.cask.cdap</groupId>
+    <version>3.4.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>cdap-hbase-compat-1.2-cdh5.7.0</artifactId>
+  <name>CDAP HBase 1.2-CDH5.7.0 Compatibility</name>
+  <packaging>jar</packaging>
+
+  <repositories>
+    <repository>
+      <id>cloudera</id>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+  <dependency>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap-common</artifactId>
+    <version>${project.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap-data-fabric</artifactId>
+    <version>${project.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>co.cask.tephra</groupId>
+    <artifactId>tephra-hbase-compat-1.1</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.hadoop</groupId>
+    <artifactId>hadoop-common</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.hbase</groupId>
+    <artifactId>hbase-common</artifactId>
+    <version>${hbase12cdh570.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.hbase</groupId>
+    <artifactId>hbase-client</artifactId>
+    <version>${hbase12cdh570.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.hbase</groupId>
+    <artifactId>hbase-protocol</artifactId>
+    <version>${hbase12cdh570.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.hbase</groupId>
+    <artifactId>hbase-server</artifactId>
+    <version>${hbase12cdh570.version}</version>
+  </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-fabric</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common-unit-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minicluster</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase12cdh570.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-testing-util</artifactId>
+      <version>${hbase12cdh570.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>test-jar</id>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>dist</id>
+      <properties>
+        <package.dirs>opt</package.dirs>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.4</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>copy-dependencies</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration>
+                  <excludeArtifactIds>*</excludeArtifactIds>
+                  <includeArtifactIds>tephra-hbase-compat-1.1</includeArtifactIds>
+                  <silent>true</silent>
+                  <includeScope>compile</includeScope>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>rpm-prepare</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>deb-prepare</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>rpm</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.3.1</version>
+          </plugin>
+
+          <!-- Extra deployment for rpm package. -->
+          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>deploy-rpm</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                  <version>${project.version}</version>
+                  <groupId>${dist.deploy.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <packaging>noarch.rpm</packaging>
+                  <generatePom>false</generatePom>
+                  <file>${project.build.directory}/${project.artifactId}-${package.version}-1.noarch.rpm</file>
+                  <classifier>1</classifier>
+                  <repositoryId>continuuity</repositoryId>
+                  <url>${deploy.url}</url>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>deb</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.3.1</version>
+          </plugin>
+
+          <!-- Extra deployment for deb package -->
+          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>deploy-deb</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                  <version>${project.version}</version>
+                  <groupId>${dist.deploy.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <packaging>deb</packaging>
+                  <generatePom>false</generatePom>
+                  <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
+                  <repositoryId>continuuity</repositoryId>
+                  <url>${deploy.url}</url>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>tgz</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>2.4</version>
+          </plugin>
+
+          <!-- Extra deployment for tgz package -->
+          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>deploy-tgz</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                  <version>${project.version}</version>
+                  <groupId>${dist.deploy.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <packaging>tar.gz</packaging>
+                  <generatePom>false</generatePom>
+                  <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
+                  <repositoryId>continuuity</repositoryId>
+                  <url>${deploy.url}</url>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
+
+</project>

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/Filters.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/Filters.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase12cdh570;
+
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+
+/**
+ * Utility methods for working with HBase filters.
+ */
+public final class Filters {
+  /**
+   * Adds {@code overrideFilter} on to {@code baseFilter}, if it exists, otherwise replaces it.
+   */
+  public static Filter combine(Filter overrideFilter, Filter baseFilter) {
+    if (baseFilter != null) {
+      FilterList filterList = new FilterList(FilterList.Operator.MUST_PASS_ALL);
+      filterList.addFilter(baseFilter);
+      filterList.addFilter(overrideFilter);
+      return filterList;
+    }
+    return overrideFilter;
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementFilter.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase12cdh570;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.filter.FilterBase;
+
+import java.io.IOException;
+
+/**
+ * Simple filter for increment columns that includes all cell values in a column with a "delta" prefix up to and
+ * including the first cell it finds that is not an increment.  This allows the {@link IncrementHandler}
+ * coprocessor to return the correct value for an increment column by summing the last total sum plus all newer
+ * delta values.
+ */
+public class IncrementFilter extends FilterBase {
+  @Override
+  public ReturnCode filterKeyValue(Cell cell) throws IOException {
+    if (IncrementHandler.isIncrement(cell)) {
+      // all visible increments should be included until we get to a non-increment
+      return ReturnCode.INCLUDE;
+    } else {
+      // as soon as we find a KV to include we can move to the next column
+      return ReturnCode.INCLUDE_AND_NEXT_COL;
+    }
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementHandler.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementHandler.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase12cdh570;
+
+import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.increment.hbase.TimestampOracle;
+import co.cask.cdap.data2.util.hbase.HTable12CDH570NameConverter;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.Region;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
+import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+/**
+ * HBase coprocessor that handles reading and writing read-less increment operations.
+ *
+ * <p>Writes of incremental values are performed as normal {@code Put}s, flagged with a special attribute
+ * {@link HBaseTable#DELTA_WRITE}.  The coprocessor intercepts these
+ * writes and rewrites the cell value to use a special marker prefix.</p>
+ *
+ * <p>For read (for {@code Get} and {@code Scan}) operations, all of the delta values are summed up for a column,
+ * up to and including the most recent "full" (non-delta) value.  The sum of these delta values, plus the full value
+ * (if found) is returned for the column.</p>
+ *
+ * <p>To mitigate the performance impact on reading, this coprocessor also overrides the scanner used in flush and
+ * compaction operations, using {@link IncrementSummingScanner} to generate a new "full" value aggregated from
+ * all the successfully committed delta values.</p>
+ */
+public class IncrementHandler extends BaseRegionObserver {
+
+  private Region region;
+  private IncrementHandlerState state;
+
+
+  @Override
+  public void start(CoprocessorEnvironment e) throws IOException {
+    if (e instanceof RegionCoprocessorEnvironment) {
+      RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
+      this.region = ((RegionCoprocessorEnvironment) e).getRegion();
+      this.state = new IncrementHandlerState(env.getConfiguration(),
+                                             env.getRegion().getTableDesc(),
+                                             new HTable12CDH570NameConverter());
+
+      HTableDescriptor tableDesc = env.getRegion().getTableDesc();
+      for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
+        state.initFamily(columnDesc.getName(), convertFamilyValues(columnDesc.getValues()));
+      }
+    }
+  }
+
+  @VisibleForTesting
+  public void setTimestampOracle(TimestampOracle timeOracle) {
+    state.setTimestampOracle(timeOracle);
+  }
+
+  private Map<byte[], byte[]> convertFamilyValues(Map<ImmutableBytesWritable, ImmutableBytesWritable> writableValues) {
+    Map<byte[], byte[]> converted = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> e : writableValues.entrySet()) {
+      converted.put(e.getKey().get(), e.getValue().get());
+    }
+    return converted;
+  }
+
+  @Override
+  public void preGetOp(ObserverContext<RegionCoprocessorEnvironment> ctx, Get get, List<Cell> results)
+    throws IOException {
+    Scan scan = new Scan(get);
+    scan.setMaxVersions();
+    scan.setFilter(Filters.combine(new IncrementFilter(), scan.getFilter()));
+    RegionScanner scanner = null;
+    try {
+      scanner = new IncrementSummingScanner(region, scan.getBatch(), region.getScanner(scan), ScanType.USER_SCAN);
+      scanner.next(results);
+      ctx.bypass();
+    } finally {
+      if (scanner != null) {
+        scanner.close();
+      }
+    }
+  }
+
+  @Override
+  public void prePut(ObserverContext<RegionCoprocessorEnvironment> ctx, Put put, WALEdit edit, Durability durability)
+    throws IOException {
+    // we assume that if any of the column families written to are transactional, the entire write is transactional
+    boolean transactional = state.containsTransactionalFamily(put.getFamilyCellMap().keySet());
+    boolean isIncrement = put.getAttribute(HBaseTable.DELTA_WRITE) != null;
+
+    if (isIncrement || !transactional) {
+      // incremental write
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+
+      long tsToAssign = 0;
+      if (!transactional) {
+        tsToAssign = state.getUniqueTimestamp();
+      }
+      for (Map.Entry<byte[], List<Cell>> entry : put.getFamilyCellMap().entrySet()) {
+        List<Cell> newCells = new ArrayList<>(entry.getValue().size());
+        for (Cell cell : entry.getValue()) {
+          // rewrite the cell value with a special prefix to identify it as a delta
+          // for 0.98 we can update this to use cell tags
+          byte[] newValue = isIncrement ?
+              Bytes.add(IncrementHandlerState.DELTA_MAGIC_PREFIX, CellUtil.cloneValue(cell)) :
+              CellUtil.cloneValue(cell);
+          newCells.add(CellUtil.createCell(CellUtil.cloneRow(cell), CellUtil.cloneFamily(cell),
+                                           CellUtil.cloneQualifier(cell),
+                                           transactional ? cell.getTimestamp() : tsToAssign,
+                                           cell.getTypeByte(), newValue));
+        }
+        newFamilyMap.put(entry.getKey(), newCells);
+      }
+      put.setFamilyCellMap(newFamilyMap);
+    }
+    // put completes normally with value prefix marker
+  }
+
+  @Override
+  public void preDelete(ObserverContext<RegionCoprocessorEnvironment> e, Delete delete, WALEdit edit,
+                        Durability durability) throws IOException {
+    boolean transactional = state.containsTransactionalFamily(delete.getFamilyCellMap().keySet());
+    if (!transactional) {
+      long tsToAssign = state.getUniqueTimestamp();
+      delete.setTimestamp(tsToAssign);
+      // new key values
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+      for (Map.Entry<byte[], List<Cell>> entry : delete.getFamilyCellMap().entrySet()) {
+        List<Cell> newCells = new ArrayList<>(entry.getValue().size());
+        for (Cell kv : entry.getValue()) {
+          // replace the timestamp
+          newCells.add(CellUtil.createCell(CellUtil.cloneRow(kv),
+              CellUtil.cloneFamily(kv),
+              CellUtil.cloneQualifier(kv),
+              tsToAssign, kv.getTypeByte(),
+              CellUtil.cloneValue(kv)));
+        }
+        newFamilyMap.put(entry.getKey(), newCells);
+      }
+      delete.setFamilyCellMap(newFamilyMap);
+    }
+  }
+
+  @Override
+  public RegionScanner preScannerOpen(ObserverContext<RegionCoprocessorEnvironment> e, Scan scan, RegionScanner s)
+    throws IOException {
+    // must see all versions to aggregate increments
+    scan.setMaxVersions();
+    scan.setFilter(Filters.combine(new IncrementFilter(), scan.getFilter()));
+    return s;
+  }
+
+  @Override
+  public RegionScanner postScannerOpen(ObserverContext<RegionCoprocessorEnvironment> ctx, Scan scan,
+                                       RegionScanner scanner)
+    throws IOException {
+    return new IncrementSummingScanner(region, scan.getBatch(), scanner, ScanType.USER_SCAN);
+  }
+
+  @Override
+  public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                  InternalScanner scanner) throws IOException {
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner,
+        ScanType.COMPACT_RETAIN_DELETES, state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
+  }
+
+  public static boolean isIncrement(Cell cell) {
+    return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandlerState.DELTA_FULL_LENGTH &&
+      Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length,
+                   IncrementHandlerState.DELTA_MAGIC_PREFIX, 0, IncrementHandlerState.DELTA_MAGIC_PREFIX.length);
+  }
+
+  @Override
+  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                    InternalScanner scanner, ScanType scanType) throws IOException {
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner, scanType,
+        state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
+  }
+
+  @Override
+  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                    InternalScanner scanner, ScanType scanType, CompactionRequest request)
+    throws IOException {
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner, scanType,
+        state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementSummingScanner.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase12cdh570;
+
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import com.google.common.base.Preconditions;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.Region;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.ScannerContext;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Transforms reads of the stored delta increments into calculated sums for each column.
+ */
+class IncrementSummingScanner implements RegionScanner {
+  private static final Log LOG = LogFactory.getLog(IncrementSummingScanner.class);
+  private static final Field SCANNER_CONTEXT_LIMITS_FIELD;
+  private static final Method GET_BATCH_METHOD;
+
+  static {
+    try {
+      Field limitsField = ScannerContext.class.getDeclaredField("limits");
+      limitsField.setAccessible(true);
+      SCANNER_CONTEXT_LIMITS_FIELD = limitsField;
+
+      Class<?> limitFieldsClass = limitsField.getType();
+      Method getBatchMethod = limitFieldsClass.getDeclaredMethod("getBatch");
+      getBatchMethod.setAccessible(true);
+      GET_BATCH_METHOD = getBatchMethod;
+    } catch (Exception e) {
+      LOG.error("Failed to get ScannerContext.LimitFields.getBatch method through reflection.");
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private final Region region;
+  private final WrappedScanner baseScanner;
+  private RegionScanner baseRegionScanner;
+  private final int batchSize;
+  private final ScanType scanType;
+  // Highest timestamp, beyond which we cannot aggregate increments during flush and compaction.
+  // Increments newer than this may still be visible to running transactions
+  private final long compactionUpperBound;
+  // scan start time to use in computing TTL
+  private final long oldestTsByTTL;
+
+  IncrementSummingScanner(Region region, int batchSize, InternalScanner internalScanner, ScanType scanType) {
+    this(region, batchSize, internalScanner, scanType, Long.MAX_VALUE, -1);
+  }
+
+  IncrementSummingScanner(Region region, int batchSize, InternalScanner internalScanner, ScanType scanType,
+                          long compationUpperBound, long oldestTsByTTL) {
+    this.region = region;
+    this.batchSize = batchSize;
+    this.baseScanner = new WrappedScanner(internalScanner);
+    if (internalScanner instanceof RegionScanner) {
+      this.baseRegionScanner = (RegionScanner) internalScanner;
+    }
+    this.scanType = scanType;
+    this.compactionUpperBound = compationUpperBound;
+    this.oldestTsByTTL = oldestTsByTTL;
+  }
+
+  @Override
+  public HRegionInfo getRegionInfo() {
+    return region.getRegionInfo();
+  }
+
+  @Override
+  public boolean isFilterDone() throws IOException {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.isFilterDone();
+    }
+    throw new IllegalStateException(
+      "RegionScanner.isFilterDone() called when the wrapped scanner is not a RegionScanner");
+  }
+
+  @Override
+  public boolean reseek(byte[] bytes) throws IOException {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.reseek(bytes);
+    }
+    throw new IllegalStateException(
+      "RegionScanner.reseek() called when the wrapped scanner is not a RegionScanner");
+  }
+
+  @Override
+  public long getMaxResultSize() {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.getMaxResultSize();
+    }
+    throw new IllegalStateException(
+      "RegionScanner.isFilterDone() called when the wrapped scanner is not a RegionScanner");
+  }
+
+
+  @Override
+  public long getMvccReadPoint() {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.getMvccReadPoint();
+    }
+    throw new IllegalStateException(
+      "RegionScanner.isFilterDone() called when the wrapped scanner is not a RegionScanner");
+  }
+
+  /**
+   * @return The limit on the number of cells to retrieve on each call to next(). See
+   * {@link Scan#setBatch(int)}
+   */
+  @Override
+  public int getBatch() {
+    return batchSize;
+  }
+
+  @Override
+  public boolean nextRaw(List<Cell> cells) throws IOException {
+    return nextRaw(cells, ScannerContext.newBuilder().setBatchLimit(batchSize).build());
+  }
+
+  @Override
+  public boolean nextRaw(List<Cell> cells, ScannerContext scannerContext) throws IOException {
+    return nextInternal(cells, scannerContext);
+  }
+
+  @Override
+  public boolean next(List<Cell> cells) throws IOException {
+    return next(cells, ScannerContext.newBuilder().setBatchLimit(batchSize).build());
+  }
+
+  @Override
+  public boolean next(List<Cell> cells, ScannerContext scannerContext) throws IOException {
+    return nextInternal(cells, scannerContext);
+  }
+
+  private boolean nextInternal(List<Cell> cells, ScannerContext scannerContext) throws IOException {
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("nextInternal called with limit=" + scannerContext);
+    }
+    Cell previousIncrement = null;
+    long runningSum = 0;
+    int addedCnt = 0;
+    baseScanner.startNext();
+    Cell cell;
+    int limit = getBatchLimit(scannerContext);
+
+    while ((cell = baseScanner.peekNextCell(scannerContext)) != null && (limit <= 0 || addedCnt < limit)) {
+      // we use the "peek" semantics so that only once cell is ever emitted per iteration
+      // this makes is clearer and easier to enforce that the returned results are <= limit
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Checking cell " + cell);
+      }
+      // any cells visible to in-progress transactions must be kept unchanged
+      if (cell.getTimestamp() > compactionUpperBound) {
+        if (previousIncrement != null) {
+          // if previous increment is present, only emit the previous increment, reset it, and continue.
+          // the current cell will be consumed on the next iteration, if we have not yet reached the limit
+          if (LOG.isTraceEnabled()) {
+            LOG.trace("Including increment: sum=" + runningSum + ", cell=" + previousIncrement);
+          }
+          cells.add(newCell(previousIncrement, runningSum));
+          addedCnt++;
+          previousIncrement = null;
+          runningSum = 0;
+
+          continue;
+        }
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Including cell visible to in-progress, cell=" + cell);
+        }
+        cells.add(cell);
+        addedCnt++;
+        baseScanner.nextCell(scannerContext);
+        continue;
+      }
+
+      // compact any delta writes
+      if (IncrementHandler.isIncrement(cell)) {
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Found increment for row=" + Bytes.toStringBinary(CellUtil.cloneRow(cell)) + ", " +
+              "column=" + Bytes.toStringBinary(CellUtil.cloneQualifier(cell)));
+        }
+        if (!sameCell(previousIncrement, cell)) {
+          if (previousIncrement != null) {
+            // if different qualifier, and prev qualifier non-null
+            // emit the previous sum
+            if (LOG.isTraceEnabled()) {
+              LOG.trace("Including increment: sum=" + runningSum + ", cell=" + previousIncrement);
+            }
+            cells.add(newCell(previousIncrement, runningSum));
+            previousIncrement = null;
+            addedCnt++;
+            // continue without advancing, current cell will be consumed on the next iteration
+            continue;
+          }
+          previousIncrement = cell;
+          runningSum = 0;
+        }
+        // add this increment to the tally
+        runningSum += Bytes.toLong(cell.getValueArray(),
+            cell.getValueOffset() + IncrementHandlerState.DELTA_MAGIC_PREFIX.length);
+      } else {
+        // otherwise (not an increment)
+        if (previousIncrement != null) {
+          if (sameCell(previousIncrement, cell) && !CellUtil.isDelete(cell)) {
+            // if qualifier matches previous and this is a long, add to running sum, emit
+            runningSum += Bytes.toLong(cell.getValueArray(), cell.getValueOffset());
+            // this cell already processed as part of the previous increment's sum, so consume it
+            baseScanner.nextCell(scannerContext);
+          }
+          if (LOG.isTraceEnabled()) {
+            LOG.trace("Including increment: sum=" + runningSum + ", cell=" + previousIncrement);
+          }
+          // if this put is a different cell from the previous increment, then
+          // we only emit the previous increment, reset it, and continue.
+          // the current cell will be consumed on the next iteration, if we have not yet reached the limit
+          cells.add(newCell(previousIncrement, runningSum));
+          addedCnt++;
+          previousIncrement = null;
+          runningSum = 0;
+
+          continue;
+        }
+        // otherwise emit the current cell
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Including raw cell: " + cell);
+        }
+
+        // apply any configured TTL
+        if (cell.getTimestamp() > oldestTsByTTL) {
+          cells.add(cell);
+          addedCnt++;
+        }
+      }
+      // if we made it this far, consume the current cell
+      baseScanner.nextCell(scannerContext);
+    }
+    // emit any left over increment, if we hit the end
+    if (previousIncrement != null) {
+      // in any situation where we exited due to limit, previousIncrement should already be null
+      Preconditions.checkState(getBatch() <= 0 || addedCnt < getBatch(), "addedCnt=%s, limit=%s", addedCnt, getBatch());
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Including leftover increment: sum=" + runningSum + ", cell=" + previousIncrement);
+      }
+      cells.add(newCell(previousIncrement, runningSum));
+    }
+
+    boolean hasMore = baseScanner.hasMore();
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("nextInternal done with limit=" + getBatch() + " hasMore=" + hasMore);
+    }
+    return hasMore;
+  }
+
+  /**
+   * Gets the batch limit from the given {@link ScannerContext} through reflection.
+   */
+  private int getBatchLimit(ScannerContext scannerContext) {
+    // We need to to access the batch limit (limit on number of columns) in the ScannerContext.
+    // The ScannerContext does not exposes its method to get the limits and has it as an integer inside a classs
+    // LimitFields. So get this through reflection. Also, we cannot depend on the limit tracking of the
+    // internal scanner as it does not differentiate between an increment cell and a non-increment cell.
+    // So, we read all the cells from the internal scanner in batches of limit and do the tracking for columns
+    // by ourselves.
+    try {
+      return (Integer) GET_BATCH_METHOD.invoke(SCANNER_CONTEXT_LIMITS_FIELD.get(scannerContext));
+    } catch (Exception e) {
+      throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);
+    }
+  }
+
+  private boolean sameCell(Cell first, Cell second) {
+    if (first == null && second == null) {
+      return true;
+    } else if (first == null || second == null) {
+      return false;
+    }
+
+    return CellUtil.matchingRow(first, second) &&
+      CellUtil.matchingFamily(first, second) &&
+      CellUtil.matchingQualifier(first, second);
+  }
+
+  private Cell newCell(Cell toCopy, long value) {
+    byte[] newValue = Bytes.toBytes(value);
+    if (scanType == ScanType.COMPACT_RETAIN_DELETES) {
+      newValue = Bytes.add(IncrementHandlerState.DELTA_MAGIC_PREFIX, newValue);
+    }
+    return CellUtil.createCell(CellUtil.cloneRow(toCopy), CellUtil.cloneFamily(toCopy),
+                               CellUtil.cloneQualifier(toCopy), toCopy.getTimestamp(),
+                               KeyValue.Type.Put.getCode(), newValue);
+  }
+
+  @Override
+  public void close() throws IOException {
+    baseScanner.close();
+  }
+
+  /**
+   * Wraps the underlying store or region scanner in an API that hides the details of calling and managing the
+   * buffered batch of results.
+   */
+  private static class WrappedScanner implements Closeable {
+    private boolean hasMore;
+    private byte[] currentRow;
+    private List<Cell> cellsToConsume = new ArrayList<>();
+    private int currentIdx;
+    private final InternalScanner scanner;
+
+    public WrappedScanner(InternalScanner scanner) {
+      this.scanner = scanner;
+    }
+
+    /**
+     * Called to signal the start of the next() call by the scanner.
+     */
+    public void startNext() {
+      currentRow = null;
+    }
+
+    /**
+     * Returns the next available cell for the current row, without advancing the pointer.  Calling this method
+     * multiple times in a row will continue to return the same cell.
+     *
+     * @param scannerContext The {@link ScannerContext} instance encapsulating all limits that should
+     * be tracked.
+     * @return the next available cell or null if no more cells are available for the current row
+     * @throws IOException
+     */
+    public Cell peekNextCell(ScannerContext scannerContext) throws IOException {
+      if (currentIdx >= cellsToConsume.size()) {
+        // finished current batch
+        cellsToConsume.clear();
+        currentIdx = 0;
+        hasMore = scanner.next(cellsToConsume, scannerContext);
+      }
+      Cell cell = null;
+      if (currentIdx < cellsToConsume.size()) {
+        cell = cellsToConsume.get(currentIdx);
+        if (currentRow == null) {
+          currentRow = CellUtil.cloneRow(cell);
+        } else if (!CellUtil.matchingRow(cell, currentRow)) {
+          // moved on to the next row
+          // don't consume current cell and signal no more cells for this row
+          return null;
+        }
+      }
+      return cell;
+    }
+
+    /**
+     * Returns the next available cell for the current row and advances the pointer to the next cell.  This method
+     * can be called multiple times in a row to advance through all the available cells.
+     *
+     * @param scannerContext The {@link ScannerContext} instance encapsulating all limits that should
+     * be tracked.
+     * @return the next available cell or null if no more cells are available for the current row
+     * @throws IOException
+     */
+    public Cell nextCell(ScannerContext scannerContext) throws IOException {
+      Cell cell = peekNextCell(scannerContext);
+      if (cell != null) {
+        currentIdx++;
+      }
+      return cell;
+    }
+
+    /**
+     * Returns whether or not the underlying scanner has more rows.
+     */
+    public boolean hasMore() {
+      return currentIdx < cellsToConsume.size() ? true : hasMore;
+    }
+
+    @Override
+    public void close() throws IOException {
+      scanner.close();
+    }
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementTxFilter.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementTxFilter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase12cdh570;
+
+import co.cask.tephra.Transaction;
+import co.cask.tephra.hbase11.coprocessor.TransactionVisibilityFilter;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+
+import java.util.Map;
+
+/**
+ * {@link TransactionVisibilityFilter}'s default behavior is to give only latest valid version for the transactional
+ * cell to its sub-filters. However the {@link IncrementFilter} need to see all previous valid versions for readless
+ * increments, since increments are stored as just the different versions of the same cell. This {@link Filter}
+ * extends the {@link TransactionVisibilityFilter} and overrides the
+ * {@link TransactionVisibilityFilter#determineReturnCode} method to achieve this.
+ */
+public class IncrementTxFilter extends TransactionVisibilityFilter {
+  /**
+   * Creates a new instance of the {@link Filter}.
+   * @param tx the current transaction to apply. Only data visible to this transaction will be returned
+   * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
+   * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
+   *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param scanType the type of scan operation being performed
+   * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
+   *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
+   *                   {@link ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
+   */
+  public IncrementTxFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues, ScanType scanType,
+                           Filter cellFilter) {
+    super(tx, ttlByFamily, allowEmptyValues, scanType, Filters.combine(new IncrementFilter(), cellFilter));
+  }
+
+  @Override
+  protected ReturnCode determineReturnCode(ReturnCode txFilterCode, ReturnCode subFilterCode) {
+    switch (subFilterCode) {
+      case INCLUDE:
+        return ReturnCode.INCLUDE;
+      case INCLUDE_AND_NEXT_COL:
+        return ReturnCode.INCLUDE_AND_NEXT_COL;
+      case SKIP:
+        return txFilterCode == ReturnCode.INCLUDE ? ReturnCode.SKIP : ReturnCode.NEXT_COL;
+      default:
+        return subFilterCode;
+    }
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase12cdh570/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase12cdh570/DefaultTransactionProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.coprocessor.hbase12cdh570;
+
+import co.cask.cdap.data2.increment.hbase12cdh570.IncrementTxFilter;
+import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
+import co.cask.cdap.data2.util.hbase.HTable12CDH570NameConverter;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.coprocessor.TransactionStateCache;
+import co.cask.tephra.hbase11.coprocessor.CellSkipFilter;
+import co.cask.tephra.hbase11.coprocessor.TransactionProcessor;
+import com.google.common.base.Supplier;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+
+/**
+ * Implementation of the {@link TransactionProcessor}
+ * coprocessor that uses {@link co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCache}
+ * to automatically refresh transaction state.
+ */
+public class DefaultTransactionProcessor extends TransactionProcessor {
+  @Override
+  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
+    String sysConfigTablePrefix
+      = new HTable12CDH570NameConverter().getSysConfigTablePrefix(env.getRegion().getTableDesc());
+    return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
+  }
+
+  @Override
+  protected Filter getTransactionFilter(Transaction tx, ScanType scanType, Filter filter) {
+    IncrementTxFilter incrementTxFilter = new IncrementTxFilter(tx, ttlByFamily, allowEmptyValues, scanType, filter);
+    return new CellSkipFilter(incrementTxFilter);
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/DequeueFilter.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/DequeueFilter.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.coprocessor.hbase12cdh570;
+
+import co.cask.cdap.data2.queue.ConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import co.cask.cdap.data2.transaction.queue.hbase.DequeueScanAttributes;
+import co.cask.tephra.Transaction;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.exceptions.DeserializationException;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Server-side filter for dequeue operation
+ */
+// todo: unit-test it (without DequeueScanObserver)
+public class DequeueFilter extends FilterBase {
+  private ConsumerConfig consumerConfig;
+  private Transaction transaction;
+  private byte[] stateColumnName;
+
+  private boolean stopScan;
+  private boolean skipRow;
+
+  private int counter;
+  private long writePointer;
+
+  // For Writable
+  private DequeueFilter() {
+  }
+
+  public DequeueFilter(ConsumerConfig consumerConfig, Transaction transaction) {
+    this.consumerConfig = consumerConfig;
+    this.transaction = transaction;
+    this.stateColumnName = Bytes.add(QueueEntryRow.STATE_COLUMN_PREFIX,
+                                     Bytes.toBytes(consumerConfig.getGroupId()));
+  }
+
+  @Override
+  public void reset() throws IOException {
+    stopScan = false;
+    skipRow = false;
+  }
+
+  @Override
+  public boolean filterAllRemaining() {
+    return stopScan;
+  }
+
+  @Override
+  public boolean filterRowKey(byte[] buffer, int offset, int length) {
+    // last 4 bytes in a row key
+    counter = Bytes.toInt(buffer, offset + length - Ints.BYTES, Ints.BYTES);
+    // row key is queue_name + writePointer + counter
+    writePointer = Bytes.toLong(buffer, offset + length - Longs.BYTES - Ints.BYTES, Longs.BYTES);
+
+    // If writes later than the reader pointer, abort the loop, as entries that comes later are all uncommitted.
+    // this is probably not needed due to the limit of the scan to the stop row, but to be safe...
+    if (writePointer > transaction.getReadPointer()) {
+      stopScan = true;
+      return true;
+    }
+
+    // If the write is in the excluded list, ignore it.
+    if (transaction.isExcluded(writePointer)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean hasFilterRow() {
+    return true;
+  }
+
+  @Override
+  public void filterRowCells(List<Cell> cells) {
+    byte[] dataBytes = null;
+    byte[] metaBytes = null;
+    byte[] stateBytes = null;
+    // list is very short so it is ok to loop thru to find columns
+    for (Cell cell : cells) {
+      if (CellUtil.matchingQualifier(cell, QueueEntryRow.DATA_COLUMN)) {
+        dataBytes = CellUtil.cloneValue(cell);
+      } else if (CellUtil.matchingQualifier(cell, QueueEntryRow.META_COLUMN)) {
+        metaBytes = CellUtil.cloneValue(cell);
+      } else if (CellUtil.matchingQualifier(cell, stateColumnName)) {
+        stateBytes = CellUtil.cloneValue(cell);
+      }
+    }
+
+    if (dataBytes == null || metaBytes == null) {
+      skipRow = true;
+      return;
+    }
+
+    QueueEntryRow.CanConsume canConsume =
+      QueueEntryRow.canConsume(consumerConfig, transaction, writePointer, counter, metaBytes, stateBytes);
+
+    // Only skip the row when canConsumer == NO, so that in case of NO_INCLUDING_ALL_OLDER, the client
+    // can still see the row and move the scan start row.
+    skipRow = canConsume == QueueEntryRow.CanConsume.NO;
+  }
+
+  @Override
+  public ReturnCode filterKeyValue(Cell cell) throws IOException {
+    return ReturnCode.INCLUDE;
+  }
+
+  @Override
+  public boolean filterRow() {
+    return skipRow;
+  }
+
+  /* Writable implementation for HBase 0.94 */
+
+  public void write(DataOutput out) throws IOException {
+    DequeueScanAttributes.write(out, consumerConfig);
+    DequeueScanAttributes.write(out, transaction);
+  }
+
+  public void readFields(DataInput in) throws IOException {
+    this.consumerConfig = DequeueScanAttributes.readConsumerConfig(in);
+    this.transaction = DequeueScanAttributes.readTx(in);
+  }
+
+  /* Serialization support for HBase 0.98+ */
+
+  public byte[] toByteArray() throws IOException {
+    // TODO: in the future actual serialization here should be done using protobufs
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    write(new DataOutputStream(bos));
+    return bos.toByteArray();
+  }
+
+  public static Filter parseFrom(final byte [] pbBytes) throws DeserializationException {
+    DequeueFilter filter = new DequeueFilter();
+    try {
+      filter.readFields(new DataInputStream(new ByteArrayInputStream(pbBytes)));
+    } catch (IOException ioe) {
+      throw new DeserializationException(ioe);
+    }
+    return filter;
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/DequeueScanObserver.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/DequeueScanObserver.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.coprocessor.hbase12cdh570;
+
+import co.cask.cdap.data2.queue.ConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.hbase.DequeueScanAttributes;
+import co.cask.tephra.Transaction;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class DequeueScanObserver extends BaseRegionObserver {
+  @Override
+  public RegionScanner preScannerOpen(ObserverContext<RegionCoprocessorEnvironment> e, Scan scan, RegionScanner s)
+    throws IOException {
+    ConsumerConfig consumerConfig = DequeueScanAttributes.getConsumerConfig(scan);
+    Transaction tx = DequeueScanAttributes.getTx(scan);
+
+    if (consumerConfig == null || tx == null) {
+      return super.preScannerOpen(e, scan, s);
+    }
+
+    Filter dequeueFilter = new DequeueFilter(consumerConfig, tx);
+
+    Filter existing = scan.getFilter();
+    if (existing != null) {
+      Filter combined = new FilterList(FilterList.Operator.MUST_PASS_ALL, existing, dequeueFilter);
+      scan.setFilter(combined);
+    } else {
+      scan.setFilter(dequeueFilter);
+    }
+
+    return super.preScannerOpen(e, scan, s);
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/HBaseQueueRegionObserver.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.transaction.queue.coprocessor.hbase12cdh570;
+
+import co.cask.cdap.common.queue.QueueName;
+import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
+import co.cask.cdap.data2.transaction.queue.ConsumerEntryState;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
+import co.cask.cdap.data2.transaction.queue.hbase.SaltedHBaseQueueStrategy;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.CConfigurationReader;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCache;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerInstance;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.QueueConsumerConfig;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HTable12CDH570NameConverter;
+import co.cask.tephra.coprocessor.TransactionStateCache;
+import co.cask.tephra.persist.TransactionVisibilityState;
+import com.google.common.base.Supplier;
+import com.google.common.io.InputSupplier;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.ScannerContext;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * RegionObserver for queue table. This class should only have JSE and HBase classes dependencies only.
+ * It can also has dependencies on CDAP classes provided that all the transitive dependencies stay within
+ * the mentioned scope.
+ *
+ * This region observer does queue eviction during flush time and compact time by using queue consumer state
+ * information to determine if a queue entry row can be omitted during flush/compact.
+ */
+public final class HBaseQueueRegionObserver extends BaseRegionObserver {
+
+  private static final Log LOG = LogFactory.getLog(HBaseQueueRegionObserver.class);
+
+  private TableName configTableName;
+  private CConfigurationReader cConfReader;
+  TransactionStateCache txStateCache;
+  private Supplier<TransactionVisibilityState> txSnapshotSupplier;
+  private ConsumerConfigCache configCache;
+
+  private int prefixBytes;
+  private String namespaceId;
+  private String appName;
+  private String flowName;
+
+  @Override
+  public void start(CoprocessorEnvironment env) {
+    if (env instanceof RegionCoprocessorEnvironment) {
+      HTableDescriptor tableDesc = ((RegionCoprocessorEnvironment) env).getRegion().getTableDesc();
+      String hTableName = tableDesc.getNameAsString();
+
+      String prefixBytes = tableDesc.getValue(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES);
+      try {
+        // Default to SALT_BYTES for the older salted queue implementation.
+        this.prefixBytes = prefixBytes == null ? SaltedHBaseQueueStrategy.SALT_BYTES : Integer.parseInt(prefixBytes);
+      } catch (NumberFormatException e) {
+        // Shouldn't happen for table created by cdap.
+        LOG.error("Unable to parse value of '" + HBaseQueueAdmin.PROPERTY_PREFIX_BYTES + "' property. " +
+                    "Default to " + SaltedHBaseQueueStrategy.SALT_BYTES, e);
+        this.prefixBytes = SaltedHBaseQueueStrategy.SALT_BYTES;
+      }
+
+      HTable12CDH570NameConverter nameConverter = new HTable12CDH570NameConverter();
+      namespaceId = nameConverter.from(tableDesc).getNamespace().getId();
+      appName = HBaseQueueAdmin.getApplicationName(hTableName);
+      flowName = HBaseQueueAdmin.getFlowName(hTableName);
+
+      Configuration conf = env.getConfiguration();
+      String hbaseNamespacePrefix = nameConverter.getNamespacePrefix(tableDesc);
+      TableId queueConfigTableId = HBaseQueueAdmin.getConfigTableId(namespaceId);
+      final String sysConfigTablePrefix = nameConverter.getSysConfigTablePrefix(tableDesc);
+      txStateCache = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf).get();
+      txSnapshotSupplier = new Supplier<TransactionVisibilityState>() {
+        @Override
+        public TransactionVisibilityState get() {
+          return txStateCache.getLatestState();
+        }
+      };
+      configTableName = nameConverter.toTableName(hbaseNamespacePrefix, queueConfigTableId);
+      cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
+      configCache = createConfigCache(env);
+    }
+  }
+
+  @Override
+  public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e,
+                                  Store store, InternalScanner scanner) throws IOException {
+    if (!e.getEnvironment().getRegion().isAvailable()) {
+      return scanner;
+    }
+
+    LOG.info("preFlush, creates EvictionInternalScanner");
+    return new EvictionInternalScanner("flush", e.getEnvironment(), scanner);
+  }
+
+  @Override
+  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                    InternalScanner scanner, ScanType type,
+                                    CompactionRequest request) throws IOException {
+    if (!e.getEnvironment().getRegion().isAvailable()) {
+      return scanner;
+    }
+
+    LOG.info("preCompact, creates EvictionInternalScanner");
+    return new EvictionInternalScanner("compaction", e.getEnvironment(), scanner);
+  }
+
+  // needed for queue unit-test
+  @SuppressWarnings("unused")
+  private void updateCache() throws IOException {
+    ConsumerConfigCache configCache = this.configCache;
+    if (configCache != null) {
+      configCache.updateCache();
+    }
+  }
+
+  private ConsumerConfigCache getConfigCache(CoprocessorEnvironment env) {
+    if (!configCache.isAlive()) {
+      configCache = createConfigCache(env);
+    }
+    return configCache;
+  }
+
+  private ConsumerConfigCache createConfigCache(final CoprocessorEnvironment env) {
+    return ConsumerConfigCache.getInstance(configTableName, cConfReader,
+                                           txSnapshotSupplier, new InputSupplier<HTableInterface>() {
+      @Override
+      public HTableInterface getInput() throws IOException {
+        return env.getTable(configTableName);
+      }
+    });
+  }
+
+  // need for queue unit-test
+  private TransactionStateCache getTxStateCache() {
+    return txStateCache;
+  }
+
+  /**
+   * An {@link InternalScanner} that will skip queue entries that are safe to be evicted.
+   */
+  private final class EvictionInternalScanner implements InternalScanner {
+
+    private final String triggeringAction;
+    private final RegionCoprocessorEnvironment env;
+    private final InternalScanner scanner;
+    // This is just for object reused to reduce objects creation.
+    private final ConsumerInstance consumerInstance;
+    private byte[] currentQueue;
+    private byte[] currentQueueRowPrefix;
+    private QueueConsumerConfig consumerConfig;
+    private long totalRows = 0;
+    private long rowsEvicted = 0;
+    // couldn't be evicted due to incomplete view of row
+    private long skippedIncomplete = 0;
+
+    private EvictionInternalScanner(String action, RegionCoprocessorEnvironment env, InternalScanner scanner) {
+      this.triggeringAction = action;
+      this.env = env;
+      this.scanner = scanner;
+      this.consumerInstance = new ConsumerInstance(0, 0);
+    }
+
+    @Override
+    public boolean next(List<Cell> results) throws IOException {
+      return next(results, ScannerContext.newBuilder().setBatchLimit(-1).build());
+    }
+
+    @Override
+    public boolean next(List<Cell> results, ScannerContext scannerContext) throws IOException {
+      boolean hasNext = scanner.next(results, scannerContext);
+
+      while (!results.isEmpty()) {
+        totalRows++;
+        // Check if it is eligible for eviction.
+        Cell cell = results.get(0);
+
+        // If current queue is unknown or the row is not a queue entry of current queue,
+        // it either because it scans into next queue entry or simply current queue is not known.
+        // Hence needs to find the currentQueue
+        if (currentQueue == null || !QueueEntryRow.isQueueEntry(currentQueueRowPrefix, prefixBytes, cell.getRowArray(),
+                                                                cell.getRowOffset(), cell.getRowLength())) {
+          // If not eligible, it either because it scans into next queue entry or simply current queue is not known.
+          currentQueue = null;
+        }
+
+        // This row is a queue entry. If currentQueue is null, meaning it's a new queue encountered during scan.
+        if (currentQueue == null) {
+          QueueName queueName = QueueEntryRow.getQueueName(namespaceId, appName, flowName, prefixBytes,
+                                                           cell.getRowArray(), cell.getRowOffset(),
+                                                           cell.getRowLength());
+          currentQueue = queueName.toBytes();
+          currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
+          consumerConfig = getConfigCache(env).getConsumerConfig(currentQueue);
+        }
+
+        if (consumerConfig == null) {
+          // no config is present yet, so cannot evict
+          return hasNext;
+        }
+
+        if (canEvict(consumerConfig, results)) {
+          rowsEvicted++;
+          results.clear();
+          hasNext = scanner.next(results, scannerContext);
+        } else {
+          break;
+        }
+      }
+
+      return hasNext;
+    }
+
+    @Override
+    public void close() throws IOException {
+      LOG.info("Region " + env.getRegionInfo().getRegionNameAsString() + " " + triggeringAction +
+                 ", rows evicted: " + rowsEvicted + " / " + totalRows + ", skipped incomplete: " + skippedIncomplete);
+      scanner.close();
+    }
+
+    /**
+     * Determines the given queue entry row can be evicted.
+     * @param result All KeyValues of a queue entry row.
+     * @return true if it can be evicted, false otherwise.
+     */
+    private boolean canEvict(QueueConsumerConfig consumerConfig, List<Cell> result) {
+      // If no consumer group, this queue is dead, should be ok to evict.
+      if (consumerConfig.getNumGroups() == 0) {
+        return true;
+      }
+
+      // If unknown consumer config (due to error), keep the queue.
+      if (consumerConfig.getNumGroups() < 0) {
+        return false;
+      }
+
+      // TODO (terence): Right now we can only evict if we see all the data columns.
+      // It's because it's possible that in some previous flush, only the data columns are flush,
+      // then consumer writes the state columns. In the next flush, it'll only see the state columns and those
+      // should not be evicted otherwise the entry might get reprocessed, depending on the consumer start row state.
+      // This logic is not perfect as if flush happens after enqueue and before dequeue, that entry may never get
+      // evicted (depends on when the next compaction happens, whether the queue configuration has been change or not).
+
+      // There are two data columns, "d" and "m".
+      // If the size == 2, it should not be evicted as well,
+      // as state columns (dequeue) always happen after data columns (enqueue).
+      if (result.size() <= 2) {
+        skippedIncomplete++;
+        return false;
+      }
+
+      // "d" and "m" columns always comes before the state columns, prefixed with "s".
+      Iterator<Cell> iterator = result.iterator();
+      Cell cell = iterator.next();
+      if (!QueueEntryRow.isDataColumn(cell.getQualifierArray(), cell.getQualifierOffset())) {
+        skippedIncomplete++;
+        return false;
+      }
+      cell = iterator.next();
+      if (!QueueEntryRow.isMetaColumn(cell.getQualifierArray(), cell.getQualifierOffset())) {
+        skippedIncomplete++;
+        return false;
+      }
+
+      // Need to determine if this row can be evicted iff all consumer groups have committed process this row.
+      int consumedGroups = 0;
+      // Inspect each state column
+      while (iterator.hasNext()) {
+        cell = iterator.next();
+        if (!QueueEntryRow.isStateColumn(cell.getQualifierArray(), cell.getQualifierOffset())) {
+          continue;
+        }
+        // If any consumer has a state != PROCESSED, it should not be evicted
+        if (!isProcessed(cell, consumerInstance)) {
+          break;
+        }
+        // If it is PROCESSED, check if this row is smaller than the consumer instance startRow.
+        // Essentially a loose check of committed PROCESSED.
+        byte[] startRow = consumerConfig.getStartRow(consumerInstance);
+        if (startRow != null && compareRowKey(cell, startRow) < 0) {
+          consumedGroups++;
+        }
+      }
+
+      // It can be evicted if from the state columns, it's been processed by all consumer groups
+      // Otherwise, this row has to be less than smallest among all current consumers.
+      // The second condition is for handling consumer being removed after it consumed some entries.
+      // However, the second condition alone is not good enough as it's possible that in hash partitioning,
+      // only one consumer is keep consuming when the other consumer never proceed.
+      return consumedGroups == consumerConfig.getNumGroups()
+        || compareRowKey(result.get(0), consumerConfig.getSmallestStartRow()) < 0;
+    }
+
+    private int compareRowKey(Cell cell, byte[] row) {
+      return Bytes.compareTo(cell.getRowArray(), cell.getRowOffset() + prefixBytes,
+                             cell.getRowLength() - prefixBytes, row, 0, row.length);
+    }
+
+    /**
+     * Returns {@code true} if the given {@link KeyValue} has a {@link ConsumerEntryState#PROCESSED} state and
+     * also put the consumer information into the given {@link ConsumerInstance}.
+     * Otherwise, returns {@code false} and the {@link ConsumerInstance} is left untouched.
+     */
+    private boolean isProcessed(Cell cell, ConsumerInstance consumerInstance) {
+      int stateIdx = cell.getValueOffset() + cell.getValueLength() - 1;
+      boolean processed = cell.getValueArray()[stateIdx] == ConsumerEntryState.PROCESSED.getState();
+
+      if (processed) {
+        // Column is "s<groupId>"
+        long groupId = Bytes.toLong(cell.getQualifierArray(), cell.getQualifierOffset() + 1);
+        // Value is "<writePointer><instanceId><state>"
+        int instanceId = Bytes.toInt(cell.getValueArray(), cell.getValueOffset() + Bytes.SIZEOF_LONG);
+        consumerInstance.setGroupInstance(groupId, instanceId);
+      }
+      return processed;
+    }
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase12CDH570QueueConsumer.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase12CDH570QueueConsumer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.queue.QueueName;
+import co.cask.cdap.data2.transaction.queue.ConsumerEntryState;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import com.google.common.primitives.Ints;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.BinaryPrefixComparator;
+import org.apache.hadoop.hbase.filter.BitComparator;
+import org.apache.hadoop.hbase.filter.CompareFilter;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
+
+import java.util.Map;
+
+/**
+ * Implementation of {@link HBaseQueueConsumer} for CDH 5.7.0 version of HBase 1.2.x
+ */
+final class HBase12CDH570QueueConsumer extends HBaseQueueConsumer {
+  private final Filter processedStateFilter;
+
+  HBase12CDH570QueueConsumer(CConfiguration cConf, HTable hTable, QueueName queueName,
+                             HBaseConsumerState consumerState, HBaseConsumerStateStore stateStore,
+                             HBaseQueueStrategy queueStrategy) {
+    super(cConf, hTable, queueName, consumerState, stateStore, queueStrategy);
+    this.processedStateFilter = createStateFilter();
+  }
+
+  @Override
+  protected Scan createScan(byte[] startRow, byte[] stopRow, int numRows, Map<String, byte[]> attributes) {
+    // Scan the table for queue entries.
+    Scan scan = new Scan();
+    scan.setStartRow(startRow);
+    scan.setStopRow(stopRow);
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, QueueEntryRow.DATA_COLUMN);
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, QueueEntryRow.META_COLUMN);
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, stateColumnName);
+    scan.setFilter(createFilter());
+    scan.setMaxVersions(1);
+
+    for (Map.Entry<String, byte[]> entry : attributes.entrySet()) {
+      scan.setAttribute(entry.getKey(), entry.getValue());
+    }
+
+    return scan;
+  }
+
+  /**
+   * Creates a HBase filter that will filter out rows that that has committed state = PROCESSED.
+   */
+  private Filter createFilter() {
+    return new FilterList(FilterList.Operator.MUST_PASS_ONE, processedStateFilter, new SingleColumnValueFilter(
+      QueueEntryRow.COLUMN_FAMILY, stateColumnName, CompareFilter.CompareOp.GREATER,
+      new BinaryPrefixComparator(Bytes.toBytes(transaction.getReadPointer()))
+    ));
+  }
+
+  /**
+   * Creates a HBase filter that will filter out rows with state column state = PROCESSED (ignoring transaction).
+   */
+  private Filter createStateFilter() {
+    byte[] processedMask = new byte[Ints.BYTES * 2 + 1];
+    processedMask[processedMask.length - 1] = ConsumerEntryState.PROCESSED.getState();
+    return new SingleColumnValueFilter(QueueEntryRow.COLUMN_FAMILY, stateColumnName,
+                                       CompareFilter.CompareOp.NOT_EQUAL,
+                                       new BitComparator(processedMask, BitComparator.BitwiseOp.AND));
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase12CDH570QueueUtil.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase12CDH570QueueUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.queue.QueueName;
+import org.apache.hadoop.hbase.client.HTable;
+
+/**
+ * Implementation of {@link HBaseQueueUtil} for CDH 5.7.0 version of HBase 1.2.x
+ */
+public class HBase12CDH570QueueUtil extends HBaseQueueUtil {
+  @Override
+  public HBaseQueueConsumer getQueueConsumer(CConfiguration cConf,
+                                             HTable hTable, QueueName queueName,
+                                             HBaseConsumerState consumerState, HBaseConsumerStateStore stateStore,
+                                             HBaseQueueStrategy queueStrategy) {
+    return new HBase12CDH570QueueConsumer(cConf, hTable, queueName, consumerState, stateStore, queueStrategy);
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570DeleteBuilder.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570DeleteBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Delete;
+
+/**
+ * Implementation of {@link DeleteBuilder} for CDH 5.7.0 of HBase 1.2.x
+ */
+class HBase12CDH570DeleteBuilder extends DefaultDeleteBuilder {
+
+  HBase12CDH570DeleteBuilder(byte[] row) {
+    super(row);
+  }
+
+  HBase12CDH570DeleteBuilder(Delete delete) {
+    super(delete);
+  }
+
+  @Override
+  public DeleteBuilder setAttribute(String name, byte[] value) {
+    delete.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder setId(String id) {
+    delete.setId(id);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder setTimestamp(long timestamp) {
+    delete.setTimestamp(timestamp);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570GetBuilder.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570GetBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Get;
+
+/**
+ * Implementation of {@link GetBuilder} for CDH 5.7.0 version of HBase 1.2.x
+ */
+class HBase12CDH570GetBuilder extends DefaultGetBuilder {
+
+  HBase12CDH570GetBuilder(byte[] row) {
+    super(row);
+  }
+
+  HBase12CDH570GetBuilder(Get get) {
+    super(get);
+  }
+
+  @Override
+  public GetBuilder setCheckExistenceOnly(boolean checkExistenceOnly) {
+    get.setCheckExistenceOnly(checkExistenceOnly);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setClosestRowBefore(boolean closestRowBefore) {
+    get.setClosestRowBefore(closestRowBefore);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setAttribute(String name, byte[] value) {
+    get.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setCacheBlocks(boolean cacheBlocks) {
+    get.setCacheBlocks(cacheBlocks);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setId(String id) {
+    get.setId(id);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570HTableDescriptorBuilder.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570HTableDescriptorBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Implementation of {@link HTableDescriptorBuilder} for CDH 5.7.0 version of HBase 1.2.x
+ */
+public class HBase12CDH570HTableDescriptorBuilder extends HTableDescriptorBuilder {
+  HBase12CDH570HTableDescriptorBuilder(TableName tableName) {
+    super(tableName);
+  }
+
+  HBase12CDH570HTableDescriptorBuilder(HTableDescriptor descriptorToCopy) {
+    super(descriptorToCopy);
+  }
+
+  /* Methods whose signature changed in HBase 1.0 due to HBASE-10841 */
+  @Override
+  public HTableDescriptorBuilder setValue(byte[] key, byte[] value) {
+    instance.setValue(key, value);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder setValue(String key, String value) {
+    instance.setValue(key, value);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addFamily(HColumnDescriptor columnDescriptor) {
+    instance.addFamily(columnDescriptor);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addCoprocessor(String className) throws IOException {
+    instance.addCoprocessor(className);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addCoprocessor(String className, Path jarFilePath, int priority,
+                                                Map<String, String> keyValues) throws IOException {
+    instance.addCoprocessor(className, jarFilePath, priority, keyValues);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570PutBuilder.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570PutBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Put;
+
+/**
+ * Implementation of {@link PutBuilder} for CDH 5.7.0 version of HBase 1.2.x
+ */
+class HBase12CDH570PutBuilder extends DefaultPutBuilder {
+
+  HBase12CDH570PutBuilder(Put put) {
+    super(put);
+  }
+
+  HBase12CDH570PutBuilder(byte[] row) {
+    super(row);
+  }
+
+  @Override
+  public PutBuilder setAttribute(String name, byte[] value) {
+    put.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public PutBuilder setId(String id) {
+    put.setId(id);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570ScanBuilder.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570ScanBuilder.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.IsolationLevel;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.apache.hadoop.hbase.security.visibility.Authorizations;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Implementation of {@link ScanBuilder} for CDH 5.7.0 version of HBase 1.2.x
+ */
+class HBase12CDH570ScanBuilder extends DefaultScanBuilder {
+
+  HBase12CDH570ScanBuilder() {
+    super();
+  }
+
+  HBase12CDH570ScanBuilder(Scan other) throws IOException {
+    super(other);
+  }
+
+  @Override
+  public ScanBuilder setAttribute(String name, byte[] value) {
+    scan.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setId(String id) {
+    scan.setId(id);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setAuthorizations(Authorizations authorizations) {
+    scan.setAuthorizations(authorizations);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setACL(String user, Permission perms) {
+    scan.setACL(user, perms);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setACL(Map<String, Permission> perms) {
+    scan.setACL(perms);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setBatch(int batch) {
+    scan.setBatch(batch);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setCacheBlocks(boolean cacheBlocks) {
+    scan.setCacheBlocks(cacheBlocks);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setCaching(int caching) {
+    scan.setCaching(caching);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setIsolationLevel(IsolationLevel level) {
+    scan.setIsolationLevel(level);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setLoadColumnFamiliesOnDemand(boolean value) {
+    scan.setLoadColumnFamiliesOnDemand(value);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxResultSize(long maxResultSize) {
+    scan.setMaxResultSize(maxResultSize);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxResultsPerColumnFamily(int limit) {
+    scan.setMaxResultsPerColumnFamily(limit);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setRaw(boolean raw) {
+    scan.setRaw(raw);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setRowOffsetPerColumnFamily(int offset) {
+    scan.setRowOffsetPerColumnFamily(offset);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setSmall(boolean small) {
+    scan.setSmall(small);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.data2.increment.hbase12cdh570.IncrementHandler;
+import co.cask.cdap.data2.transaction.coprocessor.hbase12cdh570.DefaultTransactionProcessor;
+import co.cask.cdap.data2.transaction.queue.coprocessor.hbase12cdh570.DequeueScanObserver;
+import co.cask.cdap.data2.transaction.queue.coprocessor.hbase12cdh570.HBaseQueueRegionObserver;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.NamespaceNotFoundException;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.io.compress.Compression;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ *
+ */
+public class HBase12CDH570TableUtil extends HBaseTableUtil {
+
+  private final HTable12CDH570NameConverter nameConverter = new HTable12CDH570NameConverter();
+
+  @Override
+  public HTable createHTable(Configuration conf, TableId tableId) throws IOException {
+    Preconditions.checkArgument(tableId != null, "Table id should not be null");
+    return new HTable(conf, nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public HTableDescriptorBuilder buildHTableDescriptor(TableId tableId) {
+    Preconditions.checkArgument(tableId != null, "Table id should not be null");
+    return new HBase12CDH570HTableDescriptorBuilder(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public HTableDescriptorBuilder buildHTableDescriptor(HTableDescriptor descriptorToCopy) {
+    Preconditions.checkArgument(descriptorToCopy != null, "Table descriptor should not be null");
+    return new HBase12CDH570HTableDescriptorBuilder(descriptorToCopy);
+  }
+
+  @Override
+  public HTableDescriptor getHTableDescriptor(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    return admin.getTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public boolean hasNamespace(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    try {
+      admin.getNamespaceDescriptor(nameConverter.toHBaseNamespace(tablePrefix, namespace));
+      return true;
+    } catch (NamespaceNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public void createNamespaceIfNotExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    if (!hasNamespace(admin, namespace)) {
+      NamespaceDescriptor namespaceDescriptor =
+        NamespaceDescriptor.create(nameConverter.toHBaseNamespace(tablePrefix, namespace)).build();
+      admin.createNamespace(namespaceDescriptor);
+    }
+  }
+
+  @Override
+  public void deleteNamespaceIfExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    if (hasNamespace(admin, namespace)) {
+      admin.deleteNamespace(nameConverter.toHBaseNamespace(tablePrefix, namespace));
+    }
+  }
+
+  @Override
+  public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public void modifyTable(HBaseAdmin admin, HTableDescriptor tableDescriptor) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
+    admin.modifyTable(tableDescriptor.getTableName(), tableDescriptor);
+  }
+
+  @Override
+  public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    return admin.getTableRegions(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public List<TableId> listTablesInNamespace(HBaseAdmin admin, Id.Namespace namespaceId) throws IOException {
+    List<TableId> tableIds = Lists.newArrayList();
+    HTableDescriptor[] hTableDescriptors =
+      admin.listTableDescriptorsByNamespace(nameConverter.toHBaseNamespace(tablePrefix, namespaceId));
+    for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
+      if (isCDAPTable(hTableDescriptor)) {
+        tableIds.add(nameConverter.from(hTableDescriptor));
+      }
+    }
+    return tableIds;
+  }
+
+  @Override
+  public List<TableId> listTables(HBaseAdmin admin) throws IOException {
+    List<TableId> tableIds = Lists.newArrayList();
+    HTableDescriptor[] hTableDescriptors = admin.listTables();
+    for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
+      if (isCDAPTable(hTableDescriptor)) {
+        tableIds.add(nameConverter.from(hTableDescriptor));
+      }
+    }
+    return tableIds;
+  }
+
+  @Override
+  public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
+    switch (type) {
+      case LZO:
+        columnDescriptor.setCompressionType(Compression.Algorithm.LZO);
+        break;
+      case SNAPPY:
+        columnDescriptor.setCompressionType(Compression.Algorithm.SNAPPY);
+        break;
+      case GZIP:
+        columnDescriptor.setCompressionType(Compression.Algorithm.GZ);
+        break;
+      case NONE:
+        columnDescriptor.setCompressionType(Compression.Algorithm.NONE);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported compression type: " + type);
+    }
+  }
+
+  @Override
+  public void setBloomFilter(HColumnDescriptor columnDescriptor, BloomType type) {
+    switch (type) {
+      case ROW:
+        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROW);
+        break;
+      case ROWCOL:
+        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROWCOL);
+        break;
+      case NONE:
+        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.NONE);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
+    }
+  }
+
+  @Override
+  public CompressionType getCompression(HColumnDescriptor columnDescriptor) {
+    Compression.Algorithm type = columnDescriptor.getCompressionType();
+    switch (type) {
+      case LZO:
+        return CompressionType.LZO;
+      case SNAPPY:
+        return CompressionType.SNAPPY;
+      case GZ:
+        return CompressionType.GZIP;
+      case NONE:
+        return CompressionType.NONE;
+      default:
+        throw new IllegalArgumentException("Unsupported compression type: " + type);
+    }
+  }
+
+  @Override
+  public BloomType getBloomFilter(HColumnDescriptor columnDescriptor) {
+    org.apache.hadoop.hbase.regionserver.BloomType type = columnDescriptor.getBloomFilterType();
+    switch (type) {
+      case ROW:
+        return BloomType.ROW;
+      case ROWCOL:
+        return BloomType.ROWCOL;
+      case NONE:
+        return BloomType.NONE;
+      default:
+        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
+    }
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getTransactionDataJanitorClassForVersion() {
+    return DefaultTransactionProcessor.class;
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getQueueRegionObserverClassForVersion() {
+    return HBaseQueueRegionObserver.class;
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getDequeueScanObserverClassForVersion() {
+    return DequeueScanObserver.class;
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getIncrementHandlerClassForVersion() {
+    return IncrementHandler.class;
+  }
+
+  @Override
+  protected HTableNameConverter getHTableNameConverter() {
+    return nameConverter;
+  }
+
+  @Override
+  public ScanBuilder buildScan() {
+    return new HBase12CDH570ScanBuilder();
+  }
+
+  @Override
+  public ScanBuilder buildScan(Scan scan) throws IOException {
+    return new HBase12CDH570ScanBuilder(scan);
+  }
+
+  @Override
+  public PutBuilder buildPut(byte[] row) {
+    return new HBase12CDH570PutBuilder(row);
+  }
+
+  @Override
+  public PutBuilder buildPut(Put put) {
+    return new HBase12CDH570PutBuilder(put);
+  }
+
+  @Override
+  public GetBuilder buildGet(byte[] row) {
+    return new HBase12CDH570GetBuilder(row);
+  }
+
+  @Override
+  public GetBuilder buildGet(Get get) {
+    return new HBase12CDH570GetBuilder(get);
+  }
+
+  @Override
+  public DeleteBuilder buildDelete(byte[] row) {
+    return new HBase12CDH570DeleteBuilder(row);
+  }
+
+  @Override
+  public DeleteBuilder buildDelete(Delete delete) {
+    return new HBase12CDH570DeleteBuilder(delete);
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HTable12CDH570NameConverter.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HTable12CDH570NameConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.proto.Id;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+
+/**
+ * Utility methods for dealing with HBase table name conversions in CDH 5.7.0 version of HBase 1.2.x
+ */
+public class HTable12CDH570NameConverter extends HTableNameConverter {
+
+  @Override
+  public String getSysConfigTablePrefix(HTableDescriptor htd) {
+    return getNamespacePrefix(htd) + "_" + Id.Namespace.SYSTEM.getId() + ":";
+  }
+
+  @Override
+  public TableId from(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getTableName()).getTableId();
+  }
+
+  @Override
+  public String getNamespacePrefix(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getTableName()).getTablePrefix();
+  }
+
+  public TableName toTableName(String tablePrefix, TableId tableId) {
+    return TableName.valueOf(toHBaseNamespace(tablePrefix, tableId.getNamespace()),
+                             getHBaseTableName(tablePrefix, tableId));
+  }
+
+  private PrefixedTableId prefixedTableIdFromTableName(TableName tableName) {
+    return fromHBaseTableName(tableName.getNamespaceAsString(), tableName.getQualifierAsString());
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data/hbase/HBase12CDH570Test.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data/hbase/HBase12CDH570Test.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.hbase;
+
+import com.google.common.base.Function;
+import com.google.common.base.Throwables;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.MiniHBaseCluster;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.Region;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.JVMClusterUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * {@link HBaseTestBase} implementation supporting HBase 1.1.
+ */
+public class HBase12CDH570Test extends HBaseTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(HBase12CDH570Test.class);
+
+  protected HBaseTestingUtility testUtil = new HBaseTestingUtility();
+
+  @Override
+  public Configuration getConfiguration() {
+    return testUtil.getConfiguration();
+  }
+
+  @Override
+  public int getZKClientPort() {
+    return testUtil.getZkCluster().getClientPort();
+  }
+
+  @Override
+  public void doStartHBase() throws Exception {
+    testUtil.startMiniCluster();
+  }
+
+  @Override
+  public void stopHBase() throws Exception {
+    testUtil.shutdownMiniCluster();
+  }
+
+  @Override
+  public MiniHBaseCluster getHBaseCluster() {
+    return testUtil.getHBaseCluster();
+  }
+
+  @Override
+  public HRegion createHRegion(byte[] tableName, byte[] startKey,
+                               byte[] stopKey, String callingMethod, Configuration conf,
+                               byte[]... families)
+      throws IOException {
+    if (conf == null) {
+      conf = new Configuration();
+    }
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (byte [] family : families) {
+      htd.addFamily(new HColumnDescriptor(family));
+    }
+    HRegionInfo info = new HRegionInfo(htd.getTableName(), startKey, stopKey, false);
+    Path path = new Path(conf.get(HConstants.HBASE_DIR), callingMethod);
+    FileSystem fs = FileSystem.get(conf);
+    if (fs.exists(path)) {
+      if (!fs.delete(path, true)) {
+        throw new IOException("Failed delete of " + path);
+      }
+    }
+    return HRegion.createHRegion(info, path, conf, htd);
+  }
+
+  @Override
+  public <T> Map<byte[], T> forEachRegion(byte[] tableName, Function<HRegion, T> function) {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
+    Map<byte[], T> results = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+    // make sure consumer config cache is updated
+    for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
+      List<Region> serverRegions = t.getRegionServer().getOnlineRegions(TableName.valueOf(tableName));
+      for (Region region : serverRegions) {
+        results.put(region.getRegionInfo().getRegionName(), function.apply((HRegion) region));
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public void waitUntilTableAvailable(byte[] tableName, long timeoutInMillis)
+      throws IOException, InterruptedException {
+    testUtil.waitTableAvailable(tableName, timeoutInMillis);
+    testUtil.waitUntilAllRegionsAssigned(TableName.valueOf(tableName), timeoutInMillis);
+  }
+
+  @Override
+  public Runnable createFlushRegion(final HRegion region) {
+    return new Runnable() {
+      @Override
+      public void run() {
+        try {
+          region.flushcache(true, false);
+        } catch (IOException e) {
+          throw Throwables.propagate(e);
+        }
+      }
+    };
+  }
+
+  @Override
+  public Runnable createCompactRegion(final HRegion region, final boolean majorCompact) {
+    return new Runnable() {
+      @Override
+      public void run() {
+        try {
+          region.compact(majorCompact);
+        } catch (IOException e) {
+          throw Throwables.propagate(e);
+        }
+      }
+    };
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementHandlerTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase12cdh570;
+
+import co.cask.cdap.data2.increment.hbase.AbstractIncrementHandlerTest;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.increment.hbase.TimestampOracle;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
+import co.cask.cdap.test.SlowTests;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for the HBase 1.1 version of the {@link IncrementHandler} coprocessor.
+ */
+@Category(SlowTests.class)
+public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
+
+  @Override
+  public void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception {
+    Result res = table.get(new Get(row));
+    Cell resA = res.getColumnLatestCell(FAMILY, col);
+    assertFalse(res.isEmpty());
+    assertNotNull(resA);
+    assertEquals(expected, Bytes.toLong(resA.getValue()));
+
+    Scan scan = new Scan(row);
+    scan.addFamily(FAMILY);
+    ResultScanner scanner = table.getScanner(scan);
+    Result scanRes = scanner.next();
+    assertNotNull(scanRes);
+    assertFalse(scanRes.isEmpty());
+    Cell scanResA = scanRes.getColumnLatestCell(FAMILY, col);
+    assertArrayEquals(row, scanResA.getRow());
+    assertEquals(expected, Bytes.toLong(scanResA.getValue()));
+  }
+
+  public void assertColumns(HTable table, byte[] row, byte[][] cols, long[] expected) throws Exception {
+    assertEquals(cols.length, expected.length);
+
+    Get get = new Get(row);
+    Scan scan = new Scan(row);
+    for (byte[] col : cols) {
+      get.addColumn(FAMILY, col);
+      scan.addColumn(FAMILY, col);
+    }
+
+    // check get
+    Result res = table.get(get);
+    assertFalse(res.isEmpty());
+    for (int i = 0; i < cols.length; i++) {
+      Cell resCell = res.getColumnLatestCell(FAMILY, cols[i]);
+      assertNotNull(resCell);
+      assertEquals(expected[i], Bytes.toLong(resCell.getValue()));
+    }
+
+    // check scan
+    ResultScanner scanner = table.getScanner(scan);
+    Result scanRes = scanner.next();
+    assertNotNull(scanRes);
+    assertFalse(scanRes.isEmpty());
+    for (int i = 0; i < cols.length; i++) {
+      Cell scanResCell = scanRes.getColumnLatestCell(FAMILY, cols[i]);
+      assertArrayEquals(row, scanResCell.getRow());
+      assertEquals(expected[i], Bytes.toLong(scanResCell.getValue()));
+    }
+  }
+
+  @Override
+  public HTable createTable(TableId tableId) throws Exception {
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableDescriptorBuilder tableDesc = tableUtil.buildHTableDescriptor(tableId);
+    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");
+    tableDesc.addFamily(columnDesc);
+    tableDesc.addCoprocessor(IncrementHandler.class.getName());
+    HTableDescriptor htd = tableDesc.build();
+    TEST_HBASE.getHBaseAdmin().createTable(htd);
+    TEST_HBASE.waitUntilTableAvailable(htd.getName(), 5000);
+    return tableUtil.createHTable(conf, tableId);
+  }
+
+  @Override
+  public RegionWrapper createRegion(TableId tableId, Map<String, String> familyProperties) throws Exception {
+    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    for (Map.Entry<String, String> prop : familyProperties.entrySet()) {
+      columnDesc.setValue(prop.getKey(), prop.getValue());
+    }
+    return new HBase98RegionWrapper(
+        IncrementSummingScannerTest.createRegion(TEST_HBASE.getConfiguration(), cConf, tableId, columnDesc));
+  }
+
+  public static ColumnCell convertCell(Cell cell) {
+    return new ColumnCell(CellUtil.cloneRow(cell), CellUtil.cloneFamily(cell), CellUtil.cloneQualifier(cell),
+        cell.getTimestamp(), CellUtil.cloneValue(cell));
+  }
+
+  public class HBase98RegionWrapper implements RegionWrapper {
+    private final HRegion region;
+
+    public HBase98RegionWrapper(HRegion region) {
+      this.region = region;
+    }
+
+    @Override
+    public void initialize() throws IOException {
+      region.initialize();
+    }
+
+    @Override
+    public void put(Put put) throws IOException {
+      region.put(put);
+    }
+
+    @Override
+    public boolean scanRegion(List<ColumnCell> results, byte[] startRow) throws IOException {
+      return scanRegion(results, startRow, null);
+    }
+
+    @Override
+    public boolean scanRegion(List<ColumnCell> results, byte[] startRow, byte[][] columns) throws IOException {
+      Scan scan = new Scan().setMaxVersions().setStartRow(startRow);
+      if (columns != null) {
+        for (int i = 0; i < columns.length; i++) {
+          scan.addColumn(FAMILY, columns[i]);
+        }
+      }
+      RegionScanner rs = region.getScanner(scan);
+      try {
+        List<Cell> tmpResults = new ArrayList<>();
+        boolean hasMore = rs.next(tmpResults);
+        for (Cell cell : tmpResults) {
+          results.add(convertCell(cell));
+        }
+        return hasMore;
+      } finally {
+        rs.close();
+      }
+    }
+
+    @Override
+    public boolean flush() throws IOException {
+      // we flush all stores and don't write flush request marker to WAL. This mimics the flush behavior which we
+      // have in older versions.
+      HRegion.FlushResult result = region.flushcache(true, false);
+      return result.isCompactionNeeded();
+    }
+
+    @Override
+    public void compact(boolean majorCompact) throws IOException {
+      region.compact(majorCompact);
+    }
+
+    @Override
+    public void setCoprocessorTimestampOracle(TimestampOracle timeOracle) {
+      Coprocessor cp = region.getCoprocessorHost().findCoprocessor(IncrementHandler.class.getName());
+      assertNotNull(cp);
+      ((IncrementHandler) cp).setTimestampOracle(timeOracle);
+    }
+
+    @Override
+    public void close() throws IOException {
+      region.close();
+    }
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementSummingScannerTest.java
@@ -1,0 +1,606 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase12cdh570;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data.hbase.HBase12CDH570Test;
+import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.MockRegionServerServices;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.ScannerContext;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.wal.WAL;
+import org.apache.hadoop.hbase.wal.WALFactory;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link IncrementSummingScanner} implementation.
+ */
+public class IncrementSummingScannerTest {
+
+  @ClassRule
+  public static final HBase12CDH570Test TEST_HBASE = new HBase12CDH570Test();
+
+  private static final byte[] TRUE = Bytes.toBytes(true);
+  private static Configuration conf;
+  private static CConfiguration cConf;
+
+  @BeforeClass
+  public static void setupBeforeClass() throws Exception {
+    conf = TEST_HBASE.getConfiguration();
+    cConf = CConfiguration.create();
+  }
+
+  @Test
+  public void testIncrementScanning() throws Exception {
+    TableId tableId = TableId.from(Id.Namespace.DEFAULT, "TestIncrementSummingScanner");
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c");
+    HRegion region = createRegion(tableId, familyBytes);
+    try {
+      region.initialize();
+
+      // test handling of a single increment value alone
+      Put p = new Put(Bytes.toBytes("r1"));
+      p.add(familyBytes, columnBytes, Bytes.toBytes(3L));
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      Scan scan = new Scan();
+      RegionScanner scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      List<Cell> results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      Cell cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(3L, Bytes.toLong(cell.getValue()));
+
+      // test handling of a single total sum
+      p = new Put(Bytes.toBytes("r2"));
+      p.add(familyBytes, columnBytes, Bytes.toBytes(5L));
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r2"));
+
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(5L, Bytes.toLong(cell.getValue()));
+
+      // test handling of multiple increment values
+      long now = System.currentTimeMillis();
+      p = new Put(Bytes.toBytes("r3"));
+      for (int i = 0; i < 5; i++) {
+        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes((long) (i + 1)));
+      }
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r3"));
+      scan.setMaxVersions();
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(15L, Bytes.toLong(cell.getValue()));
+
+      // test handling of multiple increment values followed by a total sum, then other increments
+      now = System.currentTimeMillis();
+      p = new Put(Bytes.toBytes("r4"));
+      for (int i = 0; i < 3; i++) {
+        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
+      }
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      // this put will appear as a "total" sum prior to all the delta puts
+      p = new Put(Bytes.toBytes("r4"));
+      p.add(familyBytes, columnBytes, now - 5, Bytes.toBytes(5L));
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r4"));
+      scan.setMaxVersions();
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(8L, Bytes.toLong(cell.getValue()));
+
+      // test handling of an increment column followed by a non-increment column
+      p = new Put(Bytes.toBytes("r4"));
+      p.add(familyBytes, Bytes.toBytes("c2"), Bytes.toBytes("value"));
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r4"));
+      scan.setMaxVersions();
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(2, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(8L, Bytes.toLong(cell.getValue()));
+
+      cell = results.get(1);
+      assertNotNull(cell);
+      assertEquals("value", Bytes.toString(cell.getValue()));
+
+      // test handling of an increment column followed by a delete
+      now = System.currentTimeMillis();
+      Delete d = new Delete(Bytes.toBytes("r5"));
+      d.deleteColumn(familyBytes, columnBytes, now - 3);
+      region.delete(d);
+
+      p = new Put(Bytes.toBytes("r5"));
+      for (int i = 2; i >= 0; i--) {
+        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
+      }
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r5"));
+      scan.setMaxVersions();
+      scan.setRaw(true);
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.COMPACT_RETAIN_DELETES);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      // delete marker will not be returned for user scan
+      assertEquals(2, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(3L, Bytes.toLong(cell.getValue(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length, 8));
+      // next cell should be the delete
+      cell = results.get(1);
+      assertTrue(CellUtil.isDelete(cell));
+    } finally {
+      region.close();
+    }
+
+  }
+
+  @Test
+  public void testFlushAndCompact() throws Exception {
+    TableId tableId = TableId.from(Id.Namespace.DEFAULT, "TestFlushAndCompact");
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c");
+    HRegion region = createRegion(tableId, familyBytes);
+    try {
+      region.initialize();
+
+      // load an initial set of increments
+      long ts = System.currentTimeMillis();
+      byte[] row1 = Bytes.toBytes("row1");
+      for (int i = 0; i < 50; i++) {
+        Put p = new Put(row1);
+        p.add(familyBytes, columnBytes, ts, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        ts++;
+        region.put(p);
+      }
+
+      byte[] row2 = Bytes.toBytes("row2");
+      ts = System.currentTimeMillis();
+      // start with a full put
+      Put row2P = new Put(row2);
+      row2P.add(familyBytes, columnBytes, ts++, Bytes.toBytes(10L));
+      region.put(row2P);
+      for (int i = 0; i < 10; i++) {
+        Put p = new Put(row2);
+        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+      }
+
+      // force a region flush
+      region.flushcache(true, false);
+      region.waitForFlushesAndCompactions();
+
+      Result r1 = region.get(new Get(row1));
+      assertNotNull(r1);
+      assertFalse(r1.isEmpty());
+      // row1 should have a full put aggregating all 50 incrments
+      Cell r1Cell = r1.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r1Cell);
+      assertEquals(50L, Bytes.toLong(r1Cell.getValue()));
+
+      Result r2 = region.get(new Get(row2));
+      assertNotNull(r2);
+      assertFalse(r2.isEmpty());
+      // row2 should have a full put aggregating prior put + 10 increments
+      Cell r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r2Cell);
+      assertEquals(20L, Bytes.toLong(r2Cell.getValue()));
+
+      // add 30 more increments to row2
+      for (int i = 0; i < 30; i++) {
+        Put p = new Put(row2);
+        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+      }
+
+      // row2 should now have a full put aggregating prior 20 value + 30 increments
+      r2 = region.get(new Get(row2));
+      assertNotNull(r2);
+      assertFalse(r2.isEmpty());
+      r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r2Cell);
+      assertEquals(50L, Bytes.toLong(r2Cell.getValue()));
+
+      // force another region flush
+      region.flushcache(true, false);
+      region.waitForFlushesAndCompactions();
+
+      // add 100 more increments to row2
+      for (int i = 0; i < 100; i++) {
+        Put p = new Put(row2);
+        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+      }
+
+      // row2 should now have a full put aggregating prior 50 value + 100 increments
+      r2 = region.get(new Get(row2));
+      assertNotNull(r2);
+      assertFalse(r2.isEmpty());
+      r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r2Cell);
+      assertEquals(150L, Bytes.toLong(r2Cell.getValue()));
+    } finally {
+      region.close();
+    }
+  }
+
+  @Test
+  public void testWithBatchLimit() throws Exception {
+    TableId tableId = TableId.from(Id.Namespace.DEFAULT, "testWithBatchLimit");
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c2");
+
+    HRegion region = createRegion(tableId, familyBytes);
+    try {
+      region.initialize();
+      long now = System.currentTimeMillis();
+      // put a non increment columns
+      Put p = new Put(Bytes.toBytes("r4"));
+      p.add(familyBytes, Bytes.toBytes("c1"), Bytes.toBytes("value1"));
+      region.put(p);
+
+      // now put some increment deltas in a column
+      p = new Put(Bytes.toBytes("r4"));
+      for (int i = 0; i < 3; i++) {
+        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
+      }
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      // put some non - increment columns
+      p = new Put(Bytes.toBytes("r4"));
+      p.add(familyBytes, Bytes.toBytes("c3"), Bytes.toBytes("value3"));
+      region.put(p);
+
+      p = new Put(Bytes.toBytes("r4"));
+      p.add(familyBytes, Bytes.toBytes("c4"), Bytes.toBytes("value4"));
+      region.put(p);
+
+      p = new Put(Bytes.toBytes("r4"));
+      p.add(familyBytes, Bytes.toBytes("c5"), Bytes.toBytes("value5"));
+      region.put(p);
+
+      // this put will appear as a "total" sum prior to all the delta puts
+      p = new Put(Bytes.toBytes("r4"));
+      p.add(familyBytes, columnBytes, now - 5, Bytes.toBytes(5L));
+      region.put(p);
+
+      Scan scan = new Scan(Bytes.toBytes("r4"));
+      scan.setMaxVersions();
+      RegionScanner scanner = new IncrementSummingScanner(region, 3, region.getScanner(scan), ScanType.USER_SCAN);
+      List<Cell> results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(3, results.size());
+      Cell cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals("value1", Bytes.toString(cell.getValue()));
+      cell = results.get(1);
+      assertNotNull(cell);
+      assertEquals(8L, Bytes.toLong(cell.getValue()));
+      cell = results.get(2);
+      assertNotNull(cell);
+      assertEquals("value3", Bytes.toString(cell.getValue()));
+    } finally {
+      region.close();
+    }
+  }
+
+  @Test
+  public void testMultiColumnFlushAndCompact() throws Exception {
+    TableId tableId = TableId.from(Id.Namespace.DEFAULT, "testMultiColumnFlushAndCompact");
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c");
+    byte[] columnBytes2 = Bytes.toBytes("c2");
+    HRegion region = createRegion(tableId, familyBytes);
+    try {
+      region.initialize();
+
+      long now = 1;
+      byte[] row1 = Bytes.toBytes("row1");
+      byte[] row2 = Bytes.toBytes("row2");
+
+      // Initial put to row1,c2
+      Put row1P = new Put(row1);
+      row1P.add(familyBytes, columnBytes2, now - 1, Bytes.toBytes(5L));
+      region.put(row1P);
+
+      // Initial put to row2,c
+      Put row2P = new Put(row2);
+      row2P.add(familyBytes, columnBytes, now - 1, Bytes.toBytes(10L));
+      region.put(row2P);
+
+      // Generate some increments
+      long ts = now;
+      for (int i = 0; i < 50; i++) {
+        region.put(generateIncrementPut(familyBytes, columnBytes, row1, ts));
+        region.put(generateIncrementPut(familyBytes, columnBytes, row2, ts));
+        region.put(generateIncrementPut(familyBytes, columnBytes2, row1, ts));
+        ts++;
+      }
+
+      // First scanner represents flush scanner
+      RegionScanner scanner =
+        new IncrementSummingScanner(region, -1, region.getScanner(new Scan().setMaxVersions()),
+                                    ScanType.COMPACT_RETAIN_DELETES, now + 15, -1);
+      // Second scanner is a user scan, this is to help in easy asserts
+      scanner = new IncrementSummingScanner(region, -1, scanner, ScanType.USER_SCAN);
+
+      List<Cell> results = Lists.newArrayList();
+      assertTrue(scanner.next(results, ScannerContext.newBuilder().setBatchLimit(10).build()));
+      assertEquals(2, results.size());
+      Cell cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals("row1", Bytes.toString(cell.getRow()));
+      assertEquals("c", Bytes.toString(cell.getQualifier()));
+      assertEquals(50, Bytes.toLong(cell.getValue()));
+
+      cell = results.get(1);
+      assertNotNull(cell);
+      assertEquals("row1", Bytes.toString(cell.getRow()));
+      assertEquals("c2", Bytes.toString(cell.getQualifier()));
+      assertEquals(55, Bytes.toLong(cell.getValue()));
+
+      results.clear();
+      assertFalse(scanner.next(results, ScannerContext.newBuilder().setBatchLimit(10).build()));
+      assertEquals(1, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals("row2", Bytes.toString(cell.getRow()));
+      assertEquals(60, Bytes.toLong(cell.getValue()));
+    } finally {
+      region.close();
+    }
+  }
+
+  @Test
+  public void testIncrementScanningWithBatchAndUVB() throws Exception {
+    TableId tableId = TableId.from(Id.Namespace.DEFAULT, "TestIncrementSummingScannerWithUpperVisibilityBound");
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c");
+    HRegion region = createRegion(tableId, familyBytes);
+    try {
+      region.initialize();
+
+      long start = 0;
+      long now = start;
+      long counter1 = 0;
+
+      // adding 5 delta increments
+      for (int i = 0; i < 5; i++) {
+        Put p = new Put(Bytes.toBytes("r1"), now++);
+        p.add(familyBytes, columnBytes, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+        counter1++;
+      }
+
+      // different combinations of uvb and limit (see batch test above)
+      // At least these cases we want to cover for batch:
+      // * batch=<not set> // unlimited by default
+      // * batch=1
+      // * batch size less than delta inc group size
+      // * batch size greater than delta inc group size
+      // * batch size is bigger than all delta incs available
+      // At least these cases we want to cover for uvb:
+      // * uvb=<not set> // 0
+      // * uvb less than max tx of delta inc
+      // * uvb greater than max tx of delta inc
+      // * multiple uvbs applied to simulate multiple flush & compactions
+      // Also: we want different combinations of batch limit & uvbs
+      for (int i = 0; i < 7; i++) {
+        for (int k = 0; k < 4; k++) {
+          long[] uvbs = new long[k];
+          for (int l = 0; l < uvbs.length; l++) {
+            uvbs[l] = start + (k + 1) * (l + 1);
+          }
+          verifyCounts(region, new Scan().setMaxVersions(), new long[]{counter1}, i > 0 ? i : -1, uvbs);
+        }
+      }
+
+      // Now test same with two groups of increments
+      int counter2 = 0;
+      for (int i = 0; i < 5; i++) {
+        Put p = new Put(Bytes.toBytes("r2"), now + i);
+        p.add(familyBytes, columnBytes, Bytes.toBytes(2L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+        counter2 += 2;
+      }
+
+      for (int i = 0; i < 12; i++) {
+        for (int k = 0; k < 4; k++) {
+          long[] uvbs = new long[k];
+          for (int l = 0; l < uvbs.length; l++) {
+            uvbs[l] = start + (k + 1) * (l + 1);
+          }
+          verifyCounts(region, new Scan().setMaxVersions(), new long[]{counter1, counter2}, i > 0 ? i : -1, uvbs);
+        }
+      }
+
+    } finally {
+      region.close();
+    }
+  }
+
+  private Put generateIncrementPut(byte[] familyBytes, byte[] columnBytes, byte [] row, long ts) {
+    Put p = new Put(row);
+    p.add(familyBytes, columnBytes, ts, Bytes.toBytes(1L));
+    p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+    return p;
+  }
+
+  private void verifyCounts(HRegion region, Scan scan, long[] counts) throws Exception {
+    verifyCounts(region, scan, counts, -1);
+  }
+
+  private void verifyCounts(HRegion region, Scan scan, long[] counts, int batch) throws Exception {
+    RegionScanner scanner = new IncrementSummingScanner(region, batch, region.getScanner(scan), ScanType.USER_SCAN);
+    // init with false if loop will execute zero times
+    boolean hasMore = counts.length > 0;
+    for (long count : counts) {
+      List<Cell> results = Lists.newArrayList();
+      hasMore = scanner.next(results);
+      assertEquals(1, results.size());
+      Cell cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(count, Bytes.toLong(cell.getValue()));
+    }
+    assertFalse(hasMore);
+  }
+
+  private void verifyCounts(HRegion region, Scan scan, long[] counts, int batch, long[] upperVisBound)
+      throws Exception {
+    // The idea is to chain IncrementSummingScanner: first couple respect the upperVisBound and may produce multiple
+    // cells for single value. This is what happens during flush or compaction. Second one will mimic user scan over
+    // flushed or compacted: it should merge all delta increments appropriately.
+    RegionScanner scanner = region.getScanner(scan);
+
+    for (int i = 0; i < upperVisBound.length; i++) {
+      scanner = new IncrementSummingScanner(region, batch, scanner,
+          ScanType.COMPACT_RETAIN_DELETES, upperVisBound[i], -1);
+    }
+    scanner = new IncrementSummingScanner(region, batch, scanner, ScanType.USER_SCAN);
+    // init with false if loop will execute zero times
+    boolean hasMore = counts.length > 0;
+    for (long count : counts) {
+      List<Cell> results = Lists.newArrayList();
+      hasMore = scanner.next(results);
+      assertEquals(1, results.size());
+      Cell cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(count, Bytes.toLong(cell.getValue()));
+    }
+    assertFalse(hasMore);
+  }
+
+  private HRegion createRegion(TableId tableId, byte[] family) throws Exception {
+    return createRegion(conf, cConf, tableId, new HColumnDescriptor(family));
+  }
+
+  static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
+                              HColumnDescriptor cfd) throws Exception {
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(tableId);
+    cfd.setMaxVersions(Integer.MAX_VALUE);
+    cfd.setKeepDeletedCells(true);
+    htd.addFamily(cfd);
+    htd.addCoprocessor(IncrementHandler.class.getName());
+
+    HTableDescriptor desc = htd.build();
+    String tableName = desc.getNameAsString();
+    Path tablePath = new Path("/tmp/" + tableName);
+    Path hlogPath = new Path("/tmp/hlog-" + tableName);
+    FileSystem fs = FileSystem.get(hConf);
+    assertTrue(fs.mkdirs(tablePath));
+    WALFactory walFactory = new WALFactory(hConf, null, hlogPath.toString());
+    WAL hLog = walFactory.getWAL(new byte[]{1});
+    HRegionInfo regionInfo = new HRegionInfo(desc.getTableName());
+    HRegionFileSystem regionFS = HRegionFileSystem.createRegionOnFileSystem(hConf, fs, tablePath, regionInfo);
+    return new HRegion(regionFS, hLog, hConf, desc,
+                       new LocalRegionServerServices(hConf, ServerName.valueOf(
+                           InetAddress.getLocalHost().getHostName(), 0, System.currentTimeMillis())));
+  }
+
+  private static class LocalRegionServerServices extends MockRegionServerServices {
+    private final ServerName serverName;
+
+    public LocalRegionServerServices(Configuration conf, ServerName serverName) {
+      super(conf);
+      this.serverName = serverName;
+    }
+
+    @Override
+    public ServerName getServerName() {
+      return serverName;
+    }
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase12CDH570QueueTest.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase12CDH570QueueTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase;
+
+import co.cask.cdap.test.XSlowTests;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Queue test implementation running on HBase 1.2 (CDH).
+ */
+@Category(XSlowTests.class)
+public class HBase12CDH570QueueTest extends HBaseQueueTest {
+  // nothing to override
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtilTest.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtilTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.test.XSlowTests;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import org.junit.experimental.categories.Category;
+
+/**
+ *
+ */
+@Category(XSlowTests.class)
+public class HBase12CDH570TableUtilTest extends AbstractHBaseTableUtilTest {
+
+  private final HTableNameConverter nameConverter = new HTable12CDH570NameConverter();
+
+  @Override
+  protected HBaseTableUtil getTableUtil() {
+    HBase12CDH570TableUtil hBaseTableUtil = new HBase12CDH570TableUtil();
+    hBaseTableUtil.setCConf(cConf);
+    return hBaseTableUtil;
+  }
+
+  @Override
+  protected HTableNameConverter getNameConverter() {
+    return nameConverter;
+  }
+
+  @Override
+  protected String getTableNameAsString(TableId tableId) {
+    Preconditions.checkArgument(tableId != null, "TableId should not be null.");
+    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+    if (Id.Namespace.DEFAULT.equals(tableId.getNamespace())) {
+      return nameConverter.getHBaseTableName(tablePrefix, tableId);
+    }
+    return Joiner.on(':').join(nameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()),
+                               nameConverter.getHBaseTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  protected boolean namespacesSupported() {
+    return true;
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/util/hbase/HTable12CDH570NameConverterTest.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/util/hbase/HTable12CDH570NameConverterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.proto.Id;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HTable12CDH570NameConverterTest {
+  @Test
+  public void testGetSysConfigTablePrefix() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
+
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(TableId.from("user", "some_table"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
+    htd = tableUtil.buildHTableDescriptor(TableId.from(Id.Namespace.DEFAULT, "table_in_default_ns"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
+  }
+}

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -187,7 +187,8 @@
       <properties>
         <package.depends>--depends cdap --depends cdap-hbase-compat-0.96 --depends cdap-hbase-compat-0.98
         --depends cdap-hbase-compat-1.0 --depends cdap-hbase-compat-1.0-cdh
-        --depends cdap-hbase-compat-1.1 --depends cdap-hbase-compat-1.0-cdh5.5.0</package.depends>
+        --depends cdap-hbase-compat-1.1 --depends cdap-hbase-compat-1.0-cdh5.5.0
+        --depends cdap-hbase-compat-1.2-cdh5.7.0</package.depends>
         <stage.artifacts.dir>${stage.opt.dir}/artifacts</stage.artifacts.dir>
         <stage.runtime.ext.dir>${stage.opt.dir}/ext/runtimes</stage.runtime.ext.dir>
         <additional.artifacts.jar.pattern>**/target/*.jar</additional.artifacts.jar.pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
     <hbase10cdh550.version>1.0.0-cdh5.5.0</hbase10cdh550.version>
     <hbase10.version>1.0.1.1</hbase10.version>
     <hbase11.version>1.1.1</hbase11.version>
+    <hbase12cdh570.version>1.2.0-cdh5.7.0</hbase12cdh570.version>
     <hive.version>1.1.0</hive.version>
     <hsql.version>2.2.4</hsql.version>
     <http.component.version>4.2.5</http.component.version>
@@ -131,7 +132,7 @@
     <snappy.version>1.1.1.7</snappy.version>
     <shiro.version>1.2.1</shiro.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <tephra.version>0.6.5</tephra.version>
+    <tephra.version>0.7.1-SNAPSHOT</tephra.version>
     <thrift.version>0.9.0</thrift.version>
     <twill.version>0.7.0-incubating</twill.version>
     <unboundid.version>2.3.6</unboundid.version>
@@ -2431,6 +2432,7 @@
         <module>cdap-hbase-compat-1.0-cdh</module>
         <module>cdap-hbase-compat-1.0</module>
         <module>cdap-hbase-compat-1.1</module>
+        <module>cdap-hbase-compat-1.2-cdh5.7.0</module>
         <module>cdap-common</module>
         <module>cdap-docs-gen</module>
         <module>cdap-watchdog-api</module>


### PR DESCRIPTION
For supporting CDH 5.7 which comes with HBase version 1.2.0-cdh5.7.0, we need to add new compatibility module. `HTableDescriptor.addFamily` method in 1.2.0-cdh5.7.0 returns `void` while other Apache HBase versions (ranging from 0.99 - 1.2.0) are having `HTableDescriptor` as return type. Because of which master process fails to start on the cluster with exception
```java
Exception in thread "main" java.lang.NoSuchMethodError: org.apache.hadoop.hbase.HTableDescriptor.addFamily(Lorg/apache/hadoop/hbase/HColumnDescriptor;)Lorg/apache/hadoop/hbase/HTableDescriptor;
        at co.cask.cdap.data2.util.hbase.HBase11HTableDescriptorBuilder.addFamily(HBase11HTableDescriptorBuilder.java:54)
        at co.cask.cdap.data2.util.hbase.ConfigurationTable.write(ConfigurationTable.java:79)
        at co.cask.cdap.data.runtime.main.MasterServiceMain.updateConfigurationTable(MasterServiceMain.java:552)
        at co.cask.cdap.data.runtime.main.MasterServiceMain.start(MasterServiceMain.java:232)
        at co.cask.cdap.common.runtime.DaemonMain.doMain(DaemonMain.java:58)
        at co.cask.cdap.data.runtime.main.MasterServiceMain.main(MasterServiceMain.java:156)
```  

