### PR TITLE
Should not override the 'copy-dependencies' id. Using a different id

### DIFF
--- a/cdap-kafka/pom.xml
+++ b/cdap-kafka/pom.xml
@@ -78,7 +78,7 @@
             <version>2.8</version>
             <executions>
               <execution>
-                <id>copy-dependencies</id>
+                <id>copy-dependencies-standalone</id>
                 <phase>prepare-package</phase>
                 <goals>
                   <goal>copy-dependencies</goal>


### PR DESCRIPTION
This bug causes rpm/deb to not have lib directory for kafka. Bug introduced by PR #5503 