### PR TITLE
CDAP-5424 Record lineage for external sources/sinks

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchSinkContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchSinkContext.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.api.batch;
 
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 
 import java.util.Map;
@@ -28,15 +29,18 @@ import java.util.Map;
 public interface BatchSinkContext extends BatchContext {
 
   /**
-   * Overrides the output configuration of this MapReduce job to also allow writing to the specified dataset by
+   * Overrides the output configuration of this job to also allow writing to the specified dataset by
    * its name.
    *
    * @param datasetName the name of the output dataset
+   * @deprecated Deprecated since 3.4.0.
+   *             Use {@link #addOutput(Output)} instead
    */
+  @Deprecated
   void addOutput(String datasetName);
 
   /**
-   * Updates the output configuration of this MapReduce job to also allow writing to the specified dataset.
+   * Updates the output configuration of this job to also allow writing to the specified dataset.
    * Currently, the dataset specified in must be an {@link OutputFormatProvider}.
    * You may want to use this method instead of {@link #addOutput(String)} if your output dataset uses runtime
    * arguments set in your own program logic.
@@ -44,15 +48,28 @@ public interface BatchSinkContext extends BatchContext {
    * @param datasetName the name of the output dataset
    * @param arguments the arguments to use when instantiating the dataset
    * @throws IllegalArgumentException if the specified dataset is not an OutputFormatProvider.
+   * @deprecated Deprecated since 3.4.0.
+   *             Use {@link #addOutput(Output)} instead
    */
+  @Deprecated
   void addOutput(String datasetName, Map<String, String> arguments);
 
   /**
-   * Updates the output configuration of this MapReduce job to also allow writing using the given OutputFormatProvider.
+   * Updates the output configuration of this job to also allow writing using the given OutputFormatProvider.
    *
    * @param outputName the name of the output
    * @param outputFormatProvider the outputFormatProvider which specifies an OutputFormat and configuration to be used
    *                             when writing to this output
+   * @deprecated Deprecated since 3.4.0.
+   *             Use {@link #addOutput(Output)} instead
    */
+  @Deprecated
   void addOutput(String outputName, OutputFormatProvider outputFormatProvider);
+
+  /**
+   * Updates the output configuration of this job to also allow writing using the given output.
+   *
+   * @param output output to be used
+   */
+  void addOutput(Output output);
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchSourceContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchSourceContext.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.api.batch;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.batch.BatchReadable;
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
@@ -36,7 +37,10 @@ public interface BatchSourceContext extends BatchContext {
    * Overrides the input configuration of this Batch job to use the specific stream.
    *
    * @param stream the input stream.
+   * @deprecated Deprecated since 3.4.0.
+   *             Use {@link #setInput(Input)} instead
    */
+  @Deprecated
   void setInput(StreamBatchReadable stream);
 
   /**
@@ -44,7 +48,10 @@ public interface BatchSourceContext extends BatchContext {
    * the specified dataset by its name.
    *
    * @param datasetName the name of the input dataset.
+   * @deprecated Deprecated since 3.4.0.
+   *             Use {@link #setInput(Input)} instead
    */
+  @Deprecated
   void setInput(String datasetName);
 
   /**
@@ -53,7 +60,10 @@ public interface BatchSourceContext extends BatchContext {
    *
    * @param datasetName the the name of the input dataset
    * @param arguments the arguments to use when instantiating the dataset
+   * @deprecated Deprecated since 3.4.0.
+   *             Use {@link #setInput(Input)} instead
    */
+  @Deprecated
   void setInput(String datasetName, Map<String, String> arguments);
 
   /**
@@ -62,7 +72,10 @@ public interface BatchSourceContext extends BatchContext {
    *
    * @param datasetName the name of the input dataset
    * @param splits the data selection splits
+   * @deprecated Deprecated since 3.4.0.
+   *             Use {@link #setInput(Input)} instead
    */
+  @Deprecated
   void setInput(String datasetName, List<Split> splits);
 
   /**
@@ -72,7 +85,10 @@ public interface BatchSourceContext extends BatchContext {
    * @param datasetName the name of the input dataset
    * @param arguments the arguments to use when instantiating the dataset
    * @param splits the data selection splits
+   * @deprecated Deprecated since 3.4.0.
+   *             Use {@link #setInput(Input)} instead
    */
+  @Deprecated
   void setInput(String datasetName, Map<String, String> arguments, List<Split> splits);
 
   /**
@@ -80,8 +96,18 @@ public interface BatchSourceContext extends BatchContext {
    * {@link InputFormatProvider}.
    *
    * @param inputFormatProvider provider for InputFormat and configurations to be used
+   * @deprecated Deprecated since 3.4.0.
+   *             Use {@link #setInput(Input)} instead
    */
+  @Deprecated
   void setInput(InputFormatProvider inputFormatProvider);
+
+  /**
+   * Overrides the input configuration of this Batch job to the specified {@link Input}.
+   *
+   * @param input the input to be used
+   */
+  void setInput(Input input);
 
   /**
    * Overrides the input configuration of this MapReduce job to write to the specified dataset instance.

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/AbstractSparkBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/AbstractSparkBatchContext.java
@@ -26,7 +26,7 @@ import co.cask.cdap.etl.batch.AbstractBatchContext;
  */
 public abstract class AbstractSparkBatchContext extends AbstractBatchContext implements BatchContext {
 
-  private final SparkClientContext sparkContext;
+  protected final SparkClientContext sparkContext;
 
   public AbstractSparkBatchContext(SparkClientContext sparkContext, LookupProvider lookupProvider, String stageId) {
     super(sparkContext, sparkContext, sparkContext.getMetrics(), lookupProvider, stageId,

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSinkContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSinkContext.java
@@ -16,10 +16,12 @@
 
 package co.cask.cdap.etl.batch.spark;
 
+import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.etl.common.ExternalDatasets;
 
 import java.util.Collections;
 import java.util.Map;
@@ -50,5 +52,11 @@ public class SparkBatchSinkContext extends AbstractSparkBatchContext implements 
   @Override
   public void addOutput(String outputName, OutputFormatProvider outputFormatProvider) {
     sinkFactory.addOutput(getStageName(), outputName, outputFormatProvider);
+  }
+
+  @Override
+  public void addOutput(Output output) {
+    Output trackableOutput = ExternalDatasets.makeTrackable(sparkContext.getAdmin(), output);
+    sinkFactory.addOutput(getStageName(), trackableOutput);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSourceContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSourceContext.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.batch.spark;
 
 import co.cask.cdap.api.data.batch.BatchReadable;
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
@@ -24,6 +25,7 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.etl.common.ExternalDatasets;
 
 import java.util.Collections;
 import java.util.List;
@@ -80,6 +82,12 @@ public class SparkBatchSourceContext extends AbstractSparkBatchContext implement
     } else {
       throw new IllegalArgumentException("Input dataset must be a BatchReadable or InputFormatProvider.");
     }
+  }
+
+  @Override
+  public void setInput(Input input) {
+    Input trackableInput = ExternalDatasets.makeTrackable(sparkContext.getAdmin(), input);
+    sourceFactory = SparkBatchSourceFactory.create(trackableInput);
   }
 
   @Nullable

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSourceFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSourceFactory.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.batch.spark;
 
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
@@ -91,6 +92,21 @@ final class SparkBatchSourceFactory {
   static SparkBatchSourceFactory create(String datasetName, Map<String, String> datasetArgs,
                                         @Nullable List<Split> splits) {
     return new SparkBatchSourceFactory(null, null, new DatasetInfo(datasetName, datasetArgs, splits));
+  }
+
+  static SparkBatchSourceFactory create(Input input) {
+    if (input instanceof Input.DatasetInput) {
+      // Note if input format provider is trackable then it comes in as DatasetInput
+      Input.DatasetInput datasetInput = (Input.DatasetInput) input;
+      return create(datasetInput.getName(), datasetInput.getArguments(), datasetInput.getSplits());
+    } else if (input instanceof Input.StreamInput) {
+      Input.StreamInput streamInput = (Input.StreamInput) input;
+      return create(streamInput.getStreamBatchReadable());
+    } else if (input instanceof Input.InputFormatProviderInput) {
+      Input.InputFormatProviderInput ifpInput = (Input.InputFormatProviderInput) input;
+      return new SparkBatchSourceFactory(null, ifpInput.getInputFormatProvider(), null);
+    }
+    throw new IllegalArgumentException("Unknown input format type: " + input.getClass().getCanonicalName());
   }
 
   static SparkBatchSourceFactory deserialize(InputStream inputStream) throws IOException {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceSinkContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceSinkContext.java
@@ -16,11 +16,13 @@
 
 package co.cask.cdap.etl.batch.mapreduce;
 
+import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.etl.common.ExternalDatasets;
 import co.cask.cdap.etl.log.LogContext;
 
 import java.util.HashSet;
@@ -75,6 +77,19 @@ public class MapReduceSinkContext extends MapReduceBatchContext implements Batch
       }
     });
     outputNames.add(outputName);
+  }
+
+  @Override
+  public void addOutput(final Output output) {
+    Output trackableOutput = LogContext.runWithoutLoggingUnchecked(new Callable<Output>() {
+      @Override
+      public Output call() throws Exception {
+        Output trackableOutput = ExternalDatasets.makeTrackable(mrContext.getAdmin(), output);
+        mrContext.addOutput(trackableOutput);
+        return trackableOutput;
+      }
+    });
+    outputNames.add(trackableOutput.getAlias());
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceSourceContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceSourceContext.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.batch.mapreduce;
 
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
@@ -24,6 +25,7 @@ import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.etl.common.ExternalDatasets;
 import co.cask.cdap.etl.log.LogContext;
 
 import java.util.List;
@@ -101,6 +103,18 @@ public class MapReduceSourceContext extends MapReduceBatchContext implements Bat
       @Override
       public Void call() throws Exception {
         mrContext.setInput(inputFormatProvider);
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public void setInput(final Input input) {
+    LogContext.runWithoutLoggingUnchecked(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        Input trackableInput =  ExternalDatasets.makeTrackable(mrContext.getAdmin(), input);
+        mrContext.addInput(trackableInput);
         return null;
       }
     });

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ExternalDatasets.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ExternalDatasets.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.batch.InputFormatProvider;
+import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import com.google.common.base.Throwables;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class is used to create external datasets to track external sources/sinks.
+ */
+public final class ExternalDatasets {
+  private static final String NAME_PREFIX = "hydrator-ext-";
+
+  /**
+   * If the input is an external source then an external dataset is created for tracking purpose and returned.
+   * If the input is a regular dataset or a stream then it is already trackable, hence same input is returned.
+   *
+   * @param admin {@link Admin} used to create external dataset
+   * @param input input to be tracked
+   * @return an external dataset if input is an external source, otherwise the same input that is passed-in is returned
+   */
+  public static Input makeTrackable(Admin admin, Input input) {
+    // If input is not an external source, return the same input as it can be tracked by itself.
+    if (!(input instanceof Input.InputFormatProviderInput)) {
+      return input;
+    }
+
+    // Input is an external source, create an external dataset so that it can be tracked.
+    String inputName = input.getName();
+    InputFormatProvider inputFormatProvider = ((Input.InputFormatProviderInput) input).getInputFormatProvider();
+    Map<String, String> inputFormatConfiguration = inputFormatProvider.getInputFormatConfiguration();
+
+    // Input is a dataset that implements input format provider,
+    // this too can be tracked by itself without creating an external dataset
+    if (inputFormatProvider instanceof Dataset) {
+      return input;
+    }
+
+    try {
+      // Create an external dataset for the input format for lineage tracking
+      String datasetName = NAME_PREFIX + inputName;
+      Map<String, String> arguments = new HashMap<>();
+      arguments.put("input.format.class", inputFormatProvider.getInputFormatClassName());
+      arguments.putAll(inputFormatConfiguration);
+      if (!admin.datasetExists(datasetName)) {
+        // Note: the dataset properties are the same as the arguments since we cannot identify them separately
+        // since they are mixed up in a single configuration object (CDAP-5674)
+        // Also, the properties of the external dataset created will contain runtime arguments for the same reason.
+        admin.createDataset(datasetName, "externalDataset", DatasetProperties.builder().addAll(arguments).build());
+      }
+      return Input.ofDataset(datasetName, Collections.unmodifiableMap(arguments)).alias(input.getAlias());
+    } catch (DatasetManagementException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /**
+   * If the output is an external sink then an external dataset is created for tracking purpose and returned.
+   * If the output is a regular dataset then it is already trackable, hence same output is returned.
+   *
+   * @param admin {@link Admin} used to create external dataset
+   * @param output output to be tracked
+   * @return an external dataset if output is an external sink, otherwise the same output is returned
+   */
+  public static Output makeTrackable(Admin admin, Output output) {
+    // If output is not an external sink, return the same output as it can be tracked by itself.
+    if (!(output instanceof Output.OutputFormatProviderOutput)) {
+      return output;
+    }
+
+    // Output is an external sink, create an external dataset so that it can be tracked.
+    String outputName = output.getName();
+    OutputFormatProvider outputFormatProvider = ((Output.OutputFormatProviderOutput) output).getOutputFormatProvider();
+    Map<String, String> outputFormatConfiguration = outputFormatProvider.getOutputFormatConfiguration();
+
+    // Output is a dataset that implements input format provider,
+    // this can be tracked by itself without creating an external dataset
+    if (outputFormatProvider instanceof Dataset) {
+      return output;
+    }
+
+    // Output is an external sink, create an external dataset so that it can be tracked.
+    try {
+      // Create an external dataset for the output format for lineage tracking
+      String datasetName = NAME_PREFIX + outputName;
+      Map<String, String> arguments = new HashMap<>();
+      arguments.put("output.format.class", outputFormatProvider.getOutputFormatClassName());
+      arguments.putAll(outputFormatConfiguration);
+      if (!admin.datasetExists(datasetName)) {
+        // Note: the dataset properties are the same as the arguments since we cannot identify them separately
+        // since they are mixed up in a single configuration object (CDAP-5674)
+        // Also, the properties of the external dataset created will contain runtime arguments for the same reason.
+        admin.createDataset(datasetName, "externalDataset", DatasetProperties.builder().addAll(arguments).build());
+      }
+      return Output.ofDataset(datasetName, Collections.unmodifiableMap(arguments)).alias(output.getAlias());
+    } catch (DatasetManagementException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  // To prevent instantiation
+  private ExternalDatasets() {}
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockExternalSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockExternalSink.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.batch;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+import com.google.gson.Gson;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Mock sink that writes records to a Table and has a utility method for getting all records written.
+ */
+@Plugin(type = BatchSink.PLUGIN_TYPE)
+@Name(MockExternalSink.PLUGIN_NAME)
+public class MockExternalSink extends BatchSink<StructuredRecord, NullWritable, String> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  public static final String PLUGIN_NAME = "MockExternalSink";
+  private static final Gson GSON = new Gson();
+  private final Config config;
+
+  public MockExternalSink(Config config) {
+    this.config = config;
+  }
+
+  /**
+   * Config for the sink.
+   */
+  public static class Config extends PluginConfig {
+    @Nullable
+    private String name;
+    private String alias;
+    private String dirName;
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) throws Exception {
+    OutputFormatProvider outputFormatProvider = new OutputFormatProvider() {
+      @Override
+      public String getOutputFormatClassName() {
+        return TextOutputFormat.class.getCanonicalName();
+      }
+
+      @Override
+      public Map<String, String> getOutputFormatConfiguration() {
+        return ImmutableMap.of(TextOutputFormat.OUTDIR, config.dirName);
+      }
+    };
+
+    if (config.name != null) {
+      Output output = Output.of(config.name, outputFormatProvider);
+      output.alias(config.alias);
+      context.addOutput(output);
+    } else {
+      context.addOutput(config.alias, outputFormatProvider);
+    }
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<KeyValue<NullWritable, String>> emitter)
+    throws Exception {
+    emitter.emit(new KeyValue<>(NullWritable.get(), GSON.toJson(input)));
+  }
+
+  /**
+   * Returns {@link ETLPlugin} for MockExternalSink.
+   *
+   * @param name name of the provider, use null for backwards compatibility
+   * @param alias alias of the provider
+   * @param dirName directory name
+   * @return {@link ETLPlugin} for MockExternalSink
+   */
+  public static ETLPlugin getPlugin(@Nullable String name, String alias, String dirName) {
+    Map<String, String> properties = new HashMap<>();
+    if (name != null) {
+      properties.put("name", name);
+    }
+    properties.put("alias", alias);
+    properties.put("dirName", dirName);
+    return new ETLPlugin(PLUGIN_NAME, BatchSink.PLUGIN_TYPE, properties, null);
+  }
+
+  /**
+   * Used to read the records written by this sink.
+   *
+   * @param dirName directory where output files are found
+   */
+  public static List<StructuredRecord> readOutput(String dirName) throws Exception {
+    File dir = new File(dirName);
+    File[] files = dir.listFiles(new FilenameFilter() {
+      @Override
+      public boolean accept(File dir, String name) {
+        return name.startsWith("part");
+      }
+    });
+    if (files == null) {
+      return Collections.emptyList();
+    }
+
+    List<StructuredRecord> records = new ArrayList<>();
+    for (File file : files) {
+      records.addAll(Lists.transform(Files.readLines(file, Charsets.UTF_8),
+                                     new Function<String, StructuredRecord>() {
+                                       @Override
+                                       public StructuredRecord apply(String input) {
+                                         return GSON.fromJson(input, StructuredRecord.class);
+                                       }
+                                     }));
+    }
+    return records;
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("name", new PluginPropertyField("name", "", "string", false));
+    properties.put("alias", new PluginPropertyField("alias", "", "string", true));
+    properties.put("dirName", new PluginPropertyField("dirName", "", "string", true));
+    return new PluginClass(BatchSink.PLUGIN_TYPE, PLUGIN_NAME, "",
+                           MockExternalSink.class.getName(), "config", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockExternalSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockExternalSource.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.batch;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.batch.InputFormatProvider;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.io.Files;
+import com.google.gson.Gson;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mock source that can be used to write a list of records in a Table and reads them out in a pipeline run.
+ */
+@Plugin(type = BatchSource.PLUGIN_TYPE)
+@Name(MockExternalSource.PLUGIN_NAME)
+public class MockExternalSource extends BatchSource<LongWritable, Text, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  public static final String PLUGIN_NAME = "MockExternalSource";
+  private static final Gson GSON = new Gson();
+  private final Config config;
+
+  public MockExternalSource(Config config) {
+    this.config = config;
+  }
+
+  /**
+   * Config for the source.
+   */
+  public static class Config extends PluginConfig {
+    private String name;
+    private String dirName;
+  }
+
+  @Override
+  public void transform(KeyValue<LongWritable, Text> input, Emitter<StructuredRecord> emitter) throws Exception {
+    emitter.emit(GSON.fromJson(input.getValue().toString(), StructuredRecord.class));
+  }
+
+  @Override
+  public void prepareRun(BatchSourceContext context) throws Exception {
+    context.setInput(Input.of(config.name, new InputFormatProvider() {
+      @Override
+      public String getInputFormatClassName() {
+        return TextInputFormat.class.getCanonicalName();
+      }
+
+      @Override
+      public Map<String, String> getInputFormatConfiguration() {
+        return ImmutableMap.of(TextInputFormat.INPUT_DIR, config.dirName);
+      }
+    }));
+  }
+
+  public static ETLPlugin getPlugin(String name, String dirName) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("name", name);
+    properties.put("dirName", dirName);
+    return new ETLPlugin(PLUGIN_NAME, BatchSource.PLUGIN_TYPE, properties, null);
+  }
+
+  /**
+   * Used to write the input records for the pipeline run. Should be called after the pipeline has been created.
+   *
+   * @param fileName file to write the records into
+   * @param records records that should be the input for the pipeline
+   */
+  public static void writeInput(String fileName,
+                                Iterable<StructuredRecord> records) throws Exception {
+    String output = Joiner.on("\n").join(Iterables.transform(records,
+                                                             new Function<StructuredRecord, String>() {
+                                                               @Override
+                                                               public String apply(StructuredRecord input) {
+                                                                 return GSON.toJson(input);
+                                                               }
+                                                             })
+    );
+    Files.write(output, new File(fileName), Charsets.UTF_8);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("name", new PluginPropertyField("name", "", "string", true));
+    properties.put("dirName", new PluginPropertyField("dirName", "", "string", true));
+    return new PluginClass(BatchSource.PLUGIN_TYPE, PLUGIN_NAME, "", MockExternalSource.class.getName(),
+                           "config", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
@@ -20,6 +20,8 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.etl.api.PipelineConfigurable;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.realtime.RealtimeSource;
+import co.cask.cdap.etl.mock.batch.MockExternalSink;
+import co.cask.cdap.etl.mock.batch.MockExternalSource;
 import co.cask.cdap.etl.mock.batch.NodeStatesAction;
 import co.cask.cdap.etl.mock.batch.aggregator.FieldCountAggregator;
 import co.cask.cdap.etl.mock.batch.aggregator.IdentityAggregator;
@@ -50,6 +52,7 @@ public class HydratorTestBase extends TestBase {
   private static final Set<PluginClass> BATCH_MOCK_PLUGINS = ImmutableSet.of(
     FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS,
     co.cask.cdap.etl.mock.batch.MockSink.PLUGIN_CLASS, co.cask.cdap.etl.mock.batch.MockSource.PLUGIN_CLASS,
+    MockExternalSource.PLUGIN_CLASS, MockExternalSink.PLUGIN_CLASS,
     DoubleTransform.PLUGIN_CLASS, ErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
     IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS
   );
@@ -91,6 +94,7 @@ public class HydratorTestBase extends TestBase {
                       BATCH_MOCK_PLUGINS,
                       co.cask.cdap.etl.mock.batch.MockSource.class,
                       co.cask.cdap.etl.mock.batch.MockSink.class,
+                      MockExternalSource.class, MockExternalSink.class,
                       DoubleTransform.class, ErrorTransform.class, IdentityTransform.class,
                       IntValueFilterTransform.class, StringValueFilterTransform.class,
                       FieldCountAggregator.class, IdentityAggregator.class,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/SystemDatasetRuntimeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/SystemDatasetRuntimeModule.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.lib.external.ExternalDatasetModule;
 import co.cask.cdap.data2.dataset2.lib.file.FileSetModule;
 import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetModule;
 import co.cask.cdap.data2.dataset2.lib.partitioned.TimePartitionedFileSetModule;
@@ -139,5 +140,6 @@ public class SystemDatasetRuntimeModule extends RuntimeModule {
     mapBinder.addBinding("usage").toInstance(new UsageDatasetModule());
     mapBinder.addBinding("metadata").toInstance(new MetadataDatasetModule());
     mapBinder.addBinding("lineage").toInstance(new LineageDatasetModule());
+    mapBinder.addBinding("externalDataset").toInstance(new ExternalDatasetModule());
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDataset.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.external;
+
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.data.batch.InputFormatProvider;
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
+import co.cask.cdap.api.dataset.Dataset;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Represents a data source/sink that is external to CDAP. No physical manifestation of this dataset exists in CDAP.
+ */
+@Beta
+public class ExternalDataset implements Dataset, InputFormatProvider, OutputFormatProvider {
+  private final String inputFormatClassName;
+  private final String outputFormatClassName;
+  private final Map<String, String> inputFormatConfiguration;
+  private final Map<String, String> outputFormatConfiguration;
+
+  public ExternalDataset(Map<String, String> runtimeArgs) {
+    // A runtime instantiation of external dataset can be a source or a sink, not both
+    this.inputFormatClassName = runtimeArgs.get("input.format.class");
+    this.outputFormatClassName = runtimeArgs.get("output.format.class");
+    this.inputFormatConfiguration =
+      this.inputFormatClassName != null ? runtimeArgs : Collections.<String, String>emptyMap();
+    this.outputFormatConfiguration =
+      this.outputFormatClassName != null ? runtimeArgs : Collections.<String, String>emptyMap();
+  }
+
+  @Override
+  public String getInputFormatClassName() {
+    return inputFormatClassName;
+  }
+
+  @Override
+  public Map<String, String> getInputFormatConfiguration() {
+    return inputFormatConfiguration;
+  }
+
+  @Override
+  public String getOutputFormatClassName() {
+    return outputFormatClassName;
+  }
+
+  @Override
+  public Map<String, String> getOutputFormatConfiguration() {
+    return outputFormatConfiguration;
+  }
+
+  @Override
+  public void close() throws IOException {
+    // Nothing to do
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDatasetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDatasetAdmin.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.external;
+
+import co.cask.cdap.api.dataset.DatasetAdmin;
+
+import java.io.IOException;
+
+/**
+ * Admin for {@link ExternalDataset}.
+ */
+public class ExternalDatasetAdmin implements DatasetAdmin {
+  @Override
+  public boolean exists() throws IOException {
+    // this dataset always exists since it is a trivial implementation
+    return true;
+  }
+
+  @Override
+  public void create() throws IOException {
+    // nothing to do
+  }
+
+  @Override
+  public void drop() throws IOException {
+    // nothing to do
+  }
+
+  @Override
+  public void truncate() throws IOException {
+    // nothing to do
+  }
+
+  @Override
+  public void upgrade() throws IOException {
+    // nothing to do
+  }
+
+  @Override
+  public void close() throws IOException {
+    // nothing to do
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDatasetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDatasetDefinition.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.external;
+
+import co.cask.cdap.api.dataset.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Dataset definition for {@link ExternalDataset}.
+ */
+public class ExternalDatasetDefinition implements DatasetDefinition<ExternalDataset, ExternalDatasetAdmin> {
+
+  private final String name;
+
+  public ExternalDatasetDefinition(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public DatasetSpecification configure(String instanceName, DatasetProperties properties) {
+    return DatasetSpecification.builder(instanceName, getName())
+      .properties(properties.getProperties())
+      .build();
+  }
+
+  @Override
+  public ExternalDatasetAdmin getAdmin(DatasetContext datasetContext, DatasetSpecification spec,
+                                       ClassLoader classLoader) throws IOException {
+    return new ExternalDatasetAdmin();
+  }
+
+  @Override
+  public ExternalDataset getDataset(DatasetContext datasetContext, DatasetSpecification spec,
+                                    Map<String, String> arguments, ClassLoader classLoader) throws IOException {
+    return new ExternalDataset(arguments);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDatasetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDatasetModule.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.external;
+
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+
+/**
+ * Dataset module for {@link ExternalDataset}.
+ */
+public class ExternalDatasetModule implements DatasetModule {
+  @Override
+  public void register(DatasetDefinitionRegistry registry) {
+    registry.add(new ExternalDatasetDefinition("externalDataset"));
+  }
+}


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-5424

TODO:
- [ ] Identify input/output providers that are regular datasets - https://issues.cask.co/browse/CDAP-5675
- [x] Distinguish between name and alias for external datasets
- [x] Backwards compatibility
- [x] Add test
- [x] Use dataset runtime arguments to pass input/output configuration instead of dataset properties.

Build - http://builds.cask.co/browse/CDAP-DUT3961-15
Depends on https://github.com/caskdata/cdap/pull/5586