### PR TITLE
(CDAP-4358) (CDAP-5594) (CDAP-5621) Fix flaky tests

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -174,7 +174,7 @@ public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
       metricStore.query(new MetricDataQuery(
         0,
         System.currentTimeMillis() / 1000L,
-        60,
+        Integer.MAX_VALUE,
         "system." + Constants.Metrics.Name.Dataset.OP_COUNT,
         AggregationFunction.SUM,
         ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getId(),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunnerTest.java
@@ -195,7 +195,7 @@ public class WorkerProgramRunnerTest {
           metricStore.query(new MetricDataQuery(
             0,
             System.currentTimeMillis() / 1000L,
-            60,
+            Integer.MAX_VALUE,
             "system." + Constants.Metrics.Name.Dataset.OP_COUNT,
             AggregationFunction.SUM,
             ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getId(),

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkTestRun.java
@@ -213,7 +213,7 @@ public class SparkTestRun extends TestFrameworkTestBase {
           getMetricsManager().query(new MetricDataQuery(
             0,
             System.currentTimeMillis() / 1000L,
-            60,
+            Integer.MAX_VALUE,
             "system." + Constants.Metrics.Name.Dataset.OP_COUNT,
             AggregationFunction.SUM,
             ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getId(),


### PR DESCRIPTION
- The max resolution table should be used to query for aggregates.
  Otherwise there are chances that they are recorded on
  separated cell on lower resolution table.