### PR TITLE
Hydrator++ UI bug fix

### DIFF
--- a/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
+++ b/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
@@ -68,6 +68,7 @@
     <ul class="navbar-list" ng-if="Navbar.activeProduct === 'hydrator'">
       <li>
         <a ui-sref="hydratorplusplus.create({ namespace: $stateParams.namespace })"
+           ui-sref-opts="{ inherit: false }"
            ng-class="{ 'active': Navbar.highlightTab === 'hydratorStudioPlusPlus'}">
           Studio
         </a>

--- a/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.less
+++ b/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.less
@@ -26,6 +26,7 @@ my-schema-editor {
     }
     &.trash {
       .btn {
+        padding: 0;
         background: transparent;
       }
     }

--- a/cdap-ui/app/features/hydratorplusplus/bottompanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/bottompanel.less
@@ -449,7 +449,10 @@ body.theme-cdap.state-hydratorplusplus {
     }
     .node-config .bottompanel-body {
       @media (min-width: @screen-lg-min) {
-        padding: 0;
+        padding: 0px;
+        .no-plugin-properties-message {
+          margin: 10px;
+        }
         > p, .validator-plugin > div {
           padding: 20px 10px;
         }

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/create-studio-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/create-studio-ctrl.js
@@ -16,7 +16,7 @@
 
 class HydratorPlusPlusStudioCtrl {
   // Holy cow. Much DI. Such angular.
-  constructor(HydratorPlusPlusLeftPanelStore, HydratorPlusPlusConfigActions, $stateParams, rConfig, $rootScope, $scope, HydratorPlusPlusDetailNonRunsStore, HydratorPlusPlusNodeConfigStore, DAGPlusPlusNodesActionsFactory, HydratorPlusPlusHydratorService, HydratorPlusPlusConsoleActions, rSelectedArtifact, rArtifacts, myLocalStorage) {
+  constructor(HydratorPlusPlusLeftPanelStore, HydratorPlusPlusConfigActions, $stateParams, rConfig, $rootScope, $scope, HydratorPlusPlusDetailNonRunsStore, HydratorPlusPlusNodeConfigStore, DAGPlusPlusNodesActionsFactory, HydratorPlusPlusHydratorService, HydratorPlusPlusConsoleActions, rSelectedArtifact, rArtifacts, myLocalStorage, HydratorPlusPlusConfigStore, $window) {
     // This is required because before we fireup the actions related to the store, the store has to be initialized to register for any events.
 
     this.myLocalStorage = myLocalStorage;
@@ -66,6 +66,30 @@ class HydratorPlusPlusStudioCtrl {
       config.artifact = artifact;
       HydratorPlusPlusConfigActions.initializeConfigStore(config);
     }
+
+    var confirmOnPageExit = function (e) {
+
+      if (!HydratorPlusPlusConfigStore.getIsStateDirty()) { return; }
+      // If we haven't been passed the event get the window.event
+      e = e || $window.event;
+      var message = 'You have unsaved changes.';
+      // For IE6-8 and Firefox prior to version 4
+      if (e) {
+        e.returnValue = message;
+      }
+      // For Chrome, Safari, IE8+ and Opera 12+
+      return message;
+    };
+    $window.onbeforeunload = confirmOnPageExit;
+
+    $scope.$on('$stateChangeStart', function (event) {
+      if (HydratorPlusPlusConfigStore.getIsStateDirty()) {
+        var response = confirm('You have unsaved changes. Are you sure you want to exit this page?');
+        if (!response) {
+          event.preventDefault();
+        }
+      }
+    });
   }
   toggleSidebar() {
     this.isExpanded = !this.isExpanded;
@@ -73,7 +97,7 @@ class HydratorPlusPlusStudioCtrl {
   }
 }
 
-HydratorPlusPlusStudioCtrl.$inject = ['HydratorPlusPlusLeftPanelStore', 'HydratorPlusPlusConfigActions', '$stateParams', 'rConfig', '$rootScope', '$scope', 'HydratorPlusPlusDetailNonRunsStore', 'HydratorPlusPlusNodeConfigStore', 'DAGPlusPlusNodesActionsFactory', 'HydratorPlusPlusHydratorService', 'HydratorPlusPlusConsoleActions','rSelectedArtifact', 'rArtifacts', 'myLocalStorage'];
+HydratorPlusPlusStudioCtrl.$inject = ['HydratorPlusPlusLeftPanelStore', 'HydratorPlusPlusConfigActions', '$stateParams', 'rConfig', '$rootScope', '$scope', 'HydratorPlusPlusDetailNonRunsStore', 'HydratorPlusPlusNodeConfigStore', 'DAGPlusPlusNodesActionsFactory', 'HydratorPlusPlusHydratorService', 'HydratorPlusPlusConsoleActions','rSelectedArtifact', 'rArtifacts', 'myLocalStorage', 'HydratorPlusPlusConfigStore', '$window'];
 
 angular.module(PKG.name + '.feature.hydratorplusplus')
   .controller('HydratorPlusPlusStudioCtrl', HydratorPlusPlusStudioCtrl);

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
@@ -101,6 +101,7 @@ class HydratorPlusPlusLeftPanelCtrl {
         if (!proceedToNextStep) {
           this.selectedArtifact = this.artifactToRevert;
         } else {
+          this.HydratorPlusPlusConfigStore.setState(this.HydratorPlusPlusConfigStore.getDefaults());
           this.$state.go('hydratorplusplus.create', {
             namespace: this.$state.params.namespace,
             artifactType: this.selectedArtifact.name,
@@ -200,6 +201,7 @@ class HydratorPlusPlusLeftPanelCtrl {
         if (!jsonData.config.connections) {
           jsonData.config.connections = generateLinearConnections(jsonData.config);
         }
+        this.HydratorPlusPlusConfigStore.setState(this.HydratorPlusPlusConfigStore.getDefaults());
         this.$state.go('hydratorplusplus.create', { data: jsonData });
       }
     };

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
@@ -173,14 +173,16 @@ class HydratorPlusPlusLeftPanelCtrl {
       }
 
       let isNotValid = this.NonStorePipelineErrorFactory.validateImportJSON(jsonData);
-      let validArtifact = isValidArtifact(jsonData.artifact);
-
       if (isNotValid) {
         this.myAlertOnValium.show({
           type: 'danger',
           content: isNotValid
         });
-      } else if (!validArtifact.name || !validArtifact.version || !validArtifact.scope) {
+        return;
+      }
+
+      let validArtifact = isValidArtifact(jsonData.artifact);
+      if (!validArtifact.name || !validArtifact.version || !validArtifact.scope) {
         let invalidFields = [];
         if (!validArtifact.name) {
           invalidFields.push('Artifact name');

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/popovers/pre-configured-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/popovers/pre-configured-ctrl.js
@@ -15,13 +15,14 @@
  */
 
 class HydratorPlusPlusPreConfiguredCtrl {
-  constructor (rTemplateType, GLOBALS, myPipelineTemplatesApi, HydratorPlusPlusHydratorService, HydratorPlusPlusCanvasFactory, DAGPlusPlusNodesActionsFactory, $state) {
+  constructor (rTemplateType, GLOBALS, myPipelineTemplatesApi, HydratorPlusPlusHydratorService, HydratorPlusPlusCanvasFactory, DAGPlusPlusNodesActionsFactory, $state, HydratorPlusPlusConfigStore) {
     this.currentPage = 1;
     this.templates = [];
     this.HydratorPlusPlusHydratorService = HydratorPlusPlusHydratorService;
     this.HydratorPlusPlusCanvasFactory = HydratorPlusPlusCanvasFactory;
     this.myPipelineTemplatesApi = myPipelineTemplatesApi;
     this.DAGPlusPlusNodesActionsFactory = DAGPlusPlusNodesActionsFactory;
+    this.HydratorPlusPlusConfigStore = HydratorPlusPlusConfigStore;
     this.$state = $state;
 
     this.typeFilter = (rTemplateType === GLOBALS.etlBatch? GLOBALS.etlBatch: GLOBALS.etlRealtime);
@@ -41,6 +42,7 @@ class HydratorPlusPlusPreConfiguredCtrl {
         content: 'Imported pre-defined app has issues. Please check the JSON of the imported pre-defined app.'
       });
     } else {
+      this.HydratorPlusPlusConfigStore.setState(this.HydratorPlusPlusConfigStore.getDefaults());
       this.$state.go('hydratorplusplus.create', {
         data: result
       });
@@ -78,6 +80,6 @@ class HydratorPlusPlusPreConfiguredCtrl {
 
 }
 
-HydratorPlusPlusPreConfiguredCtrl.$inject = ['rTemplateType', 'GLOBALS', 'myPipelineTemplatesApi', 'HydratorPlusPlusHydratorService', 'HydratorPlusPlusCanvasFactory', 'DAGPlusPlusNodesActionsFactory', '$state'];
+HydratorPlusPlusPreConfiguredCtrl.$inject = ['rTemplateType', 'GLOBALS', 'myPipelineTemplatesApi', 'HydratorPlusPlusHydratorService', 'HydratorPlusPlusCanvasFactory', 'DAGPlusPlusNodesActionsFactory', '$state', 'HydratorPlusPlusConfigStore'];
 angular.module(`${PKG.name}.feature.hydratorplusplus`)
   .controller('HydratorPlusPlusPreConfiguredCtrl', HydratorPlusPlusPreConfiguredCtrl);

--- a/cdap-ui/app/features/hydratorplusplus/routes.js
+++ b/cdap-ui/app/features/hydratorplusplus/routes.js
@@ -158,7 +158,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
                         content: 'Invalid configuration JSON.'
                       });
                       $q.reject(false);
-                      // FIXME: We should not have done this. But ui-router when rejected on a 'resolve:' function takes it to the parent state apparaently
+                      // FIXME: We should not have done this. But ui-router when rejected on a 'resolve:' function takes it to the parent state apparently
                       // and in our case the parent state is 'hydratorplusplus and since its an abstract state it goes to home.'
                       $state.go('hydrator.list');
                       return;
@@ -169,7 +169,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
                         content: 'Pipeline is created using older version of hydrator. Please upgrage the pipeline to newer version(3.4) to view in UI.'
                       });
                       $q.reject(false);
-                      // FIXME: We should not have done this. But ui-router when rejected on a 'resolve:' function takes it to the parent state apparaently
+                      // FIXME: We should not have done this. But ui-router when rejected on a 'resolve:' function takes it to the parent state apparently
                       // and in our case the parent state is 'hydratorplusplus and since its an abstract state it goes to home.'
                       $state.go('hydrator.list');
                       return;

--- a/cdap-ui/app/features/hydratorplusplus/services/hydrator-service.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/hydrator-service.js
@@ -15,7 +15,7 @@
  */
 
 class HydratorPlusPlusHydratorService {
-  constructor(GLOBALS, DAGPlusPlusFactory, uuid, $state, $rootScope, myPipelineApi, $q, IMPLICIT_SCHEMA, DAGPlusPlusNodesStore) {
+  constructor(GLOBALS, DAGPlusPlusFactory, uuid, $state, $rootScope, myPipelineApi, $q, IMPLICIT_SCHEMA, DAGPlusPlusNodesStore, myHelpers) {
     this.GLOBALS = GLOBALS;
     this.DAGPlusPlusFactory = DAGPlusPlusFactory;
     this.uuid = uuid;
@@ -25,6 +25,7 @@ class HydratorPlusPlusHydratorService {
     this.$q = $q;
     this.IMPLICIT_SCHEMA = IMPLICIT_SCHEMA;
     this.DAGPlusPlusNodesStore = DAGPlusPlusNodesStore;
+    this.myHelpers = myHelpers;
   }
 
   getNodesAndConnectionsFromConfig(pipeline) {
@@ -125,25 +126,23 @@ class HydratorPlusPlusHydratorService {
 
     return this.myPipelineApi.fetchPluginProperties(params)
       .$promise
-      .then(function(res = []) {
+      .then((res = []) => {
         let nodeArtifact = node.plugin.artifact;
         if (node.plugin && !node.plugin.artifact && res.length) {
-          let lastElement = res.length - 1;
-          node._backendProperties = res[lastElement].properties || {};
-          node.description = res[lastElement].description;
-          node.plugin.artifact = res[lastElement].artifact;
+          let lastElementIndex = res.length - 1;
+          node._backendProperties = res[lastElementIndex].properties || {};
+          node.description = res[lastElementIndex].description;
+          node.plugin.artifact = res[lastElementIndex].artifact;
           defer.resolve(node);
-          return defer.promise;
+        } else {
+          let match = res.filter(plug => angular.equals(plug.artifact, nodeArtifact));
+          let pluginProperties = (match.length? match[0].properties: {});
+          if (res.length && this.myHelpers.objectQuery(node, 'description', 'length')) {
+            node.description = res[0].description;
+          }
+          node._backendProperties = pluginProperties;
+          defer.resolve(node);
         }
-
-        let match = res.filter(plug => angular.equals(plug.artifact, nodeArtifact));
-        var pluginProperties = (match.length? match[0].properties: {});
-        if (res.length && (!node.description || (node.description && !node.description.length))) {
-          node.description = res[0].description;
-        }
-        node._backendProperties = pluginProperties;
-
-        defer.resolve(node);
         return defer.promise;
       });
   }
@@ -268,6 +267,6 @@ class HydratorPlusPlusHydratorService {
   }
 
 }
-HydratorPlusPlusHydratorService.$inject = ['GLOBALS', 'DAGPlusPlusFactory', 'uuid', '$state', '$rootScope', 'myPipelineApi', '$q', 'IMPLICIT_SCHEMA', 'DAGPlusPlusNodesStore'];
+HydratorPlusPlusHydratorService.$inject = ['GLOBALS', 'DAGPlusPlusFactory', 'uuid', '$state', '$rootScope', 'myPipelineApi', '$q', 'IMPLICIT_SCHEMA', 'DAGPlusPlusNodesStore', 'myHelpers'];
 angular.module(`${PKG.name}.feature.hydratorplusplus`)
   .service('HydratorPlusPlusHydratorService', HydratorPlusPlusHydratorService);

--- a/cdap-ui/app/features/hydratorplusplus/services/hydrator-service.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/hydrator-service.js
@@ -122,16 +122,27 @@ class HydratorPlusPlusHydratorService {
       extensionType: node.type,
       pluginName: node.plugin.name
     };
-    let nodeArtifact = node.plugin.artifact;
+
     return this.myPipelineApi.fetchPluginProperties(params)
       .$promise
       .then(function(res = []) {
+        let nodeArtifact = node.plugin.artifact;
+        if (node.plugin && !node.plugin.artifact && res.length) {
+          let lastElement = res.length - 1;
+          node._backendProperties = res[lastElement].properties || {};
+          node.description = res[lastElement].description;
+          node.plugin.artifact = res[lastElement].artifact;
+          defer.resolve(node);
+          return defer.promise;
+        }
+
         let match = res.filter(plug => angular.equals(plug.artifact, nodeArtifact));
         var pluginProperties = (match.length? match[0].properties: {});
         if (res.length && (!node.description || (node.description && !node.description.length))) {
           node.description = res[0].description;
         }
         node._backendProperties = pluginProperties;
+
         defer.resolve(node);
         return defer.promise;
       });

--- a/cdap-ui/app/features/hydratorplusplus/templates/create/popovers/plugin-edit-form.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/create/popovers/plugin-edit-form.html
@@ -54,9 +54,9 @@
           </div>
         </div>
 
-        <div ng-if="HydratorPlusPlusNodeConfigCtrl.state.noproperty === 0">
-          <div class="well well-lg">
-            <p>No Properties for this Plugin.</p>
+        <div ng-if="HydratorPlusPlusNodeConfigCtrl.state.noproperty === 0" class="no-plugin-properties-message">
+          <div class="well well-lg text-center">
+            <h4>No Properties found for Plugin '{{HydratorPlusPlusNodeConfigCtrl.state.node.plugin.name}}'</h4>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- CDAP-5619, CDAP-5557: Show appropriate message in bottom panel when imported config json doesn't have artifact information or has invalid artifact information.
- CDAP-5297: Handling pipelines created using old hydrator. Show warning message for pipelines created using old hydrator and prevents showing detailed view requesting user to upgrade their pipeline.
- CDAP-4692: Prevents user from accidentally navigating away from the studio view. Shows browser native alert message before proceeding with the navigation.
- Fixes the trash icon in the node config panel not overflow its container.