### PR TITLE
CDAP-5605 fix incorrect aggregator metrics

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.workflow.NodeStatus;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.datapipeline.mock.NaiveBayesClassifier;
 import co.cask.cdap.datapipeline.mock.NaiveBayesTrainer;
 import co.cask.cdap.datapipeline.mock.SpamMessage;
@@ -53,6 +54,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -61,8 +63,10 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  *
@@ -87,6 +91,11 @@ public class DataPipelineTest extends HydratorTestBase {
     addPluginArtifact(new ArtifactId(NamespaceId.DEFAULT.getNamespace(), "spark-plugins", "1.0.0"),
                       APP_ARTIFACT_ID,
                       NaiveBayesTrainer.class, NaiveBayesClassifier.class);
+  }
+
+  @After
+  public void cleanupTest() throws Exception {
+    getMetricsManager().resetAll();
   }
 
   @Test
@@ -124,6 +133,9 @@ public class DataPipelineTest extends HydratorTestBase {
     Set<StructuredRecord> expected = ImmutableSet.of(recordSamuel, recordBob);
     Set<StructuredRecord> actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
     Assert.assertEquals(expected, actual);
+
+    validateMetric(2, appId, "source.records.out");
+    validateMetric(2, appId, "sink.records.in");
   }
 
   @Test
@@ -168,6 +180,10 @@ public class DataPipelineTest extends HydratorTestBase {
     Set<StructuredRecord> expected = ImmutableSet.of(recordSamuel, recordBob);
     Set<StructuredRecord> actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
     Assert.assertEquals(expected, actual);
+
+    validateMetric(1, appId, "source1.records.out");
+    validateMetric(1, appId, "source2.records.out");
+    validateMetric(2, appId, "sink.records.in");
   }
 
   @Test
@@ -177,7 +193,9 @@ public class DataPipelineTest extends HydratorTestBase {
      *           |--> transform1 --|
      * source2 --|                 |
      *                             |--> transform2 --> sink2
-     * source3 --------------------|
+     *                                     ^
+     *                                     |
+     * source3 ----------------------------|
      */
     ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
       .addStage(new ETLStage("source1", MockSource.getPlugin("msInput1")))
@@ -231,6 +249,16 @@ public class DataPipelineTest extends HydratorTestBase {
     expected = ImmutableSet.of(recordSamuel, recordBob, recordJane);
     actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
     Assert.assertEquals(expected, actual);
+
+    validateMetric(1, appId, "source1.records.out");
+    validateMetric(1, appId, "source2.records.out");
+    validateMetric(1, appId, "source3.records.out");
+    validateMetric(2, appId, "transform1.records.in");
+    validateMetric(2, appId, "transform1.records.out");
+    validateMetric(3, appId, "transform2.records.in");
+    validateMetric(3, appId, "transform2.records.out");
+    validateMetric(2, appId, "sink1.records.in");
+    validateMetric(3, appId, "sink2.records.in");
   }
 
   @Test
@@ -300,6 +328,17 @@ public class DataPipelineTest extends HydratorTestBase {
     Set<StructuredRecord> expected = ImmutableSet.of(recordSamuel);
     Set<StructuredRecord> actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
     Assert.assertEquals(expected, actual);
+
+    validateMetric(3, appId, "source.records.out");
+    validateMetric(3, appId, "filter1.records.in");
+    validateMetric(2, appId, "filter1.records.out");
+    validateMetric(2, appId, "aggregator1.records.in");
+    validateMetric(2, appId, "aggregator1.records.out");
+    validateMetric(2, appId, "aggregator2.records.in");
+    validateMetric(2, appId, "aggregator2.records.out");
+    validateMetric(2, appId, "filter2.records.in");
+    validateMetric(1, appId, "filter2.records.out");
+    validateMetric(1, appId, "sink.records.out");
   }
 
   private void testParallelAggregators(Engine engine) throws Exception {
@@ -377,6 +416,18 @@ public class DataPipelineTest extends HydratorTestBase {
       StructuredRecord.builder(outputSchema2).set("item", 4L).set("ct", 1L).build());
     actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
     Assert.assertEquals(expected, actual);
+
+    validateMetric(5, appId, "source.records.out");
+    validateMetric(5, appId, "agg1.records.in");
+    // 2 users, but FieldCountAggregator always emits an 'all' group
+    validateMetric(3, appId, "agg1.aggregator.groups");
+    validateMetric(3, appId, "agg1.records.out");
+    validateMetric(5, appId, "agg2.records.in");
+    // 4 items, but FieldCountAggregator always emits an 'all' group
+    validateMetric(5, appId, "agg2.aggregator.groups");
+    validateMetric(5, appId, "agg2.records.out");
+    validateMetric(3, appId, "sink1.records.in");
+    validateMetric(5, appId, "sink2.records.in");
   }
 
   @Test
@@ -440,7 +491,7 @@ public class DataPipelineTest extends HydratorTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "SinglePhaseApp");
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "SparkSinkApp");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
 
