### PR TITLE
CDAP-5718 documenting new data pipeline plugin types

### DIFF
--- a/cdap-docs/cdap-apps/source/hydrator/custom.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/custom.rst
@@ -15,43 +15,31 @@ Overview
 This section is intended for developers writing custom ETL plugins. Users of these should
 refer to the :ref:`Included Applications <cdap-apps-index>`.
 
-CDAP provides for the creation of custom ETL plugins for batch/real-time sources/sinks and
-transformations to extend the existing ``cdap-etl-batch`` and ``cdap-etl-realtime`` system artifacts.
+CDAP provides for the creation of custom ETL plugins to extend the existing ``cdap-etl-batch``,
+``cdap-etl-realtime``, and ``cdap-data-pipeline`` system artifacts.
 
 
 Plugin Types and Maven Archetypes
 =================================
-In ETL applications, there are five plugin types:
+In Hydrator, there are eight plugin types:
 
 - Batch Source (*batchsource*)
 - Batch Sink (*batchsink*)
 - Real-time Source (*realtimesource*)
 - Real-time Sink (*realtimesink*)
 - Transformation (*transform*)
+- Batch Aggregator (*batchaggregator*)
+- Spark Computer (*sparkcompute*)
+- Spark Sink (*sparksink*) 
 
-There are five corresponding Maven archetypes available for starting a plugin project.
+To get started, you can use one of the Maven archetypes to create your project: 
 
-Available Annotations
----------------------
-These annotations may be used with the plugin classes:
+- cdap-data-pipeline-plugins-archetype (contains all batch plugin types)
+- cdap-etl-realtime-source-archetype (contains a realtime source)
+- cdap-etl-realtime-sink-archetype (contains a realtime sink)
+- cdap-etl-transform-archetype (contains a transform)
 
-- ``@Plugin``: The class to be exposed as a plugin needs to be annotated with the ``@Plugin``
-  annotation and the type of the plugin should be specified (*source*, *sink*, *transformation*).
-  By default, the plugin type will be ‘plugin’.
-
-- ``@Name``: Annotation used to name the plugin as well as the properties in the
-  Configuration class of the plugin.
-
-- ``@Description``: Annotation used to add a description.
-
-- ``@Nullable``: Annotation indicates that the specific configuration property is
-  optional. Such a plugin class can be used without that property being specified.
-
-
-Creating a Batch Source
-=======================
-A batch source plugin can be created from a Maven archetype. This command will create a
-project for the plugin from the archetype:
+This command will create a project from the archetype:
 
 .. container:: highlight
 
@@ -59,16 +47,86 @@ project for the plugin from the archetype:
 
     |$| mvn archetype:generate \\
           -DarchetypeGroupId=co.cask.cdap \\
-          -DarchetypeArtifactId=cdap-etl-batch-source-archetype \\
+          -DarchetypeArtifactId=<archetype> \\
           -DarchetypeVersion=\ |release| \\
           -DgroupId=org.example.plugin
 
 You can replace the groupId with your own organization, but it must not be ``co.cask.cdap``.
 
+Plugin Basics
+=============
+
+Plugin Class Annotations
+------------------------
+These annotations are used for plugin classes:
+
+- ``@Plugin``: The class to be exposed as a plugin needs to be annotated with the ``@Plugin``
+  annotation and the type of the plugin must be specified.
+
+- ``@Name``: Annotation used to name the plugin.
+
+- ``@Description``: Annotation used to add a description of the plugin.
+
+Plugin Config
+-------------
+Each plugin can define a plugin config that specifies what properties the plugin requires.
+When a user creates a pipeline, they will need to provide these properties in order to
+use the plugin. This is done by extending the `PluginConfig` class, and populating that
+class with the field your plugin requires. Each field can be annotated to provide more
+information to users:
+
+- ``@Name``: The name of the field. Defaults to Java field name. You may want to use this
+  if you want the user facing name to use syntax that is not legal Java syntax.
+
+- ``@Description``: A description for the field.
+
+- ``@Nullable``: Indicates that the specific configuration property is
+  optional. Such a plugin class can be used without that property being specified.
+
+At this time, fields in a `PluginConfig` must be primitive Java types (boxed or unboxed).
+
 .. highlight:: java
 
-In order to implement a Batch Source (to be used in the ETL Batch artifact), you extend
-the ``BatchSource`` class. You need to define the types of the KEY and VALUE that the Batch
+Example::
+ 
+  @Plugin(type = BatchSource.PLUGIN_TYPE)
+  @Name("MyBatchSource")
+  @Description("This is my Batch Source")
+  public class MyBatchSource extends BatchSource<LongWritable, Text, StructuredRecord> {
+    private final Conf conf;
+
+    public MyBatchSource(Conf conf) {
+      this.conf = conf;
+    )
+
+    public static class Conf extends PluginConfig {
+      @Name("input-path")
+      @Description("Input path for the source")
+      private String inputPath;
+
+      @Nullable
+      @Description("Whether to clean up the previous run's output. Defaults to false.")
+      private Boolean cleanOutput;
+
+      public Conf() {
+        cleanOutput = false;
+      }
+    }
+    ...
+  }
+
+In this example, we have a plugin of type `batchsource`, named `MyBatchSource`.
+This plugin takes two configuration properties. The first is named `input-path` and is required.
+The second is named `cleanOutput`, and is optional. Note that optional configuration fields should
+have their default values set in the no-argument constructor.
+
+Creating a Batch Source
+=======================
+
+.. highlight:: java
+
+In order to implement a Batch Source (to be used in the ETL Batch artifact or Data Pipeline artifact), you extend the
+``BatchSource`` class. You need to define the types of the KEY and VALUE that the Batch
 Source will receive and the type of object that the Batch Source will emit to the
 subsequent stage (which could be either a Transformation or a Batch Sink). After defining
 the types, only one method is required to be implemented:
@@ -77,48 +135,143 @@ the types, only one method is required to be implemented:
 
 .. rubric:: Methods
 
-- ``prepareRun()``: Used to configure the Hadoop Job configuration (for example, set the
-  ``InputFormatClass``).
+- ``prepareRun()``: Used to configure the input for each run of the pipeline. This is called by
+  the client that will submit the job for the pipeline run.
+- ``onRunFinish()``: Used to run any required logic at the end of a pipeline run. This is called
+  by the client that submitted the job for the pipeline run.
 - ``configurePipeline()``: Used to create any streams or datasets or perform any validation
   on the application configuration that are required by this plugin.
 - ``initialize()``: Initialize the Batch Source. Guaranteed to be executed before any call
-  to the plugin’s ``transform`` method.
+  to the plugin’s ``transform`` method. This is called by each executor of the job. For example,
+  if the MapReduce engine is being used, each mapper will call this method.
+- ``destroy()``: Destroy any resources created by initialize. Guaranteed to be executed after all calls
+  to the plugin’s ``transform`` method have been made. This is called by each executor of the job.
+  For example, if the MapReduce engine is being used, each mapper will call this method.
 - ``transform()``: This method will be called for every input key-value pair generated by
   the batch job. By default, the value is emitted to the subsequent stage.
 
 Example::
 
