### PR TITLE
Changing IntegrationTestBase to use ApplicationId instead of Id.Application

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -39,6 +39,7 @@ import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.StreamDetail;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.security.authentication.client.AccessToken;
 import co.cask.cdap.security.authentication.client.AuthenticationClient;
 import co.cask.cdap.security.authentication.client.basic.BasicAuthenticationClient;
@@ -314,8 +315,8 @@ public abstract class IntegrationTestBase {
     return deployApplication(Id.Namespace.DEFAULT, applicationClz);
   }
 
-  protected ApplicationManager getApplicationManager(Id.Application appId) throws Exception {
-    return getTestManager().getApplicationManager(appId);
+  protected ApplicationManager getApplicationManager(ApplicationId applicationId) throws Exception {
+    return getTestManager().getApplicationManager(applicationId);
   }
 
   private boolean isUserDataset(DatasetSpecificationSummary specification) {

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -46,6 +46,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -179,8 +180,8 @@ public class IntegrationTestManager implements TestManager {
   }
 
   @Override
-  public ApplicationManager getApplicationManager(Id.Application appId) {
-    return new RemoteApplicationManager(appId, clientConfig, restClient);
+  public ApplicationManager getApplicationManager(ApplicationId applicationId) {
+    return new RemoteApplicationManager(applicationId.toId(), clientConfig, restClient);
   }
 
   @Override

--- a/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
+++ b/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
@@ -20,6 +20,8 @@ import co.cask.cdap.StandaloneTester;
 import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -64,8 +66,8 @@ public class IntegrationTestBaseTest extends IntegrationTestBase {
   @Test
   public void testGetApplicationManager() throws Exception {
     ApplicationManager applicationManager = deployApplication(TestApplication.class);
-    ApplicationManager testApplicationManager = getApplicationManager(Id.Application.from(Id.Namespace.DEFAULT,
-                                                                                          TestApplication.NAME));
+    ApplicationId applicationId = NamespaceId.DEFAULT.app(TestApplication.NAME);
+    ApplicationManager testApplicationManager = getApplicationManager(applicationId);
     Assert.assertEquals(applicationManager.getFlowManager(TestFlow.NAME).getFlowletInstances(TestFlowlet.NAME),
                         testApplicationManager.getFlowManager(TestFlow.NAME).getFlowletInstances(TestFlowlet.NAME));
 

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -29,6 +29,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.NamespaceId;
 
@@ -83,7 +84,7 @@ public interface TestManager {
    * @param appId the id of deployed application
    * @return An {@link ApplicationManager} to manage the deployed application.
    */
-  ApplicationManager getApplicationManager(Id.Application appId) throws Exception;
+  ApplicationManager getApplicationManager(ApplicationId appId) throws Exception;
 
   /**
    * Adds the specified artifact.

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -43,6 +43,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -161,7 +162,8 @@ public class UnitTestManager implements TestManager {
       MockAppConfigurer configurer = new MockAppConfigurer(app);
       app.configure(configurer, new DefaultApplicationContext<>(configObject));
       appFabricClient.deployApplication(namespace, applicationClz, appConfig, bundleEmbeddedJars);
-      return appManagerFactory.create(Id.Application.from(namespace, configurer.getName()));
+      ApplicationId applicationId = new ApplicationId(namespace.getId(), configurer.getName());
+      return appManagerFactory.create(applicationId.toId());
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
@@ -175,8 +177,8 @@ public class UnitTestManager implements TestManager {
   }
 
   @Override
-  public ApplicationManager getApplicationManager(Id.Application appId) {
-    return appManagerFactory.create(appId);
+  public ApplicationManager getApplicationManager(ApplicationId applicationId) {
+    return appManagerFactory.create(applicationId.toId());
   }
 
   @Override


### PR DESCRIPTION
Changing IntegrationTestBase to use ApplicationId instead of Id.Application

Issue: https://issues.cask.co/browse/CDAP-5690
Build: http://builds.cask.co/browse/CDAP-DUT4010-6