### PR TITLE
disable audit logging in standalone tester

### DIFF
--- a/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
+++ b/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
@@ -75,6 +75,7 @@ public class StandaloneTester extends ExternalResource {
     cConf.setBoolean(Constants.Explore.EXPLORE_ENABLED, true);
     cConf.setBoolean(Constants.Explore.START_ON_DEMAND, true);
     cConf.setBoolean(StandaloneMain.DISABLE_UI, true);
+    cConf.setBoolean(Constants.Audit.ENABLED, false);
 
     for (int i = 0; i < configs.length; i += 2) {
       cConf.set(configs[i].toString(), configs[i + 1].toString());


### PR DESCRIPTION
this PR https://github.com/caskdata/cdap/pull/5650 broke the build, as standalone tester creates standalone main instance.

disabling audit log in standalone tester config.

build running: http://builds.cask.co/browse/CDAP-DUT4059-1