### PR TITLE
CDAP-5784 Upgrade steps have hydrator upgrade as the wrong step

### DIFF
--- a/cdap-docs/admin-manual/source/upgrading/cloudera.rst
+++ b/cdap-docs/admin-manual/source/upgrading/cloudera.rst
@@ -65,8 +65,8 @@ CDAP:
    upgrade steps against the running services.  From the CDAP Service page, select "Run CDAP
    Post-Upgrade Tasks."
 
-#. To upgrade existing ETL applications created using the 3.2.x versions of ``cdap-etl-batch`` or 
-   ``cdap-etl-realtime``, there are :ref:`separate instructions <cdap-apps-etl-upgrade>`.
+#. To upgrade existing ETL applications created using the |previous-short-version|\.x versions of 
+   ``cdap-etl-batch`` or ``cdap-etl-realtime``, there are :ref:`separate instructions <cdap-apps-etl-upgrade>`.
 
 #. You must recompile and then redeploy your applications prior to using them.
 

--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -99,12 +99,12 @@ upgrade instructions for the earlier versions and upgrade first to
    
      $ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade force
      
-#. To upgrade existing ETL applications created using the 3.2.x versions of ``cdap-etl-batch`` or 
-   ``cdap-etl-realtime``, there are :ref:`separate instructions on doing so <cdap-apps-etl-upgrade>`.
-
 #. Restart the CDAP processes::
 
      $ for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i start ; done
+
+#. To upgrade existing ETL applications created using the 3.2.x versions of ``cdap-etl-batch`` or 
+   ``cdap-etl-realtime``, there are :ref:`separate instructions on doing so <cdap-apps-etl-upgrade>`.
 
 
 .. _admin-upgrading-packages-upgrading-hadoop:

--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -103,8 +103,8 @@ upgrade instructions for the earlier versions and upgrade first to
 
      $ for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i start ; done
 
-#. To upgrade existing ETL applications created using the 3.2.x versions of ``cdap-etl-batch`` or 
-   ``cdap-etl-realtime``, there are :ref:`separate instructions on doing so <cdap-apps-etl-upgrade>`.
+#. To upgrade existing ETL applications created using the |previous-short-version|\.x versions of ``cdap-etl-batch``
+   or ``cdap-etl-realtime``, there are :ref:`separate instructions on doing so <cdap-apps-etl-upgrade>`.
 
 
 .. _admin-upgrading-packages-upgrading-hadoop:

--- a/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
@@ -8,32 +8,43 @@
 ETL Upgrade Procedure
 =====================
 
-If you wish to upgrade ETL applications created using the 3.2.x versions of
-``cdap-etl-batch`` or ``cdap-etl-realtime``, you can use the ETL upgrade tool packaged
+If you wish to upgrade ETL applications created using the |previous-short-version|\.x versions
+of ``cdap-etl-batch`` or ``cdap-etl-realtime``, you can use the ETL upgrade tool packaged
 with the distributed version of CDAP. You would want to run this tool to upgrade
 applications that were created with earlier versions of the artifacts, that you would
 like to open in the |version| version of Cask Hydrator Studio.
 
-The tool will connect to an instance of CDAP, look for any applications that use 3.2.x
+The tool will connect to an instance of CDAP, look for any applications that use |previous-short-version|\.x
 versions of the ``cdap-etl-batch`` or ``cdap-etl-realtime`` artifacts, and then update the
 application to use the |version| version of those artifacts. CDAP must be running when you
 run the command:
 
-.. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> upgrade
+.. container:: highlight
+
+  .. parsed-literal::
+  
+    |$| java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> upgrade
 
 You can also upgrade just the ETL applications within a specific namespace:
 
-.. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> -n <namespace> upgrade
+.. container:: highlight
+
+  .. parsed-literal::
+  
+    |$| java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> -n <namespace> upgrade
 
 You can also upgrade just one ETL application:
 
-.. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> -n <namespace> -p <app-name> upgrade
+.. container:: highlight
+
+  .. parsed-literal::
+  
+    |$| java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> -n <namespace> -p <app-name> upgrade
 
 If you have authentication turned on, you also need to store an authentication token in a file and pass the file to the tool:
 
-.. parsed-literal::
-  java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> -a <tokenfile> upgrade
+.. container:: highlight
 
+  .. parsed-literal::
+  
+    |$| java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> -a <tokenfile> upgrade


### PR DESCRIPTION
Reverse last two steps of upgrade process.

Fix for https://issues.cask.co/browse/CDAP-5784

Passes [Quick Build 3](http://builds.cask.co/browse/CDAP-DOB189-3).