### PR TITLE
[CDAP-5490] Fix showing success messages after a failure from backend 

### DIFF
--- a/cdap-ui/app/services/alert-on-valium/alert-on-valium.js
+++ b/cdap-ui/app/services/alert-on-valium/alert-on-valium.js
@@ -33,6 +33,7 @@ angular.module(PKG.name + '.services')
           isAnAlertOpened = false;
         });
       } else {
+        alertObj.$scope.type = obj.type;
         alertObj.$scope.content = obj.content;
         alertObj.$scope.title = obj.title;
       }


### PR DESCRIPTION
Ways to repeat the error,
- Try editing stream properties.
- Have an error while saving it.
- Fix the error and re-save it without closing the error message.
- The success message will also be shown as error.

We are right now only updating the message instead we should update both message and the style.