### PR TITLE
[CDAP-5850] - Filters out externalDataset from being surfaced in UI

### DIFF
--- a/cdap-ui/app/features/admin/controllers/namespace/datasets-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/datasets-ctrl.js
@@ -33,7 +33,8 @@ angular.module(PKG.name + '.feature.admin')
         }
         $scope.dataList = res.filter(function(dataset) {
           return dataset.type !== 'externalDataset';
-        });
+        })
+        .concat($scope.dataList);
       });
 
     myStreamApi.list(params)

--- a/cdap-ui/app/features/admin/controllers/namespace/datasets-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/namespace/datasets-ctrl.js
@@ -28,7 +28,12 @@ angular.module(PKG.name + '.feature.admin')
     myDatasetApi.list(params)
       .$promise
       .then(function (res) {
-        $scope.dataList = $scope.dataList.concat(res);
+        if (!Array.isArray(res)) {
+          return;
+        }
+        $scope.dataList = res.filter(function(dataset) {
+          return dataset.type !== 'externalDataset';
+        });
       });
 
     myStreamApi.list(params)

--- a/cdap-ui/app/features/data/list-ctrl.js
+++ b/cdap-ui/app/features/data/list-ctrl.js
@@ -29,6 +29,9 @@ angular.module(PKG.name + '.feature.data')
       .$promise
       .then(function (res) {
         this.dataList = res
+          .filter( function(dataset) {
+            return dataset.type !== 'externalDataset';
+          })
           .map(function(dataset) {
             dataset.dataType = 'Dataset';
 

--- a/cdap-ui/app/features/overview/controllers/apps-section-ctrl.js
+++ b/cdap-ui/app/features/overview/controllers/apps-section-ctrl.js
@@ -41,7 +41,7 @@ angular.module(PKG.name + '.feature.overview')
       .$promise
       .then(function(res) {
         this.dataList = this.dataList.concat(res).filter(function(dataset) {
-          return dataset.name.indexOf('_') !== 0;
+          return (dataset.name.indexOf('_') !== 0 && dataset.type !== 'externalDataset');
         });
       }.bind(this));
 


### PR DESCRIPTION
- Hides external datasets from being surfaced in UI

##### Note
There is one caveat still. We could see the external dataset & local dataset in datasets tab under a MR program. This should be a backend fix and we will address this in 3.5