@@ -481,6 +532,9 @@ public class DataPipelineTest extends HydratorTestBase {
     Assert.assertEquals(1.0d, Bytes.toDouble(classifiedTexts.get().read("free money money")), 0.01d);
     Assert.assertEquals(0.0d, Bytes.toDouble(classifiedTexts.get().read("what are you doing today")), 0.01d);
     Assert.assertEquals(0.0d, Bytes.toDouble(classifiedTexts.get().read("genuine report")), 0.01d);
+
+    validateMetric(10, appId, "source.records.out");
+    validateMetric(10, appId, "customsink.records.in");
   }
 
   private void testSinglePhaseWithSparkCompute() throws Exception {
@@ -504,7 +558,7 @@ public class DataPipelineTest extends HydratorTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "SinglePhaseApp");
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "SparkComputeApp");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
 
@@ -541,5 +595,19 @@ public class DataPipelineTest extends HydratorTestBase {
     expected.add(new SpamMessage("genuine report", 0.0));
 
     Assert.assertEquals(expected, results);
+
+    validateMetric(4, appId, "source.records.out");
+    validateMetric(4, appId, "sparkcompute.records.in");
+    validateMetric(4, appId, "sink.records.in");
+  }
+
+  private void validateMetric(long expected, Id.Application appId,
+                              String metric) throws TimeoutException, InterruptedException {
+    Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, appId.getNamespaceId(),
+                                               Constants.Metrics.Tag.APP, appId.getId(),
+                                               Constants.Metrics.Tag.WORKFLOW, SmartWorkflow.NAME);
+    getMetricsManager().waitForTotalMetricCount(tags, "user." + metric, expected, 20, TimeUnit.SECONDS);
+    // wait for won't throw an exception if the metric count is greater than expected
+    Assert.assertEquals(expected, getMetricsManager().getTotalMetric(tags, "user." + metric));
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformDetail.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformDetail.java
@@ -19,7 +19,6 @@ package co.cask.cdap.etl.common;
 import co.cask.cdap.etl.api.Destroyable;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
-import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.api.Transformation;
 
 import java.util.Collection;
