### PR TITLE
[CDAP-5832] - Fixes switching between namespaces in tracker

### DIFF
--- a/cdap-ui/app/features/tracker/routes.js
+++ b/cdap-ui/app/features/tracker/routes.js
@@ -36,7 +36,6 @@ angular.module(PKG.name + '.feature.tracker')
         resolve: {
           rTrackerApp: function (myTrackerApi, $q, $stateParams, $state, UI_CONFIG, myAlertOnValium) {
             let defer = $q.defer();
-
             let params = {
               namespace: $stateParams.namespace
             };
@@ -68,7 +67,7 @@ angular.module(PKG.name + '.feature.tracker')
                   });
 
                   if (!isRunning) {
-                    $state.go('tracker-enable');
+                    $state.go('tracker-enable', $stateParams);
                   } else {
                     defer.resolve(true);
                   }
@@ -79,7 +78,7 @@ angular.module(PKG.name + '.feature.tracker')
                   });
                 });
               }, () => {
-                $state.go('tracker-enable');
+                $state.go('tracker-enable', $stateParams);
               });
 
             return defer.promise;


### PR DESCRIPTION
- While switching namespaces we check if tracker is enabled in a particular namespace if not we go to `enable-tracker` state. This state inherits from `ns` which has a namespace in its url. 

When we use `$state.go('enable-tracker')` we are missing out on the namespace information while the namespace switch happens. Passing the `$stateParams` fixes this.