-  @Plugin(type = "batchsource")
-  @Name("MyBatchSource")
-  @Description("Demo Source")
-  public class MyBatchSource extends BatchSource<LongWritable, String, String> {
+  /**
+   * Batch Source that reads from a FileSet that has its data formatted as text.
+   *
+   * LongWritable is the first parameter because that is the key used by Hadoop's {@link TextInputFormat}.
+   * Similarly, Text is the second parameter because that is the value used by Hadoop's {@link TextInputFormat}.
+   * {@link StructuredRecord} is the third parameter because that is what the source will output.
+   * All the plugins included with Hydrator operate on StructuredRecord.
+   */
+  @Plugin(type = BatchSource.PLUGIN_TYPE)
+  @Name(TextFileSetSource.NAME)
+  @Description("Reads from a FileSet that has its data formatted as text.")
+  public class TextFileSetSource extends BatchSource<LongWritable, Text, StructuredRecord> {
+    public static final String NAME = "TextFileSet";
+    public static final Schema OUTPUT_SCHEMA = Schema.recordOf(
+      "textRecord",
+      Schema.Field.of("position", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("text", Schema.of(Schema.Type.STRING))
+    );
+    private final Conf config;
 
+    /**
+     * Config properties for the plugin.
+     */
+    public static class Conf extends PluginConfig {
+      public static final String FILESET_NAME = "fileSetName";
+      public static final String CREATE_IF_NOT_EXISTS = "createIfNotExists";
+      public static final String DELETE_INPUT_ON_SUCCESS = "deleteInputOnSuccess";
+
+      // The name annotation tells CDAP what the property name is. It is optional, and defaults to the variable name.
+      // Note:  only primitives (including boxed types) and string are the types that are supported
+      @Name(FILESET_NAME)
+      @Description("The name of the FileSet to read from.")
+      private String fileSetName;
+
+      // A nullable fields tells CDAP that this is an optional field.
+      @Nullable
+      @Name(CREATE_IF_NOT_EXISTS)
+      @Description("Whether to create the FileSet if it doesn't already exist. Defaults to false.")
+      private Boolean createIfNotExists;
+
+      @Nullable
+      @Name(DELETE_INPUT_ON_SUCCESS)
+      @Description("Whether to delete the data read by the source after the run succeeds. Defaults to false.")
+      private Boolean deleteInputOnSuccess;
+
+      // Use a no-args constructor to set field defaults.
+      public Conf() {
+        fileSetName = "";
+        createIfNotExists = false;
+        deleteInputOnSuccess = false;
+      }
+    }
+
+    // CDAP will pass in a config with its fields populated based on the configuration given when creating the pipeline.
+    public TextFileSetSource(Conf config) {
+      this.config = config;
+    }
+
+    // configurePipeline is called exactly once when the pipeline is being created.
+    // Any static configuration should be performed here.
     @Override
-    public void prepareRun(BatchSourceContext context) {
-      Job job = context.getHadoopJob();
-      job.setInputFormatClass(...);
-      // Other Hadoop job configuration related to Input
+    public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+      // if the user has set createIfNotExists to true, create the FileSet here.
+      if (config.createIfNotExists) {
+        pipelineConfigurer.createDataset(config.fileSetName,
+                                         FileSet.class,
+                                         FileSetProperties.builder()
+                                           .setInputFormat(TextInputFormat.class)
+                                           .setOutputFormat(TextOutputFormat.class)
+                                           .setEnableExploreOnCreate(true)
+                                           .setExploreFormat("text")
+                                           .setExploreSchema("text string")
+                                           .build()
+        );
+      }
+      // set the output schema of this stage so that stages further down the pipeline will know their input schema.
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(OUTPUT_SCHEMA);
+    }
+
+    // prepareRun is called before every pipeline run, and is used to configure what the input should be,
+    // as well as any arguments the input should use. It is called by the client that is submitting the batch job.
+    @Override
+    public void prepareRun(BatchSourceContext context) throws IOException {
+      context.setInput(Input.ofDataset(config.fileSetName));
+    }
+
+    // onRunFinish is called at the end of the pipeline run by the client that submitted the batch job.
+    @Override
+    public void onRunFinish(boolean succeeded, BatchSourceContext context) {
+      // perform any actions that should happen at the end of the run.
+      // in our case, we want to delete the data read during this run if the run succeeded.
+      if (succeeded && config.deleteInputOnSuccess) {
+        FileSet fileSet = context.getDataset(config.fileSetName);
+        for (Location inputLocation : fileSet.getInputLocations()) {
+          try {
+            inputLocation.delete(true);
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      }
+    }
+
+    // transform is used to transform the key-value pair output by the input into objects output by this source.
+    // The output should be a StructuredRecord if you want the source to be compatible with the plugins included
+    // with Hydrator.
+    @Override
+    public void transform(KeyValue<LongWritable, Text> input, Emitter<StructuredRecord> emitter) throws Exception {
+      emitter.emit(StructuredRecord.builder(OUTPUT_SCHEMA)
+                     .set("position", input.getKey().get())
+                     .set("text", input.getValue().toString())
+                     .build()
+      );
     }
   }
 
-
 Creating a Batch Sink
 =====================
-A batch sink plugin can be created from this Maven archetype:
 
-.. container:: highlight
-
-  .. parsed-literal::
-
-    |$| mvn archetype:generate \\
-          -DarchetypeGroupId=co.cask.cdap \\
-          -DarchetypeArtifactId=cdap-etl-batch-sink-archetype \\
-          -DarchetypeVersion=\ |release| \\
-          -DgroupId=org.example.plugin
-
-You can replace the groupId with your own organization, but it must not be ``co.cask.cdap``.
-
-In order to implement a Batch Sink (to be used in the ETL Batch artifact), you extend the
+In order to implement a Batch Sink (to be used in the ETL Batch artifact or Data Pipeline artifact), you extend the
 ``BatchSink`` class. Similar to a Batch Source, you need to define the types of the KEY and
 VALUE that the Batch Sink will write in the Batch job and the type of object that it will
 accept from the previous stage (which could be either a Transformation or a Batch Source).
@@ -131,11 +284,18 @@ After defining the types, only one method is required to be implemented:
 
 .. rubric:: Methods
 
-- ``prepareRun()``: Used to configure the Hadoop Job configuration (for ex, set ``OutputFormatClass``).
-- ``configurePipeline()``: Used to create any datasets or perform any validation
+- ``prepareRun()``: Used to configure the output for each run of the pipeline. This is called by
+  the client that will submit the job for the pipeline run.
+- ``onRunFinish()``: Used to run any required logic at the end of a pipeline run. This is called
+  by the client that submitted the job for the pipeline run.
+- ``configurePipeline()``: Used to create any streams or datasets or perform any validation
   on the application configuration that are required by this plugin.
-- ``initialize()``: Initialize the Batch Sink runtime. Guaranteed to be executed before
-  any call to the plugin’s ``transform`` method.
+- ``initialize()``: Initialize the Batch Sink. Guaranteed to be executed before any call
+  to the plugin’s ``transform`` method. This is called by each executor of the job. For example,
+  if the MapReduce engine is being used, each mapper will call this method.
+- ``destroy()``: Destroy any resources created by initialize. Guaranteed to be executed after all calls
+  to the plugin’s ``transform`` method have been made. This is called by each executor of the job.
+  For example, if the MapReduce engine is being used, each mapper will call this method.
 - ``transform()``: This method will be called for every object that is received from the
   previous stage. The logic inside the method will transform the object to the key-value
   pair expected by the Batch Sink's output format. If you don't override this method, the
@@ -143,35 +303,102 @@ After defining the types, only one method is required to be implemented:
 
 Example::
 
-  @Plugin(type = "batchsink")
-  @Name("MyBatchSink")
-  @Description("Demo Sink")
-  public class MyBatchSink extends BatchSink<String, String, NullWritable> {
+  /**
+   * Batch Sink that writes to a FileSet in text format.
+   * Each record will be written as a single line, with record fields separated by a configurable separator.
+   *
+   * StructuredRecord is the first parameter because that is the input to the sink.
+   * The second and third parameters are the key and value expected by Hadoop's {@link TextOutputFormat}.
+   */
+  @Plugin(type = BatchSink.PLUGIN_TYPE)
+  @Name(TextFileSetSink.NAME)
+  @Description("Writes to a FileSet in text format.")
+  public class TextFileSetSink extends BatchSink<StructuredRecord, NullWritable, Text> {
+    public static final String NAME = "TextFileSet";
+    private final Conf config;
+
+    /**
+     * Config properties for the plugin.
+     */
+    public static class Conf extends PluginConfig {
+      public static final String FILESET_NAME = "fileSetName";
+      public static final String FIELD_SEPARATOR = "fieldSeparator";
+
+      // The name annotation tells CDAP what the property name is. It is optional, and defaults to the variable name.
+      // Note:  only primitives (including boxed types) and string are the types that are supported
+      @Name(FILESET_NAME)
+      @Description("The name of the FileSet to read from.")
+      private String fileSetName;
+
+      @Nullable
+      @Name(FIELD_SEPARATOR)
+      @Description("The separator to use to join input record fields together. Defaults to ','.")
+      private String fieldSeparator;
+
+      // Use a no-args constructor to set field defaults.
+      public Conf() {
+        fileSetName = "";
+        fieldSeparator = ",";
+      }
+    }
+
+    // CDAP will pass in a config with its fields populated based on the configuration given when creating the pipeline.
+    public TextFileSetSink(Conf config) {
+      this.config = config;
+    }
+
+    // configurePipeline is called exactly once when the pipeline is being created.
+    // Any static configuration should be performed here.
+    @Override
+    public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+      // create the FileSet here.
+      pipelineConfigurer.createDataset(config.fileSetName,
+                                       FileSet.class,
+                                       FileSetProperties.builder()
+                                         .setInputFormat(TextInputFormat.class)
+                                         .setOutputFormat(TextOutputFormat.class)
+                                         .setEnableExploreOnCreate(true)
+                                         .setExploreFormat("text")
+                                         .setExploreSchema("text string")
+                                         .build()
+      );
+    }
+
+    // prepareRun is called before every pipeline run, and is used to configure what the input should be,
+    // as well as any arguments the input should use. It is called by the client that is submitting the batch job.
+    @Override
+    public void prepareRun(BatchSinkContext context) throws Exception {
+      context.addOutput(Output.ofDataset(config.fileSetName));
+    }
 
     @Override
-    public void prepareRun(BatchSinkContext context) {
-      Job job = context.getHadoopJob();
-      job.setOutputFormatClass(...);
-      // Other Hadoop job configuration related to Output
-    }
-  }
+    public void transform(StructuredRecord input, Emitter<KeyValue<NullWritable, Text>> emitter) throws Exception {
+      StringBuilder joinedFields = new StringBuilder();
+      Iterator<Schema.Field> fieldIter = input.getSchema().getFields().iterator();
+      if (!fieldIter.hasNext()) {
+        // shouldn't happen
+        return;
+      }
 
+      Object val = input.get(fieldIter.next().getName());
+      if (val != null) {
+        joinedFields.append(val);
+      }
+      while (fieldIter.hasNext()) {
+        String fieldName = fieldIter.next().getName();
+        joinedFields.append(config.fieldSeparator);
+        val = input.get(fieldName);
+        if (val != null) {
+          joinedFields.append(val);
+        }
+      }
+      emitter.emit(new KeyValue<>(NullWritable.get(), new Text(joinedFields.toString())));
+    }
+
+  }
 
 Creating a Real-Time Source
 ===========================
-A real-time source plugin can be created from this Maven archetype:
-
-.. container:: highlight
-
-  .. parsed-literal::
-
-    |$| mvn archetype:generate \\
-          -DarchetypeGroupId=co.cask.cdap \\
-          -DarchetypeArtifactId=cdap-etl-realtime-source-archetype \\
-          -DarchetypeVersion=\ |release| \\
-          -DgroupId=org.example.plugin
-
-You can replace the groupId with your own organization, but it must not be ``co.cask.cdap``.
 
 .. highlight:: java
 
@@ -253,19 +480,6 @@ Example::
 
 Creating a Real-Time Sink
 =========================
-A real-time sink plugin can be created from this Maven archetype:
-
-.. container:: highlight
-
-  .. parsed-literal::
-
-    |$| mvn archetype:generate \\
-          -DarchetypeGroupId=co.cask.cdap \\
-          -DarchetypeArtifactId=cdap-etl-realtime-sink-archetype \\
-          -DarchetypeVersion=\ |release| \\
-          -DgroupId=org.example.plugin
-
-You can replace the groupId with your own organization, but it must not be ``co.cask.cdap``.
 
 .. highlight:: java
 
@@ -306,21 +520,6 @@ Example::
 
 Creating a Transformation
 =========================
-In ETL applications, a transformation operation is applied on one object at a time,
-converting it into zero or more transformed outputs. A Transformation plugin can be created
-using this Maven archetype:
-
-.. container:: highlight
-
-  .. parsed-literal::
-
-    |$| mvn archetype:generate \\
-          -DarchetypeGroupId=co.cask.cdap \\
-          -DarchetypeArtifactId=cdap-etl-transform-archetype \\
-          -DarchetypeVersion=\ |release| \\
-          -DgroupId=org.example.plugin
-
-You can replace the groupId with your own organization, but it must not be ``co.cask.cdap``.
 
 The only method that needs to be implemented is:
 
@@ -446,6 +645,271 @@ functions as part of your JavaScript::
   if (!coreValidator.isDate(input.date)) {
   . . .
 
+Creating a Batch Aggregator
+===========================
+
+In order to implement a Batch Aggregator (to be used in the Data Pipeline artifact), you extend the
+``BatchAggregator`` class. Unlike a ``Transform``, a ``BatchAggregator`` operates on a collection of
+records instead of only on one record at a time. An aggregation takes place in two steps --
+groupBy and aggregate. In the groupBy step, the aggregator zero or more group keys for each
+input record. Before the aggregate step occurs, Hydrator will take all records that have the same
+group key, and collect them in a group. If a record did not have any group keys, it is filtered out.
+If a record had multiple group keys, it will belong to multiple groups. The aggregate step is then
+called. In this step, the plugin gets the group key and all the records that had that group key.
+It is then left to the plugin to decide what to do with the group.
+
+.. highlight:: java
+
+.. rubric:: Methods
+
+- ``configurePipeline()``: Used to create any streams or datasets or perform any validation
+  on the application configuration that are required by this plugin.
+- ``initialize()``: Initialize the Batch Aggregator. Guaranteed to be executed before any call
+  to the plugin’s ``groupBy`` or ``aggregate`` methods. This is called by each executor of the job.
+  For example, if the MapReduce engine is being used, each mapper will call this method.
+- ``destroy()``: Destroy any resources created by initialize. Guaranteed to be executed after all calls
+  to the plugin’s ``groupBy`` or ``aggregate`` methods have been made. This is called by each executor of the job.
+  For example, if the MapReduce engine is being used, each mapper will call this method.
+- ``groupBy()``: This method will be called for every object that is received from the
+  previous stage. This method returns zero or more group keys for each object it recieves.
+  Objects with the same group key will be grouped together for the aggregate method.
+- ``aggregate()``: The method is called after every object has been assigned their group keys.
+  This method is called once for each group key emitted b the groupBy method.
+  The method recieves a group key as well as an iterator over all object that had that group key.
+  Objects emitted in this method are the output for this stage. 
+
+Example::
+
+  /**
+   * Aggregator that counts how many times each word appears in records input to the aggregator.
+   */
+  @Plugin(type = BatchAggregator.PLUGIN_TYPE)
+  @Name(WordCountAggregator.NAME)
+  @Description("Counts how many times each word appears in all records input to the aggregator.")
+  public class WordCountAggregator extends BatchAggregator<String, StructuredRecord, StructuredRecord> {
+    public static final String NAME = "WordCount";
+    public static final Schema OUTPUT_SCHEMA = Schema.recordOf(
+      "wordCount",
+      Schema.Field.of("word", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("count", Schema.of(Schema.Type.LONG))
+    );
+    private static final Pattern WHITESPACE = Pattern.compile("\\s");
+    private final Conf config;
+
+    /**
+     * Config properties for the plugin.
+     */
+    public static class Conf extends PluginConfig {
+      @Description("The field from the input records containing the words to count.")
+      private String field;
+    }
+
+    public WordCountAggregator(Conf config) {
+      this.config = config;
+    }
+
+    @Override
+    public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+      // any static configuration validation should happen here.
+      // We will check that the field is in the input schema and is of type string.
+      Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
+      // a null input schema means its unknown until runtime, or its not constant
+      if (inputSchema != null) {
+        // if the input schema is constant and known at configure time, check that the input field exists and is a string.
+        Schema.Field inputField = inputSchema.getField(config.field);
+        if (inputField == null) {
+          throw new IllegalArgumentException(
+            String.format("Field '%s' does not exist in input schema %s.", config.field, inputSchema));
+        }
+        Schema fieldSchema = inputField.getSchema();
+        Schema.Type fieldType = fieldSchema.isNullable() ? fieldSchema.getNonNullable().getType() : fieldSchema.getType();
+        if (fieldType != Schema.Type.STRING) {
+          throw new IllegalArgumentException(
+            String.format("Field '%s' is of illegal type %s. Must be of type %s.",
+                          config.field, fieldType, Schema.Type.STRING));
+        }
+      }
+      // set the output schema so downstream stages will know their input schema.
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(OUTPUT_SCHEMA);
+    }
+
+    @Override
+    public void groupBy(StructuredRecord input, Emitter<String> groupKeyEmitter) throws Exception {
+      String val = input.get(config.field);
+      if (val == null) {
+        return;
+      }
+
+      for (String word : WHITESPACE.split(val)) {
+        groupKeyEmitter.emit(word);
+      }
+    }
+
+    @Override
+    public void aggregate(String groupKey, Iterator<StructuredRecord> groupValues,
+                          Emitter<StructuredRecord> emitter) throws Exception {
+      long count = 0;
+      while (groupValues.hasNext()) {
+        groupValues.next();
+        count++;
+      }
+      emitter.emit(StructuredRecord.builder(OUTPUT_SCHEMA).set("word", groupKey).set("count", count).build());
+    }
+  }
+
+Creating a SparkCompute Plugin
+==============================
+
+In order to implement a SparkCompute Plugin (to be used in the Data Pipeline artifact), you extend the
+``SparkCompute`` class. A ``SparkCompute`` plugin is similar to a ``Transform``, except instead of
+transforming its input record by record, it transforms an entire collection of records into another
+collection of records. In a ``SparkCompute`` plugin, you are given access to anything you would be
+able to do in a Spark program. 
+
+.. highlight:: java
+
+.. rubric:: Methods
+
+- ``configurePipeline()``: Used to create any streams or datasets or perform any validation
+  on the application configuration that are required by this plugin.
+- ``transform()``: This method is given a Spark RDD containing every object that is received from the
+  previous stage. This method then performs Spark operations on the input to transform it into
+  an output RDD that will be sent to the next stage.
+
+Example::
+
+  /**
+   * SparkCompute plugin that counts how many times each word appears in records input to the compute stage.
+   */
+  @Plugin(type = SparkCompute.PLUGIN_TYPE)
+  @Name(WordCountCompute.NAME)
+  @Description("Counts how many times each word appears in all records input to the aggregator.")
+  public class WordCountCompute extends SparkCompute<StructuredRecord, StructuredRecord> {
+    public static final String NAME = "WordCount";
+    public static final Schema OUTPUT_SCHEMA = Schema.recordOf(
+      "wordCount",
+      Schema.Field.of("word", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("count", Schema.of(Schema.Type.LONG))
+    );
+    private final Conf config;
+
+    /**
+     * Config properties for the plugin.
+     */
+    public static class Conf extends PluginConfig {
+      @Description("The field from the input records containing the words to count.")
+      private String field;
+    }
+
+    public WordCountCompute(Conf config) {
+      this.config = config;
+    }
+
+    @Override
+    public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+      // any static configuration validation should happen here.
+      // We will check that the field is in the input schema and is of type string.
+      Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
+      if (inputSchema != null) {
+        WordCount wordCount = new WordCount(config.field);
+        wordCount.validateSchema(inputSchema);
+      }
+      // set the output schema so downstream stages will know their input schema.
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(OUTPUT_SCHEMA);
+    }
+
+    @Override
+    public JavaRDD<StructuredRecord> transform(SparkExecutionPluginContext sparkExecutionPluginContext,
+                                               JavaRDD<StructuredRecord> javaRDD) throws Exception {
+      WordCount wordCount = new WordCount(config.field);
+      return wordCount.countWords(javaRDD)
+        .flatMap(new FlatMapFunction<Tuple2<String, Long>, StructuredRecord>() {
+          @Override
+          public Iterable<StructuredRecord> call(Tuple2<String, Long> stringLongTuple2) throws Exception {
+            List<StructuredRecord> output = new ArrayList<>();
+            output.add(StructuredRecord.builder(OUTPUT_SCHEMA)
+                         .set("word", stringLongTuple2._1())
+                         .set("count", stringLongTuple2._2())
+                         .build());
+            return output;
+          }
+        });
+    }
+  }
+
+Creating a Spark Sink
+=====================
+
+In order to implement a SparkSink Plugin (to be used in the Data Pipeline artifact), you extend the
+``SparkSink`` class. A ``SparkSink`` is like a ``SparkCompute`` plugin, except that it has no
+output. This means other plugins cannot be connected to it. In this way, it is also similar to a
+``BatchSink``. In a ``SparkSink``, you are given access to anything you would be able to do in a Spark program. 
+For example, one common use case is to train a machine learning model in this plugin.
+
+.. highlight:: java
+
+.. rubric:: Methods
+
+- ``configurePipeline()``: Used to create any streams or datasets or perform any validation
+  on the application configuration that are required by this plugin.
+- ``run()``: This method is given a Spark RDD containing every object that is received from the
+  previous stage. This method then performs Spark operations on the input, and usually saves the
+  result to a dataset.
+
+Example::
+
+  /**
+   * SparkSink plugin that counts how many times each word appears in records input to it and stores the result in
+   * a KeyValueTable.
+   */
+  @Plugin(type = SparkSink.PLUGIN_TYPE)
+  @Name(WordCountSink.NAME)
+  @Description("Counts how many times each word appears in all records input to the aggregator.")
+  public class WordCountSink extends SparkSink<StructuredRecord> {
+    public static final String NAME = "WordCount";
+    private final Conf config;
+
+    /**
+     * Config properties for the plugin.
+     */
+    public static class Conf extends PluginConfig {
+      @Description("The field from the input records containing the words to count.")
+      private String field;
+
+      @Description("The name of the KeyValueTable to write to.")
+      private String tableName;
+    }
+
+    public WordCountSink(Conf config) {
+      this.config = config;
+    }
+
+    @Override
+    public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+      // any static configuration validation should happen here.
+      // We will check that the field is in the input schema and is of type string.
+      Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
+      if (inputSchema != null) {
+        WordCount wordCount = new WordCount(config.field);
+        wordCount.validateSchema(inputSchema);
+      }
+      pipelineConfigurer.createDataset(config.tableName, KeyValueTable.class, DatasetProperties.EMPTY);
+    }
+
+    @Override
+    public void run(SparkExecutionPluginContext sparkExecutionPluginContext,
+                    JavaRDD<StructuredRecord> javaRDD) throws Exception {
+      WordCount wordCount = new WordCount(config.field);
+      JavaPairRDD outputRDD = wordCount.countWords(javaRDD)
+        .mapToPair(new PairFunction<Tuple2<String, Long>, byte[], byte[]>() {
+          @Override
+          public Tuple2<byte[], byte[]> call(Tuple2<String, Long> stringLongTuple2) throws Exception {
+            return new Tuple2<>(Bytes.toBytes(stringLongTuple2._1()), Bytes.toBytes(stringLongTuple2._2()));
+          }
+        });
+      sparkExecutionPluginContext.saveAsDataset(outputRDD, config.tableName);
+    }
+  }
 
 .. highlight:: java
 
@@ -458,6 +922,49 @@ Test Framework for Plugins
 
 Additional information on unit testing with CDAP is in the Developers’ Manual section
 on :ref:`Testing a CDAP Application <test-framework>`.
+
+In addition, CDAP provides a ``hydrator-test`` module that contains several mock plugins
+for you to use in tests with your custom plugins. To use the module, add a dependency to
+your pom::
+
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>hydrator-test</artifactId>
+      <version>${cdap.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+Then extend the ``HydratorTestBase`` class, and create a method that will setup up the
+application artifact and mock plugins, as well as the artifact containing your custom plugins::
+
+  /**
+   * Unit tests for our plugins.
+   */
+  public class PipelineTest extends HydratorTestBase {
+    private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("data-pipeline", "1.0.0");
+    @ClassRule
+    public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
+    @BeforeClass
+    public static void setupTestClass() throws Exception {
+      ArtifactId parentArtifact = NamespaceId.DEFAULT.artifact(APP_ARTIFACT.getName(), APP_ARTIFACT.getVersion());
+
+      // add the data-pipeline artifact and mock plugins
+      setupBatchArtifacts(parentArtifact, DataPipelineApp.class);
+
+      // add our plugins artifact with the data-pipeline artifact as its parent.
+      // this will make our plugins available to data-pipeline.
+      addPluginArtifact(NamespaceId.DEFAULT.artifact("example-plugins", "1.0.0"),
+                        parentArtifact,
+                        TextFileSetSource.class,
+                        TextFileSetSink.class,
+                        WordCountAggregator.class,
+                        WordCountCompute.class,
+                        WordCountSink.class);
+    }
+
+You can then add test cases as you see fit. The ``cdap-data-pipeline-plugins-archetype``
+includes an example of this.
 
 .. highlight:: java
 

--- a/cdap-docs/cdap-apps/source/hydrator/custom.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/custom.rst
@@ -21,7 +21,7 @@ CDAP provides for the creation of custom ETL plugins to extend the existing ``cd
 
 Plugin Types and Maven Archetypes
 =================================
-In Hydrator, there are eight plugin types:
+In Cask Hydrator, there are eight plugin types:
 
 - Batch Source (*batchsource*)
 - Batch Sink (*batchsink*)
@@ -29,17 +29,17 @@ In Hydrator, there are eight plugin types:
 - Real-time Sink (*realtimesink*)
 - Transformation (*transform*)
 - Batch Aggregator (*batchaggregator*)
-- Spark Computer (*sparkcompute*)
+- Spark Compute (*sparkcompute*)
 - Spark Sink (*sparksink*) 
 
 To get started, you can use one of the Maven archetypes to create your project: 
 
-- cdap-data-pipeline-plugins-archetype (contains all batch plugin types)
-- cdap-etl-realtime-source-archetype (contains a realtime source)
-- cdap-etl-realtime-sink-archetype (contains a realtime sink)
-- cdap-etl-transform-archetype (contains a transform)
+- ``cdap-data-pipeline-plugins-archetype`` (contains all batch plugin types)
+- ``cdap-etl-realtime-source-archetype`` (contains a realtime source)
+- ``cdap-etl-realtime-sink-archetype`` (contains a realtime sink)
+- ``cdap-etl-transform-archetype`` (contains a transform)
 
-This command will create a project from the archetype:
+This command will create a project from an archetype:
 
 .. container:: highlight
 
@@ -50,6 +50,8 @@ This command will create a project from the archetype:
           -DarchetypeArtifactId=<archetype> \\
           -DarchetypeVersion=\ |release| \\
           -DgroupId=org.example.plugin
+          
+where ``<archetype>`` is one of the archetypes listed above.
 
 You can replace the groupId with your own organization, but it must not be ``co.cask.cdap``.
 
@@ -71,19 +73,19 @@ Plugin Config
 -------------
 Each plugin can define a plugin config that specifies what properties the plugin requires.
 When a user creates a pipeline, they will need to provide these properties in order to
-use the plugin. This is done by extending the `PluginConfig` class, and populating that
-class with the field your plugin requires. Each field can be annotated to provide more
+use the plugin. This is done by extending the ``PluginConfig`` class, and populating that
+class with the fields your plugin requires. Each field can be annotated to provide more
 information to users:
 
-- ``@Name``: The name of the field. Defaults to Java field name. You may want to use this
-  if you want the user facing name to use syntax that is not legal Java syntax.
+- ``@Name``: The name of the field. Defaults to the Java field name. You may want to use this
+  if you want the user-facing name to use syntax that is not legal Java syntax.
 
 - ``@Description``: A description for the field.
 
 - ``@Nullable``: Indicates that the specific configuration property is
   optional. Such a plugin class can be used without that property being specified.
 
-At this time, fields in a `PluginConfig` must be primitive Java types (boxed or unboxed).
+At this time, fields in a ``PluginConfig`` must be primitive Java types (boxed or unboxed).
 
 .. highlight:: java
 
@@ -91,7 +93,7 @@ Example::
  
   @Plugin(type = BatchSource.PLUGIN_TYPE)
   @Name("MyBatchSource")
-  @Description("This is my Batch Source")
+  @Description("This is my Batch Source.")
   public class MyBatchSource extends BatchSource<LongWritable, Text, StructuredRecord> {
     private final Conf conf;
 
@@ -101,7 +103,7 @@ Example::
 
     public static class Conf extends PluginConfig {
       @Name("input-path")
-      @Description("Input path for the source")
+      @Description("Input path for the source.")
       private String inputPath;
 
       @Nullable
@@ -115,23 +117,22 @@ Example::
     ...
   }
 
-In this example, we have a plugin of type `batchsource`, named `MyBatchSource`.
-This plugin takes two configuration properties. The first is named `input-path` and is required.
-The second is named `cleanOutput`, and is optional. Note that optional configuration fields should
+In this example, we have a plugin of type ``batchsource``, named ``MyBatchSource``.
+This plugin takes two configuration properties. The first is named ``input-path`` and is required.
+The second is named ``cleanOutput`` and is optional. Note that optional configuration fields should
 have their default values set in the no-argument constructor.
-
-Creating a Batch Source
-=======================
 
 .. highlight:: java
 
-In order to implement a Batch Source (to be used in the ETL Batch artifact or Data Pipeline artifact), you extend the
+Creating a Batch Source
+=======================
+In order to implement a Batch Source (to be used in either the ETL Batch or Data Pipeline artifacts), you extend the
 ``BatchSource`` class. You need to define the types of the KEY and VALUE that the Batch
 Source will receive and the type of object that the Batch Source will emit to the
 subsequent stage (which could be either a Transformation or a Batch Sink). After defining
-the types, only one method is required to be implemented:
+the types, only one method is required to be implemented::
 
-  ``prepareRun()``
+  prepareRun()
 
 .. rubric:: Methods
 
@@ -144,7 +145,7 @@ the types, only one method is required to be implemented:
 - ``initialize()``: Initialize the Batch Source. Guaranteed to be executed before any call
   to the plugin’s ``transform`` method. This is called by each executor of the job. For example,
   if the MapReduce engine is being used, each mapper will call this method.
-- ``destroy()``: Destroy any resources created by initialize. Guaranteed to be executed after all calls
+- ``destroy()``: Destroy any resources created by ``initialize``. Guaranteed to be executed after all calls
   to the plugin’s ``transform`` method have been made. This is called by each executor of the job.
   For example, if the MapReduce engine is being used, each mapper will call this method.
 - ``transform()``: This method will be called for every input key-value pair generated by
@@ -158,7 +159,7 @@ Example::
    * LongWritable is the first parameter because that is the key used by Hadoop's {@link TextInputFormat}.
    * Similarly, Text is the second parameter because that is the value used by Hadoop's {@link TextInputFormat}.
    * {@link StructuredRecord} is the third parameter because that is what the source will output.
-   * All the plugins included with Hydrator operate on StructuredRecord.
+   * All the plugins included with Hydrator operate on StructuredRecords.
    */
   @Plugin(type = BatchSource.PLUGIN_TYPE)
   @Name(TextFileSetSource.NAME)
@@ -181,7 +182,7 @@ Example::
       public static final String DELETE_INPUT_ON_SUCCESS = "deleteInputOnSuccess";
 
       // The name annotation tells CDAP what the property name is. It is optional, and defaults to the variable name.
-      // Note:  only primitives (including boxed types) and string are the types that are supported
+      // Note: only primitives (including boxed types) and string are the types that are supported.
       @Name(FILESET_NAME)
       @Description("The name of the FileSet to read from.")
       private String fileSetName;
@@ -227,7 +228,7 @@ Example::
                                            .build()
         );
       }
-      // set the output schema of this stage so that stages further down the pipeline will know their input schema.
+      // Set the output schema of this stage so that stages further down the pipeline will know their input schema.
       pipelineConfigurer.getStageConfigurer().setOutputSchema(OUTPUT_SCHEMA);
     }
 
@@ -270,17 +271,16 @@ Example::
 
 Creating a Batch Sink
 =====================
-
-In order to implement a Batch Sink (to be used in the ETL Batch artifact or Data Pipeline artifact), you extend the
+In order to implement a Batch Sink (to be used in either the ETL Batch or Data Pipeline artifacts), you extend the
 ``BatchSink`` class. Similar to a Batch Source, you need to define the types of the KEY and
 VALUE that the Batch Sink will write in the Batch job and the type of object that it will
 accept from the previous stage (which could be either a Transformation or a Batch Source).
 
 .. highlight:: java
 
-After defining the types, only one method is required to be implemented:
+After defining the types, only one method is required to be implemented::
 
-  ``prepareRun()``
+  prepareRun()
 
 .. rubric:: Methods
 
@@ -293,13 +293,13 @@ After defining the types, only one method is required to be implemented:
 - ``initialize()``: Initialize the Batch Sink. Guaranteed to be executed before any call
   to the plugin’s ``transform`` method. This is called by each executor of the job. For example,
   if the MapReduce engine is being used, each mapper will call this method.
-- ``destroy()``: Destroy any resources created by initialize. Guaranteed to be executed after all calls
+- ``destroy()``: Destroy any resources created by ``initialize``. Guaranteed to be executed after all calls
   to the plugin’s ``transform`` method have been made. This is called by each executor of the job.
   For example, if the MapReduce engine is being used, each mapper will call this method.
 - ``transform()``: This method will be called for every object that is received from the
   previous stage. The logic inside the method will transform the object to the key-value
   pair expected by the Batch Sink's output format. If you don't override this method, the
-  incoming object is set as the Key and the Value is set to null.
+  incoming object is set as the key and the value is set to null.
 
 Example::
 
@@ -325,7 +325,7 @@ Example::
       public static final String FIELD_SEPARATOR = "fieldSeparator";
 
       // The name annotation tells CDAP what the property name is. It is optional, and defaults to the variable name.
-      // Note:  only primitives (including boxed types) and string are the types that are supported
+      // Note: only primitives (including boxed types) and string are the types that are supported.
       @Name(FILESET_NAME)
       @Description("The name of the FileSet to read from.")
       private String fileSetName;
@@ -397,14 +397,13 @@ Example::
 
   }
 
-Creating a Real-Time Source
-===========================
-
 .. highlight:: java
 
-The only method that needs to be implemented is:
+Creating a Real-Time Source
+===========================
+The only method that needs to be implemented is::
 
-	``poll()``
+  poll()
 
 .. rubric:: Methods
 
@@ -442,7 +441,7 @@ Example::
       @Name("param")
       @Description("Source Param")
       private String param;
-      // Note:  only primitives (included boxed types) and string are the types that are supported
+      // Note: only primitives (included boxed types) and string are the types that are supported.
 
     }
 
@@ -478,14 +477,13 @@ Example::
   }
 
 
