### PR TITLE
Removed extra message.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -176,7 +176,6 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   @Override
   protected void startUp() throws Exception {
     LoggingContextAccessor.setLoggingContext(loggingContext);
-    LOG.info("Starting Workflow {}", workflowSpec);
 
     // Using small size thread pool is enough, as the API we supported are just simple lookup.
     httpService = NettyHttpService.builder()


### PR DESCRIPTION
Since `WorfklowDriver.run` method already has same message, its not required in `startUp`