### PR TITLE
CDAP-4735 expose java ExtClassLoader to programs

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/FilterClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/FilterClassLoader.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.common.lang;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import java.io.IOException;
@@ -34,7 +33,7 @@ import java.util.Set;
  */
 public final class FilterClassLoader extends ClassLoader {
 
-  private final ClassLoader bootstrapClassLoader;
+  private final ClassLoader extensionClassLoader;
   private final Filter filter;
 
   /**
@@ -102,7 +101,7 @@ public final class FilterClassLoader extends ClassLoader {
    */
   public FilterClassLoader(ClassLoader parentClassLoader, Filter filter) {
     super(parentClassLoader);
-    this.bootstrapClassLoader = new URLClassLoader(new URL[0], null);
+    this.extensionClassLoader = new URLClassLoader(new URL[0], ClassLoader.getSystemClassLoader().getParent());
     this.filter = filter;
   }
 
@@ -110,7 +109,7 @@ public final class FilterClassLoader extends ClassLoader {
   protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
     // Try to load it from bootstrap class loader first
     try {
-      return bootstrapClassLoader.loadClass(name);
+      return extensionClassLoader.loadClass(name);
     } catch (ClassNotFoundException e) {
       if (filter.acceptResource(classNameToResourceName(name))) {
         return super.loadClass(name, resolve);
@@ -138,7 +137,7 @@ public final class FilterClassLoader extends ClassLoader {
 
   @Override
   public URL getResource(String name) {
-    URL resource = bootstrapClassLoader.getResource(name);
+    URL resource = extensionClassLoader.getResource(name);
     if (resource != null) {
       return resource;
     }
@@ -147,7 +146,7 @@ public final class FilterClassLoader extends ClassLoader {
 
   @Override
   public Enumeration<URL> getResources(String name) throws IOException {
-    Enumeration<URL> resources = bootstrapClassLoader.getResources(name);
+    Enumeration<URL> resources = extensionClassLoader.getResources(name);
     if (resources.hasMoreElements()) {
       return resources;
     }
@@ -156,7 +155,7 @@ public final class FilterClassLoader extends ClassLoader {
 
   @Override
   public InputStream getResourceAsStream(String name) {
-    InputStream resourceStream = bootstrapClassLoader.getResourceAsStream(name);
+    InputStream resourceStream = extensionClassLoader.getResourceAsStream(name);
     if (resourceStream != null) {
       return resourceStream;
     }

--- a/cdap-common/src/test/java/co/cask/cdap/common/lang/FilterClassLoaderTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/lang/FilterClassLoaderTest.java
@@ -55,6 +55,22 @@ public class FilterClassLoaderTest {
   }
 
   @Test
+  public void testExtensionResourcesVisible() throws ClassNotFoundException {
+    // isn't really a way to guarantee what classes are in the extensions directory.
+    // so we'll just check that if the system classloader can load it, the filter classloader should be able to load it.
+    ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+    Object o;
+    try {
+      o = systemClassLoader.loadClass("com.sun.nio.zipfs.ZipInfo");
+    } catch (ClassNotFoundException e) {
+      // class isn't in extensions, this test will be a no-op
+      return;
+    }
+    FilterClassLoader classLoader = FilterClassLoader.create(this.getClass().getClassLoader());
+    Assert.assertEquals(o.getClass(), classLoader.loadClass("com.sun.nio.zipfs.ZipInfo").getClass());
+  }
+
+  @Test
   public void testHadoopResourcesVisible() throws ClassNotFoundException {
     FilterClassLoader classLoader = FilterClassLoader.create(this.getClass().getClassLoader());
     ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(classLoader);


### PR DESCRIPTION
This fix makes the FilterClassLoader delegate first to the
ExtClassLoader instead of the bootstrap classloader. This is so
that programs can load extension classes, such as the Nashorn
classes included in Java 8.