### PR TITLE
[CDAP-5568, CDAP-5587, CDAP-5354] Fix unsaved changes behavior hydrator++

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -206,9 +206,9 @@ angular.module(PKG.name + '.commons')
             });
           }, true);
         }
-
-        vm.fitToScreen();
-
+        if (vm.isDisabled) {
+          vm.fitToScreen();
+        }
       });
     }
 

--- a/cdap-ui/app/directives/plugin-templates/plugin-templates.html
+++ b/cdap-ui/app/directives/plugin-templates/plugin-templates.html
@@ -170,7 +170,7 @@
 </div>
 <div class="modal-footer">
   <div class="form-buttons text-right">
-    <button type="submit" ng-click="PluginTemplatesCtrl.submitted = true && PluginTemplatesCtrl.save(templateCreateEditForm.$valid)" class="btn btn-success">
+    <button type="submit" ng-click="PluginTemplatesCtrl.submitted = true && PluginTemplatesCtrl.save(templateCreateEditForm.$valid)" class="btn btn-orange">
       <span ng-if="!PluginTemplatesCtrl.isEdit">Add</span>
       <span ng-if="PluginTemplatesCtrl.isEdit">Save</span>
     </button>

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
@@ -97,14 +97,15 @@ class HydratorPlusPlusLeftPanelCtrl {
 
   onArtifactChange() {
     this._checkAndShowConfirmationModalOnDirtyState()
-      .then(saveState => {
-        if (saveState) {
+      .then(proceedToNextStep => {
+        if (!proceedToNextStep) {
           this.selectedArtifact = this.artifactToRevert;
         } else {
           this.$state.go('hydratorplusplus.create', {
+            namespace: this.$state.params.namespace,
             artifactType: this.selectedArtifact.name,
-            data: null
-          });
+            data: null,
+          }, {reload: true, inherit: false});
         }
       });
   }
@@ -113,7 +114,11 @@ class HydratorPlusPlusLeftPanelCtrl {
     let fileBrowserClickCB = () => {
       document.getElementById('pipeline-import-config-link').click();
     };
-    this._checkAndShowConfirmationModalOnDirtyState(() => {}, () => this.$timeout(fileBrowserClickCB));
+    // This is not using the promise pattern as browsers NEED to have the click on the call stack to generate the click on input[type=file] button programmatically in like line:115.
+    // When done in promise we go into the promise ticks and the then callback is called in the next tick which prevents the browser to open the file dialog
+    // as a file dialog is opened ONLY when manually clicked by the user OR transferring the click to another button in the same call stack
+    // TL;DR Can't open file dialog programmatically. If we need to, we need to transfer the click from a user on a button directly into the input file dialog button.
+    this._checkAndShowConfirmationModalOnDirtyState(fileBrowserClickCB);
   }
 
   importFile(files) {
@@ -217,16 +222,16 @@ class HydratorPlusPlusLeftPanelCtrl {
       });
     };
     this._checkAndShowConfirmationModalOnDirtyState()
-      .then(saveState =>{
-        if (!saveState) {
+      .then(proceedToNextStep =>{
+        if (proceedToNextStep) {
           openTemplatesPopup();
         }
       });
   }
 
-  _checkAndShowConfirmationModalOnDirtyState(yesCb, noCb) {
-    let isSavePipeline = true;
-    let isStoreDirty = this.HydratorPlusPlusConfigStore.getIsStateDirty();
+  _checkAndShowConfirmationModalOnDirtyState(proceedCb) {
+    let goTonextStep = true;
+    let isStoreDirty = this.HydratorPlusPlusConfigStore.getIsStateDirty(); // 0=proceed 1=cancel
     if (isStoreDirty) {
       return this.$uibModal.open({
         templateUrl: '/assets/features/hydratorplusplus/templates/create/popovers/canvas-overwrite-confirmation.html',
@@ -234,35 +239,50 @@ class HydratorPlusPlusLeftPanelCtrl {
         backdrop: 'static',
         keyboard: false,
         windowTopClass: 'confirm-modal hydrator-modal',
-        controller: ['$scope', function($scope) {
-          $scope.yes = () => {
-            if (yesCb) {
-              yesCb();
-            } else {
-              isSavePipeline = true;
+        controller: ['$scope', 'HydratorPlusPlusConfigStore', 'HydratorPlusPlusConfigActions', function($scope, HydratorPlusPlusConfigStore, HydratorPlusPlusConfigActions) {
+          $scope.isSaving = false;
+          $scope.discard = () => {
+            goTonextStep = true;
+            if (proceedCb) {
+              proceedCb();
             }
             $scope.$close();
           };
-          $scope.no = () => {
-            if (noCb) {
-              noCb();
-            } else {
-              isSavePipeline = false;
+          $scope.save = () => {
+            let pipelineName = HydratorPlusPlusConfigStore.getName();
+            if (!pipelineName.length) {
+              HydratorPlusPlusConfigActions.saveAsDraft();
+              goTonextStep = false;
+              $scope.$close();
+              return;
             }
+            var unsub = HydratorPlusPlusConfigStore.registerOnChangeListener( () => {
+              let isStateDirty = HydratorPlusPlusConfigStore.getIsStateDirty();
+              // This is solely used for showing the spinner icon until the modal is closed.
+              if(!isStateDirty) {
+                unsub();
+                goTonextStep = true;
+                $scope.$close();
+              }
+            });
+            HydratorPlusPlusConfigActions.saveAsDraft();
+            $scope.isSaving = true;
+          };
+          $scope.cancel = () => {
             $scope.$close();
+            goTonextStep = false;
           };
         }]
       })
       .closed
       .then(() => {
-        return isSavePipeline;
+        return goTonextStep;
       });
     } else {
-      if (noCb) {
-        noCb();
-      } else {
-        return this.$q.when(false);
+      if (proceedCb) {
+        proceedCb();
       }
+      return this.$q.when(goTonextStep);
     }
   }
   onLeftSidePanelItemClicked(event, node) {

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
@@ -231,7 +231,7 @@ class HydratorPlusPlusLeftPanelCtrl {
 
   _checkAndShowConfirmationModalOnDirtyState(proceedCb) {
     let goTonextStep = true;
-    let isStoreDirty = this.HydratorPlusPlusConfigStore.getIsStateDirty(); // 0=proceed 1=cancel
+    let isStoreDirty = this.HydratorPlusPlusConfigStore.getIsStateDirty();
     if (isStoreDirty) {
       return this.$uibModal.open({
         templateUrl: '/assets/features/hydratorplusplus/templates/create/popovers/canvas-overwrite-confirmation.html',

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/toppanel-ctrl.js
@@ -15,9 +15,8 @@
  */
 
 class HydratorPlusPlusTopPanelCtrl{
-  constructor(GLOBALS, $stateParams, HydratorPlusPlusConfigStore, HydratorPlusPlusConfigActions, $uibModal, HydratorPlusPlusConsoleActions, DAGPlusPlusNodesActionsFactory) {
+  constructor($stateParams, HydratorPlusPlusConfigStore, HydratorPlusPlusConfigActions, $uibModal, HydratorPlusPlusConsoleActions, DAGPlusPlusNodesActionsFactory) {
 
-    this.GLOBALS = GLOBALS;
     this.HydratorPlusPlusConfigStore = HydratorPlusPlusConfigStore;
     this.HydratorPlusPlusConfigActions = HydratorPlusPlusConfigActions;
     this.$uibModal = $uibModal;
@@ -125,15 +124,7 @@ class HydratorPlusPlusTopPanelCtrl{
     });
   }
   onSaveDraft() {
-    var config = this.HydratorPlusPlusConfigStore.getState();
-    if (!config.name) {
-      this.HydratorPlusPlusConsoleActions.addMessage({
-        type: 'error',
-        content: this.GLOBALS.en.hydrator.studio.error['MISSING-NAME']
-      });
-      return;
-    }
-    this.HydratorPlusPlusConfigActions.saveAsDraft(config);
+    this.HydratorPlusPlusConfigActions.saveAsDraft();
   }
   onValidate() {
     this.HydratorPlusPlusConsoleActions.resetMessages();
@@ -150,7 +141,7 @@ class HydratorPlusPlusTopPanelCtrl{
   }
 }
 
-HydratorPlusPlusTopPanelCtrl.$inject = ['GLOBALS', '$stateParams', 'HydratorPlusPlusConfigStore', 'HydratorPlusPlusConfigActions', '$uibModal', 'HydratorPlusPlusConsoleActions', 'DAGPlusPlusNodesActionsFactory'];
+HydratorPlusPlusTopPanelCtrl.$inject = ['$stateParams', 'HydratorPlusPlusConfigStore', 'HydratorPlusPlusConfigActions', '$uibModal', 'HydratorPlusPlusConsoleActions', 'DAGPlusPlusNodesActionsFactory'];
 
 angular.module(PKG.name + '.feature.hydratorplusplus')
   .controller('HydratorPlusPlusTopPanelCtrl', HydratorPlusPlusTopPanelCtrl);

--- a/cdap-ui/app/features/hydratorplusplus/leftpanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/leftpanel.less
@@ -590,6 +590,11 @@ body.theme-cdap.state-hydratorplusplus-create {
         }
       }
     }
+    &.confirm-modal.hydrator-modal {
+      .modal-dialog {
+        max-width: 500px;
+      }
+    }
   }
   @media(min-width: @screen-md) {
     .modal {

--- a/cdap-ui/app/features/hydratorplusplus/routes.js
+++ b/cdap-ui/app/features/hydratorplusplus/routes.js
@@ -29,7 +29,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
       })
 
         .state('hydratorplusplus.create', {
-          url: '/studio?draftId&artifactType',
+          url: '/studio?artifactType&draftId',
           params: {
             data: null
           },

--- a/cdap-ui/app/features/hydratorplusplus/templates/create/popovers/canvas-overwrite-confirmation.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/create/popovers/canvas-overwrite-confirmation.html
@@ -16,13 +16,20 @@
 
 <div class="modal-body">
   <div>
-    <span>You have unsaved changes.</span>
-  </div>
-  <div>
-    <span>Do you want to stay at this page?</span>
+    <span>Do you wish to save your work before navigating away?</span>
   </div>
 </div>
 <div class="modal-footer">
-  <button class="btn btn-grey" ng-click="no()">No</button>
-  <button class="btn btn-blue" ng-click="yes()">Yes</button>
+  <div class="pull-left">
+    <button class="btn btn-grey" ng-click="discard()" ng-disabled="isSaving">Don't Save</button>
+  </div>
+  <div class="pull-right">
+    <button class="btn btn-success" ng-click="save()" ng-disabled="isSaving">
+      <span ng-if="isSaving">
+        <span class="fa fa-spin fa-refresh"></span>
+      </span>
+      <span>Save</span>
+    </button>
+    <button class="btn btn-grey" ng-click="cancel()" ng-disabled="isSaving">Cancel</button>
+  </div>
 </div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/create/popovers/canvas-overwrite-confirmation.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/create/popovers/canvas-overwrite-confirmation.html
@@ -24,12 +24,12 @@
     <button class="btn btn-grey" ng-click="discard()" ng-disabled="isSaving">Don't Save</button>
   </div>
   <div class="pull-right">
-    <button class="btn btn-success" ng-click="save()" ng-disabled="isSaving">
+    <button class="btn btn-grey" ng-click="cancel()" ng-disabled="isSaving">Cancel</button>
+    <button class="btn btn-orange" ng-click="save()" ng-disabled="isSaving">
       <span ng-if="isSaving">
         <span class="fa fa-spin fa-refresh"></span>
       </span>
       <span>Save</span>
     </button>
-    <button class="btn btn-grey" ng-click="cancel()" ng-disabled="isSaving">Cancel</button>
   </div>
 </div>


### PR DESCRIPTION
- Fixes the message to be `Do you wish to save your work before navigating away?` when the user has un-saved changes in the dag and is trying to do one of the following,
  - Change artifact
  - Import a pipeline
  - Choose a plugin template
- Saves the draft if the user wises to save it before navigating away
- Shows appropriate message in console if the pipeline does not have a name to be saved as draft.
- Fixes updating default state on config store once a draft has been saved.