### PR TITLE
UI Hydrator++ Bug fixes 

### DIFF
--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.html
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.html
@@ -50,7 +50,7 @@
            ng-show="MySidePanel.openedGroup === null || MySidePanel.openedGroup === group.name">
         <div class="item-body" ng-class="{'view-icon': MySidePanel.view === 'icon', 'view-list': MySidePanel.view === 'list'}">
 
-          <div ng-if="MySidePanel.view === 'icon'" ng-repeat="plugin in group.filtered = (group.plugins | filter: {name: MySidePanel.searchText}) track by $index"
+          <div ng-if="MySidePanel.view === 'icon'" ng-repeat="plugin in group.filtered = (group.plugins | filter: {name: MySidePanel.searchText} | orderBy: 'name') track by $index"
                class="plugin-item {{plugin.nodeClass}}"
                my-popover
                data-placement="right"
@@ -65,7 +65,7 @@
           <div class="no-item-message" ng-if="group.filtered.length === 0">
             <h4>No {{MySidePanel.itemGenericName}} found.</h4>
           </div>
-          <div ng-if="MySidePanel.view === 'list'" ng-repeat="plugin in group.filtered = (group.plugins | filter: {name: MySidePanel.searchText}) track by $index"
+          <div ng-if="MySidePanel.view === 'list'" ng-repeat="plugin in group.filtered = (group.plugins | filter: {name: MySidePanel.searchText} | orderBy: 'name') track by $index"
                class="plugin-item {{plugin.nodeClass}}"
                ng-click="MySidePanel.onItemClicked($event, plugin)">
             <span ng-if="plugin.icon" class="text-center fa {{plugin.icon}}"></span>

--- a/cdap-ui/app/features/hydratorplusplus/leftpanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/leftpanel.less
@@ -497,12 +497,6 @@ body.theme-cdap.state-hydratorplusplus-create {
       &:before, &:after {
         padding: 2px;
       }
-      &:before{
-        content: "(";
-      }
-      &:after {
-        content: ")";
-      }
     }
   }
 

--- a/cdap-ui/app/features/hydratorplusplus/services/create/stores/left-panel-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/stores/left-panel-store.js
@@ -54,6 +54,7 @@ var mapPluginTemplatesWithMoreInfo = (type, DAGPlusPlusFactory, popoverTemplate)
     plugin.type = type;
     plugin.icon = DAGPlusPlusFactory.getIcon(plugin.pluginName);
     plugin.template = popoverTemplate;
+    plugin.name = plugin.pluginTemplate;
     if (plugin.pluginTemplate) {
       plugin.nodeClass = 'plugin-templates';
     }


### PR DESCRIPTION
[CDAP-5788](https://issues.cask.co/browse/CDAP-5788) - Remove braces `(` & `)` around the plugin counts in hydrator++'s left panel.
[CDAP-5775](https://issues.cask.co/browse/CDAP-5775) - Alphabetically sorts plugins in left panel in hydrator++