### PR TITLE
CDAP-5020 Add Hydrator version to documentation

### DIFF
--- a/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/batchsinks/index.rst
+++ b/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/batchsinks/index.rst
@@ -8,6 +8,8 @@
 Batch Sinks
 ===========
 
+Hydrator Version |cdap-hydrator-version|
+
 .. toctree::
     :maxdepth: 1
     :glob:

--- a/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/batchsources/index.rst
+++ b/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/batchsources/index.rst
@@ -8,6 +8,8 @@
 Batch Sources
 =============
 
+Hydrator Version |cdap-hydrator-version|
+
 .. toctree::
     :maxdepth: 1
     :glob:

--- a/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/index.rst
+++ b/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/index.rst
@@ -16,7 +16,8 @@ can be explored using RESTful APIs.
 If you are creating a custom plugin to extend the existing system artifacts, its name
 should not collide with existing names for ease of use in the CDAP UI.
 
-Shipped with CDAP, the plugins listed below are available for creating ETL applications.
+Shipped with CDAP, the plugins listed below (Hydrator Version |cdap-hydrator-version|) are
+available for creating ETL applications.
 
 
 .. toctree::

--- a/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/realtimesinks/index.rst
+++ b/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/realtimesinks/index.rst
@@ -8,6 +8,8 @@
 Real-time Sinks
 ===============
 
+Hydrator Version |cdap-hydrator-version|
+
 .. toctree::
     :maxdepth: 1
     :glob:

--- a/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/realtimesources/index.rst
+++ b/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/realtimesources/index.rst
@@ -8,6 +8,8 @@
 Real-time Sources
 =================
 
+Hydrator Version |cdap-hydrator-version|
+
 .. toctree::
     :maxdepth: 1
     :glob:

--- a/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/shared-plugins/core.rst
+++ b/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/shared-plugins/core.rst
@@ -8,6 +8,8 @@
 Shared Plugins: CoreValidator
 =============================
 
+Hydrator Version |cdap-hydrator-version|
+
 .. rubric:: Description
 
 A system-supplied validator that offers a set of functions that can be called from the validator transform.

--- a/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/shared-plugins/index.rst
+++ b/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/shared-plugins/index.rst
@@ -8,6 +8,8 @@
 Shared Plugins
 ==============
 
+Hydrator Version |cdap-hydrator-version|
+
 .. toctree::
     :maxdepth: 1
     :glob:

--- a/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/transforms/index.rst
+++ b/cdap-docs/cdap-apps/source/_includes/hydrator-plugins/transforms/index.rst
@@ -8,6 +8,8 @@
 Transformations 
 ===============
 
+Hydrator Version |cdap-hydrator-version|
+
 .. toctree::
     :maxdepth: 1
     :glob:

--- a/cdap-docs/cdap-apps/source/conf.py
+++ b/cdap-docs/cdap-apps/source/conf.py
@@ -15,12 +15,21 @@ from common_conf import *
 
 html_short_title_toc, html_short_title, html_context = set_conf_for_manual()
 
+rst_epilog += """
+.. |cdap-hydrator-version| replace:: %(cdap-hydrator-version)s
+
+.. |literal-cdap-hydrator-version| replace:: ``%(cdap-hydrator-version)s``
+
+""" % {'cdap-hydrator-version': os.environ.get('HYDRATOR_VERSION')}
+
+
 def setup(app):
     # Call imported setup
     _setup(app)
     
     # Add a custom config value that can be used for conditional content
     app.add_config_value('release_version', '', 'env')
+
 
 # Set the condition
 if version == ('3.2.0'):


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/CDAP-5020

Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DOB169-1)

Adds the hydrator version to the documentation in:

- [index page](http://builds.cask.co/artifact/CDAP-DOB169/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/cdap-apps/hydrator/hydrator-plugins/index.html)
- [section pages](http://builds.cask.co/artifact/CDAP-DOB169/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/cdap-apps/hydrator/hydrator-plugins/batchsources/index.html)
- [bottom of each plugin page](http://builds.cask.co/artifact/CDAP-DOB169/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/cdap-apps/hydrator/hydrator-plugins/batchsources/azureblobstore.html)