### PR TITLE
Fix workflow CLI test to verify a log message from the workflow inste…

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -505,7 +505,7 @@ public class CLIMainTest extends CLITestBase {
   }
 
   @Test
-  public void testWorkflowToken() throws Exception {
+  public void testWorkflows() throws Exception {
     String workflow = String.format("%s.%s", FakeApp.NAME, FakeWorkflow.NAME);
     File doneFile = TMP_FOLDER.newFile("fake.done");
     Map<String, String> runtimeArgs = ImmutableMap.of("done.file", doneFile.getAbsolutePath());
@@ -546,7 +546,7 @@ public class CLIMainTest extends CLITestBase {
       cli, String.format("get workflow token %s %s at node %s scope user key %s", workflow, runId,
                          FakeWorkflow.FakeAction.ANOTHER_FAKE_NAME, FakeWorkflow.FakeAction.TOKEN_KEY), fakeNodeValue);
 
-    testCommandOutputContains(cli, "get workflow logs " + workflow, "Starting Workflow");
+    testCommandOutputContains(cli, "get workflow logs " + workflow, FakeWorkflow.FAKE_LOG);
 
     // stop workflow
     testCommandOutputContains(cli, "stop workflow " + workflow,

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeWorkflow.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeWorkflow.java
@@ -22,6 +22,8 @@ import co.cask.cdap.api.workflow.WorkflowConfigurer;
 import co.cask.cdap.api.workflow.WorkflowContext;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +33,10 @@ import java.util.concurrent.TimeUnit;
  */
 public class FakeWorkflow implements Workflow {
 
+  private static final Logger LOG = LoggerFactory.getLogger(FakeWorkflow.class);
+
   public static final String NAME = "FakeWorkflow";
+  public static final String FAKE_LOG = "Running " + NAME;
 
   @Override
   public void configure(WorkflowConfigurer configurer) {
@@ -67,6 +72,7 @@ public class FakeWorkflow implements Workflow {
 
     @Override
     public void run() {
+      LOG.info(FAKE_LOG);
       File doneFile = new File(getContext().getRuntimeArguments().get("done.file"));
       while (!doneFile.exists()) {
         try {


### PR DESCRIPTION
…ad of the one from the driver.

This is causing failures in the release branch since #5603 removed a log message that this verification was testing for.

Build: http://builds.cask.co/browse/CDAP-DUT4007
