### PR TITLE
CDAP-5786 fix hydrator etl-realtime upgrade

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v1/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v1/ETLConfig.java
@@ -116,7 +116,7 @@ public class ETLConfig extends Config {
   }
 
   public List<ETLStage> getSinks() {
-    return sinks;
+    return sinks == null ? new ArrayList<ETLStage>() : sinks;
   }
 
   public List<ETLStage> getTransforms() {
@@ -124,11 +124,11 @@ public class ETLConfig extends Config {
   }
 
   public List<Connection> getConnections() {
-    return connections;
+    return connections == null ? new ArrayList<Connection>() : connections;
   }
 
   public Resources getResources() {
-    return resources;
+    return resources == null ? new Resources() : resources;
   }
 
   public Boolean isStageLoggingEnabled() {
@@ -139,9 +139,9 @@ public class ETLConfig extends Config {
                                                                                   UpgradeContext upgradeContext,
                                                                                   String sourceType,
                                                                                   String sinkType) {
-    builder.setResources(resources).addConnections(connections);
+    builder.setResources(getResources()).addConnections(getConnections());
 
-    if (!stageLoggingEnabled) {
+    if (!isStageLoggingEnabled()) {
       builder.disableStageLogging();
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v1/ETLRealtimeConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v1/ETLRealtimeConfig.java
@@ -80,7 +80,7 @@ public final class ETLRealtimeConfig extends ETLConfig
   }
 
   public Integer getInstances() {
-    return instances;
+    return instances == null ? 1 : instances;
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
@@ -46,9 +46,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-nop</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
@@ -79,6 +79,14 @@
             <configuration>
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <minimizeJar>true</minimizeJar>
+              <filters>
+                <filter>
+                  <artifact>ch.qos.logback:logback-classic</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+              </filters>
             </configuration>
             <goals>
               <goal>shade</goal>

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/UpgradeTool.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/UpgradeTool.java
@@ -26,6 +26,7 @@ import co.cask.cdap.client.config.ConnectionConfig;
 import co.cask.cdap.etl.proto.UpgradeContext;
 import co.cask.cdap.etl.proto.UpgradeableConfig;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
+import co.cask.cdap.etl.proto.v2.ETLConfig;
 import co.cask.cdap.etl.proto.v2.ETLRealtimeConfig;
 import co.cask.cdap.etl.tool.config.BatchClientBasedUpgradeContext;
 import co.cask.cdap.etl.tool.config.RealtimeClientBasedUpgradeContext;
@@ -51,12 +52,15 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Used to upgrade pipelines from older pipelines to current pipelines.
@@ -71,18 +75,18 @@ public class UpgradeTool {
   private final ApplicationClient appClient;
   private final ArtifactSummary batchArtifact;
   private final ArtifactSummary realtimeArtifact;
-  private final UpgradeContext batchUpgradeContext;
-  private final UpgradeContext realtimeUpgradeContext;
+  private final ArtifactClient artifactClient;
+  @Nullable
+  private final File errorDir;
 
-  private UpgradeTool(ClientConfig clientConfig) {
+  private UpgradeTool(ClientConfig clientConfig, @Nullable File errorDir) {
     String version = ETLVersion.getVersion();
     this.batchArtifact = new ArtifactSummary(BATCH_NAME, version, ArtifactScope.SYSTEM);
     this.realtimeArtifact = new ArtifactSummary(REALTIME_NAME, version, ArtifactScope.SYSTEM);
     this.appClient = new ApplicationClient(clientConfig);
     this.namespaceClient = new NamespaceClient(clientConfig);
-    ArtifactClient artifactClient = new ArtifactClient(clientConfig);
-    this.batchUpgradeContext = new BatchClientBasedUpgradeContext(artifactClient);
-    this.realtimeUpgradeContext = new RealtimeClientBasedUpgradeContext(artifactClient);
+    this.artifactClient = new ArtifactClient(clientConfig);
+    this.errorDir = errorDir;
   }
 
   private Set<Id.Application> upgrade() throws Exception {
@@ -117,21 +121,39 @@ public class UpgradeTool {
     String artifactName = appDetail.getArtifact().getName();
     String artifactVersion = appDetail.getVersion();
     if (BATCH_NAME.equals(artifactName)) {
+      UpgradeContext upgradeContext = new BatchClientBasedUpgradeContext(appId.getNamespace(), artifactClient);
       ETLBatchConfig upgradedConfig =
-        convertBatchConfig(artifactVersion, appDetail.getConfiguration(), batchUpgradeContext);
-      AppRequest<ETLBatchConfig> updateRequest = new AppRequest<>(batchArtifact, upgradedConfig);
-      appClient.update(appId, updateRequest);
+        convertBatchConfig(artifactVersion, appDetail.getConfiguration(), upgradeContext);
+      upgrade(appId, batchArtifact, upgradedConfig);
     } else if (REALTIME_NAME.equals(artifactName)) {
+      UpgradeContext upgradeContext = new RealtimeClientBasedUpgradeContext(appId.getNamespace(), artifactClient);
       ETLRealtimeConfig upgradedConfig =
-        convertRealtimeConfig(artifactVersion, appDetail.getConfiguration(), realtimeUpgradeContext);
-      AppRequest<ETLRealtimeConfig> updateRequest = new AppRequest<>(realtimeArtifact, upgradedConfig);
-      appClient.update(appId, updateRequest);
+        convertRealtimeConfig(artifactVersion, appDetail.getConfiguration(), upgradeContext);
+      upgrade(appId, realtimeArtifact, upgradedConfig);
     } else {
       // should never happen
       LOG.warn("Unknown app artifact {}. Skipping pipeline.", artifactName);
       return false;
     }
     return true;
+  }
+
+  private <T extends ETLConfig> void upgrade(Id.Application appId, ArtifactSummary appArtifact,
+                                             T config) throws IOException {
+    AppRequest<T> updateRequest = new AppRequest<>(appArtifact, config);
+    try {
+      appClient.update(appId, updateRequest);
+    } catch (Exception e) {
+      LOG.error("Error upgrading pipeline {}.", appId, e);
+      if (errorDir != null) {
+        File errorFile = new File(errorDir, String.format("%s-%s.json", appId.getNamespaceId(), appId.getId()));
+        LOG.error("Writing config for pipeline {} to {} for further manual investigation.",
+                  appId, errorFile.getAbsolutePath());
+        try (OutputStreamWriter outputStreamWriter = new OutputStreamWriter(new FileOutputStream(errorFile))) {
+          outputStreamWriter.write(GSON.toJson(config));
+        }
+      }
+    }
   }
 
   public static void main(String[] args) throws Exception {
@@ -157,7 +179,10 @@ public class UpgradeTool {
         "as expected by older versions of the etl artifacts."))
       .addOption(new Option("o", "outputfile", true, "File to write the converted application details provided in " +
         "the configfile option. If none is given, results will be written to the input file + '.converted'. " +
-        "The contents of this file can be sent directly to CDAP to update or create an application."));
+        "The contents of this file can be sent directly to CDAP to update or create an application."))
+      .addOption(new Option("e", "errorDir", true, "Optional directory to write any upgraded pipeline configs that " +
+        "failed to upgrade. The problematic configs can then be manually edited and upgraded separately. " +
+        "Upgrade errors may happen for pipelines that use plugins that are not backwards compatible."));
 
     CommandLineParser parser = new BasicParser();
     CommandLine commandLine = parser.parse(options, args);
@@ -184,7 +209,8 @@ public class UpgradeTool {
       System.exit(0);
     }
 
-    UpgradeTool upgradeTool = new UpgradeTool(clientConfig);
+    File errorDir = commandLine.hasOption("e") ? new File(commandLine.getOptionValue("e")) : null;
+    UpgradeTool upgradeTool = new UpgradeTool(clientConfig, errorDir);
 
     String namespace = commandLine.getOptionValue("n");
     String pipelineName = commandLine.getOptionValue("p");
@@ -217,7 +243,7 @@ public class UpgradeTool {
     }
     LOG.info("Successfully upgraded {} pipelines:", pipelines.size());
     for (Id.Application pipeline : pipelines) {
-      LOG.info("-- {}", pipeline);
+      LOG.info("  {}", pipeline);
     }
   }
 
@@ -283,7 +309,7 @@ public class UpgradeTool {
     String oldArtifactVersion = artifactFile.artifact.getVersion();
     if (BATCH_NAME.equals(artifactFile.artifact.getName())) {
       ArtifactSummary artifact = new ArtifactSummary(BATCH_NAME, version, ArtifactScope.SYSTEM);
-      UpgradeContext upgradeContext = new BatchClientBasedUpgradeContext(artifactClient);
+      UpgradeContext upgradeContext = new BatchClientBasedUpgradeContext(Id.Namespace.DEFAULT, artifactClient);
       ETLBatchConfig config = convertBatchConfig(oldArtifactVersion, artifactFile.config.toString(), upgradeContext);
       AppRequest<ETLBatchConfig> updated = new AppRequest<>(artifact, config);
       try (BufferedWriter writer = Files.newBufferedWriter(outputFile.toPath(), StandardCharsets.UTF_8)) {
@@ -291,7 +317,7 @@ public class UpgradeTool {
       }
     } else {
       ArtifactSummary artifact = new ArtifactSummary(REALTIME_NAME, version, ArtifactScope.SYSTEM);
-      UpgradeContext upgradeContext = new RealtimeClientBasedUpgradeContext(artifactClient);
+      UpgradeContext upgradeContext = new RealtimeClientBasedUpgradeContext(Id.Namespace.DEFAULT, artifactClient);
       ETLRealtimeConfig config =
         convertRealtimeConfig(oldArtifactVersion, artifactFile.config.toString(), upgradeContext);
       AppRequest<ETLRealtimeConfig> updated = new AppRequest<>(artifact, config);
@@ -325,7 +351,8 @@ public class UpgradeTool {
     ArtifactVersion artifactVersion = new ArtifactVersion(artifactSummary.getVersion());
     Integer majorVersion = artifactVersion.getMajor();
     Integer minorVersion = artifactVersion.getMinor();
-    return majorVersion != null && majorVersion == 3 && minorVersion != null && minorVersion >= 2;
+    return majorVersion != null && majorVersion == 3 && minorVersion != null && minorVersion >= 2 &&
+      minorVersion < 4;
   }
 
   private static ETLBatchConfig convertBatchConfig(String artifactVersion, String configStr,

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/BatchClientBasedUpgradeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/BatchClientBasedUpgradeContext.java
@@ -25,8 +25,8 @@ import co.cask.cdap.proto.Id;
  */
 public class BatchClientBasedUpgradeContext extends ClientBasedUpgradeContext {
 
-  public BatchClientBasedUpgradeContext(ArtifactClient artifactClient) {
-    super(artifactClient, Id.Artifact.from(Id.Namespace.SYSTEM, "cdap-etl-batch", ETLVersion.getVersion()));
+  public BatchClientBasedUpgradeContext(Id.Namespace namespace, ArtifactClient artifactClient) {
+    super(artifactClient, Id.Artifact.from(namespace, "cdap-etl-batch", ETLVersion.getVersion()));
   }
 
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/RealtimeClientBasedUpgradeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/config/RealtimeClientBasedUpgradeContext.java
@@ -25,8 +25,8 @@ import co.cask.cdap.proto.Id;
  */
 public class RealtimeClientBasedUpgradeContext extends ClientBasedUpgradeContext {
 
-  public RealtimeClientBasedUpgradeContext(ArtifactClient artifactClient) {
-    super(artifactClient, Id.Artifact.from(Id.Namespace.SYSTEM, "cdap-etl-realtime", ETLVersion.getVersion()));
+  public RealtimeClientBasedUpgradeContext(Id.Namespace namespace, ArtifactClient artifactClient) {
+    super(artifactClient, Id.Artifact.from(namespace, "cdap-etl-realtime", ETLVersion.getVersion()));
   }
 
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/resources/logback.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/resources/logback.xml
@@ -20,36 +20,6 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.out</target>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>DEBUG</level>
-            <onMatch>ACCEPT</onMatch>
-        </filter>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>INFO</level>
-            <onMatch>ACCEPT</onMatch>
-        </filter>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>TRACE</level>
-            <onMatch>ACCEPT</onMatch>
-        </filter>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>WARN</level>
-            <onMatch>DENY</onMatch>
-        </filter>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>ERROR</level>
-            <onMatch>DENY</onMatch>
-        </filter>
-        <encoder>
-            <pattern>%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
-        <target>System.err</target>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>WARN</level>
-        </filter>
         <encoder>
             <pattern>%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n</pattern>
         </encoder>
@@ -57,6 +27,5 @@
 
     <root level="debug">
         <appender-ref ref="STDOUT" />
-        <appender-ref ref="STDERR" />
     </root>
 </configuration>

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/resources/logback.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/resources/logback.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright © 2016 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>DEBUG</level>
+            <onMatch>ACCEPT</onMatch>
+        </filter>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+        </filter>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>TRACE</level>
+            <onMatch>ACCEPT</onMatch>
+        </filter>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>DENY</onMatch>
+        </filter>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>DENY</onMatch>
+        </filter>
+        <encoder>
+            <pattern>%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+        <encoder>
+            <pattern>%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="STDERR" />
+    </root>
+</configuration>

--- a/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
@@ -23,7 +23,11 @@ run the command:
 
   .. parsed-literal::
   
-    |$| java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> upgrade
+    |$| java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> -e /tmp/failedUpgrades upgrade
+
+The first argument is the host and port for the CDAP master. The second argument is a directory to write the configurations
+of any pipelines that could not be upgraded. A pipeline may fail to upgrade if the new version of a plugin used in the
+pipeline is not backwards compatible. For example, this may happen if the plugin added a new required property.
 
 You can also upgrade just the ETL applications within a specific namespace:
 


### PR DESCRIPTION
Fixed a bug in the upgrade logic that would fail if certain optional
settings -- like instances -- were not set.

Also making general improvements to the upgrade tool.
Logging was not set up correctly, so configuring error and warn
messages to write to stderr and everything else to stdout. Also
adding an option to write configs that failed to upgrade to an
error directory for manual investigation. Pipelines can fail to
upgrade if they use plugins that are not backwards compatible.