### PR TITLE
(CDAP-5862) The enum Schema representation was wrong.

### DIFF
--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/Schema.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/Schema.java
@@ -704,8 +704,8 @@ public final class Schema implements Serializable {
       return new ImmutableEntry<>(null, null);
     }
 
-    Map<V, Integer> forwardMap = new HashMap<>();
-    Map<Integer, V> reverseMap = new HashMap<>();
+    Map<V, Integer> forwardMap = new LinkedHashMap<>();
+    Map<Integer, V> reverseMap = new LinkedHashMap<>();
     int idx = 0;
     for (V value : values) {
       forwardMap.put(value, idx);

--- a/cdap-common/src/test/java/co/cask/cdap/io/DatumCodecTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/DatumCodecTest.java
@@ -286,7 +286,7 @@ public class DatumCodecTest {
   /**
    *
    */
-  public static enum TestEnum {
+  public enum TestEnum {
     VALUE1, VALUE2, VALUE3
   }
 
@@ -303,11 +303,12 @@ public class DatumCodecTest {
     writer.encode(TestEnum.VALUE2, encoder);
 
     BinaryDecoder decoder = new BinaryDecoder(input);
-    ReflectionDatumReader<TestEnum> reader = new ReflectionDatumReader<>(schema, TypeToken.of(TestEnum.class));
+    Schema readSchema = Schema.parseJson(schema.toString());
+    ReflectionDatumReader<TestEnum> reader = new ReflectionDatumReader<>(readSchema, TypeToken.of(TestEnum.class));
 
-    Assert.assertEquals(TestEnum.VALUE1, reader.read(decoder, schema));
-    Assert.assertEquals(TestEnum.VALUE3, reader.read(decoder, schema));
-    Assert.assertEquals(TestEnum.VALUE2, reader.read(decoder, schema));
+    Assert.assertEquals(TestEnum.VALUE1, reader.read(decoder, readSchema));
+    Assert.assertEquals(TestEnum.VALUE3, reader.read(decoder, readSchema));
+    Assert.assertEquals(TestEnum.VALUE2, reader.read(decoder, readSchema));
   }
 
   // this tests that the datum reader treats empty fields correctly. It reproduces the issue in ENG-2404.


### PR DESCRIPTION
- The ordering of the enum symbols are important.
  We cannot use HashMap to store symbol to ordinal.
  Need to use LinkedHashMap.