### PR TITLE
(CDAP-5242) Added documentation for audit publishing.

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1014,7 +1014,7 @@
     <name>metadata.updates.kafka.broker.list</name>
     <value>127.0.0.1:${kafka.bind.port}</value>
     <description>
-      Apache Kafka broker list to which metadata update notifications are published
+      Apache Kafka broker list to which metadata update notifications are published (deprecated)
     </description>
   </property>
 
@@ -1022,7 +1022,7 @@
     <name>metadata.updates.kafka.topic</name>
     <value>cdap-metadata-updates</value>
     <description>
-      Apache Kafka topic name to which metadata update notifications are published
+      Apache Kafka topic name to which metadata update notifications are published (deprecated)
     </description>
   </property>
 
@@ -1033,7 +1033,7 @@
       Determines if metadata updates will be published to Apache Kafka.
       External systems can subscribe to the Kafka topic determined by
       ${metadata.updates.kafka.topic} to receive notifications of metadata
-      updates.
+      updates (deprecated).
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="b3d9caac54871b9d4ea7bd81b0b8eff2"
+DEFAULT_XML_MD5_HASH="35b81e43a8203b26f484a1fb776b7496"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-docs/developers-manual/source/building-blocks/audit-logging.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/audit-logging.rst
@@ -1,0 +1,190 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2016 Cask Data, Inc.
+
+.. _audit-logging:
+
+=============
+Audit Logging
+=============
+
+Overview
+========
+Audit logging provides a chronological ledger containing evidence of operations or changes
+on CDAP entities. This information can be used to capture a trail of the activities that
+determined the state of an entity at a given point in time. These activities include the
+creation, modification, and deletion of an entity. It also includes modification of the
+entity's :ref:`metadata <metadata-lineage-metadata>`. For data entities (datasets and
+streams), it includes access information used to generate the entity's :ref:`lineage
+<metadata-lineage-lineage>`. Audit logging is an especially important feature because it
+enables users to integrate CDAP with external data governance systems such as
+:ref:`Cloudera Navigator <audit-logging-navigator-integration>`.
+
+.. _audit-logging-supported-audit-events:
+
+Supported Audit Events
+======================
+These audit events are supported in CDAP:
+
+.. list-table::
+   :widths: 30 40
+   :header-rows: 1
+
+   * - Audit Event Type
+     - Supported Entities
+   * - CREATE
+     - * Datasets
+       * Streams
+   * - UPDATE
+     - * Datasets
+       * Streams
+   * - DELETE
+     - * Datasets
+       * Streams
+   * - TRUNCATE
+     - * Datasets
+       * Streams
+   * - ACCESS
+     - * Datasets
+       * Streams
+   * - METADATA_CHANGE
+     - * Applications
+       * Artifacts
+       * Datasets
+       * Programs
+       * Streams
+
+.. _audit-logging-configuring-audit-publishing:
+
+Configuring Audit Publishing
+============================
+Audit publishing is controlled by these properties set in the ``cdap-site.xml``, as described in the
+:ref:`Administration Manual <appendix-cdap-site.xml>`:
+
+- ``audit.enabled``: Determines if publishing of audit logs is enabled; defaults to ``true``
+- ``audit.kafka.topic``: Determines the Kafka topic to publish to; defaults to ``audit``
+
+.. _audit-logging-consuming-audit-events:
+
+Consuming Audit Events
+======================
+When audit publishing is :ref:`enabled <audit-logging-configuring-audit-publishing>`, for
+:ref:`every audit event <audit-logging-supported-audit-events>`, a message is published to
+:ref:`CDAP Kafka <admin-manual-cdap-components>` to the
+:ref:`configured kafka topic <audit-logging-configuring-audit-publishing>`.
+
+The contents of the message are a JSON representation of
+the `AuditMessage
+<https://github.com/caskdata/cdap/blob/develop/cdap-proto/src/main/java/co/cask/cdap/proto/audit/AuditMessage.java>`__
+class.
+
+Here are some example JSON messages, pretty-printed:
+
+**Dataset Creation**
+
+::
+
+  {
+	  "version": 1,
+	  "time": 1000,
+	  "entityId": {
+		  "namespace": "ns1",
+		  "dataset": "ds1",
+		  "entity": "DATASET"
+	  },
+	  "user": "user1",
+	  "type": "CREATE",
+	  "payload": {}
+  }
+
+**Stream Access**
+
+::
+
+  {
+	  "version": 1,
+	  "time": 2000,
+	  "entityId": {
+		  "namespace": "ns1",
+		  "stream": "stream1",
+		  "entity": "STREAM"
+	  },
+	  "user": "user1",
+	  "type": "ACCESS",
+	  "payload": {
+		  "accessType": "WRITE",
+		  "accessor": {
+			  "namespace": "ns1",
+			  "application": "app1",
+			  "type": "Flow",
+			  "program": "flow1",
+			  "run": "run1",
+			  "entity": "PROGRAM_RUN"
+		  }
+	  }
+  }
+
+**Application Metadata Change**
+
+::
+
+  {
+	  "version": 1,
+	  "time": 3000,
+	  "entityId": {
+  		"namespace": "ns1",
+	  	"application": "app1",
+		  "entity": "APPLICATION"
+	  },
+	  "user": "user1",
+	  "type": "METADATA_CHANGE",
+	  "payload": {
+		  "previous": {
+  			"USER": {
+	  			"properties": {
+		  			"uk": "uv",
+			  		"uk1": "uv2"
+				  },
+				  "tags": ["ut1", "ut2"]
+			  },
+			  "SYSTEM": {
+				  "properties": {
+					  "sk": "sv"
+				  },
+				  "tags": []
+			  }
+		  },
+		  "additions": {
+			  "SYSTEM": {
+				  "properties": {
+					  "sk": "sv"
+				  },
+				  "tags": ["t1", "t2"]
+			  }
+		  },
+		  "deletions": {
+			  "USER": {
+				  "properties": {
+					  "uk": "uv"
+				  },
+				  "tags": ["ut1"]
+			  }
+		  }
+	  }
+  }
+
+CDAP also provides an `adapter class 
+<https://github.com/caskdata/cdap/blob/develop/cdap-proto/src/main/java/co/cask/cdap/proto/codec/AuditMessageTypeAdapter.java>`__
+to enable deserializing of the audit messages using the `GSON <https://github.com/google/gson>`__ library.
+
+.. _audit-logging-integrations:
+
+Integrations
+============
+
+.. _audit-logging-navigator-integration:
+
+Cloudera Navigator Integration
+------------------------------
+CDAP Metadata can be pushed to Cloudera Navigator for metadata discovery and search.
+Refer to :ref:`Cloudera Navigator Integration <navigator-integration>` for more information.

