### PR TITLE
CDAP-5369 Fix FuzzyRowFilter for metadata search

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -509,9 +509,12 @@ public class MetadataDataset extends AbstractDataset {
     byte[] keyBytes = mdsKey.getKey();
     // byte array is automatically initialized to 0, which implies fixed match in fuzzy info
     // the row key after targetId doesn't need to be a match.
-    byte[] infoBytes = new byte[keyBytes.length];
+    // Workaround for HBASE-15676, need to have at least one 1 in the fuzzy filter
+    byte[] infoBytes = new byte[keyBytes.length + 1];
+    infoBytes[infoBytes.length - 1] = 1;
 
-    return new ImmutablePair<>(keyBytes, infoBytes);
+    // the key array size and mask array size has to be equal so increase the size by 1
+    return new ImmutablePair<>(Bytes.concat(keyBytes, new byte[1]), infoBytes);
   }
 
   /**


### PR DESCRIPTION
with hbase 1.1 and higher

The FuzzyRowFilter implementation has changed: https://issues.apache.org/jira/browse/HBASE-13761
and it has bug where it matches everything if the mask consists of all zero. I have opened a bug in HBase: https://issues.apache.org/jira/browse/HBASE-15676 (Please see this for more details about the issue)

This fix workaround this bug and is tested on HDP 2.3 and CDH 5.7 cluster.
