### PR TITLE
Avoid trimming stacktrace, to see root cause of failure.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1450,6 +1450,7 @@
             <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
             <reuseForks>false</reuseForks>
             <reportFormat>plain</reportFormat>
+            <trimStackTrace>false</trimStackTrace>
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             </systemPropertyVariables>


### PR DESCRIPTION
Without this parameter, Junit trims the stack trace.
We effectively miss out on the root cause of the exception.
For instance: https://builds.cask.co/browse/CDAP-BUT-JOB1-276/test/case/34145108
We don't see the actual assertion exception message, because it gets wrapped within a transaction exception.