### PR TITLE
Add jcraft.jsch dependency

### DIFF
--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -176,6 +176,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-service</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
     <jetty.version>6.1.22</jetty.version>
     <jetty8.version>8.1.15.v20140411</jetty8.version>
     <jline.version>2.12</jline.version>
+    <jsch.version>0.1.42</jsch.version>
     <junit.version>4.11</junit.version>
     <kafka.version>0.8.2.2</kafka.version>
     <leveldb.version>0.6</leveldb.version>
@@ -327,6 +328,11 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${gson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.jcraft</groupId>
+        <artifactId>jsch</artifactId>
+        <version>${jsch.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
Fix build broken by #5672. Spark example app failed since it was using FileSystem and JSchException class was not found. 

Additional dependencies brought in : com.jcraft:jsch, com.jcraft:jzlib

Tested in both SDK, Distributed, CM modes

Build : http://builds.cask.co/browse/CDAP-DUT4074-1