### PR TITLE
CDAP-5580 Ability to get/put in the Workflow token through initialize and destroy methods.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowToken.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -42,7 +42,10 @@ public interface WorkflowToken {
   /**
    * Put the specified key and value into the {@link WorkflowToken}.
    * The token may store additional information about the context in which
-   * this key is being set, for example, the unique name of the workflow node.
+   * this key is being set. For example, the context information stored by the
+   * token may be the workflow node that is performing the operation, or the name
+   * of the workflow if the operation is performed in {@link AbstractWorkflow#initialize}
+   * or {@link AbstractWorkflow#destroy} method.
    * @param key the key representing the entry
    * @param value the value for the key
    * @throws UnsupportedOperationException if called in a context where the token may not be modified.
@@ -52,7 +55,10 @@ public interface WorkflowToken {
   /**
    * Put the specified key and {@link Value} into the {@link WorkflowToken}.
    * The token may store additional information about the context in which
-   * this key is being set, for example, the unique name of the workflow node.
+   * this key is being set. For example, the context information stored by the
+   * token may be the workflow node that is performing the operation, or the name
+   * of the workflow if the operation is performed in {@link AbstractWorkflow#initialize}
+   * or {@link AbstractWorkflow#destroy} method.
    * @param key the key representing entry
    * @param value the {@link Value} for the key
    * @throws UnsupportedOperationException if called in a context where the token may not be modified.
@@ -80,6 +86,8 @@ public interface WorkflowToken {
 
   /**
    * Get the value set for the specified key by the specified node for a {@link Scope#USER} scope.
+   * To get the token values set from {@link AbstractWorkflow#initialize} or
+   * {@link AbstractWorkflow#destroy} methods, provide the name of the Workflow as nodeName.
    * @param key the key to be searched
    * @param nodeName the name of the node
    * @return the {@link Value} set for the key by nodeName or <code>null</code> if the key is not
@@ -90,6 +98,8 @@ public interface WorkflowToken {
 
   /**
    * Get the value set for the specified key by the specified node for a given scope.
+   * To get the token values set from {@link AbstractWorkflow#initialize} or
+   * {@link AbstractWorkflow#destroy} methods, provide the name of the Workflow as nodeName.
    * @param key the key to be searched
    * @param nodeName the name of the node
    * @param scope the {@link WorkflowToken.Scope} for the key
@@ -140,7 +150,9 @@ public interface WorkflowToken {
 
   /**
    * Get the {@link Map} of key to {@link Value}s that were added to the {@link WorkflowToken}
-   * by specific node for a {@link Scope#USER} scope.
+   * by specific node for a {@link Scope#USER} scope. To get the token values set from
+   * {@link AbstractWorkflow#initialize} or {@link AbstractWorkflow#destroy} methods, provide
+   * the name of the Workflow as nodeName.
    * @param nodeName the unique name of the node
    * @return the map of key to values that were added by the specified node
    */
@@ -148,7 +160,9 @@ public interface WorkflowToken {
 
   /**
    * Get the {@link Map} of key to {@link Value}s that were added to the {@link WorkflowToken}
-   * by specific node for a given scope.
+   * by specific node for a given scope. To get the token values set from
+   * {@link AbstractWorkflow#initialize} or {@link AbstractWorkflow#destroy} methods, provide
+   * the name of the Workflow as nodeName.
    * @param nodeName the unique name of the node
    * @param scope the {@link WorkflowToken.Scope} for the key
    * @return the map of key to values that were added by the specified node for a given scope

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -1290,6 +1290,16 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     Assert.assertEquals(AppWithWorkflow.DummyAction.TOKEN_VALUE, nodeValueDetails.get(0).getValue());
     Assert.assertEquals(AppWithWorkflow.DummyAction.TOKEN_VALUE, nodeValueDetails.get(1).getValue());
 
+    // Get workflow level tokens
+    WorkflowTokenNodeDetail nodeDetail = getWorkflowToken(workflowId, pid, AppWithWorkflow.SampleWorkflow.NAME,
+                                                          WorkflowToken.Scope.USER, null);
+    Map<String, String> tokenData = nodeDetail.getTokenDataAtNode();
+    Assert.assertEquals(2, tokenData.size());
+    Assert.assertEquals(AppWithWorkflow.SampleWorkflow.INITIALIZE_TOKEN_VALUE,
+                        tokenData.get(AppWithWorkflow.SampleWorkflow.INITIALIZE_TOKEN_KEY));
+    Assert.assertEquals(AppWithWorkflow.SampleWorkflow.DESTROY_TOKEN_SUCCESS_VALUE,
+                        tokenData.get(AppWithWorkflow.SampleWorkflow.DESTROY_TOKEN_KEY));
+
     // Verify workflow token at a given node
     WorkflowTokenNodeDetail tokenAtNode = getWorkflowToken(workflowId, pid,
                                                            AppWithWorkflow.SampleWorkflow.FIRST_ACTION, null, null);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -49,6 +49,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.List;
@@ -62,7 +64,7 @@ import java.util.Set;
  * concrete implementations.
  */
 public class ApplicationVerificationStage extends AbstractStage<ApplicationDeployable> {
-
+  private static final Logger LOG = LoggerFactory.getLogger(ApplicationVerificationStage.class);
   private final Map<Class<?>, Verifier<?>> verifiers = Maps.newIdentityHashMap();
   private final DatasetFramework dsFramework;
   private final Store store;
@@ -183,6 +185,14 @@ public class ApplicationVerificationStage extends AbstractStage<ApplicationDeplo
   private void verifyWorkflowNode(ApplicationSpecification appSpec, WorkflowSpecification workflowSpec,
                                   WorkflowNode node, Set<String> existingNodeNames) {
     WorkflowNodeType nodeType = node.getType();
+    // TODO CDAP-5640 Add check so that node id in the Workflow should not be same as name of the Workflow.
+    if (node.getNodeId().equals(workflowSpec.getName())) {
+      String msg = String.format("Node used in Workflow has same name as that of Workflow '%s'." +
+                                   " This will conflict while getting the Workflow token details associated with" +
+                                   " the node. Please use name for the node other than the name of the Workflow.",
+                                 workflowSpec.getName());
+      LOG.warn(msg);
+    }
     switch (nodeType) {
       case ACTION:
         verifyWorkflowAction(appSpec, node);

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/WorkflowClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/WorkflowClientTestRun.java
@@ -129,7 +129,7 @@ public class WorkflowClientTestRun extends ClientTestBase {
 
     // Valid test scenarios
     WorkflowTokenDetail workflowToken = workflowClient.getWorkflowToken(workflowRunId.toId());
-    Assert.assertEquals(3, workflowToken.getTokenData().size());
+    Assert.assertEquals(5, workflowToken.getTokenData().size());
     workflowToken = workflowClient.getWorkflowToken(workflowRunId.toId(), WorkflowToken.Scope.SYSTEM);
     Assert.assertTrue(workflowToken.getTokenData().size() > 0);
     workflowToken = workflowClient.getWorkflowToken(workflowRunId.toId(), "start_time");


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-5580
Added ability to get and put in the token through `AbstractWorkflow.initialize` and `AbstractWorkflow.destroy` methods. While storing the data in the token through these methods, name of the Workflow is used as node name.