### PR TITLE
Metadata upgrade code updates

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -43,8 +43,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,7 +62,6 @@ import javax.annotation.Nullable;
  * Dataset that manages Metadata using an {@link IndexedTable}.
  */
 public class MetadataDataset extends AbstractDataset {
-  private static final Logger LOG = LoggerFactory.getLogger(MetadataDataset.class);
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
     .create();
@@ -84,13 +81,7 @@ public class MetadataDataset extends AbstractDataset {
       }
     };
 
-  //TODO: (UPG-3.3): Make this public after 3.3
-  public static final String INDEX_COLUMN = "i";          // column for metadata indexes
-
-  //TODO: (UPG-3.3): Remove this after 3.3. This is only for upgrade from 3.2 to 3.3
-  // These are the columns which were indexed in 3.2
-  public static final String CASE_INSENSITIVE_VALUE_COLUMN = "civ";
-  public static final String KEYVALUE_COLUMN = "kv";
+  static final String INDEX_COLUMN = "i";          // column for metadata indexes
 
   public static final String TAGS_KEY = "tags";
   public static final String KEYVALUE_SEPARATOR = ":";
@@ -665,108 +656,5 @@ public class MetadataDataset extends AbstractDataset {
     Metadata metadata = new Metadata(targetId, properties, tags);
     byte[] row = MdsHistoryKey.getMdsKey(targetId, System.currentTimeMillis()).getKey();
     indexedTable.put(row, Bytes.toBytes(HISTORY_COLUMN), Bytes.toBytes(GSON.toJson(metadata)));
-  }
-
-  /**
-   * Upgrades the metadata from 3.2 to 3.3 for new storage format
-   */
-  public void upgrade() {
-    new Upgrader().upgrade();
-  }
-
-  /**
-   * Upgrader class for {@link MetadataDataset}. This class contains some functions from 3.2 which have changed in 3.3
-   * in their only 3.2 format to help in reading and processing the old metadata. This inner class should be deleted
-   * after 3.3
-   */
-  private class Upgrader {
-    public void upgrade() {
-      boolean upgradePerformed = false;
-      Scanner scan = indexedTable.scan(null, null); // scan the whole table
-      try {
-        Row next;
-        while ((next = scan.next()) != null) {
-          byte[] value = next.get(VALUE_COLUMN);
-          if (next.get(CASE_INSENSITIVE_VALUE_COLUMN) != null && value != null) {
-            // if case insensitive column has value then this is an old entry from 3.2 which needs to be updated.
-            final byte[] rowKey = next.getRow();
-            String targetType = MdsKey.getTargetType(rowKey);
-            Id.NamespacedId targetId = MdsKey.getNamespacedIdFromKey(targetType, rowKey);
-            String key = getMetadataKeyFromOldFormat(targetType, rowKey);
-            MetadataEntry metadataEntry = new MetadataEntry(targetId, key, Bytes.toString(value));
-            indexedTable.delete(new Delete(rowKey));            // remove the old metadata entry
-            // add the metadata back creating new indexes. We can just use DefaultValueIndexer because
-            // in 3.2 we didn't have schema as metadata so no old records can be schema.
-            write(metadataEntry.getTargetId(), metadataEntry, new DefaultValueIndexer());
-            upgradePerformed = true;
-            LOG.info("Upgraded MetadataEntry: {}", metadataEntry);
-          }
-        }
-      } finally {
-        scan.close();
-      }
-      if (!upgradePerformed) {
-        LOG.info("No MetadataEntry found in old format. Metadata upgrade not required.");
-      }
-    }
-
-    /**
-     * Write similar to {@link MetadataDataset#write(Id.NamespacedId, MetadataEntry, Indexer)} but without history
-     * since while writting during upgrade we don't want to add history.
-     */
-    private void write(Id.NamespacedId targetId, MetadataEntry entry, Indexer indexer) {
-      String key = entry.getKey();
-      MDSKey mdsValueKey = MdsKey.getMDSValueKey(targetId, key);
-      Put put = new Put(mdsValueKey.getKey());
-
-      // add the metadata value
-      put.add(Bytes.toBytes(VALUE_COLUMN), Bytes.toBytes(entry.getValue()));
-      indexedTable.put(put);
-      // index the metadata
-      storeIndexes(targetId, entry, indexer.getIndexes(entry));
-    }
-
-    /**
-     * This to read old Metadata keys which were written with a metadata type in 3.2
-     * Its used to update from 3.2 to 3.3 and should be removed after 3.3
-     * This is almost a copy of {@link MdsKey#getMetadataKey(String, byte[])} with additional skip for MetadataType
-     * which we used to write in 3.2
-     */
-    public String getMetadataKeyFromOldFormat(String type, byte[] rowKey) {
-      MDSKey.Splitter keySplitter = new MDSKey(rowKey).split();
-      // The rowkey in the following format in 3.2
-      // [rowPrefix][targetType][targetId][metadataType][key]
-      // so skip the first few strings.
-
-      // Skip rowType
-      keySplitter.skipBytes();
-
-      // Skip targetType
-      keySplitter.skipString();
-
-      // Skip targetId
-      if (type.equals(Id.Program.class.getSimpleName())) {
-        keySplitter.skipString();
-        keySplitter.skipString();
-        keySplitter.skipString();
-        keySplitter.skipString();
-      } else if (type.equals(Id.Application.class.getSimpleName())) {
-        keySplitter.skipString();
-        keySplitter.skipString();
-      } else if (type.equals(Id.DatasetInstance.class.getSimpleName())) {
-        keySplitter.skipString();
-        keySplitter.skipString();
-      } else if (type.equals(Id.Stream.class.getSimpleName())) {
-        keySplitter.skipString();
-        keySplitter.skipString();
-      } else {
-        throw new IllegalArgumentException("Illegal Type " + type + " of metadata source.");
-      }
-
-      // Skip metadata-type as the old key as metadata type
-      keySplitter.getString();
-
-      return keySplitter.getString();
-    }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -217,9 +217,4 @@ public interface MetadataStore {
    * @return the snapshot of the metadata for entities on or before the given time
    */
   Set<MetadataRecord> getSnapshotBeforeTime(MetadataScope scope,  Set<Id.NamespacedId> entityIds, long timeMillis);
-
-  /**
-   * Upgrades the {@link MetadataStore}
-   */
-  void upgrade();
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -153,9 +153,4 @@ public class NoOpMetadataStore implements MetadataStore {
     }
     return builder.build();
   }
-
-  @Override
-  public void upgrade() {
-    // NO-OP
-  }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -29,6 +29,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionExecutorModule;
+import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.DefaultTransactionExecutor;
 import co.cask.tephra.TransactionAware;
@@ -47,6 +48,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 
 public final class DatasetFrameworkTestUtil extends ExternalResource {
@@ -142,6 +144,10 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
 
   public DatasetSpecification getSpec(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
     return framework.getDatasetSpec(datasetInstanceId);
+  }
+
+  public Collection<DatasetSpecificationSummary> list(Id.Namespace namespace) throws DatasetManagementException {
+    return framework.getInstances(namespace);
   }
 
   /**

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools;
+
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
+import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
+import co.cask.cdap.store.NamespaceStore;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Removes metadata for deleted datasets.
+ */
+final class DeletedDatasetMetadataRemover {
+  private static final Logger LOG = LoggerFactory.getLogger(DeletedDatasetMetadataRemover.class);
+  private final NamespaceStore nsStore;
+  private final MetadataStore metadataStore;
+  private final DatasetFramework dsFramework;
+
+  DeletedDatasetMetadataRemover(NamespaceStore nsStore, MetadataStore metadataStore, DatasetFramework dsFramework) {
+    this.nsStore = nsStore;
+    this.metadataStore = metadataStore;
+    this.dsFramework = dsFramework;
+  }
+
+  void remove() throws DatasetManagementException {
+    List<Id.DatasetInstance> removedDatasets = new ArrayList<>();
+    for (NamespaceMeta namespaceMeta : nsStore.list()) {
+      Set<MetadataSearchResultRecord> searchResults =
+        metadataStore.searchMetadataOnType(namespaceMeta.getName(), "*",
+                                           ImmutableSet.of(MetadataSearchTargetType.DATASET));
+      for (MetadataSearchResultRecord searchResult : searchResults) {
+        Id.NamespacedId entityId = searchResult.getEntityId();
+        Preconditions.checkState(entityId instanceof Id.DatasetInstance,
+                                 "Since search was filtered for %s, expected result to be a %s, but got a %s",
+                                 MetadataSearchTargetType.DATASET, Id.DatasetInstance.class.getSimpleName(),
+                                 entityId.getClass().getName());
+        Id.DatasetInstance datasetInstance = (Id.DatasetInstance) entityId;
+        if (!dsFramework.hasInstance(datasetInstance)) {
+          metadataStore.removeMetadata(datasetInstance);
+          removedDatasets.add(datasetInstance);
+        }
+      }
+    }
+    if (removedDatasets.isEmpty()) {
+      LOG.debug("Deleted datasets with metadata not found. No metadata removal necessary.");
+    } else {
+      LOG.info("Removed metadata for the following deleted datasets: {}.", removedDatasets);
+    }
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/ExistingEntitySystemMetadataWriter.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/ExistingEntitySystemMetadataWriter.java
@@ -55,8 +55,7 @@ import java.io.IOException;
 import java.util.Collection;
 
 /**
- * Adds system metadata for existing entities prior to 3.3.
- * TODO CDAP-4696: Remove in 3.4
+ * Updates system metadata for existing entities.
  */
 public class ExistingEntitySystemMetadataWriter {
   private static final Logger LOG = LoggerFactory.getLogger(ExistingEntitySystemMetadataWriter.class);

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemoverTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemoverTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools;
+
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
+import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
+import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
+import co.cask.cdap.data2.dataset2.InMemoryNamespaceStore;
+import co.cask.cdap.data2.metadata.publisher.MetadataChangePublisher;
+import co.cask.cdap.data2.metadata.publisher.NoOpMetadataChangePublisher;
+import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataScope;
+import co.cask.cdap.store.NamespaceStore;
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Names;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * Tests for {@link DeletedDatasetMetadataRemover}.
+ */
+public class DeletedDatasetMetadataRemoverTest {
+  @ClassRule
+  public static final DatasetFrameworkTestUtil DS_FRAMEWORK_TEST_UTIL = new DatasetFrameworkTestUtil();
+
+  private static MetadataStore metadataStore;
+  private static DeletedDatasetMetadataRemover metadataRemover;
+
+  @BeforeClass
+  public static void setup() {
+    NamespaceStore nsStore = new InMemoryNamespaceStore();
+    nsStore.create(NamespaceMeta.DEFAULT);
+
+    Injector injector = DS_FRAMEWORK_TEST_UTIL.getInjector().createChildInjector(
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          install(new FactoryModuleBuilder()
+                    .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
+                    .build(DatasetDefinitionRegistryFactory.class));
+          bind(DatasetFramework.class)
+            .annotatedWith(Names.named(DataSetsModules.BASIC_DATASET_FRAMEWORK))
+            .to(InMemoryDatasetFramework.class);
+          bind(MetadataChangePublisher.class).to(NoOpMetadataChangePublisher.class);
+          bind(MetadataStore.class).to(DefaultMetadataStore.class);
+        }
+      }
+    );
+    metadataStore = injector.getInstance(MetadataStore.class);
+    metadataRemover = new DeletedDatasetMetadataRemover(nsStore, metadataStore, DS_FRAMEWORK_TEST_UTIL.getFramework());
+  }
+
+  @Test
+  public void test() throws IOException, DatasetManagementException {
+    DatasetId ds1 = NamespaceId.DEFAULT.dataset("ds1");
+    DatasetId ds2 = NamespaceId.DEFAULT.dataset("ds2");
+    DatasetId ds3 = NamespaceId.DEFAULT.dataset("ds3");
+    DS_FRAMEWORK_TEST_UTIL.createInstance("table", ds1.toId(), DatasetProperties.EMPTY);
+    DS_FRAMEWORK_TEST_UTIL.createInstance("table", ds2.toId(), DatasetProperties.EMPTY);
+    DS_FRAMEWORK_TEST_UTIL.createInstance("table", ds3.toId(), DatasetProperties.EMPTY);
+    Assert.assertEquals(3, DS_FRAMEWORK_TEST_UTIL.list(NamespaceId.DEFAULT.toId()).size());
+    metadataStore.addTags(MetadataScope.USER, ds1.toId(), "ds1Tag1", "ds1Tag2");
+    metadataStore.setProperties(MetadataScope.USER, ds2.toId(), Collections.singletonMap("ds2Key", "ds2Value"));
+    metadataStore.addTags(MetadataScope.USER, ds3.toId(), "ds3Tag1", "ds3Tag2");
+
+    verifyMetadataRemoval(ds1);
+    verifyMetadataRemoval(ds2);
+    verifyMetadataRemoval(ds3);
+  }
+
+  private void verifyMetadataRemoval(DatasetId dsId) throws IOException, DatasetManagementException {
+    DS_FRAMEWORK_TEST_UTIL.deleteInstance(dsId.toId());
+    assertNonEmptyMetadata(dsId);
+    metadataRemover.remove();
+    assertEmptyMetadata(dsId);
+  }
+
+  private void assertNonEmptyMetadata(DatasetId dsId) {
+    MetadataRecord metadata = metadataStore.getMetadata(MetadataScope.USER, dsId.toId());
+    Assert.assertTrue(!metadata.getProperties().isEmpty() || !metadata.getTags().isEmpty());
+  }
+
+  private void assertEmptyMetadata(DatasetId dsId) {
+    MetadataRecord metadata = metadataStore.getMetadata(MetadataScope.USER, dsId.toId());
+    Assert.assertTrue(metadata.getProperties().isEmpty() && metadata.getTags().isEmpty());
+  }
+}


### PR DESCRIPTION
(CDAP-4696) Removed code for upgrading metadata storage format as well as updating the dataset specification since it is not required for an upgrade from 3.3 to 3.4
(CDAP-5402) Added an upgrade step to delete metadata for deleted datasets

Jiras:
[CDAP-4696](https://issues.cask.co/browse/CDAP-4696)
[CDAP-5402](https://issues.cask.co/browse/CDAP-5402)

Build: http://builds.cask.co/browse/CDAP-DUT3944

Tested a 3.3 -> 3.4 upgrade on a cluster