-Creating a Real-Time Sink
-=========================
-
 .. highlight:: java
 
-The only method that needs to be implemented is:
+Creating a Real-Time Sink
+=========================
+The only method that needs to be implemented is::
 
- ``write()``
+  write()
 
 .. rubric:: Methods
 
@@ -517,13 +515,13 @@ Example::
     }
   }
 
+.. highlight:: java
 
 Creating a Transformation
 =========================
+The only method that needs to be implemented is::
 
-The only method that needs to be implemented is:
-
-	``transform()``
+  transform()
 
 .. rubric:: Methods
 
@@ -535,8 +533,6 @@ The only method that needs to be implemented is:
   (which could be either another Transformation or a Sink).
 - ``destroy()``: Used to perform any cleanup before the plugin shuts down.
 
-.. highlight:: java
-
 Below is an example of a ``DuplicateTransform`` that emits copies of the incoming record
 based on the value in the record. In addition, a user metric indicating the number of
 copies in each transform is emitted. The user metrics can be queried by using the CDAP
@@ -544,7 +540,7 @@ copies in each transform is emitted. The user metrics can be queried by using th
 
   @Plugin(type = "transform")
   @Name("Duplicator")
-  @Description("Transformation Example that makes copies")
+  @Description("Transformation example that makes copies.")
 
   public class DuplicateTransform extends Transform<StructuredRecord, StructuredRecord> {
 
@@ -553,7 +549,7 @@ copies in each transform is emitted. The user metrics can be queried by using th
     public static final class Config extends PluginConfig {
 
       @Name("count")
-      @Description("Field that indicates number of copies to make")
+      @Description("Field that indicates number of copies to make.")
       private String fieldName;
     }
 
@@ -647,16 +643,15 @@ functions as part of your JavaScript::
 
 Creating a Batch Aggregator
 ===========================
-
 In order to implement a Batch Aggregator (to be used in the Data Pipeline artifact), you extend the
-``BatchAggregator`` class. Unlike a ``Transform``, a ``BatchAggregator`` operates on a collection of
-records instead of only on one record at a time. An aggregation takes place in two steps --
-groupBy and aggregate. In the groupBy step, the aggregator zero or more group keys for each
-input record. Before the aggregate step occurs, Hydrator will take all records that have the same
-group key, and collect them in a group. If a record did not have any group keys, it is filtered out.
-If a record had multiple group keys, it will belong to multiple groups. The aggregate step is then
-called. In this step, the plugin gets the group key and all the records that had that group key.
-It is then left to the plugin to decide what to do with the group.
+``BatchAggregator`` class. Unlike a ``Transform``, which operates on a single record at a time, a
+``BatchAggregator`` operates on a collection of records. An aggregation takes place in two steps:
+*groupBy* and then *aggregate*. In the *groupBy* step, the aggregator creates zero or more group keys for each
+input record. Before the *aggregate step occurs, Hydrator will take all records that have the same
+group key, and collect them into a group. If a record does not have any of the group keys, it is filtered out.
+If a record has multiple group keys, it will belong to multiple groups. The *aggregate* step is then
+called. In this step, the plugin receives group keys and all records that had that group key.
+It is then left to the plugin to decide what to do with each of the groups.
 
 .. highlight:: java
 
@@ -667,15 +662,15 @@ It is then left to the plugin to decide what to do with the group.
 - ``initialize()``: Initialize the Batch Aggregator. Guaranteed to be executed before any call
   to the plugin’s ``groupBy`` or ``aggregate`` methods. This is called by each executor of the job.
   For example, if the MapReduce engine is being used, each mapper will call this method.
-- ``destroy()``: Destroy any resources created by initialize. Guaranteed to be executed after all calls
+- ``destroy()``: Destroy any resources created by ``initialize``. Guaranteed to be executed after all calls
   to the plugin’s ``groupBy`` or ``aggregate`` methods have been made. This is called by each executor of the job.
   For example, if the MapReduce engine is being used, each mapper will call this method.
 - ``groupBy()``: This method will be called for every object that is received from the
   previous stage. This method returns zero or more group keys for each object it recieves.
-  Objects with the same group key will be grouped together for the aggregate method.
+  Objects with the same group key will be grouped together for the ``aggregate`` method.
 - ``aggregate()``: The method is called after every object has been assigned their group keys.
-  This method is called once for each group key emitted b the groupBy method.
-  The method recieves a group key as well as an iterator over all object that had that group key.
+  This method is called once for each group key emitted by the ``groupBy`` method.
+  The method recieves a group key as well as an iterator over all objects that had that group key.
   Objects emitted in this method are the output for this stage. 
 
 Example::
@@ -710,12 +705,12 @@ Example::
 
     @Override
     public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
-      // any static configuration validation should happen here.
+      // Any static configuration validation should happen here.
       // We will check that the field is in the input schema and is of type string.
       Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
-      // a null input schema means its unknown until runtime, or its not constant
+      // A null input schema means it is unknown until runtime, or it is not constant.
       if (inputSchema != null) {
-        // if the input schema is constant and known at configure time, check that the input field exists and is a string.
+        // If the input schema is constant and known at configure time, check that the input field exists and is a string.
         Schema.Field inputField = inputSchema.getField(config.field);
         if (inputField == null) {
           throw new IllegalArgumentException(
@@ -729,7 +724,7 @@ Example::
                           config.field, fieldType, Schema.Type.STRING));
         }
       }
