### PR TITLE
Redirect errors on node check and give friendly error message

### DIFF
--- a/cdap-ui/conf/ui-env.sh
+++ b/cdap-ui/conf/ui-env.sh
@@ -20,14 +20,18 @@
 # Set environment variables here.
 
 # Main cmd is the non-java command to run.
-
 MAIN_CMD=node
 
 # Check for embedded node binary, and ensure it's the correct binary ABI for this system
 if test -x ${CDAP_HOME}/ui/bin/node ; then
-  ${CDAP_HOME}/ui/bin/node --version 2>&1 >/dev/null
+  ${CDAP_HOME}/ui/bin/node --version >/dev/null 2>&1
   if [ $? -eq 0 ] ; then
     MAIN_CMD=${CDAP_HOME}/ui/bin/node
+  elif [[ $(which node 2>/dev/null) ]]; then
+    MAIN_CMD=node
+  else
+    echo "Unable to locate Node.js binary (node), is it installed and in the PATH?"
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
This hides the error output from the `node --version` test on our embedded `node` binary and gives a better output on failure to locate `node` in the system's PATH.