### PR TITLE
CDAP-5658 Remove instructions for Node.js installation from distributed CDAP

### DIFF
--- a/cdap-docs/admin-manual/source/_includes/installation/installation.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/installation.txt
@@ -1,13 +1,3 @@
-.. _|distribution|-install-node-js:
-
-Node.js Installation
---------------------
-Node.js must be installed on the node(s) where the CDAP UI service will run. We recommend
-any version of `Node.js <https://nodejs.org/>`__ |node-js-min-version|. We support Node.js
-up to |node-js-max-version|. You can download an appropriate version of Node.js from
-`nodejs.org <http://nodejs.org/dist/>`__. Detailed instructions on installing Node.js
-:ref:`are available <admin-manual-install-node.js>`.
-
 .. _|distribution|-install-packaging:
 
 Preparing Package Managers

--- a/cdap-docs/admin-manual/source/installation/ambari.rst
+++ b/cdap-docs/admin-manual/source/installation/ambari.rst
@@ -36,12 +36,6 @@ Installation using Apache Ambari
 Preparing the Cluster
 =====================
 
-.. Node.js Installation
-.. --------------------
-.. include:: /../target/_includes/ambari-installation.rst
-    :start-after: .. _ambari-install-node-js:
-    :end-before: .. _ambari-install-packaging:
-
 .. Hadoop Configuration
 .. --------------------
 .. include:: ../_includes/installation/hadoop-configuration.txt

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -66,12 +66,6 @@ These roles map to the :ref:`CDAP components <admin-manual-cdap-components>` of 
 
 - All services run as the ``'cdap'`` user installed by the parcel.
 
-.. Node.js Installation
-.. --------------------
-.. include:: /../target/_includes/cloudera-installation.rst
-    :start-after: .. _cloudera-install-node-js:
-    :end-before: .. _cloudera-install-packaging:
-
 .. Hadoop Configuration
 .. --------------------
 .. include:: ../_includes/installation/hadoop-configuration.txt

--- a/cdap-docs/admin-manual/source/installation/mapr.rst
+++ b/cdap-docs/admin-manual/source/installation/mapr.rst
@@ -35,12 +35,6 @@ ResourceManager*, or *HBase Master*, then the client configurations will already
 A typical client node should have the ``mapr-client``, ``mapr-hbase``, and ``mapr-hive``
 packages installed, and can be configured using the MapR `configure.sh
 <http://doc.mapr.com/display/MapR/configure.sh>`__ utility.
-
-.. Node.js Installation
-.. --------------------
-.. include:: /../target/_includes/mapr-installation.rst
-    :start-after: .. _mapr-install-node-js:
-    :end-before: .. _mapr-install-packaging:
  
 .. Hadoop Configuration
 .. --------------------