-      // set the output schema so downstream stages will know their input schema.
+      // Set the output schema so downstream stages will know their input schema.
       pipelineConfigurer.getStageConfigurer().setOutputSchema(OUTPUT_SCHEMA);
     }
 
@@ -759,7 +754,6 @@ Example::
 
 Creating a SparkCompute Plugin
 ==============================
-
 In order to implement a SparkCompute Plugin (to be used in the Data Pipeline artifact), you extend the
 ``SparkCompute`` class. A ``SparkCompute`` plugin is similar to a ``Transform``, except instead of
 transforming its input record by record, it transforms an entire collection of records into another
@@ -772,9 +766,9 @@ able to do in a Spark program.
 
 - ``configurePipeline()``: Used to create any streams or datasets or perform any validation
   on the application configuration that are required by this plugin.
-- ``transform()``: This method is given a Spark RDD containing every object that is received from the
-  previous stage. This method then performs Spark operations on the input to transform it into
-  an output RDD that will be sent to the next stage.
+- ``transform()``: This method is given a Spark RDD (Resilient Distributed Dataset) containing 
+  every object that is received from the previous stage. This method then performs Spark operations
+  on the input to transform it into an output RDD that will be sent to the next stage.
 
 Example::
 
@@ -807,14 +801,14 @@ Example::
 
     @Override
     public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
