### PR TITLE
Fix NamespaceClient.exists() to return boolean value instead of NotFound exception

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
@@ -52,7 +52,8 @@ public class NamespaceClientTestRun extends ClientTestBase {
     List<NamespaceMeta> namespaces = namespaceClient.list();
     int initialNamespaceCount = namespaces.size();
 
-    verifyDoesNotExist(DOES_NOT_EXIST);
+    Assert.assertFalse(String.format("Namespace '%s' must not be found", DOES_NOT_EXIST),
+                       namespaceClient.exists(DOES_NOT_EXIST));
     verifyReservedCreate();
     verifyReservedDelete();
 
@@ -119,24 +120,6 @@ public class NamespaceClientTestRun extends ClientTestBase {
     // verify that only the default namespace is left
     Assert.assertEquals(1, namespaceClient.list().size());
     Assert.assertEquals(Id.Namespace.DEFAULT.getId(), namespaceClient.list().get(0).getName());
-  }
-
-  private void verifyDoesNotExist(Id.Namespace namespaceId)
-    throws Exception {
-
-    try {
-      namespaceClient.get(namespaceId);
-      Assert.fail(String.format("Namespace '%s' must not be found", namespaceId));
-    } catch (NotFoundException e) {
-      // expected
-    }
-
-    try {
-      namespaceClient.delete(namespaceId);
-      Assert.fail(String.format("Namespace '%s' must not be found", namespaceId));
-    } catch (NotFoundException e) {
-      // expected
-    }
   }
 
   private void verifyReservedCreate() throws Exception {

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceClient.java
@@ -110,7 +110,12 @@ public abstract class AbstractNamespaceClient implements NamespaceAdmin {
 
   @Override
   public boolean exists(Id.Namespace namespaceId) throws Exception {
-    return get(namespaceId) != null;
+    try {
+      get(namespaceId);
+    } catch (NamespaceNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 
   @Override

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/InMemoryNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/InMemoryNamespaceClient.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.NamespaceNotFoundException;
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -61,16 +60,6 @@ public class InMemoryNamespaceClient extends AbstractNamespaceClient {
       throw new NamespaceNotFoundException(namespaceId);
     }
     return filtered.iterator().next();
-  }
-
-  @Override
-  public boolean exists(Id.Namespace namespaceId) throws Exception {
-    try {
-      get(namespaceId);
-    } catch (NotFoundException e) {
-      return false;
-    }
-    return true;
   }
 
   @Override


### PR DESCRIPTION
Fix NamespaceClient.exists() to catch NotFound exception instead of throwing it. 

Issue: https://issues.cask.co/browse/CDAP-5655
Build: http://builds.cask.co/browse/CDAP-DUT3988-5