### PR TITLE
Use latest IntelliJ version (backport from 3.4)

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -89,7 +89,7 @@
         },
         "idea": {
           "setup_dir": "/opt",
-          "version": "15.0.2"
+          "version": "2016.1"
         },
         "hadoop": {
           "distribution": "hdp",


### PR DESCRIPTION
Upstream removes old versions from availability, which breaks the VM build.