-      // any static configuration validation should happen here.
+      // Any static configuration validation should happen here.
       // We will check that the field is in the input schema and is of type string.
       Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
       if (inputSchema != null) {
         WordCount wordCount = new WordCount(config.field);
         wordCount.validateSchema(inputSchema);
       }
-      // set the output schema so downstream stages will know their input schema.
+      // Set the output schema so downstream stages will know their input schema.
       pipelineConfigurer.getStageConfigurer().setOutputSchema(OUTPUT_SCHEMA);
     }
 
@@ -839,12 +833,11 @@ Example::
 
 Creating a Spark Sink
 =====================
-
 In order to implement a SparkSink Plugin (to be used in the Data Pipeline artifact), you extend the
-``SparkSink`` class. A ``SparkSink`` is like a ``SparkCompute`` plugin, except that it has no
-output. This means other plugins cannot be connected to it. In this way, it is also similar to a
+``SparkSink`` class. A ``SparkSink`` is like a ``SparkCompute`` plugin except that it has no
+output. This means other plugins cannot be connected to it. In this way, it is similar to a
 ``BatchSink``. In a ``SparkSink``, you are given access to anything you would be able to do in a Spark program. 
-For example, one common use case is to train a machine learning model in this plugin.
+For example, one common use case is to train a machine-learning model in this plugin.
 
 .. highlight:: java
 
