### PR TITLE
CDAP-4213, CDAP-5657 Windows startup scripts

### DIFF
--- a/cdap-data-fabric/bin/tx-debugger.bat
+++ b/cdap-data-fabric/bin/tx-debugger.bat
@@ -25,7 +25,8 @@ SET DEFAULT_JVM_OPTS=-Xmx2048m -XX:MaxPermSize=128m
 SET HADOOP_HOME_OPTS=-Dhadoop.home.dir=%CDAP_HOME%\libexec
 
 SET CLASSPATH=%CDAP_HOME%\lib\*;%CDAP_HOME%\conf\
-SET PATH=%PATH%;%CDAP_HOME%\libexec\bin
+SET ORIG_PATH=%PATH%
+SET PATH=%PATH%;%CDAP_HOME%\libexec\bin;%CDAP_HOME%\lib\native
 
 REM Check for 64-bit version of OS. Currently not supporting 32-bit Windows
 IF NOT EXIST "%PROGRAMFILES(X86)%" (
@@ -75,3 +76,4 @@ if "%tokenFileProvided%" == "false" if exist %auth_file% (
 %JAVACMD% %DEFAULT_JVM_OPTS% %HADOOP_HOME_OPTS% %TOKEN_FILE_OPTS% -classpath %CLASSPATH% co.cask.cdap.data2.transaction.TransactionManagerDebuggerMain %*
 
 :FINALLY
+SET PATH=%ORIG_PATH%

--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright (c) 2014-2015 Cask Data, Inc.
+REM ## Copyright (c) 2014-2016 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of
@@ -18,7 +18,7 @@ REM ## the License.
 REM ##
 REM #################################################################################
 
-SET ORIGPATH=%cd%
+SET ORIG_DIR=%cd%
 SET CDAP_HOME=%~dp0
 SET CDAP_HOME=%CDAP_HOME:~0,-5%
 SET JAVACMD=%JAVA_HOME%\bin\java.exe
@@ -26,7 +26,8 @@ SET DEFAULT_JVM_OPTS=-Xmx2048m -XX:MaxPermSize=256m
 
 REM %CDAP_HOME%
 SET CLASSPATH=%CDAP_HOME%\lib\*;%CDAP_HOME%\conf\
-SET PATH=%PATH%;%CDAP_HOME%\libexec\bin
+SET ORIG_PATH=%PATH%
+SET PATH=%PATH%;%CDAP_HOME%\libexec\bin;%CDAP_HOME%\lib\native;
 
 cd %CDAP_HOME%
 
@@ -276,7 +277,8 @@ CALL :STOP
 GOTO :START
 
 :FINALLY
-cd %ORIGPATH%
+cd %ORIG_DIR%
+SET PATH=%ORIG_PATH%
 GOTO:EOF
 
 
@@ -292,3 +294,5 @@ for /F "TOKENS=*" %%b in ('dir  /a-d %CDAP_HOME%\logs 2^>NUL ^| find /c "%extens
   rename %CDAP_HOME%\logs\%extension% %extension%.1 >NUL 2>NUL
 )
 endlocal
+
+:EOF


### PR DESCRIPTION
Fix Windows startup issues by caching the original path (and then restoring it when finished), adding `%CDAP_HOME%\lib\native` to the path, and renaming a variable that is use to cache the original directory by a more appropriate name.

Similarly for `tx-debugger.bat`.

Fixes for https://issues.cask.co/browse/CDAP-4213 and https://issues.cask.co/browse/CDAP-5657.