@@ -30,12 +29,12 @@ import java.util.Collection;
 public class TransformDetail implements Emitter<Object> {
   private final Transformation transformation;
   private final Collection<String> nextStages;
-  private final DefaultEmitter defaultEmitter;
+  private final DefaultEmitter<Object> defaultEmitter;
 
-  public TransformDetail(Transformation transformation, StageMetrics metrics, Collection<String> nextStages) {
-    this.transformation = new TrackedTransform<>(transformation, metrics);
+  public TransformDetail(Transformation transformation, Collection<String> nextStages) {
+    this.transformation = transformation;
     this.nextStages = nextStages;
-    this.defaultEmitter = new DefaultEmitter<>(metrics);
+    this.defaultEmitter = new DefaultEmitter<>();
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/TransformExecutorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/TransformExecutorTest.java
@@ -36,10 +36,8 @@ public class TransformExecutorTest {
 
   @Test
   public void testEmptyTransforms() throws Exception {
-    MockMetrics mockMetrics = new MockMetrics();
     Map<String, TransformDetail> transformationMap = new HashMap<>();
     transformationMap.put("sink", new TransformDetail(new DoubleToString(),
-                                                      new DefaultStageMetrics(mockMetrics, "sink"),
                                                       new ArrayList<String>()));
 
     TransformExecutor executor =
@@ -61,20 +59,28 @@ public class TransformExecutorTest {
     Map<String, TransformDetail> transformationMap = new HashMap<>();
 
     transformationMap.put("transform1",
-                          new TransformDetail(new IntToDouble(), new DefaultStageMetrics(mockMetrics, "transform1"),
-                                              ImmutableList.of("transform2", "sink1")));
+                          new TransformDetail(
+                            new TrackedTransform<>(new IntToDouble(),
+                                                   new DefaultStageMetrics(mockMetrics, "transform1")),
+                            ImmutableList.of("transform2", "sink1")));
 
-    transformationMap.put("transform2", new TransformDetail(new Filter(100d, Threshold.LOWER),
-                                                            new DefaultStageMetrics(mockMetrics, "transform2"),
-                                                            ImmutableList.of("sink2")));
+    transformationMap.put("transform2",
+                          new TransformDetail(
+                            new TrackedTransform<>(new Filter(100d, Threshold.LOWER),
+                                                   new DefaultStageMetrics(mockMetrics, "transform2")),
+                            ImmutableList.of("sink2")));
 
-    transformationMap.put("sink1", new TransformDetail(new DoubleToString(),
-                                                       new DefaultStageMetrics(mockMetrics, "sink1"),
-                                                       ImmutableList.<String>of()));
+    transformationMap.put("sink1",
+                          new TransformDetail(
+                            new TrackedTransform<>(new DoubleToString(),
+                                                   new DefaultStageMetrics(mockMetrics, "sink1")),
+                            ImmutableList.<String>of()));
 
-    transformationMap.put("sink2", new TransformDetail(new DoubleToString(),
-                                                       new DefaultStageMetrics(mockMetrics, "sink2"),
-                                                       ImmutableList.<String>of()));
+    transformationMap.put("sink2",
+                          new TransformDetail(
+                            new TrackedTransform<>(new DoubleToString(),
+                                                   new DefaultStageMetrics(mockMetrics, "sink2")),
+                            ImmutableList.<String>of()));
 
     TransformExecutor<Integer> executor = new TransformExecutor<>(transformationMap, ImmutableSet.of("transform1"));
 
@@ -135,34 +141,48 @@ public class TransformExecutorTest {
     MockMetrics mockMetrics = new MockMetrics();
     Map<String, TransformDetail> transformationMap = new HashMap<>();
 
-    transformationMap.put("conversion", new TransformDetail(new IntToDouble(),
-                                                            new DefaultStageMetrics(mockMetrics, "conversion"),
-                                                            ImmutableList.of("filter1", "filter2")));
+    transformationMap.put("conversion",
+                          new TransformDetail(
+                            new TrackedTransform<>(new IntToDouble(),
+                                                   new DefaultStageMetrics(mockMetrics, "conversion")),
+                            ImmutableList.of("filter1", "filter2")));
 
-    transformationMap.put("filter1", new TransformDetail(new Filter(100d, Threshold.LOWER),
-                                                         new DefaultStageMetrics(mockMetrics, "filter1"),
-                                                         ImmutableList.of("limiter1", "sink1")));
+    transformationMap.put("filter1",
+                          new TransformDetail(
+                            new TrackedTransform<>(new Filter(100d, Threshold.LOWER),
+                                                   new DefaultStageMetrics(mockMetrics, "filter1")),
+                            ImmutableList.of("limiter1", "sink1")));
 
-    transformationMap.put("filter2", new TransformDetail(new Filter(1000d, Threshold.LOWER),
-                                                         new DefaultStageMetrics(mockMetrics, "filter2"),
-                                                         ImmutableList.of("limiter1", "sink2")));
+    transformationMap.put("filter2",
+                          new TransformDetail(
+                            new TrackedTransform<>(new Filter(1000d, Threshold.LOWER),
+                                                   new DefaultStageMetrics(mockMetrics, "filter2")),
+                            ImmutableList.of("limiter1", "sink2")));
 
 
-    transformationMap.put("limiter1", new TransformDetail(new Filter(5000d, Threshold.UPPER),
-                                                          new DefaultStageMetrics(mockMetrics, "limiter1"),
-                                                          ImmutableList.of("sink3")));
+    transformationMap.put("limiter1",
+                          new TransformDetail(
+                            new TrackedTransform<>(new Filter(5000d, Threshold.UPPER),
+                                                   new DefaultStageMetrics(mockMetrics, "limiter1")),
+                            ImmutableList.of("sink3")));
 
-    transformationMap.put("sink1", new TransformDetail(new DoubleToString(),
-                                                       new DefaultStageMetrics(mockMetrics, "sink1"),
-                                                       ImmutableList.<String>of()));
+    transformationMap.put("sink1",
+                          new TransformDetail(
+                            new TrackedTransform<>(new DoubleToString(),
+                                                   new DefaultStageMetrics(mockMetrics, "sink1")),
+                            ImmutableList.<String>of()));
 
-    transformationMap.put("sink2", new TransformDetail(new DoubleToString(),
-                                                       new DefaultStageMetrics(mockMetrics, "sink2"),
-                                                       ImmutableList.<String>of()));
+    transformationMap.put("sink2",
+                          new TransformDetail(
+                            new TrackedTransform<>(new DoubleToString(),
+                                                   new DefaultStageMetrics(mockMetrics, "sink2")),
+                            ImmutableList.<String>of()));
 
-    transformationMap.put("sink3", new TransformDetail(new DoubleToString(),
-                                                       new DefaultStageMetrics(mockMetrics, "sink3"),
-                                                       ImmutableList.<String>of()));
+    transformationMap.put("sink3",
+                          new TransformDetail(
+                            new TrackedTransform<>(new DoubleToString(),
+                                                   new DefaultStageMetrics(mockMetrics, "sink3")),
+                            ImmutableList.<String>of()));
 
 
 
@@ -192,32 +212,42 @@ public class TransformExecutorTest {
     Map<String, TransformDetail> transformationMap = new HashMap<>();
 
 
-    transformationMap.put("filter1", new TransformDetail(new Filter(100d, Threshold.LOWER),
-                                                         new DefaultStageMetrics(mockMetrics, "filter1"),
-                                                         ImmutableList.of("limiter1", "sink1")));
+    transformationMap.put("filter1",
+                          new TransformDetail(
+                            new TrackedTransform<>(new Filter(100d, Threshold.LOWER),
+                                                   new DefaultStageMetrics(mockMetrics, "filter1")),
+                            ImmutableList.of("limiter1", "sink1")));
 
-    transformationMap.put("filter2", new TransformDetail(new Filter(1000d, Threshold.LOWER),
-                                                         new DefaultStageMetrics(mockMetrics, "filter2"),
-                                                         ImmutableList.of("limiter1", "sink2")));
-
-
-    transformationMap.put("limiter1", new TransformDetail(new Filter(5000d, Threshold.UPPER),
-                                                          new DefaultStageMetrics(mockMetrics, "limiter1"),
-                                                          ImmutableList.of("sink3")));
-
-    transformationMap.put("sink1", new TransformDetail(new DoubleToString(),
-                                                       new DefaultStageMetrics(mockMetrics, "sink1"),
-                                                       ImmutableList.<String>of()));
-
-    transformationMap.put("sink2", new TransformDetail(new DoubleToString(),
-                                                       new DefaultStageMetrics(mockMetrics, "sink2"),
-                                                       ImmutableList.<String>of()));
-
-    transformationMap.put("sink3", new TransformDetail(new DoubleToString(),
-                                                       new DefaultStageMetrics(mockMetrics, "sink3"),
-                                                       ImmutableList.<String>of()));
+    transformationMap.put("filter2",
+                          new TransformDetail(
+                            new TrackedTransform<>(new Filter(1000d, Threshold.LOWER),
+                                                   new DefaultStageMetrics(mockMetrics, "filter2")),
+                            ImmutableList.of("limiter1", "sink2")));
 
 
+    transformationMap.put("limiter1",
+                          new TransformDetail(
+                            new TrackedTransform<>(new Filter(5000d, Threshold.UPPER),
+                                                   new DefaultStageMetrics(mockMetrics, "limiter1")),
+                            ImmutableList.of("sink3")));
+
+    transformationMap.put("sink1",
+                          new TransformDetail(
+                            new TrackedTransform<>(new DoubleToString(),
+                                                   new DefaultStageMetrics(mockMetrics, "sink1")),
+                            ImmutableList.<String>of()));
+
+    transformationMap.put("sink2",
+                          new TransformDetail(
+                            new TrackedTransform<>(new DoubleToString(),
+                                                   new DefaultStageMetrics(mockMetrics, "sink2")),
+                            ImmutableList.<String>of()));
+
+    transformationMap.put("sink3",
+                          new TransformDetail(
+                            new TrackedTransform<>(new DoubleToString(),
+                                                   new DefaultStageMetrics(mockMetrics, "sink3")),
+                            ImmutableList.<String>of()));
 
     TransformExecutor<Double> executor = new TransformExecutor<>(transformationMap,
                                                                  ImmutableSet.of("filter1", "filter2"));

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/etl/realtime/ETLWorkerTest.java
@@ -41,7 +41,9 @@ import co.cask.cdap.test.TestConfiguration;
 import co.cask.cdap.test.WorkerManager;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -53,7 +55,9 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Tests for {@link ETLWorker}.
@@ -76,6 +80,11 @@ public class ETLWorkerTest extends HydratorTestBase {
     setupRealtimeArtifacts(APP_ARTIFACT_ID, ETLRealtimeApplication.class);
   }
 
+  @After
+  public void cleanupTest() throws Exception {
+    getMetricsManager().resetAll();
+  }
+
   @Test
   @Category(SlowTests.class)
   public void testOneSourceOneSink() throws Exception {
@@ -95,7 +104,7 @@ public class ETLWorkerTest extends HydratorTestBase {
       .addConnection("source", "sink")
       .build();
 
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "testToStream");
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "simpleApp");
     AppRequest<ETLRealtimeConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
@@ -109,6 +118,9 @@ public class ETLWorkerTest extends HydratorTestBase {
     } finally {
       stopWorker(workerManager);
     }
+
+    validateMetric(2, appId, "source.records.out");
+    validateMetric(2, appId, "sink.records.in");
   }
 
   @Test
@@ -150,7 +162,7 @@ public class ETLWorkerTest extends HydratorTestBase {
       .addConnection("source", "sink")
       .build();
 
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "testToStream");
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "lookupTestApp");
     AppRequest<ETLRealtimeConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
@@ -171,6 +183,8 @@ public class ETLWorkerTest extends HydratorTestBase {
     } finally {
       stopWorker(workerManager);
     }
+    validateMetric(1, appId, "source.records.out");
+    validateMetric(1, appId, "sink.records.in");
   }
 
   @Test
@@ -225,6 +239,16 @@ public class ETLWorkerTest extends HydratorTestBase {
     } finally {
       stopWorker(workerManager);
     }
+
+    validateMetric(3, appId, "source.records.out");
+    validateMetric(3, appId, "valueFilter.records.in");
+    validateMetric(2, appId, "valueFilter.records.out");
+    validateMetric(3, appId, "double.records.in");
+    validateMetric(6, appId, "double.records.out");
+    validateMetric(3, appId, "identity.records.in");
+    validateMetric(3, appId, "identity.records.out");
+    validateMetric(2, appId, "sink1.records.in");
+    validateMetric(9, appId, "sink2.records.in");
   }
 
   private void stopWorker(WorkerManager workerManager) {
@@ -234,5 +258,15 @@ public class ETLWorkerTest extends HydratorTestBase {
     } catch (Throwable t) {
       LOG.error("Error stopping worker.", t);
     }
+  }
+
+  private void validateMetric(long expected, Id.Application appId,
+                              String metric) throws TimeoutException, InterruptedException {
+    Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, appId.getNamespaceId(),
+                                               Constants.Metrics.Tag.APP, appId.getId(),
+                                               Constants.Metrics.Tag.WORKER, ETLWorker.NAME);
+    getMetricsManager().waitForTotalMetricCount(tags, "user." + metric, expected, 20, TimeUnit.SECONDS);
+    // wait for won't throw an exception if the metric count is greater than expected
+    Assert.assertEquals(expected, getMetricsManager().getTotalMetric(tags, "user." + metric));
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/realtime/LookupSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/realtime/LookupSource.java
@@ -80,6 +80,7 @@ public class LookupSource extends RealtimeSource<StructuredRecord> {
         recordBuilder.set(entry.getKey(), entry.getValue());
       }
       writer.emit(recordBuilder.build());
+      currentState.setState("done", new byte[] { 1 });
     }
     return currentState;
   }


### PR DESCRIPTION
Fixed a bug where the metrics for records in and out of an
aggregator were incorrect because they were counting intermediate
group metrics.

Includes some refactoring so that metrics are all handled in
TrackedTransform instead of partly in TrackedTransform and partly
in DefaultEmitter. Also making the tracking classes a little more
generic so that the metric emitted can be set. This allows us to
introduce a new 'aggregator.groups' metric to count the number of
groups in an aggregator.