### PR TITLE
Fix Reference Manual Documentation Build

### DIFF
--- a/cdap-docs/reference-manual/source/http-restful-api/stream.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/stream.rst
@@ -64,27 +64,27 @@ Optionally, properties for the stream can be set by providing them in the body o
 be retrieved and modified afterwards using the ``/properties`` endpoint.
 
 .. list-table::
-:widths: 20 80
+   :widths: 20 20 60
    :header-rows: 1
 
    * - Parameter
-     - Description
      - Default Value
+     - Description
    * - ``ttl``
-     - Number of seconds that an event will be valid for, since it was ingested
      - ``Long.MAX`` (2^63 - 1)
+     - Number of seconds that an event will be valid for, since it was ingested
    * - ``format``
+     - ``text``
      - JSON Object describing the format name, schema, and settings. Accepted formats are
        ``avro``, ``csv`` (comma-separated), ``tsv`` (tab-separated), ``text``, ``clf``,
        ``grok``, and ``syslog``.
-     - ``text``
    * - ``notification.threshold.mb``
+     - 1024
      - Increment of data, in MB, that a stream has to receive before
        publishing a notification.
-     - 1024
    * - ``description``
-     - Description of the stream
      - ``null``
+     - Description of the stream
 
 If a property is not given in the request body, the default value will be used instead.
 


### PR DESCRIPTION
Fixes formatting.
Moves "Default Value" column to the middle, as that will be easier to read and understand.

Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DOB174-1)