### PR TITLE
CDAP-5550 Added default values for interval and limit for the statistics endpoint of the WorkflowStatsSLAHttpHandler.

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowStatsSLAHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowStatsSLAHttpHandlerTest.java
@@ -194,6 +194,34 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
 
     Assert.assertEquals(7, workflowStatistics.getProgramNodesList().iterator().next()
       .getWorkflowProgramDetailsList().size());
+
+    request = String.format("%s/namespaces/%s/apps/%s/workflows/%s/runs/%s/statistics?limit=0",
+                            Constants.Gateway.API_VERSION_3, Id.Namespace.DEFAULT.getId(),
+                            WorkflowApp.class.getSimpleName(), workflowProgram.getId(), runIdList.get(6).getId());
+
+    response = doGet(request);
+    Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), response.getStatusLine().getStatusCode());
+
+    request = String.format("%s/namespaces/%s/apps/%s/workflows/%s/runs/%s/statistics?limit=10&interval=10",
+                            Constants.Gateway.API_VERSION_3, Id.Namespace.DEFAULT.getId(),
+                            WorkflowApp.class.getSimpleName(), workflowProgram.getId(), runIdList.get(6).getId());
+
+    response = doGet(request);
+    Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), response.getStatusLine().getStatusCode());
+
+    request = String.format("%s/namespaces/%s/apps/%s/workflows/%s/runs/%s/statistics?limit=10&interval=10P",
+                            Constants.Gateway.API_VERSION_3, Id.Namespace.DEFAULT.getId(),
+                            WorkflowApp.class.getSimpleName(), workflowProgram.getId(), runIdList.get(6).getId());
+
+    response = doGet(request);
+    Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), response.getStatusLine().getStatusCode());
+
+    request = String.format("%s/namespaces/%s/apps/%s/workflows/%s/runs/%s/statistics?limit=20&interval=0d",
+                            Constants.Gateway.API_VERSION_3, Id.Namespace.DEFAULT.getId(),
+                            WorkflowApp.class.getSimpleName(), workflowProgram.getId(), runIdList.get(6).getId());
+
+    response = doGet(request);
+    Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), response.getStatusLine().getStatusCode());
   }
 
   @Test

--- a/cdap-docs/reference-manual/source/http-restful-api/workflow.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/workflow.rst
@@ -56,7 +56,7 @@ The request can be extended with query parameters:
      - *user* (default) returns the token for ``Scope.USER``; *system* returns the token for
        ``Scope.SYSTEM``
    * - ``key``
-     - Returns the value for a specified key; if unspecified, returns all keys.
+     - Returns the value for a specified key; if unspecified, returns all keys (optional)
 
 
 .. rubric:: Comments
@@ -164,12 +164,12 @@ where
    * - ``<workflow-id>``
      - Name of the workflow
    * - ``<start-time>``
-     - Start time of runs (in seconds); default is ``now`` (optional)
+     - Start time of runs (in seconds); if not provided, defaults to ``now`` (optional) 
    * - ``<end-time>``
-     - End time of runs (in seconds); default is ``now-1d`` (optional)
+     - End time of runs (in seconds); if not provided, defaults to ``now-1d`` (optional) 
    * - ``<percentile-1>``
      - List of percentiles (each greater than zero and less than 100) to be used for generating statistics;
-       if not provided, defaults to 90 (optional)
+       if not provided, defaults to 90 (optional) 
 
 If the query was successful, the body will contain a JSON structure of statistics.
 
@@ -276,9 +276,9 @@ where
    * - ``<run-id>``
      - UUID of the workflow run
    * - ``<limit>``
-     - The number of the records to compare against (before and after) the run
+     - The number of the records to compare against (before and after) the run; if not provided, defaults to ``10`` (optional) 
    * - ``<interval>``
-     - The time interval with which to space out the runs before and after, with units
+     - The time interval with which to space out the runs before and after, with units; if not provided, defaults to ``10s`` (optional) 
 
 If the query was successful, the body will contain a JSON structure of statistics.
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-5550
For the statistics endpoint, added default values for interval = 10s and limit = 10.

JIRA: https://issues.cask.co/browse/CDAP-5551
Added checks in the statistics endpoint so that if interval <= 0 or limit <= 0 throw `BadRequestException`
