### PR TITLE
Bugfix/cdap 4695 stream delete

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -287,7 +287,9 @@ public final class StreamHandler extends AbstractHttpHandler {
                      @PathParam("stream") String stream) throws Exception {
     Id.Stream streamId = Id.Stream.from(namespaceId, stream);
     checkStreamExists(streamId);
-
+    // On Windows, we can not move the file if it is open, and the stream writer may have an open file in this dir.
+    // Since Windows is only supported in SDK/standalone, we don't need to worry about multiple stream writers here.
+    streamWriter.close(streamId);
     streamAdmin.drop(streamId);
     responder.sendStatus(HttpResponseStatus.OK);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -239,8 +239,10 @@ public class FileStreamAdmin implements StreamAdmin {
   @Override
   public StreamConfig getConfig(Id.Stream streamId) throws IOException {
     Location configLocation = getConfigLocation(streamId);
-    Preconditions.checkArgument(configLocation.exists(), "Stream '%s' does not exist.", streamId);
-
+    if (!configLocation.exists()) {
+      throw new FileNotFoundException(String.format("Configuration file %s for stream '%s' does not exist.",
+                                                    configLocation.toURI().getPath(), streamId));
+    }
     StreamConfig config = GSON.fromJson(
       CharStreams.toString(CharStreams.newReaderSupplier(Locations.newInputSupplier(configLocation), Charsets.UTF_8)),
       StreamConfig.class);


### PR DESCRIPTION
The problem is that on Windows, you can't move/rename a file while someone has it opened. (In Unix you can). After sending data to a stream, the stream handler has an open writer on the data file. That must be closed prior to renaming the directory. I
- first commit fixes a problem after a failed delete, the stream directory exists but its config is gone. The result is that CDAP cannot start any more. this commit makes it log a warning and ignore that stream at startup.
- second commit closes the stream file writer before moving the files. 