--- a/cdap-docs/admin-manual/source/installation/packages.rst
+++ b/cdap-docs/admin-manual/source/installation/packages.rst
@@ -47,12 +47,6 @@ Please review the :ref:`Software Prerequisites <admin-manual-software-requiremen
 as a configured Hadoop, HBase, and Hive (plus an optional Spark client) needs to be configured on the
 node(s) where CDAP will run. 
 
-.. Node.js Installation
-.. --------------------
-.. include:: /../target/_includes/packages-installation.rst
-    :start-after: .. _packages-install-node-js:
-    :end-before: .. _packages-install-packaging:
-
 .. Hadoop Configuration
 .. --------------------
 .. include:: ../_includes/installation/hadoop-configuration.txt

--- a/cdap-docs/admin-manual/source/system-requirements.rst
+++ b/cdap-docs/admin-manual/source/system-requirements.rst
@@ -82,7 +82,6 @@ Software Prerequisites
 You'll need this software installed:
 
 - A :ref:`Java runtime <admin-manual-install-java-runtime>` on each CDAP node and Hadoop datanode.
-- A :ref:`Node.js runtime <admin-manual-install-node.js>` on each CDAP node.
 - A Hadoop, HBase, Hive (and optionally Spark) environment to run against.
 - To use the **ad-hoc querying capabilities of CDAP,** ensure the cluster has a compatible version of
   Hive installed. See the section on :ref:`Hadoop Compatibility <admin-manual-hadoop-compatibility-matrix>`.
@@ -111,44 +110,6 @@ CDAP is tested with the Oracle JDKs; it may work with other JDKs such as
 
 Once you have installed the JDK, you'll need to set the JAVA_HOME environment variable.
 
-.. _admin-manual-install-node.js:
-
-Node.js Runtime
----------------
-You can download an appropriate version of Node.js from `nodejs.org
-<http://nodejs.org>`__. We recommend any version of `Node.js <https://nodejs.org/>`__
-|node-js-min-version|. We support Node.js up to |node-js-max-version|.
-   
-**Installing Node.js on RPM using Yum**
-
-#. Run as root (note that running under sudo will not work)::
-
-    $ su root
-    # curl --silent --location https://rpm.nodesource.com/setup | bash -
-    # yum -y install nodejs
-
-#. Check the Node.js installation and version using::
-
-    # node --version
-
-**Installing Node.js on Debian using APT**
-
-#. Run as root (note that running under sudo will not work)::
-
-    $ su root
-    # curl -sL https://deb.nodesource.com/setup_5.x | bash -
-    # apt-get install --yes nodejs
-
-#. *Note:* If there is no root account or root password, set one using these commands, following the prompts
-   to enter a new UNIX password (which will become the password for root)::
-
-    $ sudo usermod root -p password; sudo passwd root
- 
-#. Check the Node.js installation and version using::
-
-    # node --version
-
-   
 .. _admin-manual-install-ntp:
 
 NTP (Network Time Protocol)

--- a/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
@@ -85,7 +85,3 @@ follow the provided example applications.
 The :doc:`Docker image <docker>` is intended for those developing on Linux.
 
 Follow one of the above links for download and installation instructions.
-
-
-   
-

--- a/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
@@ -27,8 +27,9 @@ The CDAP SDK runs on Linux, MacOS, and Windows, and has these requirements:
 
 - `JDK 7 or 8 <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__ 
   (required to run CDAP; note that $JAVA_HOME should be set)
-- `Node.js <http://nodejs.org/dist/>`__ (required to run the CDAP UI; we recommend any 
-  version |node-js-min-version|. We support Node.js up to |node-js-max-version|.)
+- `Node.js <https://nodejs.org>`__ (required to run the CDAP UI; we recommend any 
+  version |node-js-min-version|. We support Node.js up to |node-js-max-version|.
+  Different versions of Node.js `are available <https://nodejs.org/dist/>`__.)
 - `Apache Maven 3.0+ <http://maven.apache.org>`__ (required to build CDAP applications)
 
 If you are **running under Microsoft Windows**, you will need to have installed the 
@@ -38,6 +39,24 @@ required DLLs to run Hadoop and CDAP; currently, CDAP is supported only on 64-bi
 platforms. 
 
 .. include:: /_includes/windows-note.txt
+
+.. _developers-manual-install-node.js:
+
+.. rubric:: Node.js Runtime
+
+You can download an appropriate version of Node.js from `nodejs.org
+<https://nodejs.org>`__. We recommend any version of `Node.js <https://nodejs.org/>`__
+|node-js-min-version|. We support Node.js up to |node-js-max-version|.
+   
+You can check if ``node.js`` is installed, in your path, and an appropriate version by running the command:
+
+.. tabbed-parsed-literal::
+  :tabs: "Linux or Mac OS X",Windows
+  :dependent: linux-windows
+  :mapping: Linux,Windows
+  :languages: console,shell-session
+
+  $ node --version
 
 .. _recommend-using-an-ide:
 
@@ -66,3 +85,7 @@ follow the provided example applications.
 The :doc:`Docker image <docker>` is intended for those developing on Linux.
 
 Follow one of the above links for download and installation instructions.
+
+
+   
+


### PR DESCRIPTION
Move all references to requiring Node.js to the SDK instructions, as that is the only place they will be required.

Building as [Quick Build 1](http://builds.cask.co/browse/CDAP-DOB181-1).