### PR TITLE
Update how PartitionFilter gets serialized in the runtime arguments.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ConditionCodec.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ConditionCodec.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.dataset.lib;
+
+import co.cask.cdap.api.dataset.lib.partitioned.ComparableCodec;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import javax.annotation.Nullable;
+
+/**
+ * Codec used to serialize and deserialize {@link PartitionFilter.Condition}s.
+ */
+public class ConditionCodec extends ComparableCodec
+  implements JsonSerializer<PartitionFilter.Condition>, JsonDeserializer<PartitionFilter.Condition> {
+
+  @Override
+  public PartitionFilter.Condition deserialize(JsonElement jsonElement, Type type,
+                                               JsonDeserializationContext deserializationContext)
+    throws JsonParseException {
+
+    JsonObject jsonObject = jsonElement.getAsJsonObject();
+    boolean isSingleValue = jsonObject.get("isSingleValue").getAsBoolean();
+    if (isSingleValue) {
+      return new PartitionFilter.Condition<>(jsonObject.get("fieldName").getAsString(),
+                                             deserializeComparable(jsonObject.get("lower"), deserializationContext));
+    } else {
+      return new PartitionFilter.Condition<>(jsonObject.get("fieldName").getAsString(),
+                                             deserializeComparable(jsonObject.get("lower"), deserializationContext),
+                                             deserializeComparable(jsonObject.get("upper"), deserializationContext));
+    }
+  }
+
+  @Override
+  public JsonElement serialize(PartitionFilter.Condition condition, Type type,
+                               JsonSerializationContext jsonSerializationContext) {
+    JsonObject jsonObj = new JsonObject();
+    jsonObj.addProperty("fieldName", condition.getFieldName());
+    jsonObj.add("lower", serializeComparable(condition.getLower(), jsonSerializationContext));
+    jsonObj.add("upper", serializeComparable(condition.getUpper(), jsonSerializationContext));
+    jsonObj.addProperty("isSingleValue", condition.isSingleValue());
+    return jsonObj;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
@@ -189,7 +189,7 @@ public class PartitionFilter {
     private final T upper;
     private final boolean isSingleValue;
 
-    private Condition(String fieldName, @Nullable T lower, @Nullable T upper) {
+    Condition(String fieldName, @Nullable T lower, @Nullable T upper) {
       if (lower == null && upper == null) {
         throw new IllegalArgumentException("Either lower or upper-bound must be non-null.");
       }
@@ -199,7 +199,7 @@ public class PartitionFilter {
       this.isSingleValue = false;
     }
 
-    private Condition(String fieldName, T value) {
+    Condition(String fieldName, T value) {
       if (value == null) {
         throw new IllegalArgumentException("Value must not be null.");
       }
@@ -207,6 +207,13 @@ public class PartitionFilter {
       this.lower = value;
       this.upper = null;
       this.isSingleValue = true;
+    }
+
+    /**
+     * @return the field name of this condition
+     */
+    public String getFieldName() {
+      return fieldName;
     }
 
     /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/ComparableCodec.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/ComparableCodec.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.dataset.lib.partitioned;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSerializationContext;
+
+import javax.annotation.Nullable;
+
+/**
+ * Responsible for serialization and deserialization of {@link Comparable}.
+ */
+public class ComparableCodec {
+
+  @Nullable
+  protected JsonElement serializeComparable(@Nullable Comparable comparable,
+                                            JsonSerializationContext jsonSerializationContext) {
+    if (comparable == null) {
+      return null;
+    }
+    JsonArray jsonArray = new JsonArray();
+    jsonArray.add(jsonSerializationContext.serialize(comparable.getClass().getName()));
+    jsonArray.add(jsonSerializationContext.serialize(comparable));
+    return jsonArray;
+  }
+
+  @Nullable
+  protected Comparable deserializeComparable(@Nullable JsonElement comparableJson,
+                                             JsonDeserializationContext jsonDeserializationContext) {
+    if (comparableJson == null) {
+      return null;
+    }
+    JsonArray jsonArray = comparableJson.getAsJsonArray();
+    // the classname is serialized as the first element, the value is serialized as the second
+    Class<? extends Comparable> comparableClass = forName(jsonArray.get(0).getAsString());
+    return jsonDeserializationContext.deserialize(jsonArray.get(1), comparableClass);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Class<? extends Comparable> forName(String className) {
+    try {
+      // we know that the class is a Comparable because all partition keys are of type Comparable
+      return (Class<? extends Comparable>) Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionKeyCodec.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionKeyCodec.java
@@ -32,7 +32,8 @@ import java.util.Map;
 /**
  * Codec used to serialize and deserialize {@link PartitionKey}s.
  */
-public class PartitionKeyCodec implements JsonSerializer<PartitionKey>, JsonDeserializer<PartitionKey> {
+public class PartitionKeyCodec extends ComparableCodec
+  implements JsonSerializer<PartitionKey>, JsonDeserializer<PartitionKey> {
 
   @Override
   public PartitionKey deserialize(JsonElement jsonElement, Type type,
@@ -41,22 +42,9 @@ public class PartitionKeyCodec implements JsonSerializer<PartitionKey>, JsonDese
     PartitionKey.Builder builder = PartitionKey.builder();
     for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
       JsonArray jsonArray = entry.getValue().getAsJsonArray();
-      // the classname is serialized as the first element, the value is serialized as the second
-      Class<? extends Comparable> comparableClass = forName(jsonArray.get(0).getAsString());
-      Comparable value = jsonDeserializationContext.deserialize(jsonArray.get(1), comparableClass);
-      builder.addField(entry.getKey(), value);
+      builder.addField(entry.getKey(), deserializeComparable(jsonArray, jsonDeserializationContext));
     }
     return builder.build();
-  }
-
-  @SuppressWarnings("unchecked")
-  private Class<? extends Comparable> forName(String className) {
-    try {
-      // we know that the class is a Comparable because all partition keys are of type Comparable
-      return (Class<? extends Comparable>) Class.forName(className);
-    } catch (ClassNotFoundException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   @Override
@@ -64,10 +52,7 @@ public class PartitionKeyCodec implements JsonSerializer<PartitionKey>, JsonDese
                                JsonSerializationContext jsonSerializationContext) {
     JsonObject jsonObj = new JsonObject();
     for (Map.Entry<String, Comparable> entry : partitionKey.getFields().entrySet()) {
-      JsonArray jsonArray = new JsonArray();
-      jsonArray.add(jsonSerializationContext.serialize(entry.getValue().getClass().getName()));
-      jsonArray.add(jsonSerializationContext.serialize(entry.getValue()));
-      jsonObj.add(entry.getKey(), jsonArray);
+      jsonObj.add(entry.getKey(), serializeComparable(entry.getValue(), jsonSerializationContext));
     }
     return jsonObj;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -614,7 +614,7 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
   protected Collection<String> computeFilterInputPaths() {
     PartitionFilter filter;
     try {
-      filter = PartitionedFileSetArguments.getInputPartitionFilter(runtimeArguments, partitioning);
+      filter = PartitionedFileSetArguments.getInputPartitionFilter(runtimeArguments);
     } catch (Exception e) {
       throw new DataSetException("Partition filter must be correctly specified in arguments.");
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetArgumentsTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- *
+ * Tests for {@link PartitionedFileSetArguments}.
  */
 public class PartitionedFileSetArgumentsTest {
 
@@ -81,7 +81,31 @@ public class PartitionedFileSetArgumentsTest {
       .addValueCondition("s", "x")
       .build();
     PartitionedFileSetArguments.setInputPartitionFilter(arguments, filter);
+    // test the deprecated method (passing in PARTITIONING), at least until it is removed
     Assert.assertEquals(filter, PartitionedFileSetArguments.getInputPartitionFilter(arguments, PARTITIONING));
+
+    arguments = new HashMap<>();
+    filter = PartitionFilter.builder()
+      .addRangeCondition("i", 30, 40)
+      .addValueCondition("l", 17L)
+      .addValueCondition("s", "x")
+      .build();
+    PartitionedFileSetArguments.setInputPartitionFilter(arguments, filter);
+    Assert.assertEquals(filter, PartitionedFileSetArguments.getInputPartitionFilter(arguments));
+
+
+    arguments = new HashMap<>();
+    filter = PartitionFilter.builder()
+      .addRangeCondition("i", 30, 40)
+      .addValueCondition("s", "x")
+      .build();
+    PartitionedFileSetArguments.setInputPartitionFilter(arguments, filter);
+    Assert.assertEquals(filter, PartitionedFileSetArguments.getInputPartitionFilter(arguments));
+
+    arguments = new HashMap<>();
+    filter = PartitionFilter.ALWAYS_MATCH;
+    PartitionedFileSetArguments.setInputPartitionFilter(arguments, filter);
+    Assert.assertEquals(filter, PartitionedFileSetArguments.getInputPartitionFilter(arguments));
   }
 
 

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/codec/ConditionCodecTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/codec/ConditionCodecTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.api.dataset.lib.ConditionCodec;
+import co.cask.cdap.api.dataset.lib.PartitionFilter;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link ConditionCodec}.
+ */
+public class ConditionCodecTest {
+  private static final Gson GSON =
+    new GsonBuilder().registerTypeAdapter(PartitionFilter.Condition.class, new ConditionCodec()).create();
+
+  @Test
+  public void testSerDe() {
+    PartitionFilter filter = PartitionFilter.builder()
+      .addValueCondition("i", 42)
+      .addValueCondition("l", 17L)
+      .addValueCondition("s", "x")
+      .build();
+    testSerDe(filter);
+
+    filter = PartitionFilter.builder()
+      .addRangeCondition("i", 30, 40)
+      .addValueCondition("l", 17L)
+      .addValueCondition("s", "x")
+      .build();
+    testSerDe(filter);
+
+
+    filter = PartitionFilter.builder()
+      .addRangeCondition("i", 30, 40)
+      .addValueCondition("s", "x")
+      .build();
+    testSerDe(filter);
+
+    testSerDe(PartitionFilter.ALWAYS_MATCH);
+  }
+
+  private void testSerDe(PartitionFilter filter) {
+    String serialized = GSON.toJson(filter);
+    Assert.assertEquals(filter, GSON.fromJson(serialized, PartitionFilter.class));
+  }
+}


### PR DESCRIPTION
Fixes using PartitionFilter.ALWAYS_MATCH as the partition filter.
Now, using a custom GSON and custom serializer/deserializer to serialize the PartitionFilter into just one key of the runtime arguments map.

https://issues.cask.co/browse/CDAP-5267
http://builds.cask.co/browse/CDAP-DUT3937