### PR TITLE
Developer docs for PartitionConsumer and PartitionAcceptor

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionAcceptor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionAcceptor.java
@@ -16,11 +16,13 @@
 
 package co.cask.cdap.api.dataset.lib.partitioned;
 
+import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.dataset.lib.PartitionDetail;
 
 /**
  * Defines whether to accept {@link PartitionDetail}s, while iterating over a collection of them.
  */
+@Beta
 public interface PartitionAcceptor {
   /**
    * Return value, determining what to do with a Partition.

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionConsumer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionConsumer.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.dataset.lib.partitioned;
 
+import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.dataset.lib.Partition;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
@@ -28,6 +29,7 @@ import java.util.List;
  * the consumePartitions method must be called in its own, short transaction before the processing of the partitions.
  * This is so that other concurrent consumers can see that the partitions have been marked as IN_PROGRESS.
  */
+@Beta
 public interface PartitionConsumer {
 
   /**


### PR DESCRIPTION
Describing how to use PartitionConsume in conjunction with PartitionAcceptor.
Including a code sample in the develop docs, after describing it.

Marking the relevant classes as Beta (PartitionedFileSet itself is Beta).

https://issues.cask.co/browse/CDAP-5534

Building [Quick Build 3](http://builds.cask.co/browse/CDAP-DOB186-3)