--- a/cdap-docs/developers-manual/source/building-blocks/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/index.rst
@@ -28,6 +28,7 @@ Building Blocks
     Workflows <workflows>
     Artifacts <artifacts>
     Metadata and Lineage <metadata-lineage>
+    Audit Logging <audit-logging>
     Namespaces <namespaces>
     Transaction System <transaction-system>
 
@@ -64,6 +65,10 @@ write data through the data abstraction layer in CDAP.
   These can be retrieved and searched, and the metadata used to discover CDAP entities.
   Access of these entities is tracked, and you can view the :doc:`lineage <metadata-lineage>` of datasets and streams.
   With a lineage diagram, you can then drill down into the metadata of its nodes. 
+
+- :doc:`Audit Logging <audit-logging>` provides a chronological ledger containing evidence of operations or
+  changes on CDAP entities. This information can be used to capture a trail of the activities that 
+  determined the state of an entity at a given point in time.
 
 - A :doc:`Namespace <namespaces>` is a logical grouping of application and data in CDAP.
   Conceptually, namespaces can be thought of as a partitioning of a CDAP instance.

--- a/cdap-docs/developers-manual/source/building-blocks/metadata-lineage.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/metadata-lineage.rst
@@ -102,11 +102,17 @@ This table lists the **system** metadata annotations of CDAP entities:
      - * Schema (field names and types)
      - * View name
 
-
 .. _metadata-update-notifications:
 
 Metadata Update Notifications
 =============================
+.. topic::  **Note: Metadata Update Notifications Deprecated**
+
+    As of *CDAP v3.4.0*, *Metadata Update Notifications* have been deprecated, pending removal in a later
+    version. The :ref:`CDAP Audit Notifications <audit-logging>` contain notifications for metadata changes. Please change
+    all uses of *Metadata Update Notifications* to consume only those messages from the audit feed that have the
+    ``type`` field set to ``METADATA_CHANGE``.
+
 CDAP has the capability of publishing notifications to an external Apache Kafka instance
 upon metadata updates.
 

--- a/cdap-docs/integrations/source/partners/cloudera/navigator-integration.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/navigator-integration.rst
@@ -22,6 +22,7 @@ Resources
 - `Cloudera Navigator <http://www.cloudera.com/products/cloudera-navigator.html>`__
 - :ref:`Real-time processing using Flows <flows-flowlets-index>`
 - :cdap-kafka-flow:`Kafka Flowlet Library <>`
+- :ref:`Overview of Audit Logging in CDAP <audit-logging>`
 
 
 Getting Started
@@ -33,9 +34,9 @@ To use the Navigator Integration App, you need CDAP version 3.3.0 (or higher) an
 
 Metadata Publishing to Kafka
 ----------------------------
-The Navigator Integration App contains a flow that subscribes to the Kafka topic to which the CDAP Metadata service publishes
-the metadata updates. Hence, before using this application, you should enable publishing of metadata updates to
-Kafka, as described in the CDAP document :ref:`Enable Metadata Update Notifications <metadata-update-notifications>`.
+The Navigator Integration App contains a flow that subscribes to the Kafka topic to which the CDAP audit logs are
+published. Hence, before using this application, you should
+:ref:`enable audit publishing <audit-logging-configuring-audit-publishing>`.
 
 
 Deploying the Application


### PR DESCRIPTION
(CDAP-5247) Deprecated Metadata updates notification feed.


Issues:
* [CDAP-5242](https://issues.cask.co/browse/CDAP-5242)
* [CDAP-5247](https://issues.cask.co/browse/CDAP-5247)

[Quick Build 8](http://builds.cask.co/browse/CDAP-DOB198-8)

Relevant doc pages:
* [Audit Logging](http://builds.cask.co/artifact/CDAP-DOB198/shared/build-8/Docs-HTML/3.4.0-SNAPSHOT/en/developers-manual/building-blocks/audit-logging.html)
* [Metadata Feed Deprecation](http://builds.cask.co/artifact/CDAP-DOB198/shared/build-8/Docs-HTML/3.4.0-SNAPSHOT/en/developers-manual/building-blocks/metadata-lineage.html#metadata-update-notifications)