### PR TITLE
(CDAP-349) Make parallel Spark job possible in Standalone

### DIFF
--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
@@ -60,7 +60,7 @@ final class SparkTransactional implements Transactional {
       @Override
       public void set(TransactionalDatasetContext value) {
         String txKey = Long.toString(value.getTransaction().getWritePointer());
-        if (SparkContextCache.setLocalProperty(ACTIVE_TRANSACTION_KEY, txKey)) {
+        if (SparkRuntimeEnv.setLocalProperty(ACTIVE_TRANSACTION_KEY, txKey)) {
           transactionInfos.put(txKey, value);
         }
 
@@ -69,10 +69,10 @@ final class SparkTransactional implements Transactional {
 
       @Override
       public void remove() {
-        String txKey = SparkContextCache.getLocalProperty(ACTIVE_TRANSACTION_KEY);
+        String txKey = SparkRuntimeEnv.getLocalProperty(ACTIVE_TRANSACTION_KEY);
         if (txKey != null && !txKey.isEmpty()) {
           // Spark doesn't support unsetting of property. Hence set it to empty.
-          SparkContextCache.setLocalProperty(ACTIVE_TRANSACTION_KEY, "");
+          SparkRuntimeEnv.setLocalProperty(ACTIVE_TRANSACTION_KEY, "");
           transactionInfos.remove(txKey);
         }
         super.remove();

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -80,13 +80,13 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
     implicit val kTag: ClassTag[K] = createClassTag
     implicit val vTag: ClassTag[V] = createClassTag
     JavaPairRDD.fromRDD(
-      sec.fromDataset(SparkContextCache.getContext, datasetName, arguments.toMap, Option(splits).map(_.toIterable)))
+      sec.fromDataset(SparkRuntimeEnv.getContext, datasetName, arguments.toMap, Option(splits).map(_.toIterable)))
   }
 
   override def fromStream(streamName: String, startTime: Long, endTime: Long) : JavaRDD[StreamEvent] = {
     val ct: ClassTag[StreamEvent] = createClassTag
     JavaRDD.fromRDD(
-      sec.fromStream(SparkContextCache.getContext, streamName, startTime, endTime)(ct, (e: StreamEvent) => e))
+      sec.fromStream(SparkRuntimeEnv.getContext, streamName, startTime, endTime)(ct, (e: StreamEvent) => e))
   }
 
   override def fromStream[V](streamName: String, startTime: Long,
@@ -117,7 +117,7 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
                              dataType: Class[T]): JavaPairRDD[java.lang.Long, GenericStreamEventData[T]] = {
     implicit val dTag: ClassTag[T] = ClassTag(dataType)
     val stream: RDD[(Long, GenericStreamEventData[T])] =
-      sec.fromStream(SparkContextCache.getContext, streamName, formatSpec, startTime, endTime)
+      sec.fromStream(SparkRuntimeEnv.getContext, streamName, formatSpec, startTime, endTime)
     JavaPairRDD.fromRDD(stream.map(t => (t._1: java.lang.Long, t._2)))
   }
 
@@ -142,7 +142,7 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
                                                          decoderClass: Class[_ <: StreamEventDecoder[K, V]])
                                                         (implicit ct: ClassTag[StreamEvent]): RDD[(K, V)] = {
     val identity = (e: StreamEvent) => e
-    sec.fromStream(SparkContextCache.getContext, streamName, startTime, endTime)(ct, identity)
+    sec.fromStream(SparkRuntimeEnv.getContext, streamName, startTime, endTime)(ct, identity)
        .mapPartitions(createStreamMap(decoderClass))
   }
 

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
@@ -77,7 +77,7 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
   sparkTxService.startAndWait()
 
   // Attach a listener to the SparkContextCache, which will in turn listening to events from SparkContext.
-  SparkContextCache.addSparkListener(new SparkListener {
+  SparkRuntimeEnv.addSparkListener(new SparkListener {
 
     override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd) = applicationEndLatch.countDown
 
@@ -109,7 +109,7 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
     try {
       // If there is a SparkContext, wait for the ApplicationEnd callback
       // This make sure all jobs' transactions are committed/invalidated
-      SparkContextCache.stop.foreach(sc => applicationEndLatch.await())
+      SparkRuntimeEnv.stop.foreach(sc => applicationEndLatch.await())
     } finally {
       sparkTxService.stopAndWait()
     }

--- a/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ForkSpark.scala
+++ b/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ForkSpark.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spark.app
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+import co.cask.cdap.api.spark.{AbstractSpark, SparkExecutionContext, SparkMain}
+import co.cask.cdap.api.workflow.{Value, WorkflowForkNode}
+import com.google.common.base.Stopwatch
+import org.apache.spark.{SparkConf, SparkContext}
+
+import scala.collection.JavaConversions._
+
+/**
+  * A Spark program for testing forking Spark in workflow.
+  */
+class ForkSpark(name: String) extends AbstractSpark with SparkMain {
+
+  def this() = this(classOf[ForkSpark].getSimpleName)
+
+  override protected def configure(): Unit = {
+    setName(name)
+    setMainClass(classOf[ForkSpark])
+  }
+
+  override def run(implicit sec: SparkExecutionContext): Unit = {
+    // Touch a file in a directory provided by the runtime argument
+    // Then block until there are "n" files in that directory
+    // Where n is the number of branches in the fork
+    // This acts as a simple barrier for all spark programs in the fork
+    val barrierDir = new File(sec.getRuntimeArguments.get("barrier.dir"))
+    val file = new File(barrierDir, sec.getRunId.getId)
+    require(file.createNewFile())
+    val branchSize = getBranchSize(sec)
+    val stopWatch = new Stopwatch().start()
+    while (barrierDir.list().length < branchSize && stopWatch.elapsedTime(TimeUnit.SECONDS) < 10) {
+      TimeUnit.MILLISECONDS.sleep(100)
+    }
+
+    val conf = new SparkConf
+    val sc = new SparkContext(conf)
+
+    // Just run something in Spark, base on some property that we know is set by SparkSubmit to system properties.
+    // If fork support is implemented correctly, then those values from the SparkConf would be different for
+    // different Spark job in the branch; otherwise they'll be the same due to the barrier in place above
+    val sum = sc.parallelize(conf.get("spark.app.name").toCharArray)
+                .map(_.toInt)
+                .reduce(_ + _)
+
+    sec.getWorkflowToken.foreach(_.put("sum", Value.of(sum)))
+  }
+
+  private def getBranchSize(sec: SparkExecutionContext): Int = {
+    val workflowSpec = sec.getApplicationSpecification.getWorkflows.get(sec.getWorkflowInfo.get.getName)
+    workflowSpec.getNodes.collect { case node: WorkflowForkNode => node }.head.getBranches.size()
+  }
+}


### PR DESCRIPTION
We already have the Spark runtime ClassLoader isolation, however,
SparkSubmit uses System properties as the mean to transfer configurations
to SparkConf, hence making parallel Spark execution affecting each other.
The fix for that is to have SparkConf and SparkSubmit rewritten so that
instead of using the System properties, they use a per ClassLoader class,
SparkRuntimeEnv for those configurations

- Rename SparkContextCache to SparkRuntimeEnv
- Rewrite usage of System.setProperty to SparkRuntimeEnv.setProperty in the SparkSubmit class
- Rewrite the SparkConf constructor to pickup configurations from SparkRuntimeEnv
- Added new unit-test