@@ -852,15 +845,15 @@ For example, one common use case is to train a machine learning model in this pl
 
 - ``configurePipeline()``: Used to create any streams or datasets or perform any validation
   on the application configuration that are required by this plugin.
-- ``run()``: This method is given a Spark RDD containing every object that is received from the
-  previous stage. This method then performs Spark operations on the input, and usually saves the
-  result to a dataset.
+- ``run()``: This method is given a Spark RDD (Resilient Distributed Dataset) containing every 
+  object that is received from the previous stage. This method then performs Spark operations
+  on the input, and usually saves the result to a dataset.
 
 Example::
 
   /**
-   * SparkSink plugin that counts how many times each word appears in records input to it and stores the result in
-   * a KeyValueTable.
+   * SparkSink plugin that counts how many times each word appears in records input to it
+   * and stores the result in a KeyValueTable.
    */
   @Plugin(type = SparkSink.PLUGIN_TYPE)
   @Name(WordCountSink.NAME)
@@ -886,7 +879,7 @@ Example::
 
     @Override
     public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
-      // any static configuration validation should happen here.
+      // Any static configuration validation should happen here.
       // We will check that the field is in the input schema and is of type string.
       Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
       if (inputSchema != null) {
@@ -923,9 +916,11 @@ Test Framework for Plugins
 Additional information on unit testing with CDAP is in the Developers’ Manual section
 on :ref:`Testing a CDAP Application <test-framework>`.
 
+.. highlight:: xml
+
 In addition, CDAP provides a ``hydrator-test`` module that contains several mock plugins
 for you to use in tests with your custom plugins. To use the module, add a dependency to
-your pom::
+your ``pom.xml``::
 
     <dependency>
       <groupId>co.cask.cdap</groupId>
@@ -933,6 +928,8 @@ your pom::
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>
+
+.. highlight:: java
 
 Then extend the ``HydratorTestBase`` class, and create a method that will setup up the
 application artifact and mock plugins, as well as the artifact containing your custom plugins::
@@ -949,11 +946,11 @@ application artifact and mock plugins, as well as the artifact containing your c
     public static void setupTestClass() throws Exception {
       ArtifactId parentArtifact = NamespaceId.DEFAULT.artifact(APP_ARTIFACT.getName(), APP_ARTIFACT.getVersion());
 
-      // add the data-pipeline artifact and mock plugins
+      // Add the data pipeline artifact and mock plugins.
       setupBatchArtifacts(parentArtifact, DataPipelineApp.class);
 
-      // add our plugins artifact with the data-pipeline artifact as its parent.
-      // this will make our plugins available to data-pipeline.
+      // Add our plugins artifact with the data pipeline artifact as its parent.
+      // This will make our plugins available to the data pipeline.
       addPluginArtifact(NamespaceId.DEFAULT.artifact("example-plugins", "1.0.0"),
                         parentArtifact,
                         TextFileSetSource.class,
@@ -964,7 +961,7 @@ application artifact and mock plugins, as well as the artifact containing your c
     }
 
 You can then add test cases as you see fit. The ``cdap-data-pipeline-plugins-archetype``
-includes an example of this.
+includes an example of this unit test.
 
 .. highlight:: java
 


### PR DESCRIPTION
Adding documentation in the creating custom plugins section about
creating aggregators, spark compute plugins, and spark sinks.
Also added information about the hydrator-test module and
restructured it a little bit to avoid repetition.

Running as [Quick Build 1](http://builds.cask.co/browse/CDAP-DOB194-1)

[Page of Interest](http://builds.cask.co/artifact/CDAP-DOB194/shared/build-1/Docs-HTML/3.4.0-SNAPSHOT/en/cdap-apps/hydrator/custom.html)