### PR TITLE
Fix dist build for cdap-kafka JAR

### DIFF
--- a/cdap-kafka/pom.xml
+++ b/cdap-kafka/pom.xml
@@ -60,7 +60,7 @@
             <version>2.4</version>
             <executions>
               <execution>
-                <id>jar</id>
+                <id>jar-standalone</id>
                 <phase>prepare-package</phase>
                 <configuration combine.self="override">
                   <outputDirectory>${build.directory}/libexec</outputDirectory>


### PR DESCRIPTION
Fix another bug introduced by #5503 
So that cdap-kafka JAR is packaged under /opt/cdap/kafka/lib