### PR TITLE
[CDAP-3051] Add documentation and an example for dataset management in programs

### DIFF
--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -81,6 +81,7 @@ function download_includes() {
   download_readme_file_and_test ${includes_dir} ${ingest_url} 5fc88ec3a658062775403f5be30afbe9 cdap-stream-clients/ruby
 
   echo_red_bold "Check included example files for changes"
+  test_an_include 9e137848822e63101b699af03af7f45e ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
   test_an_include 19e6f831f28da8c7cb7e675b7a324da6 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
   test_an_include 80216a08a2b3d480e4a081722408222f ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
@@ -169,6 +169,37 @@ There are two ways to use a dataset in a program:
   sure that every thread has its own instance of each dynamic dataset |---| and in order to discard a dataset
   from the cache, every thread that uses it must individually call ``discardDataset()``.
 
+.. _dataset-admin-in-programs:
+
+.. rubric:: Dataset Management in Programs
+
+Instantiating a dataset in a program allows you to perform any of the dataset's data operations |---| the Java
+methods defined in the dataset's API. However, you cannot perform administrative operations such as creating or
+dropping a dataset. For these operations, the program context offers an ``Admin`` interface that can be obtained
+through the ``getAdmin()`` method of the context. This is available in all types of programs. For example, in
+a service handler, you can obtain the ``Admin`` through the ``HttpServiceContext``. The ``FileSetHandler`` of the
+:ref:`examples-fileset` extends ``AbstractHttpServiceHandler`` |---| its ``configure`` method saves the context
+in an instance variable and makes it available through ``getContext()``:
+
+.. literalinclude:: /../../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
+    :language: java
+    :lines: 63-68
+    :dedent: 2
+
+The handler defines several endpoints for dataset management, one of which can be used to create a new file set,
+either by cloning an existing file set's dataset properties, or using the properties submitted in the request body:
+
+.. literalinclude:: /../../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
+    :language: java
+    :lines: 167-196
+    :dedent: 2
+
+For more details, see the :ref:`examples-fileset`.
+
+Note that even though you can call dataset management methods within a transaction, these operations are *not*
+transactional, and they are not rolled back in case the current transaction fails. It is advisable not to mix data
+operations and dataset management operations within the same transaction.
+
 .. rubric::  Dataset Time-To-Live (TTL)
 
 Datasets, like :ref:`streams <streams>`, can have a Time-To-Live (TTL) property that

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -147,8 +147,8 @@ function download_includes() {
   test_an_include 7babc1855b0e3c367d65bd6d939b348f ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
 
   test_an_include 8a7b4aacee88800cd82d96b07280cc64 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
-  test_an_include 6943e3861b243c72ab212fe30bbaf5f0 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
-  test_an_include d859373458f43c169866f0b00a7bdaa5 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
+  test_an_include 9e137848822e63101b699af03af7f45e ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
+  test_an_include d116b47ead6aed5cecc3db53121c95f1 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
   
   test_an_include c2374d482454dc57c5944e557b544dba ../../cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java
 

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
@@ -52,8 +52,14 @@ public class WordCount extends AbstractMapReduce {
     job.setReducerClass(Counter.class);
     job.setNumReduceTasks(1);
 
-    context.addInput(Input.ofDataset("lines"));
-    context.addOutput("counts");
+    String inputDataset = context.getRuntimeArguments().get("input");
+    inputDataset = inputDataset != null ? inputDataset : "lines";
+
+    String outputDataset = context.getRuntimeArguments().get("output");
+    outputDataset = outputDataset != null ? outputDataset : "counts";
+
+    context.addInput(Input.ofDataset(inputDataset));
+    context.addOutput(outputDataset);
   }
 
   /**


### PR DESCRIPTION
- added dataset admin endpoints to FileSetExample
- added documentation for dataset admin in developer guide

Passes [Quick Build 5](http://builds.cask.co/browse/CDAP-DOB176-4)

Pages of interest:

- [Developers’ Guide: Dataset Admin](http://builds.cask.co/artifact/CDAP-DOB176/shared/build-5/Docs-HTML/3.4.0-SNAPSHOT/en/developers-manual/building-blocks/datasets/index.html)
- [Examples: FileSet](http://builds.cask.co/artifact/CDAP-DOB176/shared/build-5/Docs-HTML/3.4.0-SNAPSHOT/en/examples-manual/examples/fileset-example.html)