### PR TITLE
(CDAP-5822) Workaround the URLClassLoader getResourceAsStream bug

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -57,6 +57,8 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -136,7 +138,9 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
     return new Runnable() {
       @Override
       public void run() {
-        for (Object resource : resources) {
+        List<Object> resourceList = new ArrayList<>(Arrays.asList(resources));
+        Collections.reverse(resourceList);
+        for (Object resource : resourceList) {
           if (resource == null) {
             continue;
           }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -102,6 +102,7 @@ import org.apache.twill.zookeeper.ZKClientService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
@@ -350,6 +351,9 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
         throw Throwables.propagate(Throwables.getRootCause(e));
       }
     } finally {
+      if (programRunner instanceof Closeable) {
+        Closeables.closeQuietly((Closeable) programRunner);
+      }
       // Always unblock the handleCommand method if it is not unblocked before (e.g if program failed to start).
       // The controller state will make sure the corresponding command will be handled correctly in the correct state.
       runlatch.countDown();

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -246,9 +246,8 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     } catch (Exception e) {
       // See if it is due to job cancelation. If it is, then it's not an error.
       if (jobCompletion.isCancelled()) {
-        LOG.debug("Spark program execution cancelled: {}", runtimeContext);
+        LOG.info("Spark program execution cancelled: {}", runtimeContext);
       } else {
-        LOG.error("Spark program execution failure: {}", runtimeContext, e);
         throw e;
       }
     }

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SparkRuntimeEnv.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SparkRuntimeEnv.scala
@@ -176,17 +176,13 @@ object SparkRuntimeEnv {
           t.interrupt()
           t.join()
         })
-        if (context.getState() != StreamingContextState.STOPPED) {
-          context.stop(false, false)
-        }
+        context.stop(false, false)
       })
     } finally {
       sc.foreach(context => {
         val cleanup = createCleanup(context);
         try {
-          if (!context.isStopped) {
-            context.stop
-          }
+          context.stop
         } finally {
           // Just interrupt the thread to unblock any blocking call
           thread.foreach(_.interrupt())

--- a/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoaderTest.java
+++ b/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoaderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.common.lang.ClassLoaders;
+import com.google.common.io.Closeables;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Unit tests for {@link SparkRunnerClassLoader}.
+ */
+public class SparkRunnerClassLoaderTest {
+
+  @Test
+  public void testConcurrentLoadClose() throws Exception {
+    // This is for testing CDAP-5822, which apparently is a JDK bug.
+    // Since the problem manifest as a race between loading class and closing of another ClassLoader instance,
+    // we loop 100 times, which give a very high chance that the test would fail when the bug was not fixed.
+    for (int i = 0; i < 100; i++) {
+      List<URL> urls = ClassLoaders.getClassLoaderURLs(getClass().getClassLoader(), new ArrayList<URL>());
+      final URL[] urlArray = urls.toArray(new URL[urls.size()]);
+
+      SparkRunnerClassLoader firstCL = new SparkRunnerClassLoader(urlArray,
+                                                                  getClass().getClassLoader(), false, false);
+      // Load a class from the first CL.
+      firstCL.loadClass("org.apache.spark.SparkContext");
+
+      // Create a thread to load the same class name from a different CL instance
+      final CountDownLatch latch = new CountDownLatch(1);
+      final AtomicReference<Exception> exception = new AtomicReference<>();
+      Thread t = new Thread() {
+        @Override
+        public void run() {
+          SparkRunnerClassLoader secondCL = new SparkRunnerClassLoader(urlArray,
+                                                                       getClass().getClassLoader(), false, false);
+          try {
+            latch.countDown();
+            secondCL.loadClass("org.apache.spark.SparkContext");
+          } catch (Exception e) {
+            exception.set(e);
+          } finally {
+            Closeables.closeQuietly(secondCL);
+          }
+        }
+      };
+      t.start();
+
+      // When the thread started to load the class, close the first ClassLoader
+      latch.await();
+      firstCL.close();
+      t.join();
+
+      // There shouldn't be any exception raised from the thread.
+      Exception ex = exception.get();
+      if (ex != null) {
+        throw ex;
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Use getResource() instead of getResourceAsStream()

Also fixed a Spark compatibility issue on older Spark version

- Not to call the isStopped and getState method from SparkContext and StreamingContext because they are added in 1.6 and 1.5 respectively
  - The side effect is there would be a warning being logged when the spark job finished